### PR TITLE
Add null check for credentials without emails

### DIFF
--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -18,7 +18,9 @@ from skyvern.exceptions import (
 LOG = structlog.get_logger()
 
 
-def is_valid_email(email: str) -> bool:
+def is_valid_email(email: str | None) -> bool:
+    if not email:
+        return False
     pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
     return re.match(pattern, email) is not None
 
@@ -140,10 +142,9 @@ class BitwardenService:
             # if no cred matches the rule, return the first one.
             # TODO: For now hard code to choose the first valid email username
             for cred in credentials:
-                if is_valid_email(cred.get(BitwardenConstants.USERNAME, "")):
+                if is_valid_email(cred.get(BitwardenConstants.USERNAME)):
                     return cred
-
-            LOG.warning("No credential in Bitwarden matches the rule, returning the frist match")
+            LOG.warning("No credential in Bitwarden matches the rule, returning the first match")
             return credentials[0]
         finally:
             # Step 4: Log out


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 64eeaeb5282dd3f4b5b2e293f104f9cebd83ac2f  | 
|--------|--------|

### Summary:
Added null check for email credentials in `is_valid_email` and updated its usage in `get_secret_value_from_url` method of `BitwardenService`.

**Key points**:
- Updated `is_valid_email` function in `skyvern/forge/sdk/services/bitwarden.py` to handle `None` values.
- Modified `get_secret_value_from_url` method in `BitwardenService` to use the updated `is_valid_email` function.
- Added a null check for email credentials to prevent errors when email is missing.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->