### PR TITLE
Remove email file count limit

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -797,9 +797,6 @@ class SendEmailBlock(Block):
 
             # if the file path is a directory, add all files in the directory, skip directories, limit to 10 files
             if os.path.exists(path) and os.path.isdir(path):
-                if len(os.listdir(path)) > 10:
-                    LOG.warning("SendEmailBlock: Too many files in the directory, not attaching to email")
-                    continue
                 for file in os.listdir(path):
                     if os.path.isdir(os.path.join(path, file)):
                         LOG.warning("SendEmailBlock: Skipping directory", file=file)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 936c0b14197b9c14c7eef8ab17bc1e0700ac221d  | 
|--------|--------|

### Summary:
Removed the 10-file limit for email attachments when the file path is a directory in `SendEmailBlock` class.

**Key points**:
- Removed the 10-file limit for email attachments when the file path is a directory in `skyvern/forge/sdk/workflow/models/block.py`.
- Modified `_get_file_paths` method in `SendEmailBlock` class to include all files in the directory without limiting the count.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->