### PR TITLE
Support get organizations and get api keys APIs in the open source

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -232,20 +232,6 @@ class ForgeAgent:
             # TODO: shall we send task response here?
             return step, None, None
 
-        context = skyvern_context.current()
-        override_max_steps_per_run = context.max_steps_override if context else None
-        max_steps_per_run = (
-            override_max_steps_per_run
-            or task.max_steps_per_run
-            or organization.max_steps_per_run
-            or SettingsManager.get_settings().MAX_STEPS_PER_RUN
-        )
-        if max_steps_per_run and task.max_steps_per_run != max_steps_per_run:
-            await app.DATABASE.update_task(
-                task_id=task.task_id,
-                organization_id=organization.organization_id,
-                max_steps_per_run=max_steps_per_run,
-            )
         next_step: Step | None = None
         detailed_output: DetailedAgentStepOutput | None = None
         num_files_before = 0

--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -376,7 +376,6 @@ class AgentDB:
         extracted_information: dict[str, Any] | list | str | None = None,
         failure_reason: str | None = None,
         errors: list[dict[str, Any]] | None = None,
-        max_steps_per_run: int | None = None,
         organization_id: str | None = None,
     ) -> Task:
         if status is None and extracted_information is None and failure_reason is None and errors is None:
@@ -398,8 +397,6 @@ class AgentDB:
                         task.failure_reason = failure_reason
                     if errors is not None:
                         task.errors = errors
-                    if max_steps_per_run is not None:
-                        task.max_steps_per_run = max_steps_per_run
                     await session.commit()
                     updated_task = await self.get_task(task_id, organization_id=organization_id)
                     if not updated_task:

--- a/skyvern/forge/sdk/schemas/organizations.py
+++ b/skyvern/forge/sdk/schemas/organizations.py
@@ -1,5 +1,15 @@
 from pydantic import BaseModel
 
+from skyvern.forge.sdk.models import Organization, OrganizationAuthToken
+
+
+class GetOrganizationsResponse(BaseModel):
+    organizations: list[Organization]
+
+
+class GetOrganizationAPIKeysResponse(BaseModel):
+    api_keys: list[OrganizationAuthToken]
+
 
 class OrganizationUpdate(BaseModel):
     organization_name: str | None = None

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -221,7 +221,6 @@ class Task(TaskRequest):
             screenshot_url=screenshot_url,
             recording_url=recording_url,
             errors=self.errors,
-            max_steps_per_run=self.max_steps_per_run,
         )
 
 
@@ -237,7 +236,6 @@ class TaskResponse(BaseModel):
     recording_url: str | None = None
     failure_reason: str | None = None
     errors: list[dict[str, Any]] = []
-    max_steps_per_run: int | None = None
 
 
 class TaskOutput(BaseModel):


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5e0a0137810b128f46e1f4d62d3ea306eae4363b  | 
|--------|--------|

### Summary:
Moved `get organizations` and `get API keys` endpoints to `skyvern/forge/sdk/routes/agent_protocol.py`, removed `cloud/routes/organization_route.py`, and added new schemas.

**Key points**:
- Removed `cloud/routes/organization_route.py` and its references in `cloud/app.py`.
- Moved `get organizations` and `get API keys` endpoints to `skyvern/forge/sdk/routes/agent_protocol.py`.
- Added `GetOrganizationsResponse` and `GetOrganizationAPIKeysResponse` schemas in `skyvern/forge/sdk/schemas/organizations.py`.
- Updated `setup_api_app` in `cloud/app.py` to exclude `organization_router`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->