### PR TITLE
Fix notification overlap

### DIFF
--- a/skyvern-frontend/src/components/ui/toast.tsx
+++ b/skyvern-frontend/src/components/ui/toast.tsx
@@ -13,6 +13,7 @@ const ToastViewport = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <ToastPrimitives.Viewport
     ref={ref}
+    data-toast="1"
     className={cn(
       "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
       className,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 147b37ea1adb387adfc2941ba18fa16459ac9ae1  | 
|--------|--------|

### Summary:
Fixes notification overlap by adding `data-toast` attribute to `ToastViewport` and applying CSS rule for correct positioning.

**Key points**:
- Added `data-toast` attribute to `ToastViewport` component in `skyvern-frontend/src/components/ui/toast.tsx`.
- Applied CSS rule to set `bottom-20` for elements with `data-toast` attribute in `skyvern-frontend/cloud/index.css`.
- Fixes notification overlap issue by ensuring correct positioning of toasts.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->