### PR TITLE
fix select2 multi-select

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -648,16 +648,12 @@ async function getSelect2OptionElements(element) {
 
   while (true) {
     oldOptionCount = optionList.length;
-    let newOptionList = document.querySelectorAll(
-      "[id='select2-drop'] li[role='option']",
-    );
+    let newOptionList = document.querySelectorAll("[id='select2-drop'] ul li");
     if (newOptionList.length === oldOptionCount) {
       console.log("no more options loaded, wait 5s to query again");
       // sometimes need more time to load the options, so sleep 10s and try again
       await sleep(5000); // wait 5s
-      newOptionList = document.querySelectorAll(
-        "[id='select2-drop'] li[role='option']",
-      );
+      newOptionList = document.querySelectorAll("[id='select2-drop'] ul li");
       console.log(newOptionList.length, " options found, after 5s");
     }
 

--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -426,7 +426,7 @@ class Select2Dropdown(AbstractSelectDropdown):
         self, index: int, timeout: float = SettingsManager.get_settings().BROWSER_ACTION_TIMEOUT_MS
     ) -> None:
         anchor = await self.__find_anchor(timeout=timeout)
-        options = anchor.locator("li[role='option']")
+        options = anchor.locator("ul").locator("li")
         await options.nth(index).click(timeout=timeout)
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 01330c8c583c3ba9cf8a2fa5b5129285557d3279  | 
|--------|--------|

### Summary:
Fixed Select2 multi-select issue by updating DOM query selectors in `skyvern/webeye/scraper/domUtils.js` and `skyvern/webeye/utils/dom.py`.

**Key points**:
- Updated `getSelect2OptionElements` in `skyvern/webeye/scraper/domUtils.js` to use `document.querySelectorAll("[id='select2-drop'] ul li")` instead of `document.querySelectorAll("[id='select2-drop'] li[role='option']")`.
- Modified `select_by_index` in `skyvern/webeye/utils/dom.py` to use `anchor.locator("ul").locator("li")` instead of `anchor.locator("li[role='option']")`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->