### PR TITLE
Revert the change of removing index path

### DIFF
--- a/skyvern-frontend/src/router.tsx
+++ b/skyvern-frontend/src/router.tsx
@@ -35,6 +35,10 @@ const router = createBrowserRouter([
             element: <TaskDetails />,
             children: [
               {
+                index: true,
+                element: <Navigate to="actions" />,
+              },
+              {
                 path: "actions",
                 element: <TaskActions />,
               },


### PR DESCRIPTION
  Maintain index path, but navigate with exact path

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1e4ccec5c267a72668731a4246b8478779728a1e  | 
|--------|--------|

### Summary:
Reintroduces an index path in `TaskDetails` for default redirection to 'actions' sub-route in `router.tsx`.

**Key points**:
- Reintroduce `index` path in `TaskDetails` children routes in `/skyvern-frontend/src/router.tsx`
- Use `<Navigate to="actions" />` for default redirection to 'actions' sub-route


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
