### PR TITLE
Skip if selected

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -424,7 +424,6 @@ async def handle_select_option_action(
 ) -> list[ActionResult]:
     dom = DomUtil(scraped_page, page)
     skyvern_element = await dom.get_skyvern_element_by_id(action.element_id)
-    locator = skyvern_element.locator
 
     tag_name = skyvern_element.get_tag_name()
     element_dict = scraped_page.id_to_element_dict[action.element_id]
@@ -830,7 +829,7 @@ async def normal_select(
 
     action_result: List[ActionResult] = []
     is_success = False
-    locator = skyvern_element.locator
+    locator = skyvern_element.get_locator()
 
     try:
         await locator.click(

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -583,13 +583,6 @@ async def handle_select_option_action(
         click_action = ClickAction(element_id=action.element_id)
         return await chain_click(task, scraped_page, page, click_action, skyvern_element)
 
-    try:
-        current_text = await locator.input_value()
-        if current_text == action.option.label or current_text == action.option.value:
-            return [ActionSuccess()]
-    except Exception:
-        LOG.info("failed to confirm if the select option has been done, force to take the action again.")
-
     return await normal_select(action=action, skyvern_element=skyvern_element)
 
 
@@ -828,6 +821,13 @@ async def normal_select(
     action: actions.SelectOptionAction,
     skyvern_element: SkyvernElement,
 ) -> List[ActionResult]:
+    try:
+        current_text = await skyvern_element.get_attr("selected")
+        if current_text == action.option.label or current_text == action.option.value:
+            return [ActionSuccess()]
+    except Exception:
+        LOG.info("failed to confirm if the select option has been done, force to take the action again.")
+
     action_result: List[ActionResult] = []
     is_success = False
     locator = skyvern_element.locator

--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -606,8 +606,8 @@ function getSelectOptions(element) {
     });
   }
 
-  const selectedOption = element.querySelector("option:checked")
-  if (!selectedOption){
+  const selectedOption = element.querySelector("option:checked");
+  if (!selectedOption) {
     return [selectOptions, ""];
   }
 

--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -605,7 +605,13 @@ function getSelectOptions(element) {
       text: removeMultipleSpaces(option.textContent),
     });
   }
-  return selectOptions;
+
+  const selectedOption = element.querySelector("option:checked")
+  if (!selectedOption){
+    return [selectOptions, ""];
+  }
+
+  return [selectOptions, removeMultipleSpaces(selectedOption.textContent)];
 }
 
 function getListboxOptions(element) {
@@ -776,15 +782,16 @@ async function buildTreeFromBody(frame = "main.frame", open_select = false) {
       // assign shadowHostId to the shadowHost element if it doesn't have unique_id
       if (!shadowHostId) {
         shadowHostId = uniqueId();
-        shadowHost.setAttribute("unique_id", shadowHostId);
+        shadowHostEle.setAttribute("unique_id", shadowHostId);
       }
       elementObj.shadowHost = shadowHostId;
     }
 
     // get options for select element or for listbox element
     let selectOptions = null;
+    let selectedValue = "";
     if (elementTagNameLower === "select") {
-      selectOptions = getSelectOptions(element);
+      [selectOptions, selectedValue] = getSelectOptions(element);
     } else if (attrs["role"] && attrs["role"].toLowerCase() === "listbox") {
       // if "role" key is inside attrs, then get all the elements with role "option" and get their text
       selectOptions = getListboxOptions(element);
@@ -839,6 +846,9 @@ async function buildTreeFromBody(frame = "main.frame", open_select = false) {
     }
     if (selectOptions) {
       elementObj.options = selectOptions;
+    }
+    if (selectedValue) {
+      elementObj.attributes["selected"] = selectedValue;
     }
 
     return elementObj;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ecd7cef40b36ec8c3bb53cf5b94c793a7fca0e1d  | 
|--------|--------|

### Summary:
Refactored `handle_select_option_action` to check for already selected options in `normal_select` and updated `getSelectOptions` to return the selected option's text.

**Key points**:
- Updated `handle_select_option_action` in `skyvern/webeye/actions/handler.py` to remove the check for already selected options.
- Moved the check for already selected options to `normal_select` in `skyvern/webeye/actions/handler.py`.
- Modified `getSelectOptions` in `skyvern/webeye/scraper/domUtils.js` to return the selected option's text along with the options list.
- Added handling for `selected` attribute in `buildTreeFromBody` in `skyvern/webeye/scraper/domUtils.js`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->