### PR TITLE
experimentation get_value for multiple variable for a feature

### DIFF
--- a/skyvern/forge/sdk/experimentation/providers.py
+++ b/skyvern/forge/sdk/experimentation/providers.py
@@ -8,6 +8,7 @@ LOG = structlog.get_logger()
 class BaseExperimentationProvider(ABC):
     # feature_name -> distinct_id -> result
     result_map: dict[str, dict[str, bool]] = {}
+    variant_map: dict[str, dict[str, str | None]] = {}
 
     @abstractmethod
     def is_feature_enabled(self, feature_name: str, distinct_id: str, properties: dict | None = None) -> bool:
@@ -24,7 +25,25 @@ class BaseExperimentationProvider(ABC):
 
         return self.result_map[feature_name][distinct_id]
 
+    @abstractmethod
+    def get_value(self, feature_name: str, distinct_id: str, properties: dict | None = None) -> str | None:
+        """Get the value of a feature."""
+
+    def get_value_cached(self, feature_name: str, distinct_id: str, properties: dict | None = None) -> str | None:
+        """Get the value of a feature."""
+        if feature_name not in self.variant_map:
+            self.variant_map[feature_name] = {}
+        if distinct_id not in self.variant_map[feature_name]:
+            variant = self.get_value(feature_name, distinct_id, properties)
+            self.variant_map[feature_name][distinct_id] = variant
+            if variant:
+                LOG.info("Feature is found", flag=feature_name, distinct_id=distinct_id)
+        return self.variant_map[feature_name][distinct_id]
+
 
 class NoOpExperimentationProvider(BaseExperimentationProvider):
     def is_feature_enabled(self, feature_name: str, distinct_id: str, properties: dict | None = None) -> bool:
         return False
+
+    def get_value(self, feature_name: str, distinct_id: str, properties: dict | None = None) -> str | None:
+        return None


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2070e8a9205250ebc028788246797e42c738fcfc  | 
|--------|--------|

### Summary:
Added `get_value` method and caching for feature values in various experimentation providers, and tested locally.

**Key points**:
- Added `get_value` method and caching for feature values in `PostHogExperimentationProvider`, `BaseExperimentationProvider`, and `NoOpExperimentationProvider`.
- Added `get_value` method to `cloud/experimentation/providers.py` in `PostHogExperimentationProvider` class.
- Updated `BaseExperimentationProvider` in `skyvern/forge/sdk/experimentation/providers.py` to include `variant_map` for caching feature values.
- Implemented `get_value_cached` method in `BaseExperimentationProvider` for caching feature values.
- Updated `NoOpExperimentationProvider` in `skyvern/forge/sdk/experimentation/providers.py` to implement `get_value` method returning `None`.

----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->