### PR TITLE
Update task generation to use https urls

### DIFF
--- a/skyvern/forge/prompts/skyvern/generate-task.j2
+++ b/skyvern/forge/prompts/skyvern/generate-task.j2
@@ -1,6 +1,6 @@
 We are building an AI agent that can automate browser tasks. The task creation schema is a JSON object with the following fields:
 
-url: str. This is a required field. It is the starting URL for the task. This will be the first page the agent visits in order to achieve the goal.
+url: str. This is a required field. It is the starting URL for the task. This will be the first page the agent visits in order to achieve the goal. Use HTTPS URLs only.
 
 navigation_goal_reasoning: str. This is a required field. The reason why navigation goal is needed to achieve the goal. Navigation goal is needed when the agent needs to take actions on the website to achieve the goal such as clicking a button, typing in a search bar, or navigating to another URL.
 is_navigation_goal_required: bool. This is a required field. Based on the navigation_goal_reasoning, whether the navigation goal is required to achieve the task.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 63faf6627a3a148d342ed957e2fb7644dc24b9c6  | 
|--------|--------|

### Summary:
Enforced the use of HTTPS URLs in the task generation schema in `skyvern/forge/prompts/skyvern/generate-task.j2`.

**Key points**:
- Updated `skyvern/forge/prompts/skyvern/generate-task.j2` to enforce HTTPS URLs for the `url` field.
- Modified the description of the `url` field to specify that only HTTPS URLs are allowed.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->