### PR TITLE
user get_curr_org as the authentication function for generate_task api

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -670,7 +670,7 @@ async def get_workflow(
 @base_router.post("/generate/task/")
 async def generate_task(
     data: GenerateTaskRequest,
-    current_org: Organization = Depends(org_auth_service.get_current_org_with_authentication),
+    current_org: Organization = Depends(org_auth_service.get_current_org),
 ) -> TaskGeneration:
     llm_prompt = prompt_engine.load_prompt("generate-task", user_prompt=data.prompt)
     try:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6947a3d3012c856cf158a6c3976a3a1b81602c8c  | 
|--------|--------|

### Summary:
Updated `generate_task` endpoint to use `org_auth_service.get_current_org` for authentication.

**Key points**:
- Updated `generate_task` endpoint in `skyvern/forge/sdk/routes/agent_protocol.py`.
- Changed authentication dependency from `org_auth_service.get_current_org_with_authentication` to `org_auth_service.get_current_org`.
- Affects only the `generate_task` function.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->