### PR TITLE
when updating a step to canceled status, we can skip terminal status check when is_last = true

### DIFF
--- a/skyvern/forge/sdk/models.py
+++ b/skyvern/forge/sdk/models.py
@@ -66,6 +66,9 @@ class Step(BaseModel):
         if status and not old_status.can_update_to(status):
             raise ValueError(f"invalid_status_transition({old_status},{status},{self.step_id})")
 
+        if status == StepStatus.canceled:
+            return
+
         if status and status.requires_output() and output is None:
             raise ValueError(f"status_requires_output({status},{self.step_id})")
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 87cecf7ae4c7123fa11af15b60d07f1394a41e8b  | 
|--------|--------|

### Summary:
Added early return in `Step.validate_update` to skip further validation when status is `canceled`.

**Key points**:
- **File Modified**: `skyvern/forge/sdk/models.py`
- **Class Modified**: `Step`
- **Method Modified**: `validate_update`
- **Change**: Added early return if `status` is `StepStatus.canceled`.
- **Behavior**: Skips further validation checks when `status` is `canceled`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->