### PR TITLE
Show currently active key in settings

### DIFF
--- a/skyvern-frontend/src/routes/settings/Settings.tsx
+++ b/skyvern-frontend/src/routes/settings/Settings.tsx
@@ -14,10 +14,13 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { envCredential } from "@/util/env";
+import { HiddenCopyableInput } from "@/components/ui/hidden-copyable-input";
 
 function Settings() {
   const { environment, organization, setEnvironment, setOrganization } =
     useSettingsStore();
+  const apiKey = envCredential;
 
   return (
     <div className="flex flex-col gap-8">
@@ -53,6 +56,15 @@ function Settings() {
               </Select>
             </div>
           </div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader className="border-b-2">
+          <CardTitle className="text-lg">API Key</CardTitle>
+          <CardDescription>Currently active API key</CardDescription>
+        </CardHeader>
+        <CardContent className="p-8">
+          <HiddenCopyableInput value={apiKey ?? "API key not found"} />
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2f4d811367af85db7a5fe6149933821b57081d6e  | 
|--------|--------|

### Summary:
Added a new card to display the currently active API key in the `Settings` component.

**Key points**:
- Added a new card to display the currently active API key in `skyvern-frontend/src/routes/settings/Settings.tsx`.
- Imported `envCredential` from `@/util/env` to fetch the API key.
- Used `HiddenCopyableInput` component to display the API key.
- Updated the `Settings` component to include the new card for the API key.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->