### PR TITLE
set default page size to 200 for getting tasks for a workflow run

### DIFF
--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -41,7 +41,7 @@ function WorkflowRun() {
     queryFn: async () => {
       const client = await getClient(credentialGetter);
       return client
-        .get(`/tasks?workflow_run_id=${workflowRunId}`)
+        .get(`/tasks?workflow_run_id=${workflowRunId}&page_size=200`)
         .then((response) => response.data);
     },
   });


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit cfff2656b83667d06d7cba4b88d8c597ece72fea  | 
|--------|--------|

### Summary:
Set default page size to 1000 for fetching tasks in `WorkflowRun` component.

**Key points**:
- Set default page size to 1000 for fetching tasks in `WorkflowRun` component.
- Updated `skyvern-frontend/src/routes/workflows/WorkflowRun.tsx`.
- Modified `queryFn` in `useQuery` for fetching tasks to include `page_size=1000`.
- Ensures up to 1000 tasks are retrieved in a single API call for a workflow run.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->