### PR TITLE
Start using Claude 3.5 Sonnet

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -69,7 +69,7 @@ setup_llm_providers() {
         else
             update_or_add_env_var "ANTHROPIC_API_KEY" "$anthropic_api_key"
             update_or_add_env_var "ENABLE_ANTHROPIC" "true"
-            model_options+=("ANTHROPIC_CLAUDE3_OPUS" "ANTHROPIC_CLAUDE3_SONNET" "ANTHROPIC_CLAUDE3_HAIKU", "ANTHROPIC_CLAUDE3.5_SONNET")
+            model_options+=("ANTHROPIC_CLAUDE3_OPUS" "ANTHROPIC_CLAUDE3_SONNET" "ANTHROPIC_CLAUDE3_HAIKU" "ANTHROPIC_CLAUDE3.5_SONNET")
         fi
     else
         update_or_add_env_var "ENABLE_ANTHROPIC" "false"

--- a/setup.sh
+++ b/setup.sh
@@ -69,7 +69,7 @@ setup_llm_providers() {
         else
             update_or_add_env_var "ANTHROPIC_API_KEY" "$anthropic_api_key"
             update_or_add_env_var "ENABLE_ANTHROPIC" "true"
-            model_options+=("ANTHROPIC_CLAUDE3_OPUS" "ANTHROPIC_CLAUDE3_SONNET" "ANTHROPIC_CLAUDE3_HAIKU")
+            model_options+=("ANTHROPIC_CLAUDE3_OPUS" "ANTHROPIC_CLAUDE3_SONNET" "ANTHROPIC_CLAUDE3_HAIKU", "ANTHROPIC_CLAUDE3.5_SONNET")
         fi
     else
         update_or_add_env_var "ENABLE_ANTHROPIC" "false"

--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -116,6 +116,15 @@ if SettingsManager.get_settings().ENABLE_ANTHROPIC:
             add_assistant_prefix=True,
         ),
     )
+    LLMConfigRegistry.register_config(
+        "ANTHROPIC_CLAUDE3.5_SONNET",
+        LLMConfig(
+            "anthropic/claude-3-5-sonnet-20240620",
+            ["ANTHROPIC_API_KEY"],
+            supports_vision=True,
+            add_assistant_prefix=True,
+        ),
+    )
 
 if SettingsManager.get_settings().ENABLE_BEDROCK:
     # Supported through AWS IAM authentication
@@ -141,6 +150,15 @@ if SettingsManager.get_settings().ENABLE_BEDROCK:
         "BEDROCK_ANTHROPIC_CLAUDE3_HAIKU",
         LLMConfig(
             "bedrock/anthropic.claude-3-haiku-20240307-v1:0",
+            ["AWS_REGION"],
+            supports_vision=True,
+            add_assistant_prefix=True,
+        ),
+    )
+    LLMConfigRegistry.register_config(
+        "BEDROCK_ANTHROPIC_CLAUDE3.5_SONNET",
+        LLMConfig(
+            "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
             ["AWS_REGION"],
             supports_vision=True,
             add_assistant_prefix=True,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c441ec7cf200f1339a318cc23571fdb21fbc14d1  | 
|--------|--------|

### Summary:
Updated codebase to use `Claude 3.5 Sonnet` model instead of `Claude 3` for LLM API handlers and configurations.

**Key points**:
- Updated `cloud/core/llm_handlers.py` to use `claude35_sonnet_api_handler` instead of `claude3_sonnet_api_handler`.
- Modified `cloud/webeye/setup/action_complete.py` to reference `claude35_sonnet_api_handler`.
- Changed `scripts/run_task.py` and `scripts/run_workflow.py` to use `BEDROCK_ANTHROPIC_CLAUDE3.5_SONNET` for LLM API handler.
- Updated `setup.sh` to include `ANTHROPIC_CLAUDE3.5_SONNET` in model options.
- Added configuration for `ANTHROPIC_CLAUDE3.5_SONNET` and `BEDROCK_ANTHROPIC_CLAUDE3.5_SONNET` in `skyvern/forge/sdk/api/llm/config_registry.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->