### PR TITLE
Do not enforce LLMType in the TaskGeneration schema

### DIFF
--- a/skyvern/forge/sdk/schemas/task_generations.py
+++ b/skyvern/forge/sdk/schemas/task_generations.py
@@ -1,12 +1,7 @@
 from datetime import datetime
-from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict
-
-
-class LLMType(StrEnum):
-    OPENAI_GPT4O = "OPENAI_GPT4O"
 
 
 class TaskGenerationBase(BaseModel):
@@ -19,7 +14,7 @@ class TaskGenerationBase(BaseModel):
     navigation_payload: dict[str, Any] | None = None
     data_extraction_goal: str | None = None
     extracted_information_schema: dict[str, Any] | None = None
-    llm: LLMType | None = None
+    llm: str | None = None
     llm_prompt: str | None = None
     llm_response: str | None = None
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 372ad1fdcabec4c52c3949d811c0d709b709b49e  | 
|--------|--------|

### Summary:
Removed the `LLMType` enum and changed the `llm` field type to `str` in `TaskGenerationBase` to increase flexibility.

**Key points**:
- Removed `LLMType` enum from `TaskGenerationBase` in `/skyvern/forge/sdk/schemas/task_generations.py`
- Changed `llm` field type from `LLMType` to `str`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->