### PR TITLE
send webhook response before closing browser which often gets stuck

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1177,12 +1177,12 @@ class ForgeAgent:
             )
             return
 
-        await self.cleanup_browser_and_create_artifacts(close_browser_on_completion, last_step, task)
-
         # Wait for all tasks to complete before generating the links for the artifacts
         await app.ARTIFACT_MANAGER.wait_for_upload_aiotasks_for_task(task.task_id)
 
         await self.execute_task_webhook(task=task, last_step=last_step, api_key=api_key)
+
+        await self.cleanup_browser_and_create_artifacts(close_browser_on_completion, last_step, task)
 
     async def execute_task_webhook(
         self,


### PR DESCRIPTION
We've seen tasks getting stuck when closing playwright browsers. As a result, webhook requests were not successfully sent.

reordering the logic so that we send webhook request before closing the browser window.


<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e9fa2f6b079133a8b6775b3f91af90bf8d925094  | 
|--------|--------|

### Summary:
Modified `send_task_response` in `skyvern/forge/agent.py` to send the webhook response before closing the browser to prevent delays caused by browser closure issues.

**Key points**:
- **File Modified**: `skyvern/forge/agent.py`
- **Function Modified**: `send_task_response`
- **Change**: Moved the call to `cleanup_browser_and_create_artifacts` to after `execute_task_webhook` in `send_task_response`.
- **Reason**: Ensures the webhook response is sent before closing the browser, which often gets stuck during closure.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->