### PR TITLE
fix none content frame

### DIFF
--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -60,6 +60,9 @@ async def resolve_locator(
         child_frame = iframe_path.pop()
 
         frame_handler = await current_frame.query_selector(f"[{SKYVERN_ID_ATTR}='{child_frame}']")
+        if frame_handler is None:
+            raise NoneFrameError(frame_id=child_frame)
+
         content_frame = await frame_handler.content_frame()
         if content_frame is None:
             raise NoneFrameError(frame_id=child_frame)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 32d8a473552f70d28a86381de21498039e14643c  | 
|--------|--------|

### Summary:
Added a check for `None` frame handlers in `resolve_locator` function to raise `NoneFrameError` if `frame_handler` is `None`.

**Key points**:
- **File Modified**: `skyvern/webeye/utils/dom.py`
- **Function Modified**: `resolve_locator`
- **Change**: Added a check for `None` frame handlers.
- **Behavior**: Raises `NoneFrameError` if `frame_handler` is `None`.
- **Impact**: Prevents further execution with a `None` frame handler, ensuring robustness.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->