### PR TITLE
exclude aria-hidden elements

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -223,6 +223,11 @@ function isElementVisible(element) {
     return false;
   }
 
+  if (element.hasAttribute("aria-hidden")) {
+    const ariaHidden = element.getAttribute("aria-hidden").toLowerCase();
+    return ariaHidden === "false";
+  }
+
   const style = getElementComputedStyle(element);
   if (!style) return true;
   if (style.display === "contents") {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 621daf3132f43c516c9e66762067cc2b6970fe47  | 
|--------|--------|

### Summary:
Updated `isElementVisible` in `skyvern/webeye/scraper/domUtils.js` to exclude elements with `aria-hidden='true'`.

**Key points**:
- Updated `skyvern/webeye/scraper/domUtils.js`.
- Modified `isElementVisible` function to check for `aria-hidden` attribute.
- Elements with `aria-hidden='true'` are now considered not visible.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->