### PR TITLE
Reintroduce artifacts UI

### DIFF
--- a/skyvern-frontend/src/router.tsx
+++ b/skyvern-frontend/src/router.tsx
@@ -11,6 +11,7 @@ import { CreateNewTaskFormPage } from "./routes/tasks/create/CreateNewTaskFormPa
 import { TaskActions } from "./routes/tasks/detail/TaskActions";
 import { TaskRecording } from "./routes/tasks/detail/TaskRecording";
 import { TaskParameters } from "./routes/tasks/detail/TaskParameters";
+import { StepArtifactsLayout } from "./routes/tasks/detail/StepArtifactsLayout";
 
 const router = createBrowserRouter([
   {
@@ -48,6 +49,10 @@ const router = createBrowserRouter([
               {
                 path: "parameters",
                 element: <TaskParameters />,
+              },
+              {
+                path: "artifacts",
+                element: <StepArtifactsLayout />,
               },
             ],
           },

--- a/skyvern-frontend/src/routes/tasks/detail/StepArtifactsLayout.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/StepArtifactsLayout.tsx
@@ -37,7 +37,7 @@ function StepArtifactsLayout() {
   const activeStep = steps[activeIndex];
 
   return (
-    <div className="px-4 flex">
+    <div className="flex">
       <aside className="w-64 shrink-0">
         <StepNavigation
           activeIndex={activeIndex}

--- a/skyvern-frontend/src/routes/tasks/detail/TaskDetails.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/TaskDetails.tsx
@@ -121,6 +121,19 @@ function TaskDetails() {
           >
             Parameters
           </NavLink>
+          <NavLink
+            to="artifacts"
+            className={({ isActive }) => {
+              return cn(
+                "cursor-pointer px-2 py-1 rounded-md text-muted-foreground",
+                {
+                  "bg-primary-foreground text-foreground": isActive,
+                },
+              );
+            }}
+          >
+            Artifacts
+          </NavLink>
         </div>
       </div>
       <Outlet />


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 311f5310da824bff35833edcd1c99745fd7a5d45  | 
|--------|--------|

### Summary:
This PR reintroduces the artifacts UI by adding a new route, navigation link, and updating layout styling.

**Key points**:
- Added `StepArtifactsLayout` route in `/skyvern-frontend/src/router.tsx`
- Included navigation link for artifacts in `TaskDetails` component
- Updated layout styling in `StepArtifactsLayout`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
