### PR TITLE
fix t_llm_request is unbounded problem

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -190,12 +190,12 @@ class LLMAPIHandlerFactory:
                         }
                     ).encode("utf-8"),
                 )
+            t_llm_request = time.perf_counter()
             try:
                 # TODO (kerem): add a timeout to this call
                 # TODO (kerem): add a retry mechanism to this call (acompletion_with_retries)
                 # TODO (kerem): use litellm fallbacks? https://litellm.vercel.app/docs/tutorials/fallbacks#how-does-completion_with_fallbacks-work
                 LOG.info("Calling LLM API", llm_key=llm_key, model=llm_config.model_name)
-                t_llm_request = time.perf_counter()
                 response = await litellm.acompletion(
                     model=llm_config.model_name,
                     messages=messages,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 47fa925141d299cd795b5393569f78270dee443a  | 
|--------|--------|

### Summary:
Fixes unbounded `t_llm_request` issue in `llm_api_handler` function by moving its initialization before the try block.

**Key points**:
- Fixes unbounded `t_llm_request` issue in `llm_api_handler` function.
- Moves `t_llm_request = time.perf_counter()` before the try block.
- Ensures consistency with `llm_api_handler_with_router_and_fallback` function.
- Affects `skyvern/forge/sdk/api/llm/api_handler_factory.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->