### PR TITLE
Include max steps in saved task

### DIFF
--- a/skyvern-frontend/src/routes/tasks/constants.ts
+++ b/skyvern-frontend/src/routes/tasks/constants.ts
@@ -1,1 +1,3 @@
 export const PAGE_SIZE = 15;
+
+export const MAX_STEPS_DEFAULT = 10;

--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/components/ui/accordion";
 import { OrganizationApiResponse } from "@/api/types";
 import { Skeleton } from "@/components/ui/skeleton";
+import { MAX_STEPS_DEFAULT } from "../constants";
 
 const createNewTaskFormSchema = z
   .object({
@@ -94,15 +95,12 @@ function createTaskRequestObject(formValues: CreateNewTaskFormValues) {
     navigation_goal: transform(formValues.navigationGoal),
     data_extraction_goal: transform(formValues.dataExtractionGoal),
     proxy_location: "RESIDENTIAL",
-    error_code_mapping: null,
     navigation_payload: transform(formValues.navigationPayload),
     extracted_information_schema: transform(
       formValues.extractedInformationSchema,
     ),
   };
 }
-
-const MAX_STEPS_DEFAULT = 10;
 
 function CreateNewTaskForm({ initialValues }: Props) {
   const queryClient = useQueryClient();

--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskFormPage.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskFormPage.tsx
@@ -48,6 +48,8 @@ function CreateNewTaskFormPage() {
 
   const dataSchema = data.workflow_definition.blocks[0].data_schema;
 
+  const maxSteps = data.workflow_definition.blocks[0].max_steps_per_run;
+
   return (
     <SavedTaskForm
       initialValues={{
@@ -61,6 +63,7 @@ function CreateNewTaskFormPage() {
           data.workflow_definition.blocks[0].data_extraction_goal,
         extractedInformationSchema: JSON.stringify(dataSchema, null, 2),
         navigationPayload,
+        maxSteps,
       }}
     />
   );


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ffc34d25390c1331d3d9c0070ab7669b7aa024cd  | 
|--------|--------|

### Summary:
Added functionality to include a 'max steps' parameter in task creation and saving forms, updating schemas, components, and API requests accordingly.

**Key points**:
- Added `MAX_STEPS_DEFAULT` constant in `skyvern-frontend/src/routes/tasks/constants.ts`.
- Updated `createNewTaskFormSchema` in `skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx` to include `maxStepsOverride`.
- Modified `createTaskRequestObject` in `skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx` to handle `maxStepsOverride`.
- Updated `CreateNewTaskForm` component to include `maxStepsOverride` field and handle its default value.
- Added `maxSteps` field to `savedTaskFormSchema` in `skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx`.
- Modified `createTaskTemplateRequestObject` in `skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx` to include `max_steps_per_run`.
- Updated `SavedTaskForm` component to include `maxSteps` field and handle its default value.
- Updated `CreateNewTaskFormPage` component in `skyvern-frontend/src/routes/tasks/create/CreateNewTaskFormPage.tsx` to pass `maxSteps` to `SavedTaskForm`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->