### PR TITLE
add skyvern frame

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -57,7 +57,8 @@ from skyvern.webeye.actions.handler import ActionHandler
 from skyvern.webeye.actions.models import AgentStepOutput, DetailedAgentStepOutput
 from skyvern.webeye.actions.responses import ActionResult
 from skyvern.webeye.browser_factory import BrowserState
-from skyvern.webeye.scraper.scraper import ElementTreeFormat, ScrapedPage, get_page_content, scrape_website
+from skyvern.webeye.scraper.scraper import ElementTreeFormat, ScrapedPage, scrape_website
+from skyvern.webeye.utils.page import SkyvernFrame
 
 LOG = structlog.get_logger()
 
@@ -797,7 +798,8 @@ class ForgeAgent:
             )
 
         try:
-            html = await get_page_content(browser_state.page)
+            skyvern_frame = await SkyvernFrame.create_instance(frame=browser_state.page)
+            html = await skyvern_frame.get_content()
             await app.ARTIFACT_MANAGER.create_artifact(
                 step=step,
                 artifact_type=ArtifactType.HTML_ACTION,

--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any, Dict, List
+
+import structlog
+from playwright._impl._errors import TimeoutError
+from playwright.async_api import ElementHandle, Frame, Page
+
+from skyvern.constants import PAGE_CONTENT_TIMEOUT, SKYVERN_DIR
+from skyvern.exceptions import FailedToTakeScreenshot
+from skyvern.forge.sdk.settings_manager import SettingsManager
+
+LOG = structlog.get_logger()
+
+
+def load_js_script() -> str:
+    # TODO: Handle file location better. This is a hacky way to find the file location.
+    path = f"{SKYVERN_DIR}/webeye/scraper/domUtils.js"
+    try:
+        # TODO: Implement TS of domUtils.js and use the complied JS file instead of the raw JS file.
+        # This will allow our code to be type safe.
+        with open(path, "r") as f:
+            return f.read()
+    except FileNotFoundError as e:
+        LOG.exception("Failed to load the JS script", path=path)
+        raise e
+
+
+JS_FUNCTION_DEFS = load_js_script()
+
+
+class SkyvernFrame:
+    @staticmethod
+    async def take_screenshot(
+        page: Page,
+        full_page: bool = False,
+        file_path: str | None = None,
+        timeout: float = SettingsManager.get_settings().BROWSER_LOADING_TIMEOUT_MS,
+    ) -> bytes:
+        try:
+            await page.wait_for_load_state(timeout=SettingsManager.get_settings().BROWSER_LOADING_TIMEOUT_MS)
+            LOG.info("Page is fully loaded, agent is about to take screenshots")
+            start_time = time.time()
+            screenshot: bytes = bytes()
+            if file_path:
+                screenshot = await page.screenshot(
+                    path=file_path,
+                    full_page=full_page,
+                    timeout=timeout,
+                )
+            else:
+                screenshot = await page.screenshot(
+                    full_page=full_page,
+                    timeout=timeout,
+                    animations="disabled",
+                )
+            end_time = time.time()
+            LOG.info(
+                "Screenshot taking time",
+                screenshot_time=end_time - start_time,
+                full_page=full_page,
+                file_path=file_path,
+            )
+            return screenshot
+        except TimeoutError as e:
+            LOG.exception(f"Timeout error while taking screenshot: {str(e)}")
+            raise FailedToTakeScreenshot(error_message=str(e)) from e
+        except Exception as e:
+            LOG.exception(f"Unknown error while taking screenshot: {str(e)}")
+            raise FailedToTakeScreenshot(error_message=str(e)) from e
+
+    @staticmethod
+    async def take_split_screenshots(
+        page: Page,
+        url: str,
+        draw_boxes: bool = False,
+        max_number: int = SettingsManager.get_settings().MAX_NUM_SCREENSHOTS,
+    ) -> List[bytes]:
+        skyvern_page = await SkyvernFrame.create_instance(frame=page)
+        assert isinstance(skyvern_page.frame, Page)
+
+        screenshots: List[bytes] = []
+        scroll_y_px_old = -30.0
+        scroll_y_px = await skyvern_page.scroll_to_top(draw_boxes=draw_boxes)
+        # Checking max number of screenshots to prevent infinite loop
+        # We are checking the difference between the old and new scroll_y_px to determine if we have reached the end of the
+        # page. If the difference is less than 25, we assume we have reached the end of the page.
+        while abs(scroll_y_px_old - scroll_y_px) > 25 and len(screenshots) < max_number:
+            screenshot = await SkyvernFrame.take_screenshot(page=skyvern_page.frame, full_page=False)
+            screenshots.append(screenshot)
+            scroll_y_px_old = scroll_y_px
+            LOG.info("Scrolling to next page", url=url, num_screenshots=len(screenshots))
+            scroll_y_px = await skyvern_page.scroll_to_next_page(draw_boxes=draw_boxes)
+            LOG.info(
+                "Scrolled to next page",
+                scroll_y_px=scroll_y_px,
+                scroll_y_px_old=scroll_y_px_old,
+            )
+        if draw_boxes:
+            await skyvern_page.remove_bounding_boxes()
+        await skyvern_page.scroll_to_top(draw_boxes=False)
+        return screenshots
+
+    @classmethod
+    async def create_instance(cls, frame: Page | Frame) -> SkyvernFrame:
+        instance = cls(frame=frame)
+        await instance.frame.evaluate(JS_FUNCTION_DEFS)
+        return instance
+
+    def __init__(self, frame: Page | Frame) -> None:
+        self.frame = frame
+
+    def get_frame(self) -> Page | Frame:
+        return self.frame
+
+    async def get_content(self, timeout: float = PAGE_CONTENT_TIMEOUT) -> str:
+        async with asyncio.timeout(timeout):
+            return await self.frame.content()
+
+    async def get_select2_options(self, element: ElementHandle) -> List[Dict[str, Any]]:
+        await self.frame.evaluate(JS_FUNCTION_DEFS)
+        js_script = "async (element) => await getSelect2Options(element)"
+        return await self.frame.evaluate(js_script, element)
+
+    async def get_combobox_options(self, element: ElementHandle) -> List[Dict[str, Any]]:
+        await self.frame.evaluate(JS_FUNCTION_DEFS)
+        js_script = "async (element) => await getListboxOptions(element)"
+        return await self.frame.evaluate(js_script, element)
+
+    async def scroll_to_top(self, draw_boxes: bool) -> float:
+        """
+        Scroll to the top of the page and take a screenshot.
+        :param drow_boxes: If True, draw bounding boxes around the elements.
+        :param page: Page instance to take the screenshot from.
+        :return: Screenshot of the page.
+        """
+        js_script = f"async () => await scrollToTop({str(draw_boxes).lower()})"
+        scroll_y_px = await self.frame.evaluate(js_script)
+        return scroll_y_px
+
+    async def scroll_to_next_page(self, draw_boxes: bool) -> float:
+        """
+        Scroll to the next page and take a screenshot.
+        :param drow_boxes: If True, draw bounding boxes around the elements.
+        :param page: Page instance to take the screenshot from.
+        :return: Screenshot of the page.
+        """
+        js_script = f"async () => await scrollToNextPage({str(draw_boxes).lower()})"
+        scroll_y_px = await self.frame.evaluate(js_script)
+        return scroll_y_px
+
+    async def remove_bounding_boxes(self) -> None:
+        """
+        Remove the bounding boxes from the page.
+        :param page: Page instance to remove the bounding boxes from.
+        """
+        js_script = "() => removeBoundingBoxes()"
+        await self.frame.evaluate(js_script)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 83bdc02b66cf617dad411e330d045912e5fd40ef  | 
|--------|--------|

### Summary:
Introduced `SkyvernFrame` class to centralize page interactions, replacing direct Playwright calls across multiple modules.

**Key points**:
- Added `SkyvernFrame` class in `skyvern/webeye/utils/page.py` to handle page interactions.
- Replaced direct calls to Playwright's `Page` and `Frame` methods with `SkyvernFrame` methods.
- Updated `record_artifacts_after_action` in `skyvern/forge/agent.py` to use `SkyvernFrame` for HTML content extraction.
- Removed `take_screenshot_from_page` method from `skyvern/webeye/browser_factory.py` and replaced its usage with `SkyvernFrame.take_screenshot`.
- Updated `scrape_web_unsafe` and `scrape_website` in `skyvern/webeye/scraper/scraper.py` to use `SkyvernFrame` for taking split screenshots and getting page content.
- Modified `get_select2_dropdown` and `get_combobox_dropdown` methods in `skyvern/webeye/utils/dom.py` to use `SkyvernFrame` for option extraction.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->