### PR TITLE
Add new diagnostic tabs

### DIFF
--- a/skyvern-frontend/src/routes/tasks/detail/StepArtifacts.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/StepArtifacts.tsx
@@ -53,6 +53,14 @@ function StepArtifacts({ id, stepProps }: Props) {
     (artifact) => artifact.artifact_type === ArtifactType.ActionScreenshot,
   );
 
+  const visibleElementsTree = artifacts?.find(
+    (artifact) => artifact.artifact_type === ArtifactType.VisibleElementsTree,
+  );
+
+  const llmRequest = artifacts?.find(
+    (artifact) => artifact.artifact_type === ArtifactType.LLMRequest,
+  );
+
   const visibleElementsTreeTrimmed = artifacts?.find(
     (artifact) =>
       artifact.artifact_type === ArtifactType.VisibleElementsTreeTrimmed,
@@ -72,14 +80,16 @@ function StepArtifacts({ id, stepProps }: Props) {
 
   return (
     <Tabs defaultValue="info" className="w-full">
-      <TabsList className="grid w-full h-16 grid-cols-4">
+      <TabsList className="grid w-full h-16 grid-cols-5">
         <TabsTrigger value="info">Info</TabsTrigger>
         <TabsTrigger value="screenshot_llm">Annotated Screenshots</TabsTrigger>
         <TabsTrigger value="screenshot_action">Action Screenshots</TabsTrigger>
         <TabsTrigger value="element_tree_trimmed">Element Tree</TabsTrigger>
+        <TabsTrigger value="html_element_tree">HTML Element Tree</TabsTrigger>
         <TabsTrigger value="llm_prompt">Prompt</TabsTrigger>
         <TabsTrigger value="llm_response_parsed">Action List</TabsTrigger>
         <TabsTrigger value="html_raw">HTML (Raw)</TabsTrigger>
+        <TabsTrigger value="llm_request">LLM Request (Raw)</TabsTrigger>
       </TabsList>
       <TabsContent value="info">
         <div className="flex flex-col gap-6 p-4">
@@ -158,6 +168,11 @@ function StepArtifacts({ id, stepProps }: Props) {
           <JSONArtifact artifact={visibleElementsTreeTrimmed} />
         ) : null}
       </TabsContent>
+      <TabsContent value="html_element_tree">
+        {visibleElementsTree ? (
+          <JSONArtifact artifact={visibleElementsTree} />
+        ) : null}
+      </TabsContent>
       <TabsContent value="llm_prompt">
         {llmPrompt ? <TextArtifact artifact={llmPrompt} /> : null}
       </TabsContent>
@@ -168,6 +183,9 @@ function StepArtifacts({ id, stepProps }: Props) {
       </TabsContent>
       <TabsContent value="html_raw">
         {htmlRaw ? <TextArtifact artifact={htmlRaw} /> : null}
+      </TabsContent>
+      <TabsContent value="llm_request">
+        {llmRequest ? <JSONArtifact artifact={llmRequest} /> : null}
       </TabsContent>
     </Tabs>
   );


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 39ae778ac3553e4636b9d369dbec27e66f59bae2  | 
|--------|--------|

### Summary:
Adds new diagnostic tabs for 'HTML Element Tree' and 'LLM Request (Raw)' in `StepArtifacts` component, handling new artifact types and updating UI accordingly.

**Key points**:
- **File Modified**: `skyvern-frontend/src/routes/tasks/detail/StepArtifacts.tsx`
- **Component Modified**: `StepArtifacts`
- **New Tabs Added**: 'HTML Element Tree' and 'LLM Request (Raw)'
- **New Artifact Types Handled**: `ArtifactType.VisibleElementsTree` and `ArtifactType.LLMRequest`
- **UI Changes**: Updated `TabsList` to include new tabs and `TabsContent` to display corresponding content if artifacts are present.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->