### PR TITLE
record max_steps_per_run override in tasks table as well

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -232,6 +232,20 @@ class ForgeAgent:
             # TODO: shall we send task response here?
             return step, None, None
 
+        context = skyvern_context.current()
+        override_max_steps_per_run = context.max_steps_override if context else None
+        max_steps_per_run = (
+            override_max_steps_per_run
+            or task.max_steps_per_run
+            or organization.max_steps_per_run
+            or SettingsManager.get_settings().MAX_STEPS_PER_RUN
+        )
+        if max_steps_per_run and task.max_steps_per_run != max_steps_per_run:
+            await app.DATABASE.update_task(
+                task_id=task.task_id,
+                organization_id=organization.organization_id,
+                max_steps_per_run=max_steps_per_run,
+            )
         next_step: Step | None = None
         detailed_output: DetailedAgentStepOutput | None = None
         num_files_before = 0

--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -376,6 +376,7 @@ class AgentDB:
         extracted_information: dict[str, Any] | list | str | None = None,
         failure_reason: str | None = None,
         errors: list[dict[str, Any]] | None = None,
+        max_steps_per_run: int | None = None,
         organization_id: str | None = None,
     ) -> Task:
         if status is None and extracted_information is None and failure_reason is None and errors is None:
@@ -397,6 +398,8 @@ class AgentDB:
                         task.failure_reason = failure_reason
                     if errors is not None:
                         task.errors = errors
+                    if max_steps_per_run is not None:
+                        task.max_steps_per_run = max_steps_per_run
                     await session.commit()
                     updated_task = await self.get_task(task_id, organization_id=organization_id)
                     if not updated_task:

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -221,6 +221,7 @@ class Task(TaskRequest):
             screenshot_url=screenshot_url,
             recording_url=recording_url,
             errors=self.errors,
+            max_steps_per_run=self.max_steps_per_run,
         )
 
 
@@ -236,6 +237,7 @@ class TaskResponse(BaseModel):
     recording_url: str | None = None
     failure_reason: str | None = None
     errors: list[dict[str, Any]] = []
+    max_steps_per_run: int | None = None
 
 
 class TaskOutput(BaseModel):


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5b5454ce3269d416ad9b2fb4a38d2177fd5db196  | 
|--------|--------|

### Summary:
Added functionality to update the `max_steps_per_run` field in the `tasks` table when overridden during task execution, including updates to `TaskResponse` class.

**Key points**:
- **File Modified**: `skyvern/forge/agent.py`
  - **Function Modified**: `execute_step`
    - Added logic to update `max_steps_per_run` in the `tasks` table if overridden during task execution.
- **File Modified**: `skyvern/forge/sdk/db/client.py`
  - **Function Modified**: `update_task`
    - Added `max_steps_per_run` as an optional parameter to update the `tasks` table.
- **File Modified**: `skyvern/forge/sdk/schemas/tasks.py`
  - **Class Modified**: `TaskResponse`
    - Added `max_steps_per_run` field.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->