### PR TITLE
Add is_saved_task parameter

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
@@ -148,6 +148,7 @@ function createTaskTemplateRequestObject(values: SavedTaskFormValues) {
   return {
     title: values.title,
     description: values.description,
+    is_saved_task: true,
     webhook_callback_url: values.webhookCallbackUrl,
     proxy_location: values.proxyLocation,
     workflow_definition: {

--- a/skyvern-frontend/src/routes/tasks/create/SavedTasks.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTasks.tsx
@@ -20,6 +20,7 @@ function createEmptyTaskTemplate() {
   return {
     title: "New Template",
     description: "",
+    is_saved_task: true,
     webhook_callback_url: null,
     proxy_location: "RESIDENTIAL",
     workflow_definition: {
@@ -53,7 +54,9 @@ function SavedTasks() {
     queryKey: ["workflows"],
     queryFn: async () => {
       const client = await getClient(credentialGetter);
-      return client.get("/workflows").then((response) => response.data);
+      return client
+        .get("/workflows?only_saved_tasks=true")
+        .then((response) => response.data);
     },
   });
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0bf4e9d682cde2272b7c6a973ab3f21f3608059b  | 
|--------|--------|

### Summary:
Added `is_saved_task` parameter to task creation and retrieval processes in `SavedTaskForm.tsx` and `SavedTasks.tsx`.

**Key points**:
- Added `is_saved_task: true` to the task template in `skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx`.
- Modified `createEmptyTaskTemplate` in `skyvern-frontend/src/routes/tasks/create/SavedTasks.tsx` to include `is_saved_task: true`.
- Updated `useQuery` in `SavedTasks` to fetch only saved tasks by adding `only_saved_tasks=true` to the API request.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->