### PR TITLE
add a 2-min timeout for press_sequentially

### DIFF
--- a/skyvern/constants.py
+++ b/skyvern/constants.py
@@ -4,3 +4,5 @@ from pathlib import Path
 SKYVERN_ID_ATTR: str = "unique_id"
 SKYVERN_DIR = Path(__file__).parent
 REPO_ROOT_DIR = SKYVERN_DIR.parent
+
+INPUT_TEXT_TIMEOUT = 120000  # 2 minutes

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -8,7 +8,7 @@ import structlog
 from deprecation import deprecated
 from playwright.async_api import Locator, Page, TimeoutError
 
-from skyvern.constants import REPO_ROOT_DIR
+from skyvern.constants import INPUT_TEXT_TIMEOUT, REPO_ROOT_DIR
 from skyvern.exceptions import (
     ImaginaryFileUrl,
     InvalidElementForTextInput,
@@ -268,8 +268,7 @@ async def handle_input_text_action(
 
     # If the input is a text input, we type the text character by character
     # 3 times the time it takes to type the text so it has time to finish typing
-    total_timeout = max(len(text) * TEXT_INPUT_DELAY * 3, SettingsManager.get_settings().BROWSER_ACTION_TIMEOUT_MS)
-    await locator.press_sequentially(text, timeout=total_timeout)
+    await locator.press_sequentially(text, timeout=INPUT_TEXT_TIMEOUT)
     return [ActionSuccess()]
 
 

--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -4,7 +4,7 @@ from enum import StrEnum
 import structlog
 from playwright.async_api import FrameLocator, Locator, Page
 
-from skyvern.constants import SKYVERN_ID_ATTR
+from skyvern.constants import INPUT_TEXT_TIMEOUT, SKYVERN_ID_ATTR
 from skyvern.exceptions import (
     ElementIsNotLabel,
     MissingElement,
@@ -17,7 +17,6 @@ from skyvern.forge.sdk.settings_manager import SettingsManager
 from skyvern.webeye.scraper.scraper import ScrapedPage
 
 LOG = structlog.get_logger()
-TEXT_INPUT_DELAY = 10
 
 
 def resolve_locator(scrape_page: ScrapedPage, page: Page, frame: str, xpath: str) -> Locator:
@@ -97,8 +96,7 @@ class SkyvernElement:
     async def input_sequentially(
         self, text: str, default_timeout: float = SettingsManager.get_settings().BROWSER_ACTION_TIMEOUT_MS
     ) -> None:
-        total_timeout = max(len(text) * TEXT_INPUT_DELAY * 3, default_timeout)
-        await self.locator.press_sequentially(text, timeout=total_timeout)
+        await self.locator.press_sequentially(text, timeout=INPUT_TEXT_TIMEOUT)
 
 
 class DomUtil:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2548189543b1597f432a7568072437201ee813e7  | 
|--------|--------|

### Summary:
Introduced a consistent 2-minute timeout for the `press_sequentially` function across various modules by adding a constant `INPUT_TEXT_TIMEOUT` and updating relevant functions to use this constant.

**Key points**:
- Added `INPUT_TEXT_TIMEOUT` constant set to 120000 ms (2 minutes) in `cloud/webeye/teardown/action_input.py` and `skyvern/constants.py`.
- Updated `teardown_input_for_hack_autocomplete`, `teardown_input_autocomplete_by_combobox`, and `teardown_location_input_for_lever` in `cloud/webeye/teardown/action_input.py` to use `INPUT_TEXT_TIMEOUT` for `press_sequentially`.
- Updated `handle_input_text_action` in `skyvern/webeye/actions/handler.py` and `SkyvernElement.input_sequentially` in `skyvern/webeye/utils/dom.py` to use `INPUT_TEXT_TIMEOUT` for `press_sequentially`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->