### PR TITLE
Open task in new tab when cmd or ctrl

### DIFF
--- a/skyvern-frontend/src/routes/tasks/list/TaskHistory.tsx
+++ b/skyvern-frontend/src/routes/tasks/list/TaskHistory.tsx
@@ -65,7 +65,7 @@ function TaskHistory() {
       window.open(
         window.location.origin + `/tasks/${id}/actions`,
         "_blank",
-        "noopener noreferrer",
+        "noopener,noreferrer",
       );
     } else {
       navigate(`${id}/actions`);

--- a/skyvern-frontend/src/routes/tasks/list/TaskHistory.tsx
+++ b/skyvern-frontend/src/routes/tasks/list/TaskHistory.tsx
@@ -60,6 +60,18 @@ function TaskHistory() {
     return <div>Error: {error?.message}</div>;
   }
 
+  function handleNavigate(event: React.MouseEvent, id: string) {
+    if (event.ctrlKey || event.metaKey) {
+      window.open(
+        window.location.origin + `/tasks/${id}/actions`,
+        "_blank",
+        "noopener noreferrer",
+      );
+    } else {
+      navigate(`${id}/actions`);
+    }
+  }
+
   return (
     <>
       <div className="rounded-md border">
@@ -86,33 +98,25 @@ function TaskHistory() {
                   <TableRow key={task.task_id}>
                     <TableCell
                       className="w-1/4 cursor-pointer"
-                      onClick={() => {
-                        navigate(`${task.task_id}/actions`);
-                      }}
+                      onClick={(event) => handleNavigate(event, task.task_id)}
                     >
                       {task.task_id}
                     </TableCell>
                     <TableCell
                       className="w-1/4 cursor-pointer max-w-64 overflow-hidden whitespace-nowrap overflow-ellipsis"
-                      onClick={() => {
-                        navigate(`${task.task_id}/actions`);
-                      }}
+                      onClick={(event) => handleNavigate(event, task.task_id)}
                     >
                       {task.request.url}
                     </TableCell>
                     <TableCell
                       className="w-1/6 cursor-pointer"
-                      onClick={() => {
-                        navigate(`${task.task_id}/actions`);
-                      }}
+                      onClick={(event) => handleNavigate(event, task.task_id)}
                     >
                       <StatusBadge status={task.status} />
                     </TableCell>
                     <TableCell
                       className="w-1/4 cursor-pointer"
-                      onClick={() => {
-                        navigate(`${task.task_id}/actions`);
-                      }}
+                      onClick={(event) => handleNavigate(event, task.task_id)}
                     >
                       {basicTimeFormat(task.created_at)}
                     </TableCell>

--- a/skyvern-frontend/src/routes/tasks/running/QueuedTasks.tsx
+++ b/skyvern-frontend/src/routes/tasks/running/QueuedTasks.tsx
@@ -37,7 +37,7 @@ function QueuedTasks() {
       window.open(
         window.location.origin + `/tasks/${id}/actions`,
         "_blank",
-        "noopener noreferrer",
+        "noopener,noreferrer",
       );
     } else {
       navigate(`${id}/actions`);

--- a/skyvern-frontend/src/routes/tasks/running/QueuedTasks.tsx
+++ b/skyvern-frontend/src/routes/tasks/running/QueuedTasks.tsx
@@ -32,6 +32,18 @@ function QueuedTasks() {
     },
   });
 
+  function handleNavigate(event: React.MouseEvent, id: string) {
+    if (event.ctrlKey || event.metaKey) {
+      window.open(
+        window.location.origin + `/tasks/${id}/actions`,
+        "_blank",
+        "noopener noreferrer",
+      );
+    } else {
+      navigate(`${id}/actions`);
+    }
+  }
+
   return (
     <div className="rounded-md border">
       <Table>
@@ -54,9 +66,7 @@ function QueuedTasks() {
                 <TableRow
                   key={task.task_id}
                   className="w-4"
-                  onClick={() => {
-                    navigate(`${task.task_id}/actions`);
-                  }}
+                  onClick={(event) => handleNavigate(event, task.task_id)}
                 >
                   <TableCell className="w-1/4">{task.task_id}</TableCell>
                   <TableCell className="w-1/4 max-w-64 overflow-hidden whitespace-nowrap overflow-ellipsis">

--- a/skyvern-frontend/src/routes/tasks/running/RunningTasks.tsx
+++ b/skyvern-frontend/src/routes/tasks/running/RunningTasks.tsx
@@ -36,14 +36,24 @@ function RunningTasks() {
     return <div>No running tasks</div>;
   }
 
+  function handleNavigate(event: React.MouseEvent, id: string) {
+    if (event.ctrlKey || event.metaKey) {
+      window.open(
+        window.location.origin + `/tasks/${id}/actions`,
+        "_blank",
+        "noopener noreferrer",
+      );
+    } else {
+      navigate(`/tasks/${id}/actions`);
+    }
+  }
+
   return runningTasks?.map((task) => {
     return (
       <Card
         key={task.task_id}
         className="hover:bg-muted/50 cursor-pointer"
-        onClick={() => {
-          navigate(`/tasks/${task.task_id}/actions`);
-        }}
+        onClick={(event) => handleNavigate(event, task.task_id)}
       >
         <CardHeader>
           <CardTitle className="overflow-hidden text-ellipsis whitespace-nowrap">

--- a/skyvern-frontend/src/routes/tasks/running/RunningTasks.tsx
+++ b/skyvern-frontend/src/routes/tasks/running/RunningTasks.tsx
@@ -41,7 +41,7 @@ function RunningTasks() {
       window.open(
         window.location.origin + `/tasks/${id}/actions`,
         "_blank",
-        "noopener noreferrer",
+        "noopener,noreferrer",
       );
     } else {
       navigate(`/tasks/${id}/actions`);


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4e2f154803c8345591562c6e447a1346937e9722  | 
|--------|--------|

### Summary:
Add functionality to open task details in a new tab when Ctrl or Cmd is pressed during the click event in TaskHistory, QueuedTasks, and RunningTasks components.

**Key points**:
- Added `handleNavigate` function in `skyvern-frontend/src/routes/tasks/list/TaskHistory.tsx`, `skyvern-frontend/src/routes/tasks/running/QueuedTasks.tsx`, and `skyvern-frontend/src/routes/tasks/running/RunningTasks.tsx` to handle navigation.
- Modified `onClick` event handlers in these files to use `handleNavigate`.
- `handleNavigate` opens task details in a new tab if Ctrl or Cmd is pressed, otherwise navigates in the same tab.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->