### PR TITLE
Salih/new saved task parameter

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
@@ -148,6 +148,7 @@ function createTaskTemplateRequestObject(values: SavedTaskFormValues) {
   return {
     title: values.title,
     description: values.description,
+    is_saved_task: true,
     webhook_callback_url: values.webhookCallbackUrl,
     proxy_location: values.proxyLocation,
     workflow_definition: {

--- a/skyvern-frontend/src/routes/tasks/create/SavedTasks.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTasks.tsx
@@ -20,6 +20,7 @@ function createEmptyTaskTemplate() {
   return {
     title: "New Template",
     description: "",
+    is_saved_task: true,
     webhook_callback_url: null,
     proxy_location: "RESIDENTIAL",
     workflow_definition: {
@@ -53,7 +54,9 @@ function SavedTasks() {
     queryKey: ["workflows"],
     queryFn: async () => {
       const client = await getClient(credentialGetter);
-      return client.get("/workflows").then((response) => response.data);
+      return client
+        .get("/workflows?only_saved_tasks=true")
+        .then((response) => response.data);
     },
   });
 

--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -774,7 +774,6 @@ class AgentDB:
         webhook_callback_url: str | None = None,
         workflow_permanent_id: str | None = None,
         version: int | None = None,
-        is_saved_task: bool = False,
     ) -> Workflow:
         async with self.Session() as session:
             workflow = WorkflowModel(
@@ -784,7 +783,6 @@ class AgentDB:
                 workflow_definition=workflow_definition,
                 proxy_location=proxy_location,
                 webhook_callback_url=webhook_callback_url,
-                is_saved_task=is_saved_task,
             )
             if workflow_permanent_id:
                 workflow.workflow_permanent_id = workflow_permanent_id
@@ -840,8 +838,6 @@ class AgentDB:
         organization_id: str,
         page: int = 1,
         page_size: int = 10,
-        only_saved_tasks: bool = False,
-        only_workflows: bool = False,
     ) -> list[Workflow]:
         """
         Get all workflows with the latest version for the organization.
@@ -865,18 +861,17 @@ class AgentDB:
                     )
                     .subquery()
                 )
-                main_query = select(WorkflowModel).join(
-                    subquery,
-                    (WorkflowModel.organization_id == subquery.c.organization_id)
-                    & (WorkflowModel.workflow_permanent_id == subquery.c.workflow_permanent_id)
-                    & (WorkflowModel.version == subquery.c.max_version),
-                )
-                if only_saved_tasks:
-                    main_query = main_query.where(WorkflowModel.is_saved_task.is_(True))
-                elif only_workflows:
-                    main_query = main_query.where(WorkflowModel.is_saved_task.is_(False))
                 main_query = (
-                    main_query.order_by(WorkflowModel.created_at.desc()).limit(page_size).offset(db_page * page_size)
+                    select(WorkflowModel)
+                    .join(
+                        subquery,
+                        (WorkflowModel.organization_id == subquery.c.organization_id)
+                        & (WorkflowModel.workflow_permanent_id == subquery.c.workflow_permanent_id)
+                        & (WorkflowModel.version == subquery.c.max_version),
+                    )
+                    .order_by(WorkflowModel.created_at.desc())  # Example ordering by creation date
+                    .limit(page_size)
+                    .offset(db_page * page_size)
                 )
                 workflows = (await session.scalars(main_query)).all()
                 return [convert_to_workflow(workflow, self.debug_enabled) for workflow in workflows]

--- a/skyvern/forge/sdk/db/models.py
+++ b/skyvern/forge/sdk/db/models.py
@@ -189,7 +189,6 @@ class WorkflowModel(Base):
 
     workflow_permanent_id = Column(String, nullable=False, default=generate_workflow_permanent_id, index=True)
     version = Column(Integer, default=1, nullable=False)
-    is_saved_task = Column(Boolean, default=False, nullable=False)
 
 
 class WorkflowRunModel(Base):

--- a/skyvern/forge/sdk/db/utils.py
+++ b/skyvern/forge/sdk/db/utils.py
@@ -160,7 +160,6 @@ def convert_to_workflow(workflow_model: WorkflowModel, debug_enabled: bool = Fal
         webhook_callback_url=workflow_model.webhook_callback_url,
         proxy_location=(ProxyLocation(workflow_model.proxy_location) if workflow_model.proxy_location else None),
         version=workflow_model.version,
-        is_saved_task=workflow_model.is_saved_task,
         description=workflow_model.description,
         workflow_definition=WorkflowDefinition.model_validate(workflow_model.workflow_definition),
         created_at=workflow_model.created_at,

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -654,27 +654,16 @@ async def delete_workflow(
 async def get_workflows(
     page: int = Query(1, ge=1),
     page_size: int = Query(10, ge=1),
-    only_saved_tasks: bool = Query(False),
-    only_workflows: bool = Query(False),
     current_org: Organization = Depends(org_auth_service.get_current_org),
 ) -> list[Workflow]:
     """
     Get all workflows with the latest version for the organization.
     """
     analytics.capture("skyvern-oss-agent-workflows-get")
-
-    if only_saved_tasks and only_workflows:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="only_saved_tasks and only_workflows cannot be used together",
-        )
-
     return await app.WORKFLOW_SERVICE.get_workflows_by_organization_id(
         organization_id=current_org.organization_id,
         page=page,
         page_size=page_size,
-        only_saved_tasks=only_saved_tasks,
-        only_workflows=only_workflows,
     )
 
 

--- a/skyvern/forge/sdk/workflow/models/workflow.py
+++ b/skyvern/forge/sdk/workflow/models/workflow.py
@@ -44,7 +44,6 @@ class Workflow(BaseModel):
     title: str
     workflow_permanent_id: str
     version: int
-    is_saved_task: bool
     description: str | None = None
     workflow_definition: WorkflowDefinition
     proxy_location: ProxyLocation | None = None

--- a/skyvern/forge/sdk/workflow/models/yaml.py
+++ b/skyvern/forge/sdk/workflow/models/yaml.py
@@ -194,4 +194,3 @@ class WorkflowCreateYAMLRequest(BaseModel):
     proxy_location: ProxyLocation | None = None
     webhook_callback_url: str | None = None
     workflow_definition: WorkflowDefinitionYAML
-    is_saved_task: bool = False

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -281,7 +281,6 @@ class WorkflowService:
         webhook_callback_url: str | None = None,
         workflow_permanent_id: str | None = None,
         version: int | None = None,
-        is_saved_task: bool = False,
     ) -> Workflow:
         return await app.DATABASE.create_workflow(
             title=title,
@@ -292,7 +291,6 @@ class WorkflowService:
             webhook_callback_url=webhook_callback_url,
             workflow_permanent_id=workflow_permanent_id,
             version=version,
-            is_saved_task=is_saved_task,
         )
 
     async def get_workflow(self, workflow_id: str, organization_id: str | None = None) -> Workflow:
@@ -321,8 +319,6 @@ class WorkflowService:
         organization_id: str,
         page: int = 1,
         page_size: int = 10,
-        only_saved_tasks: bool = False,
-        only_workflows: bool = False,
     ) -> list[Workflow]:
         """
         Get all workflows with the latest version for the organization.
@@ -331,8 +327,6 @@ class WorkflowService:
             organization_id=organization_id,
             page=page,
             page_size=page_size,
-            only_saved_tasks=only_saved_tasks,
-            only_workflows=only_workflows,
         )
 
     async def update_workflow(
@@ -779,7 +773,6 @@ class WorkflowService:
                     webhook_callback_url=request.webhook_callback_url,
                     workflow_permanent_id=workflow_permanent_id,
                     version=existing_version + 1,
-                    is_saved_task=request.is_saved_task,
                 )
             else:
                 workflow = await self.create_workflow(
@@ -789,7 +782,6 @@ class WorkflowService:
                     organization_id=organization_id,
                     proxy_location=request.proxy_location,
                     webhook_callback_url=request.webhook_callback_url,
-                    is_saved_task=request.is_saved_task,
                 )
             # Create parameters from the request
             parameters: dict[str, PARAMETER_TYPE] = {}


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 441f9fe066b8bb6422cbfc9853a2bd9323656011  | 
|--------|--------|

### Summary:
Added `is_saved_task` parameter to task template creation and updated API to fetch only saved tasks.

**Key points**:
- Added `is_saved_task: true` to task template creation in `skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx` and `skyvern-frontend/src/routes/tasks/create/SavedTasks.tsx`.
- Updated API call in `skyvern-frontend/src/routes/tasks/create/SavedTasks.tsx` to fetch only saved tasks by adding `only_saved_tasks=true` query parameter.
- Removed `is_saved_task` parameter from `create_workflow` and `get_workflows_by_organization_id` functions in `skyvern/forge/sdk/db/client.py`.
- Removed `is_saved_task` field from `WorkflowModel` in `skyvern/forge/sdk/db/models.py`.
- Updated `get_workflows` endpoint in `skyvern/forge/sdk/routes/agent_protocol.py` to remove `only_saved_tasks` and `only_workflows` query parameters.
- Removed `is_saved_task` from `Workflow` model in `skyvern/forge/sdk/workflow/models/workflow.py` and `skyvern/forge/sdk/workflow/models/yaml.py`.
- Updated `create_workflow_from_request` in `skyvern/forge/sdk/workflow/service.py` to remove `is_saved_task` handling.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->