### PR TITLE
Fix the action history passed into extract-action prompt

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -33,6 +33,7 @@ from skyvern.forge.sdk.workflow.models.workflow import Workflow, WorkflowRun
 from skyvern.webeye.actions.actions import (
     Action,
     ActionType,
+    ActionTypeUnion,
     CompleteAction,
     UserDefinedError,
     WebAction,
@@ -600,27 +601,27 @@ class ForgeAgent(Agent):
         # Get action results from the last app.SETTINGS.PROMPT_ACTION_HISTORY_WINDOW steps
         steps = await app.DATABASE.get_task_steps(task_id=task.task_id, organization_id=task.organization_id)
         window_steps = steps[-1 * SettingsManager.get_settings().PROMPT_ACTION_HISTORY_WINDOW :]
-        action_results: list[ActionResult] = []
+        actions_and_results: list[tuple[ActionTypeUnion, list[ActionResult]]] = []
         for window_step in window_steps:
-            if window_step.output and window_step.output.action_results:
-                action_results.extend(window_step.output.action_results)
+            if window_step.output and window_step.output.actions_and_results:
+                actions_and_results.extend(window_step.output.actions_and_results)
 
-        action_results_str = json.dumps([action_result.model_dump() for action_result in action_results])
+        actions_and_results_str = json.dumps(
+            [
+                {"action": action.model_dump(), "results": [result.model_dump() for result in results]}
+                for action, results in actions_and_results
+            ]
+        )
         # Generate the extract action prompt
         navigation_goal = task.navigation_goal
-        starting_url = task.url
-        current_url = (
-            await browser_state.page.evaluate("() => document.location.href") if browser_state.page else starting_url
-        )
         extract_action_prompt = prompt_engine.load_prompt(
             "extract-action",
             navigation_goal=navigation_goal,
             navigation_payload_str=json.dumps(task.navigation_payload),
-            starting_url=starting_url,
-            current_url=current_url,
-            elements=scraped_page.element_tree_trimmed,
+            url=task.url,
+            elements=scraped_page.element_tree_trimmed,  # scraped_page.element_tree,
             data_extraction_goal=task.data_extraction_goal,
-            action_history=action_results_str,
+            action_history=actions_and_results_str,
             error_code_mapping_str=json.dumps(task.error_code_mapping) if task.error_code_mapping else None,
             utc_datetime=datetime.utcnow(),
         )

--- a/skyvern/forge/prompts/skyvern/extract-action.j2
+++ b/skyvern/forge/prompts/skyvern/extract-action.j2
@@ -6,7 +6,7 @@ Each element is tagged with an ID.
 If you see any information in red in the page screenshot, this means a condition wasn't satisfied. prioritize actions with the red information.
 If you see a popup in the page screenshot, prioritize actions on the popup.
 
-{% if "lever" in starting_url %}
+{% if "lever" in url %}
 DO NOT UPDATE ANY LOCATION FIELDS
 {% endif %}
 
@@ -41,12 +41,10 @@ Reply in JSON format with the following keys:
 Consider the action history from the last step and the screenshot together, if actions from the last step don't yield positive impact, try other actions or other action combinations.
 {% endif %}
 
-Clickable elements from `{{ current_url }}`:
+Clickable elements from `{{ url }}`:
 ```
 {{ elements }}
 ```
-
-The URL of the page you're on right now is `{{ current_url }}`.
 
 User goal:
 ```


### PR DESCRIPTION
How it looks like after this PR:
```
[
{
   "action":{
      "action_type":"input_text",
      "description":null,
      "reasoning":"The user needs to search for the entity name \\'acme inc\\' to progress towards their goal. The input field with id 17 is the correct place to input the entity name as it is labeled \\'Entity Name\\'.",
      "element_id":17,
      "file_url":null
   },
   "results":[
      {
         "success":true,
         "exception_type":null,
         "exception_message":null,
         "data":null,
         "step_retry_number":0,
         "step_order":0,
         "javascript_triggered":false,
         "interacted_with_sibling":false,
         "interacted_with_parent":false
      },
      {
         "success":true,
         "exception_type":null,
         "exception_message":null,
         "data":null,
         "step_retry_number":0,
         "step_order":0,
         "javascript_triggered":false,
         "interacted_with_sibling":false,
         "interacted_with_parent":false
      }
   ]
},
{
   "action":{
      "action_type":"click",
      "description":null,
      "reasoning":"After inputting the entity name, the user needs to click the \\'Search\\' button to perform the search. The button with id 19 is labeled \\'Search\\' and is the correct element to click to initiate the search.",
      "element_id":19,
      "file_url":null
   },
   "results":[
      {
         "success":true,
         "exception_type":null,
         "exception_message":null,
         "data":null,
         "step_retry_number":0,
         "step_order":0,
         "javascript_triggered":false,
         "interacted_with_sibling":false,
         "interacted_with_parent":false
      }
   ]
}
]
```