### PR TITLE
Revert "An element is interactable if it has a click event listener (#1119)"

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -358,8 +358,7 @@ function isInteractable(element) {
   if (
     element.hasAttribute("onclick") ||
     element.isContentEditable ||
-    element.hasAttribute("jsaction") ||
-    getEventListeners(element).click !== undefined
+    element.hasAttribute("jsaction")
   ) {
     return true;
   }


### PR DESCRIPTION
This reverts commit 89c9acde3b0c4d7cd3e25baf4ed76b541d4b28ce.

We can't use `getEventListeners` via `page.evaluate` since it's a console utility API. https://github.com/microsoft/playwright-python/issues/1839