### PR TITLE
Default to residential proxy

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -83,7 +83,7 @@ function createTaskRequestObject(formValues: CreateNewTaskFormValues) {
     webhook_callback_url: transform(formValues.webhookCallbackUrl),
     navigation_goal: transform(formValues.navigationGoal),
     data_extraction_goal: transform(formValues.dataExtractionGoal),
-    proxy_location: "NONE",
+    proxy_location: "RESIDENTIAL",
     error_code_mapping: null,
     navigation_payload: transform(formValues.navigationPayload),
     extracted_information_schema: transform(

--- a/skyvern-frontend/src/routes/tasks/create/SavedTasks.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTasks.tsx
@@ -21,7 +21,7 @@ function createEmptyTaskTemplate() {
     title: "New Template",
     description: "",
     webhook_callback_url: null,
-    proxy_location: "NONE",
+    proxy_location: "RESIDENTIAL",
     workflow_definition: {
       parameters: [
         {


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 453f9006b281208195114bae7c15a03001734049  | 
|--------|--------|

### Summary:
This PR updates the default proxy location to 'RESIDENTIAL' in task creation forms and templates within the Skyvern frontend.

**Key points**:
- Changed default proxy location from 'NONE' to 'RESIDENTIAL' in `CreateNewTaskForm.tsx` and `SavedTasks.tsx`.
- Updated `createTaskRequestObject` in `CreateNewTaskForm.tsx` to set `proxy_location` to 'RESIDENTIAL'.
- Modified `createEmptyTaskTemplate` in `SavedTasks.tsx` to use 'RESIDENTIAL' as the default proxy location.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
