### PR TITLE
make LOG_LEVEL configurable

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -29,6 +29,7 @@ class Settings(BaseSettings):
     ENV: str = "local"
     EXECUTE_ALL_STEPS: bool = True
     JSON_LOGGING: bool = False
+    LOG_LEVEL: str = "INFO"
     PORT: int = 8000
 
     # Secret key for JWT. Please generate your own secret key in production


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1a17aa920d858d4940cc78948c540f0221c440b0  | 
|--------|--------|

### Summary:
Added configurable `LOG_LEVEL` to logging setup and updated staging environment configurations to use `DEBUG` level.

**Key points**:
- Added `LOG_LEVEL` to `Settings` class in `skyvern/config.py`.
- Introduced `LOGGING_LEVEL_MAP` in `skyvern/forge/sdk/forge_log.py` to map log level strings to `logging` module constants.
- Modified `setup_logger` function in `skyvern/forge/sdk/forge_log.py` to use the configured `LOG_LEVEL` for `structlog` setup.
- Updated `infra/job-definition-staging.json`, `infra/task-definition-staging.json`, and `infra/workflow-job-definition-staging.json` to set `LOG_LEVEL` to `DEBUG`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->