### PR TITLE
Change primary button font weight

### DIFF
--- a/skyvern-frontend/src/components/ui/button-variants.ts
+++ b/skyvern-frontend/src/components/ui/button-variants.ts
@@ -6,7 +6,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90 font-bold",
         destructive:
           "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
         outline:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6edf5dae5bb1949fd19d7ef206ea09a649c21d8e  | 
|--------|--------|

### Summary:
Set primary button font weight to bold in `RootLayout.tsx` and `button-variants.ts`.

**Key points**:
- Updated `skyvern-frontend/cloud/routes/root/RootLayout.tsx` to set `font-bold` for the 'Book a Demo' button.
- Modified `skyvern-frontend/src/components/ui/button-variants.ts` to include `font-bold` in the `default` button variant.
- Ensures primary buttons have bold text for better visibility.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->