### PR TITLE
enable step created->failed

### DIFF
--- a/skyvern/forge/sdk/models.py
+++ b/skyvern/forge/sdk/models.py
@@ -19,7 +19,7 @@ class StepStatus(StrEnum):
 
     def can_update_to(self, new_status: StepStatus) -> bool:
         allowed_transitions: dict[StepStatus, set[StepStatus]] = {
-            StepStatus.created: {StepStatus.running, StepStatus.canceled},
+            StepStatus.created: {StepStatus.running, StepStatus.failed, StepStatus.canceled},
             StepStatus.running: {StepStatus.completed, StepStatus.failed, StepStatus.canceled},
             StepStatus.failed: set(),
             StepStatus.completed: set(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5a3d3c562a09a436522bd5407e5272da6d711005  | 
|--------|--------|

### Summary:
Allow `StepStatus` to transition from `created` to `failed` in `skyvern/forge/sdk/models.py`.

**Key points**:
- Modified `skyvern/forge/sdk/models.py`.
- Updated `StepStatus.can_update_to` to allow transition from `StepStatus.created` to `StepStatus.failed`.
- Added `StepStatus.failed` to the allowed transitions for `StepStatus.created`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->