### PR TITLE
fix invisible svg bug

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -863,11 +863,12 @@ async function buildTreeFromBody(frame = "main.frame", open_select = false) {
         !isScriptOrStyle(element)
       ) {
         let elementObj = null;
+        let isParentSVG = element.closest("svg");
         if (element.tagName.toLowerCase() === "svg") {
           // if element is <svg> we save all attributes and its children
           elementObj = await buildElementObject(element, false);
-        } else if (element.closest("svg")) {
-          // if elemnet is the children of <svg>
+        } else if (isParentSVG && isParentSVG.getAttribute("unique_id")) {
+          // if elemnet is the children of the <svg> with an unique_id
           elementObj = await buildElementObject(element, false);
         } else {
           // character length limit for non-interactable elements should be 5000


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit acc7e47d8a0de9cbef634df1086f8140c3b3e15b  | 
|--------|--------|

### Summary:
Fixes bug in `skyvern/webeye/scraper/domUtils.js` to ensure child elements of an `<svg>` are processed if the parent `<svg>` has a `unique_id` attribute.

**Key points**:
- **File Modified**: `skyvern/webeye/scraper/domUtils.js`
- **Function Modified**: `buildTreeFromBody`
- **Bug Fix**: Ensures child elements of an `<svg>` are processed if the parent `<svg>` has a `unique_id` attribute.
- **Change Details**: Added a check for `isParentSVG` and its `unique_id` attribute before processing child elements of `<svg>`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->