### PR TITLE
rename artifacts tab to diagnostics

### DIFF
--- a/skyvern-frontend/src/router.tsx
+++ b/skyvern-frontend/src/router.tsx
@@ -51,7 +51,7 @@ const router = createBrowserRouter([
                 element: <TaskParameters />,
               },
               {
-                path: "artifacts",
+                path: "diagnostics",
                 element: <StepArtifactsLayout />,
               },
             ],

--- a/skyvern-frontend/src/routes/tasks/detail/TaskDetails.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/TaskDetails.tsx
@@ -122,7 +122,7 @@ function TaskDetails() {
             Parameters
           </NavLink>
           <NavLink
-            to="artifacts"
+            to="diagnostics"
             className={({ isActive }) => {
               return cn(
                 "cursor-pointer px-2 py-1 rounded-md text-muted-foreground",
@@ -132,7 +132,7 @@ function TaskDetails() {
               );
             }}
           >
-            Artifacts
+            Diagnostics
           </NavLink>
         </div>
       </div>


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 588043fb046b7700eb5152d17f2739df0c50c6b5  | 
|--------|--------|

### Summary:
This PR renames the 'artifacts' tab and route to 'diagnostics' in the application's frontend.

**Key points**:
- Renamed tab and route from `artifacts` to `diagnostics`.
- Updated paths in `skyvern-frontend/src/router.tsx`.
- Updated navigation link and text in `skyvern-frontend/src/routes/tasks/detail/TaskDetails.tsx`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
