### PR TITLE
fix bug on HTML tree

### DIFF
--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -96,7 +96,7 @@ def json_to_html(element: dict) -> str:
     )
 
     # Check if the element is self-closing
-    if tag in ["img", "input", "br", "hr", "meta", "link"]:
+    if tag in ["img", "input", "br", "hr", "meta", "link"] and not option_html and not children_html:
         return f'<{tag}{attributes_html if not attributes_html else " "+attributes_html}>'
     else:
         return f'<{tag}{attributes_html if not attributes_html else " "+attributes_html}>{text}{children_html+option_html}</{tag}>'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3e281915f1a16b467a76ce4b845efcb52435b039  | 
|--------|--------|

### Summary:
Fixed self-closing tag logic in `json_to_html` function to correctly handle `option_html` and `children_html` content.

**Key points**:
- **File Modified**: `skyvern/webeye/scraper/scraper.py`
- **Function Modified**: `json_to_html`
- **Bug Fix**: Corrected self-closing tag logic to check for absence of `option_html` and `children_html`.
- **Behavior Change**: Self-closing tags like `img`, `input`, `br`, `hr`, `meta`, and `link` will only be self-closed if they have no `option_html` or `children_html` content.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->