### PR TITLE
save the elements tree in the prompt as an artifact

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -791,6 +791,11 @@ class ForgeAgent:
             artifact_type=ArtifactType.VISIBLE_ELEMENTS_TREE_TRIMMED,
             data=json.dumps(scraped_page.element_tree_trimmed, indent=2).encode(),
         )
+        await app.ARTIFACT_MANAGER.create_artifact(
+            step=step,
+            artifact_type=ArtifactType.VISIBLE_ELEMENTS_TREE_IN_PROMPT,
+            data=scraped_page.build_element_tree(element_tree_format).encode(),
+        )
 
         return scraped_page, extract_action_prompt
 

--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -763,13 +763,14 @@ class ForgeAgent:
             format=element_tree_format,
         )
 
+        element_tree_in_prompt: str = scraped_page.build_element_tree(element_tree_format)
         extract_action_prompt = prompt_engine.load_prompt(
             prompt_template,
             navigation_goal=navigation_goal,
             navigation_payload_str=json.dumps(task.navigation_payload),
             starting_url=starting_url,
             current_url=current_url,
-            elements=scraped_page.build_element_tree(element_tree_format),
+            elements=element_tree_in_prompt,
             data_extraction_goal=task.data_extraction_goal,
             action_history=actions_and_results_str,
             error_code_mapping_str=(json.dumps(task.error_code_mapping) if task.error_code_mapping else None),
@@ -794,7 +795,7 @@ class ForgeAgent:
         await app.ARTIFACT_MANAGER.create_artifact(
             step=step,
             artifact_type=ArtifactType.VISIBLE_ELEMENTS_TREE_IN_PROMPT,
-            data=scraped_page.build_element_tree(element_tree_format).encode(),
+            data=element_tree_in_prompt.encode(),
         )
 
         return scraped_page, extract_action_prompt

--- a/skyvern/forge/sdk/artifact/models.py
+++ b/skyvern/forge/sdk/artifact/models.py
@@ -24,6 +24,7 @@ class ArtifactType(StrEnum):
     VISIBLE_ELEMENTS_ID_XPATH_MAP = "visible_elements_id_xpath_map"
     VISIBLE_ELEMENTS_TREE = "visible_elements_tree"
     VISIBLE_ELEMENTS_TREE_TRIMMED = "visible_elements_tree_trimmed"
+    VISIBLE_ELEMENTS_TREE_IN_PROMPT = "visible_elements_tree_in_prompt"
 
     # DEPRECATED. pls use HTML_SCRAPE or HTML_ACTION
     HTML = "html"

--- a/skyvern/forge/sdk/artifact/storage/base.py
+++ b/skyvern/forge/sdk/artifact/storage/base.py
@@ -16,6 +16,7 @@ FILE_EXTENTSION_MAP: dict[ArtifactType, str] = {
     ArtifactType.VISIBLE_ELEMENTS_ID_XPATH_MAP: "json",
     ArtifactType.VISIBLE_ELEMENTS_TREE: "json",
     ArtifactType.VISIBLE_ELEMENTS_TREE_TRIMMED: "json",
+    ArtifactType.VISIBLE_ELEMENTS_TREE_IN_PROMPT: "txt",
     ArtifactType.HTML_SCRAPE: "html",
     ArtifactType.HTML_ACTION: "html",
     ArtifactType.TRACE: "zip",


### PR DESCRIPTION
- our element tree has two format: HTML/JSON
- save current using element format as an artifact. If the JSON format is used, we save the JSON; if the HTML format is used, we save the HTML.

 