### PR TITLE
Support up to 25 attachments

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -675,7 +675,7 @@ class UploadToS3Block(Block):
             if os.path.isdir(self.path):
                 # get all files in the directory, if there are more than 10 files, we will not upload them
                 files = os.listdir(self.path)
-                if len(files) > 10:
+                if len(files) > 25:
                     raise ValueError("Too many files in the directory, not uploading")
                 for file in files:
                     # if the file is a directory, we will not upload it

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -673,7 +673,7 @@ class UploadToS3Block(Block):
             client = self.get_async_aws_client()
             # is the file path a file or a directory?
             if os.path.isdir(self.path):
-                # get all files in the directory, if there are more than 10 files, we will not upload them
+                # get all files in the directory, if there are more than 25 files, we will not upload them
                 files = os.listdir(self.path)
                 if len(files) > 25:
                     raise ValueError("Too many files in the directory, not uploading")


### PR DESCRIPTION
<!--
ELLIPSIS_HIDDEN
-->




| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ccdeffc7646ae7629d98b8fd6d3c4e24eced5692  | 
|--------|--------|

### Summary:
This PR increases the file upload limit for the `UploadToS3Block` from 10 to 25 files in the `block.py` file.

**Key points**:
- Increased file upload limit in `UploadToS3Block` from 10 to 25.
- Modified `execute` method in `UploadToS3Block` class.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7f2ec594da40c4626f639c46e1e4befc195f023a  | 
|--------|--------|

### Summary:
This PR increases the file upload limit in the `UploadToS3Block` from 10 to 25, enhancing the file handling capabilities of the system.

**Key points**:
- Increased file upload limit in `UploadToS3Block` from 10 to 25 in `block.py`.
- Modified `execute` method in `UploadToS3Block` class to reflect new limit.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
