### PR TITLE
Force Claude3 models to output JSON object and parse it more reliably

### DIFF
--- a/skyvern/forge/sdk/api/llm/utils.py
+++ b/skyvern/forge/sdk/api/llm/utils.py
@@ -65,4 +65,3 @@ def try_to_extract_json_from_markdown_format(text):
         return match.group(1)
     else:
         return text
-    

--- a/skyvern/forge/sdk/api/llm/utils.py
+++ b/skyvern/forge/sdk/api/llm/utils.py
@@ -52,13 +52,13 @@ def parse_api_response(response: litellm.ModelResponse) -> dict[str, str]:
         raise InvalidLLMResponseFormat(str(response)) from e
 
 
-def replace_useless_text_around_json(input_string):
+def replace_useless_text_around_json(input_string: str) -> str:
     first_occurrence_of_brace = input_string.find("{")
     last_occurrence_of_brace = input_string.rfind("}")
     return input_string[first_occurrence_of_brace : last_occurrence_of_brace + 1]
 
 
-def try_to_extract_json_from_markdown_format(text):
+def try_to_extract_json_from_markdown_format(text: str) -> str:
     pattern = r"```json\s*(.*?)\s*```"
     match = re.search(pattern, text, re.DOTALL)
     if match:

--- a/skyvern/forge/sdk/api/llm/utils.py
+++ b/skyvern/forge/sdk/api/llm/utils.py
@@ -30,16 +30,16 @@ async def llm_messages_builder(
                     },
                 }
             )
-    #Anthropic models seems to struggle to always output a valid json object so we need to prefill the response to force it:
+    # Anthropic models seems to struggle to always output a valid json object so we need to prefill the response to force it:
     if SettingsManager.get_settings().ENABLE_ANTHROPIC:
-        return [{"role": "user", "content": messages},{"role": "assistant", "content": "{"}]
+        return [{"role": "user", "content": messages}, {"role": "assistant", "content": "{"}]
     return [{"role": "user", "content": messages}]
 
 
 def parse_api_response(response: litellm.ModelResponse) -> dict[str, str]:
     try:
         content = response.choices[0].message.content
-        #Since we prefilled Anthropic response with "{" we need to add it back to the response to have a valid json object:
+        # Since we prefilled Anthropic response with "{" we need to add it back to the response to have a valid json object:
         if SettingsManager.get_settings().ENABLE_ANTHROPIC:
             content = "{" + content
         content = try_to_extract_json_from_markdown_format(content)
@@ -51,14 +51,15 @@ def parse_api_response(response: litellm.ModelResponse) -> dict[str, str]:
         raise InvalidLLMResponseFormat(str(response)) from e
 
 def replace_useless_text_around_json(input_string):
-    first_occurrence_of_brace = input_string.find('{')
-    last_occurrence_of_brace = input_string.rfind('}')
-    return input_string[first_occurrence_of_brace:last_occurrence_of_brace + 1]
+    first_occurrence_of_brace = input_string.find("{")
+    last_occurrence_of_brace = input_string.rfind("}")
+    return input_string[first_occurrence_of_brace : last_occurrence_of_brace + 1]
 
 def try_to_extract_json_from_markdown_format(text):
-    pattern = r'```json\s*(.*?)\s*```'
+    pattern = r"```json\s*(.*?)\s*```"
     match = re.search(pattern, text, re.DOTALL)
     if match:
         return match.group(1)
     else:
         return text
+    

--- a/skyvern/forge/sdk/api/llm/utils.py
+++ b/skyvern/forge/sdk/api/llm/utils.py
@@ -1,11 +1,12 @@
 import base64
+import re
 from typing import Any
 
 import commentjson
 import litellm
 
 from skyvern.forge.sdk.api.llm.exceptions import EmptyLLMResponseError, InvalidLLMResponseFormat
-
+from skyvern.forge.sdk.settings_manager import SettingsManager
 
 async def llm_messages_builder(
     prompt: str,
@@ -29,17 +30,35 @@ async def llm_messages_builder(
                     },
                 }
             )
-
+    #Anthropic models seems to struggle to always output a valid json object so we need to prefill the response to force it:
+    if SettingsManager.get_settings().ENABLE_ANTHROPIC:
+        return [{"role": "user", "content": messages},{"role": "assistant", "content": "{"}]
     return [{"role": "user", "content": messages}]
 
 
 def parse_api_response(response: litellm.ModelResponse) -> dict[str, str]:
     try:
         content = response.choices[0].message.content
-        content = content.replace("```json", "")
-        content = content.replace("```", "")
+        #Since we prefilled Anthropic response with "{" we need to add it back to the response to have a valid json object:
+        if SettingsManager.get_settings().ENABLE_ANTHROPIC:
+            content = "{" + content
+        content = try_to_extract_json_from_markdown_format(content)
+        content = replace_useless_text_around_json(content)
         if not content:
             raise EmptyLLMResponseError(str(response))
         return commentjson.loads(content)
     except Exception as e:
         raise InvalidLLMResponseFormat(str(response)) from e
+
+def replace_useless_text_around_json(input_string):
+    first_occurrence_of_brace = input_string.find('{')
+    last_occurrence_of_brace = input_string.rfind('}')
+    return input_string[first_occurrence_of_brace:last_occurrence_of_brace + 1]
+
+def try_to_extract_json_from_markdown_format(text):
+    pattern = r'```json\s*(.*?)\s*```'
+    match = re.search(pattern, text, re.DOTALL)
+    if match:
+        return match.group(1)
+    else:
+        return text

--- a/skyvern/forge/sdk/api/llm/utils.py
+++ b/skyvern/forge/sdk/api/llm/utils.py
@@ -8,6 +8,7 @@ import litellm
 from skyvern.forge.sdk.api.llm.exceptions import EmptyLLMResponseError, InvalidLLMResponseFormat
 from skyvern.forge.sdk.settings_manager import SettingsManager
 
+
 async def llm_messages_builder(
     prompt: str,
     screenshots: list[bytes] | None = None,
@@ -50,10 +51,12 @@ def parse_api_response(response: litellm.ModelResponse) -> dict[str, str]:
     except Exception as e:
         raise InvalidLLMResponseFormat(str(response)) from e
 
+
 def replace_useless_text_around_json(input_string):
     first_occurrence_of_brace = input_string.find("{")
     last_occurrence_of_brace = input_string.rfind("}")
     return input_string[first_occurrence_of_brace : last_occurrence_of_brace + 1]
+
 
 def try_to_extract_json_from_markdown_format(text):
     pattern = r"```json\s*(.*?)\s*```"


### PR DESCRIPTION
Anthropic models seems to struggle to output valid json objects and it was causing Skyvern to fail +/- randomly, sometimes the anthropic output looked like this:

`Here's a JSON object : {...}`

Which caused the function parse_api_response to fail.

We can force it to output json by prefilling the response with "{": [https://docs.anthropic.com/claude/docs/prefill-claudes-response](https://docs.anthropic.com/claude/docs/prefill-claudes-response)

I also changed the way JSON is extracted from markdown, because the way it was done before might be too unreliable if some of the json data contain backticks in a string.

And I removed any text before and after the first and last braces of the data, Anthropic sometimes seemed to struggle to output the extraction format and was outputting text after the object.


Warning: This was only tested using Anthropic(with Claude 3 Opus) as I do not have OpenAI credits at the moment. Feel free to test it/edit it as necessary.
