### PR TITLE
fix the problem of verification_code not injected into string navigation goal

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1009,9 +1009,21 @@ class ForgeAgent:
         task: Task,
     ) -> dict[str, Any] | list | str | None:
         final_navigation_payload = task.navigation_payload
-        if isinstance(final_navigation_payload, dict) and task.totp_verification_url:
-            if SPECIAL_FIELD_VERIFICATION_CODE not in final_navigation_payload:
+        if task.totp_verification_url:
+            if (
+                isinstance(final_navigation_payload, dict)
+                and SPECIAL_FIELD_VERIFICATION_CODE not in final_navigation_payload
+            ):
                 final_navigation_payload[SPECIAL_FIELD_VERIFICATION_CODE] = VERIFICATION_CODE_PLACEHOLDER
+            elif (
+                isinstance(final_navigation_payload, str)
+                and SPECIAL_FIELD_VERIFICATION_CODE not in final_navigation_payload
+            ):
+                final_navigation_payload = (
+                    final_navigation_payload
+                    + "\n"
+                    + str({SPECIAL_FIELD_VERIFICATION_CODE: VERIFICATION_CODE_PLACEHOLDER})
+                )
         return final_navigation_payload
 
     async def _get_action_results(self, task: Task) -> str:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b6a7ec48ee960f831e13c1ab0ee05db45bf2ea5c  | 
|--------|--------|

### Summary:
Modified `_build_navigation_payload` in `skyvern/forge/agent.py` to handle string payloads by appending a verification code placeholder if needed.

**Key points**:
- Modified `_build_navigation_payload` in `skyvern/forge/agent.py`.
- Added handling for `final_navigation_payload` when it is a string.
- Appends verification code placeholder to string payload if `task.totp_verification_url` is present and placeholder is missing.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->