### PR TITLE
make log_exception optional for s3 file download - there are expected cases when the file is not there and the function returns None

### DIFF
--- a/skyvern/forge/sdk/api/aws.py
+++ b/skyvern/forge/sdk/api/aws.py
@@ -65,13 +65,14 @@ class AsyncAWSClient:
             LOG.exception("S3 upload failed.", uri=uri)
 
     @execute_with_async_client(client_type=AWSClientType.S3)
-    async def download_file(self, uri: str, client: AioBaseClient = None) -> bytes | None:
+    async def download_file(self, uri: str, client: AioBaseClient = None, log_exception: bool = True) -> bytes | None:
         try:
             parsed_uri = S3Uri(uri)
             response = await client.get_object(Bucket=parsed_uri.bucket, Key=parsed_uri.key)
             return await response["Body"].read()
         except Exception:
-            LOG.exception("S3 download failed", uri=uri)
+            if log_exception:
+                LOG.exception("S3 download failed", uri=uri)
             return None
 
     @execute_with_async_client(client_type=AWSClientType.S3)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e88a6241a0b7ae901c319bd8127fb05e285bc98b  | 
|--------|--------|

### Summary:
Added optional `log_exception` parameter to `download_file` method to allow suppression of exception logging in `skyvern/forge/sdk/api/aws.py`.

**Key points**:
- Added `log_exception` parameter to `download_file` method in `skyvern/forge/sdk/api/aws.py`.
- When `log_exception` is `False`, exceptions are not logged.
- Default behavior remains unchanged (exceptions are logged).


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->