### PR TITLE
Implement upload_file endpoint

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -48,7 +48,7 @@ class Settings(BaseSettings):
     # S3 bucket settings
     AWS_REGION: str = "us-east-1"
     AWS_S3_BUCKET_UPLOADS: str = "skyvern-uploads"
-    MAX_UPLOAD_FILE_SIZE: int = 100 * 1024 * 1024  # 10 MB
+    MAX_UPLOAD_FILE_SIZE: int = 10 * 1024 * 1024  # 10 MB
 
     SKYVERN_TELEMETRY: bool = True
     ANALYTICS_ID: str = "anonymous"

--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -48,6 +48,7 @@ class Settings(BaseSettings):
     # S3 bucket settings
     AWS_REGION: str = "us-east-1"
     AWS_S3_BUCKET_UPLOADS: str = "skyvern-uploads"
+    MAX_UPLOAD_FILE_SIZE: int = 100 * 1024 * 1024  # 10 MB
 
     SKYVERN_TELEMETRY: bool = True
     ANALYTICS_ID: str = "anonymous"

--- a/skyvern/forge/sdk/api/aws.py
+++ b/skyvern/forge/sdk/api/aws.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import Any, Callable
+from typing import IO, Any, Callable
 from urllib.parse import urlparse
 
 import aioboto3
@@ -53,6 +53,17 @@ class AsyncAWSClient:
             return uri
         except Exception:
             LOG.exception("S3 upload failed.", uri=uri)
+            return None
+
+    @execute_with_async_client(client_type=AWSClientType.S3)
+    async def upload_file_stream(self, uri: str, file_obj: IO[bytes], client: AioBaseClient = None) -> str | None:
+        try:
+            parsed_uri = S3Uri(uri)
+            await client.upload_fileobj(file_obj, parsed_uri.bucket, parsed_uri.key)
+            LOG.debug("Upload file stream success", uri=uri)
+            return uri
+        except Exception:
+            LOG.exception("S3 upload stream failed.", uri=uri)
             return None
 
     @execute_with_async_client(client_type=AWSClientType.S3)

--- a/skyvern/forge/sdk/api/aws.py
+++ b/skyvern/forge/sdk/api/aws.py
@@ -137,3 +137,6 @@ class S3Uri(object):
     @property
     def uri(self) -> str:
         return self._parsed.geturl()
+
+
+aws_client = AsyncAWSClient()

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1,8 +1,21 @@
+import datetime
+import uuid
 from typing import Annotated, Any
 
 import structlog
 import yaml
-from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Query, Request, Response, status
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+    Header,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+    UploadFile,
+    status,
+)
 from fastapi.responses import ORJSONResponse
 from pydantic import BaseModel
 
@@ -10,6 +23,7 @@ from skyvern import analytics
 from skyvern.exceptions import StepNotFound
 from skyvern.forge import app
 from skyvern.forge.prompts import prompt_engine
+from skyvern.forge.sdk.api.aws import aws_client
 from skyvern.forge.sdk.api.llm.exceptions import LLMProviderError
 from skyvern.forge.sdk.artifact.models import Artifact, ArtifactType
 from skyvern.forge.sdk.core import skyvern_context
@@ -735,4 +749,35 @@ async def update_organization(
         webhook_callback_url=org_update.webhook_callback_url,
         max_steps_per_run=org_update.max_steps_per_run,
         max_retries_per_step=org_update.max_retries_per_step,
+    )
+
+
+# Implement an endpoint that gets a single file and uploads it to S3
+@base_router.post("/upload_file/", include_in_schema=False)
+@base_router.post("/upload_file")
+async def upload_file(
+    file: UploadFile,
+    current_org: Organization = Depends(org_auth_service.get_current_org),
+) -> Response:
+    bucket = app.SETTINGS_MANAGER.AWS_S3_BUCKET_UPLOADS
+    todays_date = datetime.datetime.now().strftime("%Y-%m-%d")
+    uuid_prefixed_filename = f"{str(uuid.uuid4())}_{file.filename}"
+    s3_uri = (
+        f"s3://{bucket}/{app.SETTINGS_MANAGER.ENV}/{current_org.organization_id}/{todays_date}/{uuid_prefixed_filename}"
+    )
+    data: bytes = await file.read()
+    uploaded_s3_uri = await aws_client.upload_file(s3_uri, data)
+    if not uploaded_s3_uri:
+        raise HTTPException(status_code=500, detail="Failed to upload file to S3.")
+
+    # Generate a presigned URL for the uploaded file
+    presigned_urls = await aws_client.create_presigned_urls([uploaded_s3_uri])
+    if not presigned_urls:
+        raise HTTPException(status_code=500, detail="Failed to generate presigned URL.")
+
+    presigned_url = presigned_urls[0]
+    return ORJSONResponse(
+        content={"s3_uri": uploaded_s3_uri, "presigned_url": presigned_url},
+        status_code=200,
+        media_type="application/json",
     )


### PR DESCRIPTION
Uploads to:
```
s3://skyvern-uploads/<ENV>/<ORG_ID>/<TODAY'S DATE>/<UUID>_<FILENAME>
Ex:
s3://skyvern-uploads/local/o_221157791538210890/2024-07-03/2e95b6fd-9dd6-4c1b-a79f-0e8a24ab14c5_cat.avif
```
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 726cdcca4fa5bf53295606bf3fbcd24dcd7a162d  | 
|--------|--------|

### Summary:
Added `upload_file` endpoint to upload files to S3, initialized `aws_client`, and included methods for file stream uploads and size validation.

**Key points**:
- Added `upload_file` endpoint in `skyvern/forge/sdk/routes/agent_protocol.py` to upload files to S3.
- Endpoint uploads file to `s3://<bucket>/<env>/<org_id>/<date>/<uuid>_<filename>`.
- Returns S3 URI and presigned URL for the uploaded file.
- Added `aws_client` initialization in `skyvern/forge/sdk/api/aws.py`.
- Removed `AsyncAWSClient` initialization from `skyvern/forge/app.py`.
- Handles file reading, S3 upload, and presigned URL generation.
- Added `aws_client.upload_file_stream` method in `skyvern/forge/sdk/api/aws.py` to handle file stream uploads.
- Added `validate_file_size` function in `skyvern/forge/sdk/routes/agent_protocol.py` to check file size before upload.
- Updated `skyvern/config.py` to include `MAX_UPLOAD_FILE_SIZE` configuration.
- Example S3 path: `s3://skyvern-uploads/<ENV>/<ORG_ID>/<TODAY'S DATE>/<UUID>_<FILENAME>`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->