### PR TITLE
Fix HSL values for success and warning colors

### DIFF
--- a/skyvern-frontend/src/index.css
+++ b/skyvern-frontend/src/index.css
@@ -57,14 +57,11 @@
     --accent: 217.2 32.6% 17.5%;
     --accent-foreground: 210 40% 98%;
 
-    --warning: 40.6, 96.1%, 40.4%;
-    --warning-foreground: 47.9, 95.8%, 53.1%;
+    --warning: 40.6 96.1% 40.4%;
+    --warning-foreground: 54.5 91.7% 95.3%;
 
-    --warning: 40.6, 96.1%, 40.4%;
-    --warning-foreground: 54.5, 91.7%, 95.3%;
-
-    --success: 142.1, 76.2%, 36.3%;
-    --success-foreground: 138.5, 76.5%, 96.7%;
+    --success: 142.1 76.2% 36.3%;
+    --success-foreground: 138.5 76.5% 96.7%;
 
     --border: 217.2 32.6% 17.5%;
     --input: 217.2 32.6% 17.5%;


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit fa7f22675f1ea9b91fa0fc9688184585a50eba80  | 
|--------|--------|

### Summary:
This PR corrects the HSL value formatting for success and warning colors in two CSS files to ensure proper style application and consistent CSS parsing.

**Key points**:
- Corrected HSL value formatting in `--warning`, `--warning-foreground`, `--success`, and `--success-foreground` variables across two files: `/skyvern-frontend/cloud/index.css` and `/skyvern-frontend/src/index.css`.
- Ensured consistency in HSL value formatting by removing commas and adding spaces for proper CSS parsing.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->