### PR TITLE
use css selector instead of xpath

### DIFF
--- a/skyvern/exceptions.py
+++ b/skyvern/exceptions.py
@@ -47,17 +47,17 @@ class ScriptNotFound(SkyvernException):
 
 
 class MissingElement(SkyvernException):
-    def __init__(self, xpath: str | None = None, element_id: str | None = None):
+    def __init__(self, selector: str | None = None, element_id: str | None = None):
         super().__init__(
             f"Found no elements. Might be due to previous actions which removed this element."
-            f" xpath={xpath} element_id={element_id}",
+            f" selector={selector} element_id={element_id}",
         )
 
 
 class MultipleElementsFound(SkyvernException):
-    def __init__(self, num: int, xpath: str | None = None, element_id: str | None = None):
+    def __init__(self, num: int, selector: str | None = None, element_id: str | None = None):
         super().__init__(
-            f"Found {num} elements. Expected 1. num_elements={num} xpath={xpath} element_id={element_id}",
+            f"Found {num} elements. Expected 1. num_elements={num} selector={selector} element_id={element_id}",
         )
 
 
@@ -316,6 +316,11 @@ class MissingElementDict(SkyvernException):
 class MissingElementInIframe(SkyvernException):
     def __init__(self, element_id: str) -> None:
         super().__init__(f"Found no iframe includes the element. element_id={element_id}")
+
+
+class MissingElementInCSSMap(SkyvernException):
+    def __init__(self, element_id: str) -> None:
+        super().__init__(f"Found no css selector in the CSS map for the element. element_id={element_id}")
 
 
 class InputActionOnSelect2Dropdown(SkyvernException):

