### PR TITLE
fix update_task bug

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -379,7 +379,13 @@ class AgentDB:
         max_steps_per_run: int | None = None,
         organization_id: str | None = None,
     ) -> Task:
-        if status is None and extracted_information is None and failure_reason is None and errors is None:
+        if (
+            status is None
+            and extracted_information is None
+            and failure_reason is None
+            and errors is None
+            and max_steps_per_run is None
+        ):
             raise ValueError(
                 "At least one of status, extracted_information, or failure_reason must be provided to update the task"
             )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f9397a565c4a3ed9392a62883298498acf7933ad  | 
|--------|--------|

### Summary:
Added `max_steps_per_run` to the condition in `AgentDB.update_task` to raise `ValueError` if all parameters are `None`.

**Key points**:
- **File Modified**: `skyvern/forge/sdk/db/client.py`
- **Function Modified**: `AgentDB.update_task`
- **Change**: Added `max_steps_per_run` to the condition checking if all parameters are `None`.
- **Behavior**: Raises `ValueError` if `status`, `extracted_information`, `failure_reason`, `errors`, and `max_steps_per_run` are all `None`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->