### PR TITLE
close select2 when failed to select

### DIFF
--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -167,6 +167,9 @@ class Select2Dropdown:
         # wait for the options to load
         await asyncio.sleep(3)
 
+    async def close(self, timeout: float = SettingsManager.get_settings().BROWSER_ACTION_TIMEOUT_MS) -> None:
+        await self.page.locator("#select2-drop").press("Escape", timeout=timeout)
+
     async def get_options(self) -> typing.List[SkyvernOptionType]:
         options = await get_select2_options(self.page)
         return typing.cast(typing.List[SkyvernOptionType], options)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 798f1938ea80e2561fed2b662fa2646ec235e7fd  | 
|--------|--------|

### Summary:
Close select2 dropdown on selection failure in `handle_select_option_action` and add `close` method to `Select2Dropdown`.

**Key points**:
- **Modified** `handle_select_option_action` in `skyvern/webeye/actions/handler.py` to close the select2 dropdown on selection failure.
- **Added** `close` method to `Select2Dropdown` class in `skyvern/webeye/utils/dom.py` to handle closing the dropdown.
- **Logged** a message when the dropdown is closed due to a selection failure.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->