### PR TITLE
Use replace for pagination navigation

### DIFF
--- a/skyvern-frontend/src/routes/tasks/list/TaskHistory.tsx
+++ b/skyvern-frontend/src/routes/tasks/list/TaskHistory.tsx
@@ -144,7 +144,7 @@ function TaskHistory() {
                 }
                 const params = new URLSearchParams();
                 params.set("page", String(Math.max(1, page - 1)));
-                setSearchParams(params);
+                setSearchParams(params, { replace: true });
               }}
             />
           </PaginationItem>
@@ -156,7 +156,7 @@ function TaskHistory() {
               onClick={() => {
                 const params = new URLSearchParams();
                 params.set("page", String(page + 1));
-                setSearchParams(params);
+                setSearchParams(params, { replace: true });
               }}
             />
           </PaginationItem>

--- a/skyvern-frontend/src/routes/workflows/WorkflowPage.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowPage.tsx
@@ -112,7 +112,7 @@ function WorkflowPage() {
                   }
                   const params = new URLSearchParams();
                   params.set("page", String(Math.max(1, page - 1)));
-                  setSearchParams(params);
+                  setSearchParams(params, { replace: true });
                 }}
               />
             </PaginationItem>
@@ -124,7 +124,7 @@ function WorkflowPage() {
                 onClick={() => {
                   const params = new URLSearchParams();
                   params.set("page", String(page + 1));
-                  setSearchParams(params);
+                  setSearchParams(params, { replace: true });
                 }}
               />
             </PaginationItem>

--- a/skyvern-frontend/src/routes/workflows/Workflows.tsx
+++ b/skyvern-frontend/src/routes/workflows/Workflows.tsx
@@ -126,7 +126,7 @@ function Workflows() {
                     "workflowsPage",
                     String(Math.max(1, workflowsPage - 1)),
                   );
-                  setSearchParams(params);
+                  setSearchParams(params, { replace: true });
                 }}
               />
             </PaginationItem>
@@ -138,7 +138,7 @@ function Workflows() {
                 onClick={() => {
                   const params = new URLSearchParams();
                   params.set("workflowsPage", String(workflowsPage + 1));
-                  setSearchParams(params);
+                  setSearchParams(params, { replace: true });
                 }}
               />
             </PaginationItem>
@@ -203,7 +203,6 @@ function Workflows() {
           <PaginationContent>
             <PaginationItem>
               <PaginationPrevious
-                href="#"
                 className={cn({ "cursor-not-allowed": workflowRunsPage === 1 })}
                 onClick={() => {
                   if (workflowRunsPage === 1) {
@@ -214,20 +213,19 @@ function Workflows() {
                     "workflowRunsPage",
                     String(Math.max(1, workflowRunsPage - 1)),
                   );
-                  setSearchParams(params);
+                  setSearchParams(params, { replace: true });
                 }}
               />
             </PaginationItem>
             <PaginationItem>
-              <PaginationLink href="#">{workflowRunsPage}</PaginationLink>
+              <PaginationLink>{workflowRunsPage}</PaginationLink>
             </PaginationItem>
             <PaginationItem>
               <PaginationNext
-                href="#"
                 onClick={() => {
                   const params = new URLSearchParams();
                   params.set("workflowRunsPage", String(workflowRunsPage + 1));
-                  setSearchParams(params);
+                  setSearchParams(params, { replace: true });
                 }}
               />
             </PaginationItem>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 73ef82c251d824ec0362add6d78449c5c0c3a500  | 
|--------|--------|

### Summary:
Updated pagination navigation to use `replace` option in `setSearchParams` to prevent cluttering browser history.

**Key points**:
- Updated pagination navigation to use `replace` option in `setSearchParams`.
- Affected files: `skyvern-frontend/cloud/routes/billing/BillingHistory.tsx`, `skyvern-frontend/src/routes/tasks/list/TaskHistory.tsx`, `skyvern-frontend/src/routes/workflows/WorkflowPage.tsx`, `skyvern-frontend/src/routes/workflows/Workflows.tsx`.
- Ensures browser history is not cluttered with pagination changes.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->