### PR TITLE
support both int and str for element_id

### DIFF
--- a/skyvern/webeye/actions/actions.py
+++ b/skyvern/webeye/actions/actions.py
@@ -47,7 +47,7 @@ class Action(BaseModel):
     action_type: ActionType
     description: str | None = None
     reasoning: str | None = None
-    element_id: str | None = None
+    element_id: int | str | None = None
 
     # DecisiveAction (CompleteAction, TerminateAction) fields
     errors: list[UserDefinedError] | None = None
@@ -64,7 +64,7 @@ class Action(BaseModel):
 
 
 class WebAction(Action):
-    element_id: str
+    element_id: int | str
 
 
 class DecisiveAction(Action):


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 174b7cb0b1361725eae7aeb70f9dc7435adb1c35  | 
|--------|--------|

### Summary:
This PR updates the `element_id` field in the `Action` and `WebAction` classes to support both integer and string types, enhancing flexibility in element identification.

**Key points**:
- Updated `element_id` type in `Action` and `WebAction` classes to `int | str`.
- Affected file: `/skyvern/webeye/actions/actions.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
