### PR TITLE
shu/task cancel agent logic

### DIFF
--- a/skyvern/exceptions.py
+++ b/skyvern/exceptions.py
@@ -350,3 +350,15 @@ class EmptySelect(SkyvernException):
         super().__init__(
             f"nothing is selected, try to select again. element_id={element_id}",
         )
+
+
+class TaskAlreadyCanceled(SkyvernHTTPException):
+    def __init__(self, new_status: str, task_id: str):
+        super().__init__(
+            f"Invalid task status transition to {new_status} for {task_id} because task is already canceled"
+        )
+
+
+class InvalidTaskStatusTransition(SkyvernHTTPException):
+    def __init__(self, old_status: str, new_status: str, task_id: str):
+        super().__init__(f"Invalid task status transition from {old_status} to {new_status} for {task_id}")

--- a/skyvern/forge/sdk/models.py
+++ b/skyvern/forge/sdk/models.py
@@ -15,13 +15,15 @@ class StepStatus(StrEnum):
     running = "running"
     failed = "failed"
     completed = "completed"
+    canceled = "canceled"
 
     def can_update_to(self, new_status: StepStatus) -> bool:
         allowed_transitions: dict[StepStatus, set[StepStatus]] = {
-            StepStatus.created: {StepStatus.running},
-            StepStatus.running: {StepStatus.completed, StepStatus.failed},
+            StepStatus.created: {StepStatus.running, StepStatus.canceled},
+            StepStatus.running: {StepStatus.completed, StepStatus.failed, StepStatus.canceled},
             StepStatus.failed: set(),
             StepStatus.completed: set(),
+            StepStatus.canceled: set(),
         }
         return new_status in allowed_transitions[self]
 


### PR DESCRIPTION
- task cancelling
- task_canceling API
- task cancel logic in agent

<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 63502348f392066fa9d96cd259d2d18d99998bf5  | 
|--------|--------|

### Summary:
Introduced task cancellation functionality with a new API endpoint, status transition validation, and handling of invalid transitions.

**Key points**:
- Introduced task cancellation functionality with a new API endpoint, status transition validation, and handling of invalid transitions.
- Added `InvalidTaskStatusTransition` and `TaskAlreadyCanceled` exceptions in `skyvern/exceptions.py`.
- Updated `execute_step`, `fail_task`, and `update_task` methods in `skyvern/forge/agent.py` to handle task cancellation and invalid status transitions.
- Added `cancel_task` endpoint in `skyvern/forge/sdk/routes/agent_protocol.py`.
- Modified `TaskStatus` in `skyvern/forge/sdk/schemas/tasks.py` to include `canceled` status and updated status transition logic.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->