### PR TITLE
Fix download to S3 block

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -615,7 +615,7 @@ class DownloadToS3Block(Block):
 
         uri = None
         try:
-            uri = f"s3://{SettingsManager.get_settings().AWS_S3_BUCKET_DOWNLOADS}/{SettingsManager.get_settings().ENV}/{workflow_run_id}/{uuid.uuid4()}"
+            uri = f"s3://{SettingsManager.get_settings().AWS_S3_BUCKET_UPLOADS}/{SettingsManager.get_settings().ENV}/{workflow_run_id}/{uuid.uuid4()}"
             await self._upload_file_to_s3(uri, file_path)
         except Exception as e:
             LOG.error("DownloadToS3Block: Failed to upload file to S3", uri=uri, error=str(e))


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 69c722b384218a4c1045174ec5254a7956d4f046  | 
|--------|--------|

### Summary:
Corrected S3 bucket name in `DownloadToS3Block` to ensure files are uploaded to the correct bucket.

**Key points**:
- **File Modified**: `skyvern/forge/sdk/workflow/models/block.py`
- **Class Modified**: `DownloadToS3Block`
- **Method Modified**: `execute`
- **Change**: Corrected S3 bucket name from `AWS_S3_BUCKET_DOWNLOADS` to `AWS_S3_BUCKET_UPLOADS`.
- **Impact**: Ensures files are uploaded to the correct S3 bucket.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->