### PR TITLE
Cmd click for workflows and workflow runs

### DIFF
--- a/skyvern-frontend/src/routes/workflows/Workflows.tsx
+++ b/skyvern-frontend/src/routes/workflows/Workflows.tsx
@@ -98,7 +98,16 @@ function Workflows() {
                 return (
                   <TableRow
                     key={workflow.workflow_permanent_id}
-                    onClick={() => {
+                    onClick={(event) => {
+                      if (event.ctrlKey || event.metaKey) {
+                        window.open(
+                          window.location.origin +
+                            `/workflows/${workflow.workflow_permanent_id}`,
+                          "_blank",
+                          "noopener,noreferrer",
+                        );
+                        return;
+                      }
                       navigate(`${workflow.workflow_permanent_id}`);
                     }}
                     className="cursor-pointer"
@@ -174,7 +183,16 @@ function Workflows() {
                 return (
                   <TableRow
                     key={workflowRun.workflow_run_id}
-                    onClick={() => {
+                    onClick={(event) => {
+                      if (event.ctrlKey || event.metaKey) {
+                        window.open(
+                          window.location.origin +
+                            `/workflows/${workflowRun.workflow_permanent_id}/${workflowRun.workflow_run_id}`,
+                          "_blank",
+                          "noopener,noreferrer",
+                        );
+                        return;
+                      }
                       navigate(
                         `/workflows/${workflowRun.workflow_permanent_id}/${workflowRun.workflow_run_id}`,
                       );


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 53ab49376298c7c4d36ebae7d965b98b2516ea6f  | 
|--------|--------|

### Summary:
Add support for opening workflows and workflow runs in a new tab with Ctrl/Cmd click in `skyvern-frontend/src/routes/workflows/Workflows.tsx`.

**Key points**:
- Add support for opening workflows and workflow runs in a new tab with Ctrl/Cmd click.
- Modify `onClick` event in `skyvern-frontend/src/routes/workflows/Workflows.tsx` to handle `event.ctrlKey` and `event.metaKey`.
- Use `window.open` to open the link in a new tab when Ctrl/Cmd is pressed.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->