### PR TITLE
Fix setup.sh to include the last anthropic models

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -69,7 +69,7 @@ setup_llm_providers() {
         else
             update_or_add_env_var "ANTHROPIC_API_KEY" "$anthropic_api_key"
             update_or_add_env_var "ENABLE_ANTHROPIC" "true"
-            model_options+=("ANTHROPIC_CLAUDE3")
+            model_options+=("ANTHROPIC_CLAUDE3_OPUS" "ANTHROPIC_CLAUDE3_SONNET" "ANTHROPIC_CLAUDE3_HAIKU")
         fi
     else
         update_or_add_env_var "ENABLE_ANTHROPIC" "false"


### PR DESCRIPTION
Hi 👋 
the setup.sh file seems outdated for Anthropic given that there are 3 different models now, it was failing with error `skyvern.forge.sdk.api.llm.exceptions.InvalidLLMConfigError: LLM config with key ANTHROPIC_CLAUDE3 is not a valid LLMConfig`
here is a fix 😄 

