### PR TITLE
fix step output select option validation error

### DIFF
--- a/skyvern/webeye/actions/actions.py
+++ b/skyvern/webeye/actions/actions.py
@@ -35,9 +35,9 @@ class UserDefinedError(BaseModel):
 
 
 class SelectOption(BaseModel):
-    label: str | None
-    value: str | None
-    index: int | None
+    label: str | None = None
+    value: str | None = None
+    index: int | None = None
 
     def __repr__(self) -> str:
         return f"SelectOption(label={self.label}, value={self.value}, index={self.index})"


### PR DESCRIPTION
<!--
ELLIPSIS_HIDDEN
-->




| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c9700dd87ffa49697c82f557bcfb766449a2027f  | 
|--------|--------|

### Summary:
This PR sets default values for the `label`, `value`, and `index` attributes of the `SelectOption` class in `actions.py` to prevent validation errors.

**Key points**:
- Updated `SelectOption` class in `skyvern/webeye/actions/actions.py`.
- Set default values for `label`, `value`, and `index` to `None`.
- Prevents validation errors by ensuring fields are always initialized.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b092d36e544504fc0d7a554a84099f7a8c04c92c  | 
|--------|--------|

### Summary:
This PR updates the `SelectOption` class to set default values for `label`, `value`, and `index` to `None`, preventing validation errors.

**Key points**:
- Updated `SelectOption` class in `skyvern/webeye/actions/actions.py`.
- Set default values for `label`, `value`, and `index` to `None`.
- Prevents validation errors by ensuring fields are always initialized.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!--
ELLIPSIS_HIDDEN
-->
