### PR TITLE
support shadow dom

### DIFF
--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -6,7 +6,7 @@ from enum import StrEnum
 from typing import Any, Awaitable, Callable
 
 import structlog
-from playwright.async_api import Frame, Page
+from playwright.async_api import ElementHandle, Frame, Page
 from pydantic import BaseModel
 
 from skyvern.constants import PAGE_CONTENT_TIMEOUT, SKYVERN_DIR, SKYVERN_ID_ATTR
@@ -318,10 +318,10 @@ async def get_page_content(page: Page, timeout: float = PAGE_CONTENT_TIMEOUT) ->
         return await page.content()
 
 
-async def get_select2_options(page: Page) -> list[dict[str, Any]]:
+async def get_select2_options(page: Page, element: ElementHandle) -> list[dict[str, Any]]:
     await page.evaluate(JS_FUNCTION_DEFS)
-    js_script = "async () => await getSelect2Options()"
-    return await page.evaluate(js_script)
+    js_script = "async (element) => await getSelect2Options(element)"
+    return await page.evaluate(js_script, element)
 
 
 async def get_interactable_element_tree_in_frame(

--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -198,8 +198,11 @@ class Select2Dropdown:
     async def close(self, timeout: float = SettingsManager.get_settings().BROWSER_ACTION_TIMEOUT_MS) -> None:
         await self.page.locator("#select2-drop").press("Escape", timeout=timeout)
 
-    async def get_options(self) -> typing.List[SkyvernOptionType]:
-        options = await get_select2_options(self.page)
+    async def get_options(
+        self, timeout: float = SettingsManager.get_settings().BROWSER_ACTION_TIMEOUT_MS
+    ) -> typing.List[SkyvernOptionType]:
+        element_handler = await self.skyvern_element.locator.element_handle(timeout=timeout)
+        options = await get_select2_options(self.page, element_handler)
         return typing.cast(typing.List[SkyvernOptionType], options)
 
     async def select_by_index(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 83e29b2aaf454f3866b201b6bff41b363c513c0f  | 
|--------|--------|

### Summary:
Added support for handling Shadow DOM elements in the scraping process, including updates to select2 dropdown interactions.

**Key points**:
- Updated `isInteractable` in `skyvern/webeye/scraper/domUtils.js` to return `false` for elements with `shadowRoot`.
- Modified `getSelect2OptionElements` and `getSelect2Options` in `skyvern/webeye/scraper/domUtils.js` to accept an `element` parameter and use its root node.
- Added `getDOMElementBySkyvenElement` in `skyvern/webeye/scraper/domUtils.js` to locate elements within shadow roots.
- Updated `buildTreeFromBody` in `skyvern/webeye/scraper/domUtils.js` to handle shadow DOM elements and their children.
- Modified `get_select2_options` in `skyvern/webeye/scraper/scraper.py` to accept an `element` parameter.
- Updated `Select2Dropdown.get_options` in `skyvern/webeye/utils/dom.py` to pass the element to `get_select2_options`.
- Ensured all relevant functions handle shadow DOM elements appropriately.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->