### PR TITLE
make 2 top logs debug log

### DIFF
--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -41,7 +41,7 @@ class SkyvernFrame:
     ) -> bytes:
         try:
             await page.wait_for_load_state(timeout=SettingsManager.get_settings().BROWSER_LOADING_TIMEOUT_MS)
-            LOG.info("Page is fully loaded, agent is about to take screenshots")
+            LOG.debug("Page is fully loaded, agent is about to take screenshots")
             start_time = time.time()
             screenshot: bytes = bytes()
             if file_path:
@@ -57,7 +57,7 @@ class SkyvernFrame:
                     animations="disabled",
                 )
             end_time = time.time()
-            LOG.info(
+            LOG.debug(
                 "Screenshot taking time",
                 screenshot_time=end_time - start_time,
                 full_page=full_page,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 968e6c783d9cc0d7cf5a9fd5ae0a549904a099b4  | 
|--------|--------|

### Summary:
Change log level from `info` to `debug` for specific log statements in `SkyvernFrame.take_screenshot` function.

**Key points**:
- Change log level from `info` to `debug` in `skyvern/webeye/utils/page.py`
- Affected function: `SkyvernFrame.take_screenshot`
- Log statements: 'Page is fully loaded, agent is about to take screenshots' and 'Screenshot taking time'


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->