### PR TITLE
Remove successful action history. Only show the failure of the previous step in action history.

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
     MAX_RETRIES_PER_STEP: int = 5
     DEBUG_MODE: bool = False
     DATABASE_STRING: str = "postgresql+psycopg://skyvern@localhost/skyvern"
-    PROMPT_ACTION_HISTORY_WINDOW: int = 5
+    PROMPT_ACTION_HISTORY_WINDOW: int = 1
     TASK_RESPONSE_ACTION_SCREENSHOT_COUNT: int = 3
 
     ENV: str = "local"


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d463dc5d9711ffc0d04e9e571a5dda3df4ac0647  | 
|--------|--------|

### Summary:
Updated action history window to only show failed actions from the previous step in `skyvern/config.py` and `skyvern/forge/agent.py`.

**Key points**:
- Updated `PROMPT_ACTION_HISTORY_WINDOW` to 1 in `skyvern/config.py`.
- Modified `_get_action_results` in `skyvern/forge/agent.py` to exclude successful actions from the history window.
- Adjusted the slicing of `steps` to exclude the last step in `_get_action_results`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->