### PR TITLE
fix workflow task continue_on_failure

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -970,6 +970,7 @@ class WorkflowService:
                 max_steps_per_run=block_yaml.max_steps_per_run,
                 max_retries=block_yaml.max_retries,
                 complete_on_download=block_yaml.complete_on_download,
+                continue_on_failure=block_yaml.continue_on_failure,
             )
         elif block_yaml.block_type == BlockType.FOR_LOOP:
             loop_blocks = [


### PR DESCRIPTION
<!--
ELLIPSIS_HIDDEN
-->




| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f7b40dd0f0463857e0a121803213b0acd8182ca9  | 
|--------|--------|

### Summary:
This PR fixes the handling of the `continue_on_failure` attribute in task blocks within workflows.

**Key points**:
- Added `continue_on_failure` attribute to `TaskBlock` initialization in `block_yaml_to_block` method of `WorkflowService` class.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3eebef5c67a9077f0491bd1d8676a2bcb79a1787  | 
|--------|--------|

### Summary:
This PR fixes the handling of the `continue_on_failure` attribute in task blocks within workflows.

**Key points**:
- Added `continue_on_failure` attribute to `TaskBlock` initialization in `block_yaml_to_block` method of `WorkflowService` class.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3eebef5c67a9077f0491bd1d8676a2bcb79a1787  | 
|--------|--------|

### Summary:
This PR adds the `continue_on_failure` attribute to the `TaskBlock` initialization in the `WorkflowService` class to ensure workflows respect the failure handling configuration.

**Key points**:
- Added `continue_on_failure` attribute to `TaskBlock` initialization in `block_yaml_to_block` method of `WorkflowService` class.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
