### PR TITLE
support pdf printer

### DIFF
--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -28,6 +28,16 @@ def load_js_script() -> str:
         raise e
 
 
+DISABLE_PRINTER_WITH_FLAG = """
+(function() {
+    const originalPrint = window.print;
+    window.print = function() {
+        window.__printTriggered = true;
+    };
+    window.__printTriggered = false;
+})();
+"""
+
 JS_FUNCTION_DEFS = load_js_script()
 
 
@@ -102,6 +112,22 @@ class SkyvernFrame:
             await skyvern_page.remove_bounding_boxes()
         await skyvern_page.scroll_to_top(draw_boxes=False)
         return screenshots
+
+    @staticmethod
+    async def get_print_triggered(page: Page) -> bool:
+        """
+        Get print triggered on the page. Only Page instance could be printed as PDF.
+        """
+        # the flag was injected in the "window" object from the "add_init_script" when the BrowserContext initialized.
+        return await page.evaluate("window.__printTriggered")
+
+    @staticmethod
+    async def reset_print_triggered(page: Page) -> bool:
+        """
+        Get print triggered on the page. Only Page instance could be printed as PDF.
+        """
+        # the flag was injected in the "window" object from the "add_init_script" when the BrowserContext initialized.
+        return await page.evaluate("() => window.__printTriggered = false")
 
     @classmethod
     async def create_instance(cls, frame: Page | Frame) -> SkyvernFrame:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7b985ad73ccc3904cb9c16911881c743c95e70c0  | 
|--------|--------|

### Summary:
Added support for handling PDF printing by modifying click action handler and injecting a script to disable the default print dialog.

**Key points**:
- Added `get_download_dir` function in `skyvern/webeye/browser_factory.py` to initialize download directory.
- Modified `handle_click_to_download_file_action` in `skyvern/webeye/actions/handler.py` to handle PDF printing.
- Introduced `DISABLE_PRINTER_WITH_FLAG` script in `skyvern/webeye/utils/page.py` to disable default print dialog.
- Updated `create_browser_context` in `skyvern/webeye/browser_factory.py` to inject the print disabling script.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->