### PR TITLE
add cleanup function

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -899,6 +899,7 @@ class ForgeAgent:
         return await scrape_website(
             browser_state,
             task.url,
+            app.AGENT_FUNCTION.cleanup_element_tree,
             scrape_exclude=app.scrape_exclude,
         )
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2d01d99392ae8252b35f2cea18357375a6251b51  | 
|--------|--------|

### Summary:
Added a cleanup function to remove unnecessary data from the element tree during web scraping and integrated it into the scraping process.

**Key points**:
- **Added** `cleanup_element_tree` function in `skyvern/forge/agent_functions.py` to remove `rect` and `unique_id` attributes from elements.
- **Modified** `scrape_website` and `scrape_web_unsafe` functions in `skyvern/webeye/scraper/scraper.py` to call `cleanup_element_tree` during the scraping process.
- **Updated** `_scrape_with_type` function in `skyvern/forge/agent.py` to pass `cleanup_element_tree` to `scrape_website`.
- **Removed** `cleanup_elements` function from `skyvern/webeye/scraper/scraper.py` as it is now redundant.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->