### PR TITLE
Remove id for noninteractable and interactable attr in prompt

### DIFF
--- a/skyvern/forge/prompts/skyvern/extract-action-claude3-sonnet.j2
+++ b/skyvern/forge/prompts/skyvern/extract-action-claude3-sonnet.j2
@@ -2,7 +2,7 @@ Identify actions to help user progress towards the user goal using the DOM eleme
 Include only the elements that are relevant to the user goal, without altering or imagining new elements.
 Use the details from the user details to fill in necessary values. Always satisfy required fields if the field isn't already filled in. Don't return any action for the same field, if this field is already filled in and the value is the same as the one you would have filled in.
 MAKE SURE YOU OUTPUT VALID JSON. No text before or after JSON, no trailing commas, no comments (//), no unnecessary quotes, etc.
-Each element is tagged with an ID and interactable value. You should only return actions on the interactable elements.
+Each interactable element is tagged with an ID.
 If you see any information in red in the page screenshot, this means a condition wasn't satisfied. prioritize actions with the red information.
 If you see a popup in the page screenshot, prioritize actions on the popup.
 

--- a/skyvern/forge/prompts/skyvern/extract-action.j2
+++ b/skyvern/forge/prompts/skyvern/extract-action.j2
@@ -2,7 +2,7 @@ Identify actions to help user progress towards the user goal using the DOM eleme
 Include only the elements that are relevant to the user goal, without altering or imagining new elements.
 Use the details from the user details to fill in necessary values. Always satisfy required fields if the field isn't already filled in. Don't return any action for the same field, if this field is already filled in and the value is the same as the one you would have filled in.
 MAKE SURE YOU OUTPUT VALID JSON. No text before or after JSON, no trailing commas, no comments (//), no unnecessary quotes, etc.
-Each element is tagged with an ID and interactable value. You should only return actions on the interactable elements.
+Each interactable element is tagged with an ID.
 If you see any information in red in the page screenshot, this means a condition wasn't satisfied. prioritize actions with the red information.
 If you see a popup in the page screenshot, prioritize actions on the popup.
 

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -424,6 +424,9 @@ def trim_element_tree(elements: list[dict]) -> list[dict]:
         if "frame" in queue_ele:
             del queue_ele["frame"]
 
+        if not queue_ele.get("interactable"):
+            del queue_ele["id"]
+
         if "attributes" in queue_ele:
             tag_name = queue_ele["tagName"] if "tagName" in queue_ele else ""
             new_attributes = _trimmed_attributes(tag_name, queue_ele["attributes"])

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -46,7 +46,6 @@ RESERVED_ATTRIBUTES = {
 
 ELEMENT_NODE_ATTRIBUTES = {
     "id",
-    "interactable",
 }
 
 


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 04d1a7b0e5d043f9b2208c265fefa3a9625d5c6a  | 
|--------|--------|

### Summary:
This PR updates templates and scraper logic to ensure only interactable elements are tagged with an ID, enhancing data consistency and clarity.

**Key points**:
- Updated `skyvern/forge/prompts/skyvern/extract-action-claude3-sonnet.j2` and `skyvern/forge/prompts/skyvern/extract-action.j2` to clarify that only interactable elements are tagged with an ID.
- Modified `skyvern/webeye/scraper/scraper.py` to delete the 'id' attribute from elements that are not marked as interactable.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
