### PR TITLE
migrate aiohttp helper from cloud to open source

### DIFF
--- a/skyvern/exceptions.py
+++ b/skyvern/exceptions.py
@@ -416,3 +416,8 @@ class FailedToGetCurrentValueOfDropdown(SkyvernException):
         super().__init__(
             f"Failed to get current value of {dropdowm_type} dropdown. element_id={element_id}, failure_reason={fail_reason}"
         )
+
+
+class HttpException(SkyvernException):
+    def __init__(self, status_code: int, url: str, msg: str | None = None) -> None:
+        super().__init__(f"HTTP Exception, status_code={status_code}, url={url}" + (f", msg={msg}" if msg else ""))

--- a/skyvern/forge/sdk/core/aiohttp_helper.py
+++ b/skyvern/forge/sdk/core/aiohttp_helper.py
@@ -1,0 +1,45 @@
+import asyncio
+from typing import Any
+
+import aiohttp
+import structlog
+
+from skyvern.exceptions import HttpException
+
+LOG = structlog.get_logger()
+DEFAULT_REQUEST_TIMEOUT = 30
+
+
+async def aiohttp_get_json(
+    url: str,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    cookies: dict[str, str] | None = None,
+    retry: int = 0,
+    proxy: str | None = None,
+    timeout: int = DEFAULT_REQUEST_TIMEOUT,
+    raise_exception: bool = True,
+    retry_timeout: float = 0,
+) -> dict[str, Any]:
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout)) as session:
+        count = 0
+        while count <= retry:
+            try:
+                async with session.get(
+                    url,
+                    params=params,
+                    headers=headers,
+                    cookies=cookies,
+                    proxy=proxy,
+                ) as response:
+                    if response.status == 200:
+                        return await response.json()
+                    if raise_exception:
+                        raise HttpException(response.status, url)
+                    LOG.error(f"Failed to fetch data from {url}", status_code=response.status)
+                    return {}
+            except Exception:
+                if retry_timeout > 0:
+                    await asyncio.sleep(retry_timeout)
+                count += 1
+        raise Exception(f"Failed to fetch data from {url}")


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit cb9006771b3c13a3bf67f64c7efccb77e5765617  | 
|--------|--------|

### Summary:
Migrated `aiohttp_helper` module and `HttpException` class from `cloud` to `skyvern` package, updating import paths accordingly.

**Key points**:
- Migrated `aiohttp_helper` module from `cloud` to `skyvern` package.
- Updated import paths for `aiohttp_get_json` in `cloud/core/authentication.py`, `cloud/core/mihomo/mihomo.py`, `cloud/webeye/proxy.py`, and `scripts/luca/walmart_client.py`.
- Moved `aiohttp_helper.py` from `cloud/core/aiohttp_helper.py` to `skyvern/forge/sdk/core/aiohttp_helper.py`.
- Migrated `HttpException` class from `cloud/exceptions.py` to `skyvern/exceptions.py`.
- Removed `HttpException` class from `cloud/exceptions.py` and added it to `skyvern/exceptions.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->