### PR TITLE
re-enable iframe

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -809,6 +809,7 @@ class ForgeAgent:
         return await scrape_website(
             browser_state,
             task.url,
+            scrape_exclude=app.scrape_exclude,
         )
 
     async def _build_and_record_step_prompt(

--- a/skyvern/forge/app.py
+++ b/skyvern/forge/app.py
@@ -3,6 +3,7 @@ from typing import Awaitable, Callable
 from ddtrace import tracer
 from ddtrace.filters import FilterRequestsOnUrl
 from fastapi import FastAPI
+from playwright.async_api import Frame, Page
 
 from skyvern.forge.agent import ForgeAgent
 from skyvern.forge.agent_functions import AgentFunction
@@ -40,6 +41,7 @@ LLM_API_HANDLER = LLMAPIHandlerFactory.get_llm_api_handler(SettingsManager.get_s
 WORKFLOW_CONTEXT_MANAGER = WorkflowContextManager()
 WORKFLOW_SERVICE = WorkflowService()
 AGENT_FUNCTION = AgentFunction()
+scrape_exclude: Callable[[Page, Frame], Awaitable[bool]] | None = None
 authentication_function: Callable[[str], Awaitable[Organization]] | None = None
 setup_api_app: Callable[[FastAPI], None] | None = None
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2d31f6c30af3fc514be02075f5436849e3dcaa5e  | 
|--------|--------|

### Summary:
Re-enabled iframe handling in the scraping process by adding a `scrape_exclude` callback to filter specific iframes during scraping.

**Key points**:
- **`skyvern/forge/agent.py`**: Updated `_scrape_with_type` to pass `scrape_exclude` to `scrape_website`.
- **`skyvern/forge/app.py`**: Added `scrape_exclude` callback definition.
- **`skyvern/webeye/scraper/scraper.py`**: Modified `scrape_website`, `scrape_web_unsafe`, `get_interactable_element_tree`, and `get_interactable_element_tree_in_frame` to handle `scrape_exclude` callback for filtering iframes.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->