### PR TITLE
Add container util + ghost footer

### DIFF
--- a/skyvern-frontend/src/routes/root/RootLayout.tsx
+++ b/skyvern-frontend/src/routes/root/RootLayout.tsx
@@ -42,7 +42,7 @@ function RootLayout() {
             <GitHubLogoIcon className="w-6 h-6" />
           </Link>
         </div>
-        <main className="pl-72">
+        <main className="pl-72 pb-4">
           <Outlet />
         </main>
       </div>

--- a/skyvern-frontend/src/routes/settings/SettingsPageLayout.tsx
+++ b/skyvern-frontend/src/routes/settings/SettingsPageLayout.tsx
@@ -2,7 +2,7 @@ import { Outlet } from "react-router-dom";
 
 function SettingsPageLayout() {
   return (
-    <div className="max-w-6xl mx-auto px-8">
+    <div className="container mx-auto px-8">
       <main>
         <Outlet />
       </main>

--- a/skyvern-frontend/src/routes/tasks/TasksPageLayout.tsx
+++ b/skyvern-frontend/src/routes/tasks/TasksPageLayout.tsx
@@ -2,7 +2,7 @@ import { Outlet } from "react-router-dom";
 
 function TasksPageLayout() {
   return (
-    <div className="max-w-6xl mx-auto px-8">
+    <div className="container mx-auto px-8">
       <main>
         <Outlet />
       </main>

--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskLayout.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskLayout.tsx
@@ -2,7 +2,7 @@ import { Outlet } from "react-router-dom";
 
 function CreateNewTaskLayout() {
   return (
-    <main className="max-w-6xl mx-auto px-8">
+    <main className="container mx-auto px-8">
       <Outlet />
     </main>
   );


### PR DESCRIPTION
		- Use tailwind container util which sets max width based on screen size automatically
- Add a footer without any content so that main content has some bottom padding and doesn't have to think about it itself
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 503b6545ca9eb46449c639520b748a4dd54c6414  | 
|--------|--------|

### Summary:
Replaced fixed max-width with Tailwind CSS `container` utility and added a footer for consistent bottom padding in layout components.

**Key points**:
- Use Tailwind CSS `container` utility for responsive max-width in `BillingPageLayout`, `SettingsPageLayout`, `TasksPageLayout`, and `CreateNewTaskLayout`.
- Add a footer with `py-4` class to `RootLayout` components in `skyvern-frontend/cloud/routes/root/RootLayout.tsx` and `skyvern-frontend/src/routes/root/RootLayout.tsx` for consistent bottom padding.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->