### PR TITLE
Select option handler bugfix

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -516,8 +516,11 @@ async def handle_select_option_action(
         check_action = CheckboxAction(element_id=action.element_id, is_checked=True)
         return await handle_checkbox_action(check_action, page, scraped_page, task, step)
 
-    current_text = await locator.input_value()
-    if current_text == action.option.label:
+    current_value = await locator.input_value()
+    # find the text of the option with the current value
+    option_locator = locator.locator(f'option[value="{current_value}"]')
+    option_text = await option_locator.text_content()
+    if option_text == action.option.label:
         return [ActionSuccess()]
 
     try:
@@ -529,9 +532,8 @@ async def handle_select_option_action(
             label=action.option.label,
             timeout=SettingsManager.get_settings().BROWSER_ACTION_TIMEOUT_MS,
         )
-        await locator.click(
-            timeout=SettingsManager.get_settings().BROWSER_ACTION_TIMEOUT_MS,
-        )
+        # In case we need to unfocus the select element, press Tab
+        await page.keyboard.press("Tab")
         return [ActionSuccess()]
     except Exception as e:
         if action.option.index is not None:


### PR DESCRIPTION
Two bugfixes:
1. We previously added a check to not take any actions in case the selected option is the one we would select. That logic was flawed and didn't work. Now it should be fixed.
2. I was debugging [an issue](https://linear.app/wyvern-ai/issue/SKY-2401/selecting-the-invalid-option) where we were selecting the option with actual index + 1. The root cause is how we handle the select option. We click on the <select> element, we select the option with the matching label, then we click on the <select> element again. Our second click selects the next option available. Here's the loom video of the bug and the solution: https://www.loom.com/share/792a12e8240e49c4847305959d4d0ea1
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 084e3957b1826c5868023ab8002e42ac69cef7ce  | 
|--------|--------|

### Summary:
Fixes logic and behavior in `handle_select_option_action` to correctly check selected option and unfocus select element by pressing 'Tab'.

**Key points**:
- Fixes logic in `handle_select_option_action` to correctly check if the selected option is already the desired one.
- Changes behavior in `handle_select_option_action` to unfocus the select element by pressing 'Tab' instead of clicking it again.
- Affects `skyvern/webeye/actions/handler.py` file, specifically the `handle_select_option_action` function.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->