### PR TITLE
the error raised from the base validate_step_execution shouldn't be handled to fail the task

### DIFF
--- a/skyvern/exceptions.py
+++ b/skyvern/exceptions.py
@@ -266,7 +266,12 @@ class UnknownElementTreeFormat(SkyvernException):
 
 class StepTerminationError(SkyvernException):
     def __init__(self, step_id: str, reason: str) -> None:
-        super().__init__(f"Step {step_id} cannot be executed and task is terminated. Reason: {reason}")
+        super().__init__(f"Step {step_id} cannot be executed and task is failed. Reason: {reason}")
+
+
+class StepUnableToExecuteError(SkyvernException):
+    def __init__(self, step_id: str, reason: str) -> None:
+        super().__init__(f"Step {step_id} cannot be executed and task execution is stopped. Reason: {reason}")
 
 
 class UnsupportedActionType(SkyvernException):

--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -18,6 +18,7 @@ from skyvern.exceptions import (
     InvalidWorkflowTaskURLState,
     MissingBrowserStatePage,
     StepTerminationError,
+    StepUnableToExecuteError,
     TaskNotFound,
 )
 from skyvern.forge import app
@@ -329,9 +330,16 @@ class ForgeAgent:
 
             return step, detailed_output, next_step
         # TODO (kerem): Let's add other exceptions that we know about here as custom exceptions as well
+        except StepUnableToExecuteError:
+            LOG.error(
+                "Step cannot be executed. Task execution stopped",
+                task_id=task.task_id,
+                step_id=step.step_id,
+            )
+            raise
         except StepTerminationError as e:
             LOG.error(
-                "Step cannot be executed. Task terminated",
+                "Step cannot be executed. Task failed.",
                 task_id=task.task_id,
                 step_id=step.step_id,
             )

--- a/skyvern/forge/agent_functions.py
+++ b/skyvern/forge/agent_functions.py
@@ -1,6 +1,6 @@
 from playwright.async_api import Page
 
-from skyvern.exceptions import StepTerminationError
+from skyvern.exceptions import StepUnableToExecuteError
 from skyvern.forge import app
 from skyvern.forge.async_operations import AsyncOperation
 from skyvern.forge.sdk.models import Organization, Step, StepStatus
@@ -34,7 +34,7 @@ class AgentFunction:
 
         can_execute = has_valid_task_status and has_valid_step_status and has_no_running_steps
         if not can_execute:
-            raise StepTerminationError(step_id=step.step_id, reason="Cannot execute step. Reasons: {reasons}")
+            raise StepUnableToExecuteError(step_id=step.step_id, reason=f"Cannot execute step. Reasons: {reasons}")
 
     def generate_async_operations(
         self,


### PR DESCRIPTION
Some task could be in terminated/completed/timed_out status and we should not fail the task if that happens.


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8e356b2eece7d68f604082ffdb739c221980964b  | 
|--------|--------|

### Summary:
This PR introduces a new exception for unexecutable steps and updates error handling in step execution to reflect task failures more accurately.

**Key points**:
- Introduced `StepUnableToExecuteError` in `skyvern/exceptions.py`.
- Updated `StepTerminationError` message from 'terminated' to 'failed'.
- `validate_step_execution` in `skyvern/forge/agent_functions.py` raises `StepUnableToExecuteError` if step conditions aren't met.
- `execute_step` in `skyvern/forge/agent.py` handles `StepUnableToExecuteError` by logging and re-raising, and `StepTerminationError` by logging, updating step and task status, and sending task response.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->


<!--
ELLIPSIS_HIDDEN
-->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 655ab9d55372c1943f8dff0eb8713a29f63e0f79  | 
|--------|--------|

### Summary:
This PR introduces a new exception `StepUnableToExecuteError` to better handle step execution failures and updates error handling to reflect task failures more accurately.

**Key points**:
- Introduced `StepUnableToExecuteError` in `skyvern/exceptions.py`.
- Updated `StepTerminationError` message from 'terminated' to 'failed'.
- `validate_step_execution` in `skyvern/forge/agent_functions.py` raises `StepUnableToExecuteError` if step conditions aren't met, with formatted reasons.
- `execute_step` in `skyvern/forge/agent.py` handles `StepUnableToExecuteError` by logging and re-raising, and `StepTerminationError` by logging, updating step and task status, and sending task response.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d12fa3abb3da34a395aada631fad1b4a3fc06dcf  | 
|--------|--------|

### Summary:
This PR introduces a new exception `StepUnableToExecuteError` to better handle step execution failures and updates error handling to reflect task failures more accurately.

**Key points**:
- Introduced `StepUnableToExecuteError` in `skyvern/exceptions.py`.
- Updated `StepTerminationError` message from 'terminated' to 'failed'.
- `validate_step_execution` in `skyvern/forge/agent_functions.py` raises `StepUnableToExecuteError` if step conditions aren't met, with formatted reasons.
- `execute_step` in `skyvern/forge/agent.py` handles `StepUnableToExecuteError` by logging and re-raising, and `StepTerminationError` by logging, updating step and task status, and sending task response.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->