### PR TITLE
Rearrange task form

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -187,6 +188,7 @@ function CreateNewTaskForm({ initialValues }: Props) {
                   </TooltipProvider>
                 </div>
               </FormLabel>
+              <FormDescription>The starting URL for the task</FormDescription>
               <FormControl>
                 <Input placeholder="example.com" {...field} />
               </FormControl>
@@ -194,7 +196,6 @@ function CreateNewTaskForm({ initialValues }: Props) {
             </FormItem>
           )}
         />
-
         <FormField
           control={form.control}
           name="navigationGoal"
@@ -215,10 +216,13 @@ function CreateNewTaskForm({ initialValues }: Props) {
                   </TooltipProvider>
                 </div>
               </FormLabel>
+              <FormDescription>
+                How do you want Skyvern to navigate?
+              </FormDescription>
               <FormControl>
                 <Textarea
                   rows={5}
-                  placeholder="How do you want Skyvern to navigate?"
+                  placeholder="Navigation Goal"
                   {...field}
                   value={field.value === null ? "" : field.value}
                 />
@@ -247,10 +251,14 @@ function CreateNewTaskForm({ initialValues }: Props) {
                   </TooltipProvider>
                 </div>
               </FormLabel>
+              <FormDescription>
+                If you want Skyvern to extract data after it's finished
+                navigating
+              </FormDescription>
               <FormControl>
                 <Textarea
                   rows={5}
-                  placeholder="If you want Skyvern to extract data after it's finished navigating"
+                  placeholder="Data Extraction Goal"
                   {...field}
                   value={field.value === null ? "" : field.value}
                 />
@@ -279,10 +287,14 @@ function CreateNewTaskForm({ initialValues }: Props) {
                   </TooltipProvider>
                 </div>
               </FormLabel>
+              <FormDescription>
+                Any context Skyvern needs to complete its actions (ex. text that
+                may be required to fill out forms)
+              </FormDescription>
               <FormControl>
                 <Textarea
                   rows={5}
-                  placeholder="Any context Skyvern needs to complete its actions (ex. text that may be required to fill out forms)"
+                  placeholder="Navigation Payload"
                   {...field}
                   value={field.value === null ? "" : field.value}
                 />
@@ -315,9 +327,13 @@ function CreateNewTaskForm({ initialValues }: Props) {
                         </TooltipProvider>
                       </div>
                     </FormLabel>
+                    <FormDescription>
+                      Jsonc schema to force the json format for extracted
+                      information
+                    </FormDescription>
                     <FormControl>
                       <Textarea
-                        placeholder="Jsonc schema to force the json format for extracted information"
+                        placeholder="Extracted Information Schema"
                         rows={5}
                         {...field}
                         value={field.value === null ? "" : field.value}
@@ -347,9 +363,13 @@ function CreateNewTaskForm({ initialValues }: Props) {
                         </TooltipProvider>
                       </div>
                     </FormLabel>
+                    <FormDescription>
+                      The URL of a webhook endpoint to send the extracted
+                      information
+                    </FormDescription>
                     <FormControl>
                       <Input
-                        placeholder="The URL of a webhook endpoint to send the extracted information"
+                        placeholder="example.com"
                         {...field}
                         value={field.value === null ? "" : field.value}
                       />

--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -37,6 +37,12 @@ import { apiBaseUrl } from "@/util/env";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
 import { useApiCredential } from "@/hooks/useApiCredential";
 import { AxiosError } from "axios";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 
 const createNewTaskFormSchema = z
   .object({
@@ -188,37 +194,7 @@ function CreateNewTaskForm({ initialValues }: Props) {
             </FormItem>
           )}
         />
-        <FormField
-          control={form.control}
-          name="webhookCallbackUrl"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>
-                <div className="flex gap-2">
-                  Webhook Callback URL
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <InfoCircledIcon />
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-[250px]">
-                        <p>{webhookCallbackUrlDescription}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-              </FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="example.com"
-                  {...field}
-                  value={field.value === null ? "" : field.value}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+
         <FormField
           control={form.control}
           name="navigationGoal"
@@ -242,7 +218,7 @@ function CreateNewTaskForm({ initialValues }: Props) {
               <FormControl>
                 <Textarea
                   rows={5}
-                  placeholder="Navigation Goal"
+                  placeholder="How do you want Skyvern to navigate?"
                   {...field}
                   value={field.value === null ? "" : field.value}
                 />
@@ -274,7 +250,7 @@ function CreateNewTaskForm({ initialValues }: Props) {
               <FormControl>
                 <Textarea
                   rows={5}
-                  placeholder="Data Extraction Goal"
+                  placeholder="If you want Skyvern to extract data after it's finished navigating"
                   {...field}
                   value={field.value === null ? "" : field.value}
                 />
@@ -306,7 +282,7 @@ function CreateNewTaskForm({ initialValues }: Props) {
               <FormControl>
                 <Textarea
                   rows={5}
-                  placeholder="Navigation Payload"
+                  placeholder="Any context Skyvern needs to complete its actions (ex. text that may be required to fill out forms)"
                   {...field}
                   value={field.value === null ? "" : field.value}
                 />
@@ -315,38 +291,77 @@ function CreateNewTaskForm({ initialValues }: Props) {
             </FormItem>
           )}
         />
-        <FormField
-          control={form.control}
-          name="extractedInformationSchema"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>
-                <div className="flex gap-2">
-                  Extracted Information Schema
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <InfoCircledIcon />
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-[250px]">
-                        <p>{extractedInformationSchemaDescription}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-              </FormLabel>
-              <FormControl>
-                <Textarea
-                  placeholder="Extracted Information Schema"
-                  rows={5}
-                  {...field}
-                  value={field.value === null ? "" : field.value}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        <Accordion type="single" collapsible>
+          <AccordionItem value="advanced-settings">
+            <AccordionTrigger>Advanced Settings</AccordionTrigger>
+            <AccordionContent className="space-y-8 px-1 py-4">
+              <FormField
+                control={form.control}
+                name="extractedInformationSchema"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      <div className="flex gap-2">
+                        Extracted Information Schema
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <InfoCircledIcon />
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-[250px]">
+                              <p>{extractedInformationSchemaDescription}</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      </div>
+                    </FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Jsonc schema to force the json format for extracted information"
+                        rows={5}
+                        {...field}
+                        value={field.value === null ? "" : field.value}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="webhookCallbackUrl"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      <div className="flex gap-2">
+                        Webhook Callback URL
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <InfoCircledIcon />
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-[250px]">
+                              <p>{webhookCallbackUrlDescription}</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      </div>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="The URL of a webhook endpoint to send the extracted information"
+                        {...field}
+                        value={field.value === null ? "" : field.value}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+
         <div className="flex justify-end gap-3">
           <Button
             type="button"

--- a/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
@@ -39,6 +39,12 @@ import {
 } from "../data/descriptionHelperContent";
 import { SubmitEvent } from "@/types";
 import { AxiosError } from "axios";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 
 const savedTaskFormSchema = z
   .object({
@@ -298,37 +304,7 @@ function SavedTaskForm({ initialValues }: Props) {
             </FormItem>
           )}
         />
-        <FormField
-          control={form.control}
-          name="webhookCallbackUrl"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>
-                <div className="flex gap-2">
-                  Webhook Callback URL
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <InfoCircledIcon />
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-[250px]">
-                        <p>{webhookCallbackUrlDescription}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-              </FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="example.com"
-                  {...field}
-                  value={field.value === null ? "" : field.value}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+
         <FormField
           control={form.control}
           name="navigationGoal"
@@ -352,7 +328,7 @@ function SavedTaskForm({ initialValues }: Props) {
               <FormControl>
                 <Textarea
                   rows={5}
-                  placeholder="Navigation Goal"
+                  placeholder="How do you want Skyvern to navigate?"
                   {...field}
                   value={field.value === null ? "" : field.value}
                 />
@@ -384,7 +360,7 @@ function SavedTaskForm({ initialValues }: Props) {
               <FormControl>
                 <Textarea
                   rows={5}
-                  placeholder="Data Extraction Goal"
+                  placeholder="If you want Skyvern to extract data after it's finished navigating"
                   {...field}
                   value={field.value === null ? "" : field.value}
                 />
@@ -416,7 +392,7 @@ function SavedTaskForm({ initialValues }: Props) {
               <FormControl>
                 <Textarea
                   rows={5}
-                  placeholder="Navigation Payload"
+                  placeholder="Any context Skyvern needs to complete its actions (ex. text that may be required to fill out forms)"
                   {...field}
                   value={field.value === null ? "" : field.value}
                 />
@@ -425,38 +401,77 @@ function SavedTaskForm({ initialValues }: Props) {
             </FormItem>
           )}
         />
-        <FormField
-          control={form.control}
-          name="extractedInformationSchema"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>
-                <div className="flex gap-2">
-                  Extracted Information Schema
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <InfoCircledIcon />
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-[250px]">
-                        <p>{extractedInformationSchemaDescription}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-              </FormLabel>
-              <FormControl>
-                <Textarea
-                  placeholder="Extracted Information Schema"
-                  rows={5}
-                  {...field}
-                  value={field.value === null ? "" : field.value}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        <Accordion type="single" collapsible>
+          <AccordionItem value="advanced-settings">
+            <AccordionTrigger>Advanced Settings</AccordionTrigger>
+            <AccordionContent className="space-y-8 px-1 py-4">
+              <FormField
+                control={form.control}
+                name="extractedInformationSchema"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      <div className="flex gap-2">
+                        Extracted Information Schema
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <InfoCircledIcon />
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-[250px]">
+                              <p>{extractedInformationSchemaDescription}</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      </div>
+                    </FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Jsonc schema to force the json format for extracted information"
+                        rows={5}
+                        {...field}
+                        value={field.value === null ? "" : field.value}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="webhookCallbackUrl"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      <div className="flex gap-2">
+                        Webhook Callback URL
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <InfoCircledIcon />
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-[250px]">
+                              <p>{webhookCallbackUrlDescription}</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      </div>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="The URL of a webhook endpoint to send the extracted information"
+                        {...field}
+                        value={field.value === null ? "" : field.value}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+
         <div className="flex justify-end gap-3">
           <Button
             type="button"

--- a/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -297,6 +298,7 @@ function SavedTaskForm({ initialValues }: Props) {
                   </TooltipProvider>
                 </div>
               </FormLabel>
+              <FormDescription>The starting URL for the task</FormDescription>
               <FormControl>
                 <Input placeholder="example.com" {...field} />
               </FormControl>
@@ -325,10 +327,13 @@ function SavedTaskForm({ initialValues }: Props) {
                   </TooltipProvider>
                 </div>
               </FormLabel>
+              <FormDescription>
+                How do you want Skyvern to navigate?
+              </FormDescription>
               <FormControl>
                 <Textarea
                   rows={5}
-                  placeholder="How do you want Skyvern to navigate?"
+                  placeholder="Navigation Goal"
                   {...field}
                   value={field.value === null ? "" : field.value}
                 />
@@ -357,10 +362,14 @@ function SavedTaskForm({ initialValues }: Props) {
                   </TooltipProvider>
                 </div>
               </FormLabel>
+              <FormDescription>
+                If you want Skyvern to extract data after it's finished
+                navigating
+              </FormDescription>
               <FormControl>
                 <Textarea
                   rows={5}
-                  placeholder="If you want Skyvern to extract data after it's finished navigating"
+                  placeholder="Data Extraction Goal"
                   {...field}
                   value={field.value === null ? "" : field.value}
                 />
@@ -389,10 +398,14 @@ function SavedTaskForm({ initialValues }: Props) {
                   </TooltipProvider>
                 </div>
               </FormLabel>
+              <FormDescription>
+                Any context Skyvern needs to complete its actions (ex. text that
+                may be required to fill out forms)
+              </FormDescription>
               <FormControl>
                 <Textarea
                   rows={5}
-                  placeholder="Any context Skyvern needs to complete its actions (ex. text that may be required to fill out forms)"
+                  placeholder="Navigation Payload"
                   {...field}
                   value={field.value === null ? "" : field.value}
                 />
@@ -425,9 +438,13 @@ function SavedTaskForm({ initialValues }: Props) {
                         </TooltipProvider>
                       </div>
                     </FormLabel>
+                    <FormDescription>
+                      Jsonc schema to force the json format for extracted
+                      information
+                    </FormDescription>
                     <FormControl>
                       <Textarea
-                        placeholder="Jsonc schema to force the json format for extracted information"
+                        placeholder="Extracted Information Schema"
                         rows={5}
                         {...field}
                         value={field.value === null ? "" : field.value}
@@ -457,9 +474,13 @@ function SavedTaskForm({ initialValues }: Props) {
                         </TooltipProvider>
                       </div>
                     </FormLabel>
+                    <FormDescription>
+                      The URL of a webhook endpoint to send the extracted
+                      information
+                    </FormDescription>
                     <FormControl>
                       <Input
-                        placeholder="The URL of a webhook endpoint to send the extracted information"
+                        placeholder="example.com"
                         {...field}
                         value={field.value === null ? "" : field.value}
                       />

--- a/skyvern-frontend/src/routes/tasks/create/SavedTasks.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTasks.tsx
@@ -28,7 +28,7 @@ function createEmptyTaskTemplate() {
           parameter_type: "workflow",
           workflow_parameter_type: "json",
           key: "navigation_payload",
-          default_value: JSON.stringify({}),
+          default_value: "null",
         },
       ],
       blocks: [


### PR DESCRIPTION
  Put webhook callback url and extracted information schema under
  advanced settings accordion
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5e3cfc9845a4a5e8da4ae8039b91ff89f135dec9  | 
|--------|--------|

### Summary:
Rearranged `webhookCallbackUrl` and `extractedInformationSchema` fields into an advanced settings accordion and updated default `navigation_payload` value.

**Key points**:
- Moved `webhookCallbackUrl` and `extractedInformationSchema` fields into an advanced settings accordion in `CreateNewTaskForm` (`skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx`).
- Moved `webhookCallbackUrl` and `extractedInformationSchema` fields into an advanced settings accordion in `SavedTaskForm` (`skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx`).
- Changed default value for `navigation_payload` in `createEmptyTaskTemplate` from an empty object to 'null' (`skyvern-frontend/src/routes/tasks/create/SavedTasks.tsx`).


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->