### PR TITLE
cancel stop loading window

### DIFF
--- a/skyvern/constants.py
+++ b/skyvern/constants.py
@@ -15,4 +15,4 @@ class ScrapeType(StrEnum):
     RELOAD = "reload"
 
 
-SCRAPE_TYPE_ORDER = [ScrapeType.NORMAL, ScrapeType.STOPLOADING, ScrapeType.RELOAD]
+SCRAPE_TYPE_ORDER = [ScrapeType.NORMAL, ScrapeType.NORMAL, ScrapeType.RELOAD]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4c22bdbd769cc0fc274182c99cc3f76a89c22938  | 
|--------|--------|

### Summary:
Replaced `STOPLOADING` scrape type with an additional `NORMAL` scrape type in the scraping retry logic.

**Key points**:
- **Modified** `SCRAPE_TYPE_ORDER` in `skyvern/constants.py` to replace `ScrapeType.STOPLOADING` with `ScrapeType.NORMAL`.
- **Updated** `_build_and_record_step_prompt` in `skyvern/forge/agent.py` to retry normal scraping twice before reloading the page.
- **Changed** error logging message in `_build_and_record_step_prompt` to reflect the new retry logic.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->