### PR TITLE
Implement get workflow runs endpoint

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -47,6 +47,7 @@ from skyvern.forge.sdk.workflow.models.workflow import (
     RunWorkflowResponse,
     Workflow,
     WorkflowRequestBody,
+    WorkflowRun,
     WorkflowRunStatusResponse,
 )
 from skyvern.forge.sdk.workflow.models.yaml import WorkflowCreateYAMLRequest
@@ -548,6 +549,52 @@ async def execute_workflow(
     return RunWorkflowResponse(
         workflow_id=workflow_id,
         workflow_run_id=workflow_run.workflow_run_id,
+    )
+
+
+@base_router.get(
+    "/workflows/runs",
+    response_model=list[WorkflowRun],
+)
+@base_router.get(
+    "/workflows/runs/",
+    response_model=list[WorkflowRun],
+    include_in_schema=False,
+)
+async def get_workflow_runs(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(10, ge=1),
+    current_org: Organization = Depends(org_auth_service.get_current_org),
+) -> list[WorkflowRun]:
+    analytics.capture("skyvern-oss-agent-workflow-runs-get")
+    return await app.WORKFLOW_SERVICE.get_workflow_runs(
+        organization_id=current_org.organization_id,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@base_router.get(
+    "/workflows/{workflow_permanent_id}/runs",
+    response_model=list[WorkflowRun],
+)
+@base_router.get(
+    "/workflows/{workflow_permanent_id}/runs/",
+    response_model=list[WorkflowRun],
+    include_in_schema=False,
+)
+async def get_workflow_runs_for_workflow_permanent_id(
+    workflow_permanent_id: str,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(10, ge=1),
+    current_org: Organization = Depends(org_auth_service.get_current_org),
+) -> list[WorkflowRun]:
+    analytics.capture("skyvern-oss-agent-workflow-runs-get")
+    return await app.WORKFLOW_SERVICE.get_workflow_runs_for_workflow_permanent_id(
+        workflow_permanent_id=workflow_permanent_id,
+        organization_id=current_org.organization_id,
+        page=page,
+        page_size=page_size,
     )
 
 

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -364,6 +364,19 @@ class WorkflowService:
             organization_id=organization_id,
         )
 
+    async def get_workflow_runs(self, organization_id: str, page: int = 1, page_size: int = 10) -> list[WorkflowRun]:
+        return await app.DATABASE.get_workflow_runs(organization_id=organization_id, page=page, page_size=page_size)
+
+    async def get_workflow_runs_for_workflow_permanent_id(
+        self, workflow_permanent_id: str, organization_id: str, page: int = 1, page_size: int = 10
+    ) -> list[WorkflowRun]:
+        return await app.DATABASE.get_workflow_runs_for_workflow_permanent_id(
+            workflow_permanent_id=workflow_permanent_id,
+            organization_id=organization_id,
+            page=page,
+            page_size=page_size,
+        )
+
     async def create_workflow_run(self, workflow_request: WorkflowRequestBody, workflow_id: str) -> WorkflowRun:
         return await app.DATABASE.create_workflow_run(
             workflow_id=workflow_id,
@@ -414,9 +427,6 @@ class WorkflowService:
             workflow_run_id=workflow_run_id,
             status=WorkflowRunStatus.terminated,
         )
-
-    async def get_workflow_runs(self, workflow_id: str) -> list[WorkflowRun]:
-        return await app.DATABASE.get_workflow_runs(workflow_id=workflow_id)
 
     async def get_workflow_run(self, workflow_run_id: str) -> WorkflowRun:
         workflow_run = await app.DATABASE.get_workflow_run(workflow_run_id=workflow_run_id)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7d3dc50dbed2ff72fe6402b94c9b5698f5fab632  | 
|--------|--------|

### Summary:
Implemented endpoints to fetch workflow runs by `workflow_id`, `organization_id`, and `workflow_permanent_id` with pagination.

**Key points**:
- Added `get_workflow_runs_by_workflow_id` method in `skyvern/forge/sdk/db/client.py` to fetch workflow runs by `workflow_id` and `organization_id` with pagination.
- Added `get_workflow_runs` method in `skyvern/forge/sdk/db/client.py` to fetch workflow runs by `organization_id` with pagination.
- Added `get_workflow_runs_for_workflow_permanent_id` method in `skyvern/forge/sdk/db/client.py` to fetch workflow runs by `workflow_permanent_id` and `organization_id` with pagination.
- Introduced `get_workflow_runs_by_workflow_id` method in `skyvern/forge/sdk/workflow/service.py` to call the database method for fetching workflow runs by `workflow_id` and `organization_id`.
- Introduced `get_workflow_runs` method in `skyvern/forge/sdk/workflow/service.py` to call the database method for fetching workflow runs by `organization_id`.
- Introduced `get_workflow_runs_for_workflow_permanent_id` method in `skyvern/forge/sdk/workflow/service.py` to call the database method for fetching workflow runs by `workflow_permanent_id` and `organization_id`.
- Created `get_workflow_runs` endpoint in `skyvern/forge/sdk/routes/agent_protocol.py` to expose the functionality via API.
- Created `get_workflow_runs_for_workflow_permanent_id` endpoint in `skyvern/forge/sdk/routes/agent_protocol.py` to expose the functionality via API.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->