### PR TITLE
Handle navigation exception within taskblock.execute

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -16,11 +16,13 @@ from typing import Annotated, Any, Literal, Union
 import filetype
 import structlog
 from email_validator import EmailNotValidError, validate_email
+from playwright.async_api import Error
 from pydantic import BaseModel, Field
 
 from skyvern.config import settings
 from skyvern.exceptions import (
     ContextParameterValueNotFound,
+    FailedToNavigateToUrl,
     MissingBrowserStatePage,
     TaskNotFound,
     UnexpectedTaskStatus,
@@ -275,7 +277,22 @@ class TaskBlock(Block):
             )
 
             if self.url:
-                await browser_state.page.goto(self.url, timeout=settings.BROWSER_LOADING_TIMEOUT_MS)
+                try:
+                    await browser_state.page.goto(self.url, timeout=settings.BROWSER_LOADING_TIMEOUT_MS)
+                except Error as playright_error:
+                    LOG.warning(
+                        f"Error while navigating to url: {str(playright_error)}",
+                        exc_info=True,
+                    )
+                    # Make sure the task is marked as failed in the database before raising the exception
+                    exc = FailedToNavigateToUrl(url=self.url, error_message=str(playright_error))
+                    await app.DATABASE.update_task(
+                        task.task_id,
+                        status=TaskStatus.failed,
+                        organization_id=workflow.organization_id,
+                        failure_reason=str(exc),
+                    )
+                    raise exc
 
             try:
                 await app.agent.execute_step(

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -280,10 +280,7 @@ class TaskBlock(Block):
                 try:
                     await browser_state.page.goto(self.url, timeout=settings.BROWSER_LOADING_TIMEOUT_MS)
                 except Error as playright_error:
-                    LOG.warning(
-                        f"Error while navigating to url: {str(playright_error)}",
-                        exc_info=True,
-                    )
+                    LOG.warning(f"Error while navigating to url: {str(playright_error)}")
                     # Make sure the task is marked as failed in the database before raising the exception
                     exc = FailedToNavigateToUrl(url=self.url, error_message=str(playright_error))
                     await app.DATABASE.update_task(


### PR DESCRIPTION
	<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit fe683f611ae5355c066c5986b782f01a90a66f25  | 
|--------|--------|

### Summary:
Added exception handling for navigation errors in `TaskBlock.execute` to log warnings, update task status, and raise a custom exception.

**Key points**:
- **File Modified**: `skyvern/forge/sdk/workflow/models/block.py`
- **Class Modified**: `TaskBlock`
- **Method Modified**: `TaskBlock.execute`
- **Changes**:
  - Added `playwright.async_api.Error` exception handling.
  - Logs a warning message when navigation to a URL fails.
  - Updates the task status to `failed` in the database with the failure reason.
  - Raises a custom `FailedToNavigateToUrl` exception with the URL and error message.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->