--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -966,8 +966,8 @@ class ForgeAgent:
 
         await app.ARTIFACT_MANAGER.create_artifact(
             step=step,
-            artifact_type=ArtifactType.VISIBLE_ELEMENTS_ID_XPATH_MAP,
-            data=json.dumps(scraped_page.id_to_xpath_dict, indent=2).encode(),
+            artifact_type=ArtifactType.VISIBLE_ELEMENTS_ID_CSS_MAP,
+            data=json.dumps(scraped_page.id_to_css_dict, indent=2).encode(),
         )
         await app.ARTIFACT_MANAGER.create_artifact(
             step=step,

--- a/skyvern/forge/sdk/artifact/models.py
+++ b/skyvern/forge/sdk/artifact/models.py
@@ -21,11 +21,14 @@ class ArtifactType(StrEnum):
     LLM_REQUEST = "llm_request"
     LLM_RESPONSE = "llm_response"
     LLM_RESPONSE_PARSED = "llm_response_parsed"
-    VISIBLE_ELEMENTS_ID_XPATH_MAP = "visible_elements_id_xpath_map"
+    VISIBLE_ELEMENTS_ID_CSS_MAP = "visible_elements_id_css_map"
     VISIBLE_ELEMENTS_ID_FRAME_MAP = "visible_elements_id_frame_map"
     VISIBLE_ELEMENTS_TREE = "visible_elements_tree"
     VISIBLE_ELEMENTS_TREE_TRIMMED = "visible_elements_tree_trimmed"
     VISIBLE_ELEMENTS_TREE_IN_PROMPT = "visible_elements_tree_in_prompt"
+
+    # DEPRECATED. pls use VISIBLE_ELEMENTS_ID_CSS_MAP
+    VISIBLE_ELEMENTS_ID_XPATH_MAP = "visible_elements_id_xpath_map"
 
     # DEPRECATED. pls use HTML_SCRAPE or HTML_ACTION
     HTML = "html"

--- a/skyvern/forge/sdk/artifact/storage/base.py
+++ b/skyvern/forge/sdk/artifact/storage/base.py
@@ -13,7 +13,7 @@ FILE_EXTENTSION_MAP: dict[ArtifactType, str] = {
     ArtifactType.LLM_REQUEST: "json",
     ArtifactType.LLM_RESPONSE: "json",
     ArtifactType.LLM_RESPONSE_PARSED: "json",
-    ArtifactType.VISIBLE_ELEMENTS_ID_XPATH_MAP: "json",
+    ArtifactType.VISIBLE_ELEMENTS_ID_CSS_MAP: "json",
     ArtifactType.VISIBLE_ELEMENTS_ID_FRAME_MAP: "json",
     ArtifactType.VISIBLE_ELEMENTS_TREE: "json",
     ArtifactType.VISIBLE_ELEMENTS_TREE_TRIMMED: "json",
@@ -22,6 +22,8 @@ FILE_EXTENTSION_MAP: dict[ArtifactType, str] = {
     ArtifactType.HTML_ACTION: "html",
     ArtifactType.TRACE: "zip",
     ArtifactType.HAR: "har",
+    # DEPRECATED: we're using CSS selector map now
+    ArtifactType.VISIBLE_ELEMENTS_ID_XPATH_MAP: "json",
 }
 
 

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -111,7 +111,7 @@ class ScrapedPage(BaseModel):
     """
     Scraped response from a webpage, including:
     1. List of elements
-    2. ID to xpath map
+    2. ID to css map
     3. The element tree of the page (list of dicts). Each element has children and attributes.
     4. The screenshot (base64 encoded)
     5. The URL of the page
@@ -122,7 +122,7 @@ class ScrapedPage(BaseModel):
     elements: list[dict]
     id_to_element_dict: dict[str, dict] = {}
     id_to_frame_dict: dict[str, str] = {}
-    id_to_xpath_dict: dict[str, str]
+    id_to_css_dict: dict[str, str]
     element_tree: list[dict]
     element_tree_trimmed: list[dict]
     screenshots: list[bytes]
@@ -276,14 +276,14 @@ async def scrape_web_unsafe(
 
     _build_element_links(elements)
 
-    id_to_xpath_dict = {}
+    id_to_css_dict = {}
     id_to_element_dict = {}
     id_to_frame_dict = {}
 
     for element in elements:
         element_id = element["id"]
         # get_interactable_element_tree marks each interactable element with a unique_id attribute
-        id_to_xpath_dict[element_id] = f"//*[@{SKYVERN_ID_ATTR}='{element_id}']"
+        id_to_css_dict[element_id] = f"[{SKYVERN_ID_ATTR}='{element_id}']"
         id_to_element_dict[element_id] = element
         id_to_frame_dict[element_id] = element["frame"]
 
@@ -301,7 +301,7 @@ async def scrape_web_unsafe(
 
     return ScrapedPage(
         elements=elements,
-        id_to_xpath_dict=id_to_xpath_dict,
+        id_to_css_dict=id_to_css_dict,
         id_to_element_dict=id_to_element_dict,
         id_to_frame_dict=id_to_frame_dict,
         element_tree=element_tree,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit fe76bd7ac440dc1fd0f27b4a58f8e92dd1a10865  | 
|--------|--------|

### Summary:
Replaced XPath selectors with CSS selectors across the codebase for consistency and improved handling.

**Key points**:
- Replaced `xpath` with `css` selectors in `skyvern/exceptions.py` for `MissingElement` and `MultipleElementsFound` exceptions.
- Updated `skyvern/forge/agent.py` to use `id_to_css_dict` instead of `id_to_xpath_dict` for artifact creation.
- Modified `skyvern/forge/sdk/artifact/models.py` to deprecate `VISIBLE_ELEMENTS_ID_XPATH_MAP` and introduce `VISIBLE_ELEMENTS_ID_CSS_MAP`.
- Adjusted `skyvern/forge/sdk/artifact/storage/base.py` to map `VISIBLE_ELEMENTS_ID_CSS_MAP` to `json`.
- Refactored `skyvern/webeye/actions/handler.py` to use CSS selectors in various action handlers (`handle_click_action`, `handle_input_text_action`, etc.).
- Updated `skyvern/webeye/scraper/scraper.py` to build `id_to_css_dict` instead of `id_to_xpath_dict`.
- Changed `resolve_locator` function in `skyvern/webeye/utils/dom.py` to use CSS selectors.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->