### PR TITLE
Change staleTime default

### DIFF
--- a/skyvern-frontend/src/api/QueryClient.ts
+++ b/skyvern-frontend/src/api/QueryClient.ts
@@ -3,7 +3,7 @@ import { QueryClient } from "@tanstack/react-query";
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: Infinity,
+      staleTime: 5 * 60 * 1000, // 5 minutes
       retry: false,
     },
   },

--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskFormPage.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskFormPage.tsx
@@ -21,6 +21,7 @@ function CreateNewTaskFormPage() {
     },
     enabled: !!template && !sampleCases.includes(template as SampleCase),
     refetchOnWindowFocus: false,
+    staleTime: Infinity,
   });
 
   if (!template) {


### PR DESCRIPTION
  Since zero causes too much refetching and Infinity has its own issues,
  we will use 5 minutes for now

  Use Infinity for workflows because they have the save feature.

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit bab1b85887eec04d90aeb4bd92ed670df5ee0e13  | 
|--------|--------|

### Summary:
Adjusted the default `staleTime` for queries to 5 minutes and set it to `Infinity` for specific workflow queries to optimize data fetching.

**Key points**:
- Changed default `staleTime` from `Infinity` to `5 minutes` in `/skyvern-frontend/src/api/QueryClient.ts`
- Set `staleTime` to `Infinity` for workflow queries in `/skyvern-frontend/src/routes/tasks/create/CreateNewTaskFormPage.tsx`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
