### PR TITLE
optimize setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -254,20 +254,48 @@ create_organization() {
     echo ".streamlit/secrets.toml file updated with organization details."
 }
 
-# Main function
-main() {
+init_env() {
     initialize_env_file
+}
+
+init_dev_dependencies() {
     choose_python_version_or_fail
     remove_poetry_env
     install_dependencies
-    setup_postgresql
     activate_poetry_env
     install_dependencies_after_poetry_env
+}
+
+init_database() {
+    setup_postgresql
     run_alembic_upgrade
     create_organization
-    log_event "skyvern-oss-setup-complete"
-    echo "Setup completed successfully."
+}
+
+# Main function
+main() {
+    case $1 in
+        "env")
+            init_env
+            echo "Setup env dependencies successfully."
+            ;;
+        "dev")
+            init_dev_dependencies
+            echo "Setup dev dependencies successfully."
+            ;;
+        "database")
+            init_database
+            echo "Setup database successfully."
+            ;;
+        *)
+            init_env
+            init_dev_dependencies
+            init_database
+            log_event "skyvern-oss-setup-complete"
+            echo "Setup completed successfully."
+           ;;
+    esac
 }
 
 # Execute main function
-main
+main $@

--- a/setup.sh
+++ b/setup.sh
@@ -250,7 +250,7 @@ create_organization() {
     fi
 
     # Update the secrets-open-source.toml file
-    echo -e "[skyvern]\nconfigs = [\n    {\"env\" = \"local\", \"host\" = \"http://0.0.0.0:8000/api/v1\", \"orgs\" = [{name=\"Skyvern\", cred=\"$api_token\"}]}\n]" > .streamlit/secrets.toml
+    echo -e "[skyvern]\nconfigs = [\n    {\"env\" = \"local\", \"host\" = \"http://0.0.0.0:8000/api/v1\", \"orgs\" = [{name=\"Skyvern-Open-Source\", cred=\"$api_token\"}]}\n]" > .streamlit/secrets.toml
     echo ".streamlit/secrets.toml file updated with organization details."
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -250,7 +250,7 @@ create_organization() {
     fi
 
     # Update the secrets-open-source.toml file
-    echo -e "[skyvern]\nconfigs = [\n    {\"env\" = \"local\", \"host\" = \"http://0.0.0.0:8000/api/v1\", \"orgs\" = [{name=\"Skyvern-Open-Source\", cred=\"$api_token\"}]}\n]" > .streamlit/secrets.toml
+    echo -e "[skyvern]\nconfigs = [\n    {\"env\" = \"local\", \"host\" = \"http://0.0.0.0:8000/api/v1\", \"orgs\" = [{name=\"Skyvern\", cred=\"$api_token\"}]}\n]" > .streamlit/secrets.toml
     echo ".streamlit/secrets.toml file updated with organization details."
 }
 


### PR DESCRIPTION
1. `orgs.name` created in `secrets.toml` is `Skyvern`, not consistent with  orgs.name in database
2. updating LLM provider will re-init my local dev env. So I depart `setup.sh` into three parts: env, dev dependencies, database. Default is to init all, but we can only init the part we want in some cases by adding the second param like `setup.sh [env|dev|database]` 


For wise, I think the setup needs to be refactored by Python scripts or something else like CLI:
1. bash is not well-performed in Windows
2. bash is not readable enough