### PR TITLE
Stop flicker of parameters when task is running

### DIFF
--- a/skyvern-frontend/src/routes/tasks/detail/TaskParameters.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/TaskParameters.tsx
@@ -21,7 +21,7 @@ function TaskParameters() {
   const credentialGetter = useCredentialGetter();
   const {
     data: task,
-    isFetching: taskIsFetching,
+    isLoading: taskIsLoading,
     isError: taskIsError,
   } = useQuery<TaskApiResponse>({
     queryKey: ["task", taskId],
@@ -31,7 +31,7 @@ function TaskParameters() {
     },
   });
 
-  if (taskIsFetching) {
+  if (taskIsLoading) {
     return (
       <div className="h-[40rem]">
         <Skeleton className="h-full" />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 79d4b1618ede8c9b99cc9513d1399884d893e150  | 
|--------|--------|

### Summary:
Updated `useQuery` hook to use `isLoading` instead of `isFetching` to prevent parameter flickering in `TaskParameters`.

**Key points**:
- Updated `useQuery` hook in `skyvern-frontend/src/routes/tasks/detail/TaskParameters.tsx` to use `isLoading` instead of `isFetching`.
- Modified conditional check from `taskIsFetching` to `taskIsLoading` to prevent flickering of parameters when a task is running.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->