### PR TITLE
Give playwright access to CodeBlock

### DIFF
--- a/skyvern/webeye/browser_manager.py
+++ b/skyvern/webeye/browser_manager.py
@@ -85,6 +85,11 @@ class BrowserManager:
         self.pages[workflow_run.workflow_run_id] = browser_state
         return browser_state
 
+    async def get_for_workflow_run(self, workflow_run_id: str) -> BrowserState | None:
+        if workflow_run_id in self.pages:
+            return self.pages[workflow_run_id]
+        return None
+
     def set_video_artifact_for_task(self, task: Task, artifact_id: str) -> None:
         if task.workflow_run_id and task.workflow_run_id in self.pages:
             if self.pages[task.workflow_run_id].browser_artifacts.video_artifact_id:


### PR DESCRIPTION
	### Example workflow:
```
title: "Test codeblock with page access"
description: ""
workflow_definition:
  parameters: []
  blocks:
      - block_type: task
        label: simple-task
        url: https://www.ipaddress.my/
        navigation_goal: null
        data_extraction_goal: Extract the IP address and location.
      - block_type: code
        label: get_tab_details
        code: |
          print("Getting tab details")
          result = {
              "url": skyvern_page.url,
              "title": await skyvern_page.title()
          }
          print("Got details:", result)
          print("Get a cat")
          await skyvern_page.goto("https://cataas.com/cat")
```


### Result:
On 25th second, it navigates to the page from the codeblock
[2024-07-11T08_53_08.396373_a_279193442447084520_recording.webm](https://github.com/Skyvern-AI/skyvern-cloud/assets/26116031/42ba25d1-93bc-4828-b4e7-833907e9c0de)


```
WorkflowRunStatusResponse(..., outputs={
'simple-task_output': {...}, 'send_get_request_output': 
{'result': {'url': 'https://www.ipaddress.my/', 'title': 'My IP Address | IPAddress.my'}}})
````

--
<!-- ELLIPSIS_HIDDEN -->


----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e7959e1d2d49b791463a09aacf039599978e8fa2  | 
|--------|--------|

### Summary:
Added Playwright browser access to `CodeBlock`, introduced `get_for_workflow_run` method in `BrowserManager`, and provided an example workflow with its result.

**Key points**:
- Example workflow provided with a task and code block.
- Workflow navigates to a page and extracts IP address and location.
- Added Playwright browser access to `CodeBlock`.
- Introduced `get_for_workflow_run` method in `BrowserManager`.
- Modified `skyvern/forge/sdk/workflow/models/block.py`.
- `CodeBlock.execute`: Added Playwright browser page to `parameter_values` if available.
- Included `asyncio` and `__builtins__` in `parameter_values` for `exec` context.
- Wrapped user code in an async function and awaited its execution.
- Added `skyvern/webeye/browser_manager.py`.
- `BrowserManager.get_for_workflow_run`: New method to retrieve browser state for a given workflow run ID.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->