### PR TITLE
Fix router not going back to tasks page from task details

### DIFF
--- a/skyvern-frontend/src/router.tsx
+++ b/skyvern-frontend/src/router.tsx
@@ -35,10 +35,6 @@ const router = createBrowserRouter([
             element: <TaskDetails />,
             children: [
               {
-                index: true,
-                element: <Navigate to="actions" />,
-              },
-              {
                 path: "actions",
                 element: <TaskActions />,
               },

--- a/skyvern-frontend/src/routes/tasks/list/TaskHistory.tsx
+++ b/skyvern-frontend/src/routes/tasks/list/TaskHistory.tsx
@@ -87,7 +87,7 @@ function TaskHistory() {
                     <TableCell
                       className="w-1/4 cursor-pointer"
                       onClick={() => {
-                        navigate(task.task_id);
+                        navigate(`${task.task_id}/actions`);
                       }}
                     >
                       {task.task_id}
@@ -95,7 +95,7 @@ function TaskHistory() {
                     <TableCell
                       className="w-1/4 cursor-pointer max-w-64 overflow-hidden whitespace-nowrap overflow-ellipsis"
                       onClick={() => {
-                        navigate(task.task_id);
+                        navigate(`${task.task_id}/actions`);
                       }}
                     >
                       {task.request.url}
@@ -103,7 +103,7 @@ function TaskHistory() {
                     <TableCell
                       className="w-1/6 cursor-pointer"
                       onClick={() => {
-                        navigate(task.task_id);
+                        navigate(`${task.task_id}/actions`);
                       }}
                     >
                       <StatusBadge status={task.status} />
@@ -111,7 +111,7 @@ function TaskHistory() {
                     <TableCell
                       className="w-1/4 cursor-pointer"
                       onClick={() => {
-                        navigate(task.task_id);
+                        navigate(`${task.task_id}/actions`);
                       }}
                     >
                       {basicTimeFormat(task.created_at)}


### PR DESCRIPTION
  Remove index route, make more exact navigation

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 847167a9b29d5c553cb77ef1e1bc00b16de96a12  | 
|--------|--------|

### Summary:
This PR removes an index route and updates navigation paths to fix navigation issues in the task management system.

**Key points**:
- Removed index route in `skyvern-frontend/src/router.tsx`.
- Updated navigation paths in `skyvern-frontend/src/routes/tasks/list/TaskHistory.tsx` to include '/actions'.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
