### PR TITLE
Force github button height to be equal to discord button

### DIFF
--- a/skyvern-frontend/src/routes/root/RootLayout.tsx
+++ b/skyvern-frontend/src/routes/root/RootLayout.tsx
@@ -35,15 +35,17 @@ function RootLayout() {
           >
             <DiscordLogoIcon className="w-7 h-7" />
           </Link>
-          <GitHubButton
-            href="https://github.com/skyvern-ai/skyvern"
-            data-color-scheme="no-preference: dark; light: dark; dark: dark;"
-            data-size="large"
-            data-show-count="true"
-            aria-label="Star skyvern-ai/skyvern on GitHub"
-          >
-            Star
-          </GitHubButton>
+          <div className="h-7">
+            <GitHubButton
+              href="https://github.com/skyvern-ai/skyvern"
+              data-color-scheme="no-preference: dark; light: dark; dark: dark;"
+              data-size="large"
+              data-show-count="true"
+              aria-label="Star skyvern-ai/skyvern on GitHub"
+            >
+              Star
+            </GitHubButton>
+          </div>
         </div>
         <main className="pl-72 pb-4">
           <Outlet />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9f690dcfbfe4c75dc962151e8c0bf9430dbbe3dc  | 
|--------|--------|

### Summary:
Wrapped `GitHubButton` in a `div` with class `h-7` to match the height of the Discord button in `RootLayout`.

**Key points**:
- Updated `skyvern-frontend/src/routes/root/RootLayout.tsx`.
- Wrapped `GitHubButton` in a `div` with class `h-7` to match the height of the Discord button.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->