### PR TITLE
Remove href from pagination tables

### DIFF
--- a/skyvern-frontend/src/routes/tasks/list/TaskHistory.tsx
+++ b/skyvern-frontend/src/routes/tasks/list/TaskHistory.tsx
@@ -137,7 +137,6 @@ function TaskHistory() {
         <PaginationContent>
           <PaginationItem>
             <PaginationPrevious
-              href="#"
               className={cn({ "cursor-not-allowed": page === 1 })}
               onClick={() => {
                 if (page === 1) {
@@ -150,11 +149,10 @@ function TaskHistory() {
             />
           </PaginationItem>
           <PaginationItem>
-            <PaginationLink href="#">{page}</PaginationLink>
+            <PaginationLink>{page}</PaginationLink>
           </PaginationItem>
           <PaginationItem>
             <PaginationNext
-              href="#"
               onClick={() => {
                 const params = new URLSearchParams();
                 params.set("page", String(page + 1));

--- a/skyvern-frontend/src/routes/workflows/WorkflowPage.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowPage.tsx
@@ -105,7 +105,6 @@ function WorkflowPage() {
           <PaginationContent>
             <PaginationItem>
               <PaginationPrevious
-                href="#"
                 className={cn({ "cursor-not-allowed": page === 1 })}
                 onClick={() => {
                   if (page === 1) {
@@ -118,11 +117,10 @@ function WorkflowPage() {
               />
             </PaginationItem>
             <PaginationItem>
-              <PaginationLink href="#">{page}</PaginationLink>
+              <PaginationLink>{page}</PaginationLink>
             </PaginationItem>
             <PaginationItem>
               <PaginationNext
-                href="#"
                 onClick={() => {
                   const params = new URLSearchParams();
                   params.set("page", String(page + 1));

--- a/skyvern-frontend/src/routes/workflows/Workflows.tsx
+++ b/skyvern-frontend/src/routes/workflows/Workflows.tsx
@@ -116,7 +116,6 @@ function Workflows() {
           <PaginationContent>
             <PaginationItem>
               <PaginationPrevious
-                href="#"
                 className={cn({ "cursor-not-allowed": workflowsPage === 1 })}
                 onClick={() => {
                   if (workflowsPage === 1) {
@@ -132,11 +131,10 @@ function Workflows() {
               />
             </PaginationItem>
             <PaginationItem>
-              <PaginationLink href="#">{workflowsPage}</PaginationLink>
+              <PaginationLink>{workflowsPage}</PaginationLink>
             </PaginationItem>
             <PaginationItem>
               <PaginationNext
-                href="#"
                 onClick={() => {
                   const params = new URLSearchParams();
                   params.set("workflowsPage", String(workflowsPage + 1));


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 164be965bce060dd4f4dbfd51d90f87f06982bc0  | 
|--------|--------|

### Summary:
Removed `href` attributes from pagination components in multiple files to ensure navigation is handled via JavaScript.

**Key points**:
- Removed `href` attribute from `PaginationPrevious`, `PaginationLink`, and `PaginationNext` components in `skyvern-frontend/cloud/routes/billing/BillingHistory.tsx`.
- Removed `href` attribute from `PaginationPrevious`, `PaginationLink`, and `PaginationNext` components in `skyvern-frontend/src/routes/tasks/list/TaskHistory.tsx`.
- Removed `href` attribute from `PaginationPrevious`, `PaginationLink`, and `PaginationNext` components in `skyvern-frontend/src/routes/workflows/WorkflowPage.tsx`.
- Removed `href` attribute from `PaginationPrevious`, `PaginationLink`, and `PaginationNext` components in `skyvern-frontend/src/routes/workflows/Workflows.tsx`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->