### PR TITLE
clean up gpt4 routers. add model_info base_model for azure gpt router

### DIFF
--- a/skyvern/forge/sdk/api/llm/models.py
+++ b/skyvern/forge/sdk/api/llm/models.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Awaitable, Literal, Protocol
 
 from skyvern.forge.sdk.models import Step
@@ -27,6 +27,7 @@ class LLMRouterModelConfig:
     model_name: str
     # https://litellm.vercel.app/docs/routing
     litellm_params: dict[str, Any]
+    model_info: dict[str, Any] = field(default_factory=dict)
     tpm: int | None = None
     rpm: int | None = None
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2141b1956c7bf16a97067ad4bd83de8627f083f1  | 
|--------|--------|

### Summary:
Cleaned up GPT-4 routers and added `model_info` field to Azure GPT router configurations.

**Key points**:
- Removed `get_llm_router_config_for_cloud` from `cloud/__init__.py` and `cloud/llm/router.py`.
- Added `model_info` field to `LLMRouterModelConfig` in `skyvern/forge/sdk/api/llm/models.py`.
- Updated `get_gpt_turbo_router_config`, `get_llm_router_config_for_gpt4o`, and `get_massive_llm_router_config_for_gpt4o` to include `model_info`.
- Removed `ENABLE_AZURE_GPT4V_ROUTER` from `cloud/config.py`.
- Added `MAX_PARALLEL_REQUESTS` to massive Azure GPT-4O configurations in `cloud/config.py`.
- Updated `scripts/run_task.py` to use `get_llm_api_handler_with_router` for `massive-gpt4o`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->