### PR TITLE
Add header information to API spec

### DIFF
--- a/docs/running-tasks/api-spec.mdx
+++ b/docs/running-tasks/api-spec.mdx
@@ -5,7 +5,7 @@ description: 'The core building block in Skyvern'
 
 Tasks are the building block of Skyvern. They represent a single instruction to the browser to go do something using language models. Ex. “Go to alibaba and extract this information”
 
-## Request - Initiate a task (Webhook)
+## Request - Initiate a task 
 Request type: `POST`
 
 Production:`https://api.skyvern.com/api/v1/tasks/`

--- a/docs/running-tasks/api-spec.mdx
+++ b/docs/running-tasks/api-spec.mdx
@@ -6,12 +6,20 @@ description: 'The core building block in Skyvern'
 Tasks are the building block of Skyvern. They represent a single instruction to the browser to go do something using language models. Ex. “Go to alibaba and extract this information”
 
 ## Request - Initiate a task (Webhook)
+Request type: `POST`
+
+Production:`https://api.skyvern.com/api/v1/tasks/`
+
+### Header 
+
+| Parameter | Type | Required? | Sample Value | Description |
+| --- | --- | --- | --- | --- |
+| x-api-key | String | yes | ey....| Bearer token that gives your backend access to the Skyvern API. This will be manually provided by us |
 
 ### Body
 
 | Parameter | Type | Required? | Sample Value | Description |
 | --- | --- | --- | --- | --- |
-| url | String | yes | https://jobs.lever.co/leverdemo-8/45d39614-464a-4b62-a5cd-8683ce4fb80a/apply | The website that you would like to browse / scrape. This should be the ideal starting point for the agent |
 | webhook_callback_url | String | no | …  | The callback URL once our system is finished processing this async task |
 | navigation_goal | String | no | Apply for a job | The prompt that tells the agent what the user-facing goal is. This is the guiding light for the LLM as it navigates a particular website / sitemap to achieve this specified goal |
 | data_extraction_goal | String | no | Was the job application successful? | The prompt that instructs the agent to extract information once the agent has achieved its user_goal |
@@ -22,6 +30,8 @@ Tasks are the building block of Skyvern. They represent a single instruction to 
 ## Example Request (Apply for a job)
 
 ```python
+POST https://api.skyvern.com/api/v1/tasks/ 
+
 {
     "url": "https://jobs.lever.co/leverdemo-8/45d39614-464a-4b62-a5cd-8683ce4fb80a/apply",
     "navigation_goal": "Apply for a job",

--- a/docs/running-tasks/api-spec.mdx
+++ b/docs/running-tasks/api-spec.mdx
@@ -14,7 +14,7 @@ Production:`https://api.skyvern.com/api/v1/tasks/`
 
 | Parameter | Type | Required? | Sample Value | Description |
 | --- | --- | --- | --- | --- |
-| x-api-key | String | yes | ey....| Bearer token that gives your backend access to the Skyvern API. This will be manually provided by us |
+| x-api-key | String | yes | [your-api-key-here] | Bearer token that gives your backend access to the Skyvern API. This will be manually provided by us |
 
 ### Body
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8015738fb00f308e385e72e057d823d74052110b  | 
|--------|--------|

### Summary:
Added header information for the 'Initiate a task' request in the API spec documentation.

**Key points**:
- Updated `docs/running-tasks/api-spec.mdx` to include header information for the 'Initiate a task' request.
- Added `x-api-key` header parameter details, including type, requirement status, sample value, and description.
- Specified that the `x-api-key` is a bearer token provided manually.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->