### PR TITLE
shu/making scrolling debug logs

### DIFF
--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -32,7 +32,7 @@ class LLMConfigRegistry:
 
         cls.validate_config(llm_key, config)
 
-        LOG.info("Registering LLM config", llm_key=llm_key)
+        LOG.debug("Registering LLM config", llm_key=llm_key)
         cls._configs[llm_key] = config
 
     @classmethod

--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -91,9 +91,9 @@ class SkyvernFrame:
             screenshot = await SkyvernFrame.take_screenshot(page=skyvern_page.frame, full_page=False)
             screenshots.append(screenshot)
             scroll_y_px_old = scroll_y_px
-            LOG.info("Scrolling to next page", url=url, num_screenshots=len(screenshots))
+            LOG.debug("Scrolling to next page", url=url, num_screenshots=len(screenshots))
             scroll_y_px = await skyvern_page.scroll_to_next_page(draw_boxes=draw_boxes)
-            LOG.info(
+            LOG.debug(
                 "Scrolled to next page",
                 scroll_y_px=scroll_y_px,
                 scroll_y_px_old=scroll_y_px_old,


### PR DESCRIPTION
- make scrolling related logs DEBUG logs
- make Registering LLM config debug log

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit fbad122cbacb3b9894605a0dd0ccd16827616c7e  | 
|--------|--------|

### Summary:
Change log level from `info` to `debug` for specific actions in `skyvern/forge/sdk/api/llm/config_registry.py` and `skyvern/webeye/utils/page.py`.

**Key points**:
- Change log level from `info` to `debug` for registering LLM config in `skyvern/forge/sdk/api/llm/config_registry.py`.
- Change log level from `info` to `debug` for scrolling actions in `skyvern/webeye/utils/page.py`.
- Affects `register_config` method in `LLMConfigRegistry` class.
- Affects `take_split_screenshots` method in `SkyvernFrame` class.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->