### PR TITLE
try to fix screenshot timeout

### DIFF
--- a/skyvern/constants.py
+++ b/skyvern/constants.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from pathlib import Path
 
 # This is the attribute name used to tag interactable elements
@@ -6,3 +7,12 @@ SKYVERN_DIR = Path(__file__).parent
 REPO_ROOT_DIR = SKYVERN_DIR.parent
 
 INPUT_TEXT_TIMEOUT = 120000  # 2 minutes
+
+
+class ScrapeType(StrEnum):
+    NORMAL = "normal"
+    STOPLOADING = "stoploading"
+    RELOAD = "reload"
+
+
+SCRAPE_TYPE_ORDER = [ScrapeType.NORMAL, ScrapeType.STOPLOADING, ScrapeType.RELOAD]

--- a/skyvern/exceptions.py
+++ b/skyvern/exceptions.py
@@ -165,6 +165,20 @@ class FailedToNavigateToUrl(SkyvernException):
         super().__init__(f"Failed to navigate to url {url}. Error message: {error_message}")
 
 
+class FailedToReloadPage(SkyvernException):
+    def __init__(self, url: str, error_message: str) -> None:
+        self.url = url
+        self.error_message = error_message
+        super().__init__(f"Failed to reload page url {url}. Error message: {error_message}")
+
+
+class FailedToStopLoadingPage(SkyvernException):
+    def __init__(self, url: str, error_message: str) -> None:
+        self.url = url
+        self.error_message = error_message
+        super().__init__(f"Failed to stop loading page url {url}. Error message: {error_message}")
+
+
 class UnexpectedTaskStatus(SkyvernException):
     def __init__(self, task_id: str, status: str) -> None:
         super().__init__(f"Unexpected task status {status} for task {task_id}")
@@ -216,6 +230,11 @@ class StepNotFound(SkyvernHTTPException):
 class FailedToTakeScreenshot(SkyvernException):
     def __init__(self, error_message: str) -> None:
         super().__init__(f"Failed to take screenshot. Error message: {error_message}")
+
+
+class EmptyScrapePage(SkyvernException):
+    def __init__(self) -> None:
+        super().__init__("Failed to scrape the page, returned an NONE result")
 
 
 class WorkflowRunContextNotInitialized(SkyvernException):


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e79d0a21cf34f3ccbc20c373149e0bb8484d5484  | 
|--------|--------|

### Summary:
Implemented retry mechanism with different scraping strategies to address screenshot timeout issues.

**Key points**:
- **Added** `ScrapeType` enum and `SCRAPE_TYPE_ORDER` in `skyvern/constants.py` to define scraping strategies.
- **Introduced** new exceptions `FailedToReloadPage`, `FailedToStopLoadingPage`, and `EmptyScrapePage` in `skyvern/exceptions.py`.
- **Implemented** `_scrape_with_type` and updated `_build_and_record_step_prompt` in `skyvern/forge/agent.py` to retry scraping with different strategies.
- **Added** `stop_page_loading` and `reload_page` methods in `skyvern/webeye/browser_factory.py` to handle page loading states.
- **Updated** `scrape_website` in `skyvern/webeye/scraper/scraper.py` to raise `FailedToTakeScreenshot` exception for specific error handling.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->