### PR TITLE
fix element_id type for action and web action + add unit tests for actions

### DIFF
--- a/skyvern/webeye/actions/actions.py
+++ b/skyvern/webeye/actions/actions.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import Any, Dict
+from typing import Annotated, Any, Dict
 
 import structlog
 from deprecation import deprecated
@@ -47,7 +47,7 @@ class Action(BaseModel):
     action_type: ActionType
     description: str | None = None
     reasoning: str | None = None
-    element_id: int | str | None = None
+    element_id: Annotated[str, Field(coerce_numbers_to_str=True)] | None = None
 
     # DecisiveAction (CompleteAction, TerminateAction) fields
     errors: list[UserDefinedError] | None = None
@@ -64,7 +64,7 @@ class Action(BaseModel):
 
 
 class WebAction(Action):
-    element_id: int | str
+    element_id: Annotated[str, Field(coerce_numbers_to_str=True)]
 
 
 class DecisiveAction(Action):


### PR DESCRIPTION
<!--
ELLIPSIS_HIDDEN
-->




| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 11eeb717278dd638589156b5c4ae29f8baa74046  | 
|--------|--------|

### Summary:
This PR adds unit tests for `Action` and `WebAction` classes, ensuring correct parsing of `element_id`, and modifies `element_id` handling in the `actions.py`.

**Key points**:
- Added unit tests for `Action` and `WebAction` classes in `tests/unit/test_actions.py`.
- Tests validate parsing and handling of `element_id` for both string and integer inputs.
- Modified `element_id` in `Action` and `WebAction` to use `Annotated` with coercion in `skyvern/webeye/actions/actions.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c6b3366b89621454b76a5c4be72a49791466d20d  | 
|--------|--------|

### Summary:
This PR updates the `element_id` handling in `Action` and `WebAction` to ensure type consistency and adds comprehensive unit tests.

**Key points**:
- Modified `element_id` in `Action` and `WebAction` to use `Annotated[str, Field(coerce_numbers_to_str=True)]` in `skyvern/webeye/actions/actions.py`.
- Added unit tests for `Action` and `WebAction` in `tests/unit/test_actions.py` to validate parsing and handling of `element_id` for both string and integer inputs, and ensure correct handling of the new type.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
