### PR TITLE
add timeout for page.content()

### DIFF
--- a/skyvern/constants.py
+++ b/skyvern/constants.py
@@ -7,6 +7,7 @@ SKYVERN_DIR = Path(__file__).parent
 REPO_ROOT_DIR = SKYVERN_DIR.parent
 
 INPUT_TEXT_TIMEOUT = 120000  # 2 minutes
+PAGE_CONTENT_TIMEOUT = 300  # 5 mins
 
 
 class ScrapeType(StrEnum):

--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -52,7 +52,7 @@ from skyvern.webeye.actions.handler import ActionHandler
 from skyvern.webeye.actions.models import AgentStepOutput, DetailedAgentStepOutput
 from skyvern.webeye.actions.responses import ActionResult
 from skyvern.webeye.browser_factory import BrowserState
-from skyvern.webeye.scraper.scraper import ElementTreeFormat, ScrapedPage, scrape_website
+from skyvern.webeye.scraper.scraper import ElementTreeFormat, ScrapedPage, get_page_content, scrape_website
 
 LOG = structlog.get_logger()
 
@@ -786,7 +786,7 @@ class ForgeAgent:
             )
 
         try:
-            html = await browser_state.page.content()
+            html = await get_page_content(browser_state.page)
             await app.ARTIFACT_MANAGER.create_artifact(
                 step=step,
                 artifact_type=ArtifactType.HTML_ACTION,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit df3f7125c46b8a15a627e673bdc1900652e5ceeb  | 
|--------|--------|

### Summary:
Introduced a timeout for the `page.content()` method by adding a `get_page_content` function with a timeout parameter and updating relevant methods to use it.

**Key points**:
- Added `PAGE_CONTENT_TIMEOUT` constant (300 seconds) in `skyvern/constants.py`.
- Created `get_page_content` function in `skyvern/webeye/scraper/scraper.py` with a timeout parameter.
- Updated `record_artifacts_after_action` method in `skyvern/forge/agent.py` to use `get_page_content`.
- Modified `scrape_web_unsafe` function in `skyvern/webeye/scraper/scraper.py` to use `get_page_content` with error handling.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->