### PR TITLE
step output is very noisy as logs and cost us a lot in logging

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1388,7 +1388,7 @@ class ForgeAgent:
         update_comparison = {
             key: {"old": getattr(step, key), "new": value}
             for key, value in updates.items()
-            if getattr(step, key) != value
+            if getattr(step, key) != value and key != "output"
         }
         LOG.info(
             "Updating step in db",
@@ -1522,7 +1522,6 @@ class ForgeAgent:
                 step_id=step.step_id,
                 step_order=step.order,
                 step_retry=step.retry_index,
-                output=step.output,
                 max_steps=max_steps_per_run,
             )
             last_step = await self.update_step(step, is_last=True)
@@ -1539,7 +1538,6 @@ class ForgeAgent:
                 step_id=step.step_id,
                 step_order=step.order,
                 step_retry=step.retry_index,
-                output=step.output,
             )
             next_step = await app.DATABASE.create_step(
                 task_id=task.task_id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3835df685fe298d807fc37bc865156981c6d46b4  | 
|--------|--------|

### Summary:
Reduce log verbosity by excluding `output` field from log comparisons and updates in `update_step` and `handle_completed_step` functions in `skyvern/forge/agent.py`.

**Key points**:
- **File Modified**: `skyvern/forge/agent.py`
- **Function Modified**: `update_step`
  - Exclude `output` field from log comparisons and updates.
- **Function Modified**: `handle_completed_step`
  - Remove `output` field from log updates when marking steps as completed or creating next steps.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->