### PR TITLE
add api key expired message to the 403 when an api key is expired/invalid

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -566,18 +566,19 @@ class AgentDB:
         organization_id: str,
         token_type: OrganizationAuthTokenType,
         token: str,
+        valid: bool | None = True,
     ) -> OrganizationAuthToken | None:
         try:
             async with self.Session() as session:
-                if token_obj := (
-                    await session.scalars(
-                        select(OrganizationAuthTokenModel)
-                        .filter_by(organization_id=organization_id)
-                        .filter_by(token_type=token_type)
-                        .filter_by(token=token)
-                        .filter_by(valid=True)
-                    )
-                ).first():
+                query = (
+                    select(OrganizationAuthTokenModel)
+                    .filter_by(organization_id=organization_id)
+                    .filter_by(token_type=token_type)
+                    .filter_by(token=token)
+                )
+                if valid is not None:
+                    query = query.filter_by(valid=valid)
+                if token_obj := (await session.scalars(query)).first():
                     return convert_to_organization_auth_token(token_obj)
                 else:
                     return None

--- a/skyvern/forge/sdk/services/org_auth_service.py
+++ b/skyvern/forge/sdk/services/org_auth_service.py
@@ -109,11 +109,18 @@ async def _get_current_org_cached(x_api_key: str, db: AgentDB) -> Organization:
         organization_id=organization.organization_id,
         token_type=OrganizationAuthTokenType.api,
         token=x_api_key,
+        valid=None,
     )
     if not api_key_db_obj:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid credentials",
+        )
+
+    if api_key_db_obj.valid is False:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Your API key has expired. Please retrieve the latest one from https://app.skyvern.com/settings",
         )
 
     # set organization_id in skyvern context and log context


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f5025641817f3c91bef058759cd3fb21fe2ef61f  | 
|--------|--------|

### Summary:
Added specific error message for expired API keys in `skyvern/forge/sdk/db/client.py` and `skyvern/forge/sdk/services/org_auth_service.py`.

**Key points**:
- **Modified** `validate_org_auth_token` in `skyvern/forge/sdk/db/client.py` to accept a `valid` parameter.
- **Updated** `_get_current_org_cached` in `skyvern/forge/sdk/services/org_auth_service.py` to raise a specific HTTP 403 error when the API key is expired.
- **Added** specific error message for expired API keys: "Your API key has expired. Please retrieve the latest one from https://app.skyvern.com/settings".


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->