### PR TITLE
allow any origins to pass request to skyvern backend by default; make the ALLOWED_ORIGINS configurable through environment

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -31,6 +31,7 @@ class Settings(BaseSettings):
     JSON_LOGGING: bool = False
     LOG_LEVEL: str = "INFO"
     PORT: int = 8000
+    ALLOWED_ORIGINS: list[str] = ["*"]
 
     # Secret key for JWT. Please generate your own secret key in production
     SECRET_KEY: str = "RX1NvhujcJqBPi8O78-7aSfJEWuT86-fll4CzKc_uek"

--- a/skyvern/forge/api_app.py
+++ b/skyvern/forge/api_app.py
@@ -38,19 +38,9 @@ def get_agent_app(router: APIRouter = base_router) -> FastAPI:
     app = FastAPI()
 
     # Add CORS middleware
-    origins = [
-        "http://localhost:5000",
-        "http://127.0.0.1:5000",
-        "http://localhost:8000",
-        "http://127.0.0.1:8000",
-        "http://localhost:8080",
-        "http://127.0.0.1:8080",
-        # Add any other origins you want to whitelist
-    ]
-
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=origins,
+        allow_origins=SettingsManager.get_settings().ALLOWED_ORIGINS,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4c1c302071154857cc80d9e30c2d0b676ac7f49a  | 
|--------|--------|

### Summary:
Allow any origins by default and make allowed origins configurable via environment variables in `skyvern/config.py` and `skyvern/forge/api_app.py`.

**Key points**:
- Updated `skyvern/config.py` to add `ALLOWED_ORIGINS` with a default value of `[*]`.
- Modified `skyvern/forge/api_app.py` to use `SettingsManager.get_settings().ALLOWED_ORIGINS` for CORS `allow_origins` configuration.
- Allows any origin by default and makes allowed origins configurable via environment variables.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->