### PR TITLE
add step prepare and browser clean up

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -503,6 +503,10 @@ class ForgeAgent:
                 step_retry=step.retry_index,
             )
             step = await self.update_step(step=step, status=StepStatus.running)
+            await app.AGENT_FUNCTION.prepare_step_execution(
+                organization=organization, task=task, step=step, browser_state=browser_state
+            )
+
             (
                 scraped_page,
                 extract_action_prompt,

--- a/skyvern/forge/agent_functions.py
+++ b/skyvern/forge/agent_functions.py
@@ -5,6 +5,7 @@ from skyvern.forge import app
 from skyvern.forge.async_operations import AsyncOperation
 from skyvern.forge.sdk.models import Organization, Step, StepStatus
 from skyvern.forge.sdk.schemas.tasks import Task, TaskStatus
+from skyvern.webeye.browser_factory import BrowserState
 
 
 class AgentFunction:
@@ -14,7 +15,7 @@ class AgentFunction:
         step: Step,
     ) -> None:
         """
-        Checks if the step can be executed.
+        Checks if the step can be executed. It is called before the step is executed.
         :return: A tuple of whether the step can be executed and a list of reasons why it can't be executed.
         """
         reasons = []
@@ -35,6 +36,18 @@ class AgentFunction:
         can_execute = has_valid_task_status and has_valid_step_status and has_no_running_steps
         if not can_execute:
             raise StepUnableToExecuteError(step_id=step.step_id, reason=f"Cannot execute step. Reasons: {reasons}")
+
+    async def prepare_step_execution(
+        self,
+        organization: Organization | None,
+        task: Task,
+        step: Step,
+        browser_state: BrowserState,
+    ) -> None:
+        """
+        Get prepared for the step execution. It's called at the first beginning when step running.
+        """
+        return
 
     def generate_async_operations(
         self,

--- a/skyvern/webeye/browser_manager.py
+++ b/skyvern/webeye/browser_manager.py
@@ -30,6 +30,7 @@ class BrowserManager:
         (
             browser_context,
             browser_artifacts,
+            browser_cleanup,
         ) = await BrowserContextFactory.create_browser_context(
             pw,
             proxy_location=proxy_location,
@@ -41,6 +42,7 @@ class BrowserManager:
             browser_context=browser_context,
             page=None,
             browser_artifacts=browser_artifacts,
+            browser_cleanup=browser_cleanup,
         )
 
     async def get_or_create_for_task(self, task: Task) -> BrowserState:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ea97f7e349d884535fe1da4418a6b5a77f8dbc29  | 
|--------|--------|

### Summary:
Added step preparation and browser cleanup functionality across `agent`, `agent_functions`, `browser_factory`, and `browser_manager` modules.

**Key points**:
- Added `prepare_step_execution` method in `skyvern/forge/agent_functions.py` to prepare for step execution.
- Modified `agent_step` in `skyvern/forge/agent.py` to call `prepare_step_execution` before executing a step.
- Updated `BrowserContextFactory` in `skyvern/webeye/browser_factory.py` to return a `BrowserCleanupFunc`.
- Ensured `BrowserCleanupFunc` is called in `BrowserState.close` method in `skyvern/webeye/browser_factory.py`.
- Updated `BrowserManager` in `skyvern/webeye/browser_manager.py` to handle the new `BrowserCleanupFunc`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->