### PR TITLE
Move a tag href target rewriting to the core loop to prevent new tabs from being opened

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -665,13 +665,7 @@ function buildTreeFromBody(frame = "main.frame") {
     var element_id = element.getAttribute("unique_id") ?? uniqueId();
     var elementTagNameLower = element.tagName.toLowerCase();
     element.setAttribute("unique_id", element_id);
-    // if element is an "a" tag and has a target="_blank" attribute, remove the target attribute
-    // We're doing this so that skyvern can do all the navigation in a single page/tab and not open new tab
-    if (element.tagName.toLowerCase() === "a") {
-      if (element.getAttribute("target") === "_blank") {
-        element.removeAttribute("target");
-      }
-    }
+
     const attrs = {};
     for (const attr of element.attributes) {
       var attrValue = attr.value;
@@ -760,6 +754,14 @@ function buildTreeFromBody(frame = "main.frame") {
     if (element === null) {
       console.log("get a null element");
       return;
+    }
+
+    // if element is an "a" tag and has a target="_blank" attribute, remove the target attribute
+    // We're doing this so that skyvern can do all the navigation in a single page/tab and not open new tab
+    if (element.tagName.toLowerCase() === "a") {
+      if (element.getAttribute("target") === "_blank") {
+        element.removeAttribute("target");
+      }
     }
 
     // Check if the element is interactable


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a7c4192377fbb18a38914c51d93ac5e73b28af7b  | 
|--------|--------|

### Summary:
Moved 'a' tag 'target' attribute rewriting logic to 'processElement' in `skyvern/webeye/scraper/domUtils.js` to prevent new tabs from opening.

**Key points**:
- Moved 'a' tag 'target' attribute rewriting logic from 'buildTreeFromBody' to 'processElement' in `skyvern/webeye/scraper/domUtils.js`.
- Ensures 'target' attribute is removed earlier to prevent new tabs from opening.
- Updated URL list in `scripts/run_rapidand_workflows.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->