### PR TITLE
move setup_logger to skyvern/__init__.py

### DIFF
--- a/skyvern/__init__.py
+++ b/skyvern/__init__.py
@@ -1,0 +1,3 @@
+from skyvern.forge.sdk.forge_log import setup_logger
+
+setup_logger()

--- a/skyvern/forge/__main__.py
+++ b/skyvern/forge/__main__.py
@@ -2,7 +2,6 @@ import structlog
 import uvicorn
 from dotenv import load_dotenv
 
-import skyvern.forge.sdk.forge_log as forge_log
 from skyvern import analytics
 from skyvern.forge.sdk.settings_manager import SettingsManager
 
@@ -11,7 +10,6 @@ LOG = structlog.stdlib.get_logger()
 
 if __name__ == "__main__":
     analytics.capture("skyvern-oss-run-server")
-    forge_log.setup_logger()
     port = SettingsManager.get_settings().PORT
     LOG.info("Agent server starting.", host="0.0.0.0", port=port)
     load_dotenv()

--- a/skyvern/forge/app.py
+++ b/skyvern/forge/app.py
@@ -12,7 +12,6 @@ from skyvern.forge.sdk.artifact.manager import ArtifactManager
 from skyvern.forge.sdk.artifact.storage.factory import StorageFactory
 from skyvern.forge.sdk.db.client import AgentDB
 from skyvern.forge.sdk.experimentation.providers import BaseExperimentationProvider, NoOpExperimentationProvider
-from skyvern.forge.sdk.forge_log import setup_logger
 from skyvern.forge.sdk.models import Organization
 from skyvern.forge.sdk.settings_manager import SettingsManager
 from skyvern.forge.sdk.workflow.context_manager import WorkflowContextManager
@@ -27,7 +26,6 @@ tracer.configure(
     },
 )
 
-setup_logger()
 SETTINGS_MANAGER = SettingsManager.get_settings()
 DATABASE = AgentDB(
     SettingsManager.get_settings().DATABASE_STRING,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1d6fa9f5a0997ec3fc8d59c6b0040697a8efe42a  | 
|--------|--------|

### Summary:
Centralized `setup_logger` call in `skyvern/__init__.py` to ensure logger configuration on package import.

**Key points**:
- Centralized `setup_logger` call in `skyvern/__init__.py` to ensure logger configuration on package import.
- Moved `setup_logger` call to `skyvern/__init__.py`.
- Removed `setup_logger` call from `skyvern/forge/__main__.py` and `skyvern/forge/app.py`.
- Ensures logger is configured on `skyvern` package import.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->