### PR TITLE
fix for trusted types

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1146,7 +1146,19 @@ function createHintMarkersForGroups(groups) {
   for (let i = 0; i < hintMarkers.length; i++) {
     const hintMarker = hintMarkers[i];
     hintMarker.hintString = hintStrings[i];
-    hintMarker.element.innerHTML = hintMarker.hintString.toUpperCase();
+	try {
+      hintMarker.element.innerHTML = hintMarker.hintString.toUpperCase();
+    } catch (e) {
+      // Ensure trustedTypes is available
+      if (typeof trustedTypes !== 'undefined') {
+        const escapeHTMLPolicy = trustedTypes.createPolicy("default", {
+          createHTML: (string) => string,
+        });
+        hintMarker.element.innerHTML = escapeHTMLPolicy.createHTML(hintMarker.hintString.toUpperCase());
+      } else {
+        console.error("trustedTypes is not supported in this environment.");
+      }
+    }
   }
 
   return hintMarkers;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 709bc3ad80c1033b9d911570ddc52b4903f5e43b  | 
|--------|--------|

### Summary:
Enhanced `createHintMarkersForGroups` in `domUtils.js` to support environments with `trustedTypes`, ensuring compatibility with strict content security policies.

**Key points**:
- Modified `createHintMarkersForGroups` in `/skyvern/webeye/scraper/domUtils.js`.
- Added error handling for environments with `trustedTypes`.
- Uses `trustedTypes.createPolicy` if available, otherwise logs an error.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->