### PR TITLE
delete unnecessary newline in prompt

### DIFF
--- a/skyvern/forge/prompts/skyvern/extract-action.j2
+++ b/skyvern/forge/prompts/skyvern/extract-action.j2
@@ -35,8 +35,8 @@ Reply in JSON format with the following keys:
 {% endif %}
     }],
 }
-
 {% if action_history %}
+
 Consider the action history from the last step and the screenshot together, if actions from the last step don't yield positive impact, try other actions or other action combinations.
 {% endif %}
 
@@ -51,12 +51,11 @@ User goal:
 ```
 {{ navigation_goal }}
 ```
-
 {% if error_code_mapping_str %}
+
 Use the error codes and their descriptions to surface user-defined errors. Do not return any error that's not defined by the user. User defined errors:
 {{ error_code_mapping_str }}
 {% endif %}
-
 {% if data_extraction_goal %}
 
 User Data Extraction Goal:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5ae65c33836352f008fcecc8225361f1fdfb6806  | 
|--------|--------|

### Summary:
Removed unnecessary newlines in `skyvern/forge/prompts/skyvern/extract-action.j2` for cleaner formatting.

**Key points**:
- Removed unnecessary newline after the closing bracket of the JSON object in `skyvern/forge/prompts/skyvern/extract-action.j2`.
- Removed unnecessary newline before the `Consider the action history...` line.
- Removed unnecessary newline before the `Use the error codes...` line.
- Removed unnecessary newline before the `User Data Extraction Goal:` line.
- Removed unnecessary newline before the `Action results from previous steps:` line.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->