### PR TITLE
Implement upload_file endpoint

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -753,8 +753,14 @@ async def update_organization(
 
 
 async def validate_file_size(file: UploadFile) -> UploadFile:
-    # Check the file size
-    if file.size > app.SETTINGS_MANAGER.MAX_UPLOAD_FILE_SIZE:
+    try:
+        file.file.seek(0, 2)  # Move the pointer to the end of the file
+        size = file.file.tell()  # Get the current position of the pointer, which represents the file size
+        file.file.seek(0)  # Reset the pointer back to the beginning
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="Could not determine file size.") from e
+
+    if size > app.SETTINGS_MANAGER.MAX_FILE_SIZE:
         raise HTTPException(
             status_code=413,
             detail=f"File size exceeds the maximum allowed size ({app.SETTINGS_MANAGER.MAX_UPLOAD_FILE_SIZE} bytes)",


### PR DESCRIPTION
"Uploads to:\n```\ns3://skyvern-uploads/<ENV>/<ORG_ID>/<TODAY'S DATE>/<UUID>_<FILENAME>\nEx:\ns3://skyvern-uploads/local/o_221157791538210890/2024-07-03/2e95b6fd-9dd6-4c1b-a79f-0e8a24ab14c5_cat.avif\n```\n<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5f74f113cb8038b8dd8e6ef643e3e6d220d9a6b6  | 
|--------|--------|

### Summary:
Added `upload_file` endpoint to upload files to S3 with file size validation and presigned URL generation.

**Key points**:
- Added `upload_file` endpoint in `skyvern/forge/sdk/routes/agent_protocol.py` to upload files to S3.
- Endpoint uploads file to `s3://<bucket>/<env>/<org_id>/<date>/<uuid>_<filename>`.
- Returns S3 URI and presigned URL for the uploaded file.
- Added `aws_client` initialization in `skyvern/forge/sdk/api/aws.py`.
- Removed `AsyncAWSClient` initialization from `skyvern/forge/app.py`.
- Handles file reading, S3 upload, and presigned URL generation.
- Added `aws_client.upload_file_stream` method in `skyvern/forge/sdk/api/aws.py` to handle file stream uploads.
- Added `validate_file_size` function in `skyvern/forge/sdk/routes/agent_protocol.py` to check file size before upload.
- Updated `skyvern/config.py` to include `MAX_UPLOAD_FILE_SIZE` configuration.
- Example S3 path: `s3://skyvern-uploads/<ENV>/<ORG_ID>/<TODAY'S DATE>/<UUID>_<FILENAME>`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


----


<!-- ELLIPSIS_HIDDEN -->\n"