### PR TITLE
use 'click' for radio button

### DIFF
--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -79,6 +79,22 @@ class SkyvernElement:
             or (tag_name == "input" and "select2-input" in element_class)
         )
 
+    async def is_checkbox(self) -> bool:
+        tag_name = self.get_tag_name()
+        if tag_name != "input":
+            return False
+
+        button_type = await self.get_attr("type")
+        return button_type == "checkbox"
+
+    async def is_radio(self) -> bool:
+        tag_name = self.get_tag_name()
+        if tag_name != "input":
+            return False
+
+        button_type = await self.get_attr("type")
+        return button_type == "radio"
+
     def get_tag_name(self) -> str:
         return self.__static_element.get("tagName", "")
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9b33011adcebb887a4890bc9a3bf9a33c9dfbaec  | 
|--------|--------|

### Summary:
Updated `handle_select_option_action` to use `ClickAction` for radio buttons and added helper methods to identify input types.

**Key points**:
- Updated `handle_select_option_action` in `skyvern/webeye/actions/handler.py` to use `ClickAction` for radio buttons.
- Replaced `CheckboxAction` with `SelectOptionAction` for handling checkbox/radio inputs within labels.
- Added `is_checkbox` and `is_radio` methods to `SkyvernElement` in `skyvern/webeye/utils/dom.py` to identify input types.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->