### PR TITLE
fix workflow run get with workflow_permanent_id

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -533,7 +533,7 @@ async def get_workflow_run(
 ) -> WorkflowRunStatusResponse:
     analytics.capture("skyvern-oss-agent-workflow-run-get")
     return await app.WORKFLOW_SERVICE.build_workflow_run_status_response(
-        workflow_id=workflow_id,
+        workflow_permanent_id=workflow_id,
         workflow_run_id=workflow_run_id,
         organization_id=current_org.organization_id,
     )

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -6,13 +6,7 @@ import requests
 import structlog
 
 from skyvern import analytics
-from skyvern.exceptions import (
-    FailedToSendWebhook,
-    MissingValueForParameter,
-    WorkflowNotFound,
-    WorkflowOrganizationMismatch,
-    WorkflowRunNotFound,
-)
+from skyvern.exceptions import FailedToSendWebhook, MissingValueForParameter, WorkflowNotFound, WorkflowRunNotFound
 from skyvern.forge import app
 from skyvern.forge.sdk.artifact.models import ArtifactType
 from skyvern.forge.sdk.core import skyvern_context
@@ -527,17 +521,14 @@ class WorkflowService:
 
     async def build_workflow_run_status_response(
         self,
-        workflow_id: str,
+        workflow_permanent_id: str,
         workflow_run_id: str,
         organization_id: str,
     ) -> WorkflowRunStatusResponse:
-        workflow = await self.get_workflow(workflow_id=workflow_id, organization_id=organization_id)
+        workflow = await self.get_workflow_by_permanent_id(workflow_permanent_id, organization_id=organization_id)
         if workflow is None:
-            LOG.error(f"Workflow {workflow_id} not found")
-            raise WorkflowNotFound(workflow_id=workflow_id)
-        if workflow.organization_id != organization_id:
-            LOG.error(f"Workflow {workflow_id} does not belong to organization {organization_id}")
-            raise WorkflowOrganizationMismatch(workflow_id=workflow_id, organization_id=organization_id)
+            LOG.error(f"Workflow {workflow_permanent_id} not found")
+            raise WorkflowNotFound(workflow_permanent_id=workflow_permanent_id)
 
         workflow_run = await self.get_workflow_run(workflow_run_id=workflow_run_id)
         workflow_run_tasks = await app.DATABASE.get_tasks_by_workflow_run_id(workflow_run_id=workflow_run_id)
@@ -574,14 +565,14 @@ class WorkflowService:
         output_parameter_tuples: list[
             tuple[OutputParameter, WorkflowRunOutputParameter]
         ] = await self.get_output_parameter_workflow_run_output_parameter_tuples(
-            workflow_id=workflow_id, workflow_run_id=workflow_run_id
+            workflow_id=workflow_run.workflow_id, workflow_run_id=workflow_run_id
         )
         if output_parameter_tuples:
             outputs = {output_parameter.key: output.value for output_parameter, output in output_parameter_tuples}
         else:
             LOG.error(
                 "No output parameters found for workflow run",
-                workflow_id=workflow_id,
+                workflow_permanent_id=workflow_permanent_id,
                 workflow_run_id=workflow_run_id,
             )
             outputs = None
@@ -621,7 +612,7 @@ class WorkflowService:
         await app.ARTIFACT_MANAGER.wait_for_upload_aiotasks_for_tasks(all_workflow_task_ids)
 
         workflow_run_status_response = await self.build_workflow_run_status_response(
-            workflow_id=workflow.workflow_id,
+            workflow_permanent_id=workflow.workflow_permanent_id,
             workflow_run_id=workflow_run.workflow_run_id,
             organization_id=workflow.organization_id,
         )


### PR DESCRIPTION
<!--
ELLIPSIS_HIDDEN
-->
| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5000e0d6a65ebad2e4d4ca10073aa893d4abedd2  | 
|--------|--------|

### Summary:
Updated workflow identification to use `workflow_permanent_id` for consistent referencing across services.

**Key points**:
- Updated `build_workflow_run_status_response` in `WorkflowService` to use `workflow_permanent_id`.
- Modified `agent_protocol.py` to pass `workflow_permanent_id` to `build_workflow_run_status_response`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 453795eb27709423eda0cd8f8d76e7e5f1188546  | 
|--------|--------|

### Summary:
Updated workflow identification to use `workflow_permanent_id` for consistent referencing across services.

**Key points**:
- Updated `WorkflowService` to use `workflow_permanent_id` instead of `workflow_id`.
- Modified `agent_protocol.py` to pass `workflow_permanent_id` to `build_workflow_run_status_response`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
