### PR TITLE
move tracer to skyvern init

### DIFF
--- a/skyvern/__init__.py
+++ b/skyvern/__init__.py
@@ -1,3 +1,13 @@
+from ddtrace import tracer
+from ddtrace.filters import FilterRequestsOnUrl
+
 from skyvern.forge.sdk.forge_log import setup_logger
 
+tracer.configure(
+    settings={
+        "FILTERS": [
+            FilterRequestsOnUrl(r"http://.*/heartbeat$"),
+        ],
+    },
+)
 setup_logger()

--- a/skyvern/forge/app.py
+++ b/skyvern/forge/app.py
@@ -1,7 +1,5 @@
 from typing import Awaitable, Callable
 
-from ddtrace import tracer
-from ddtrace.filters import FilterRequestsOnUrl
 from fastapi import FastAPI
 from playwright.async_api import Frame, Page
 
@@ -17,14 +15,6 @@ from skyvern.forge.sdk.settings_manager import SettingsManager
 from skyvern.forge.sdk.workflow.context_manager import WorkflowContextManager
 from skyvern.forge.sdk.workflow.service import WorkflowService
 from skyvern.webeye.browser_manager import BrowserManager
-
-tracer.configure(
-    settings={
-        "FILTERS": [
-            FilterRequestsOnUrl(r"http://.*/heartbeat$"),
-        ],
-    },
-)
 
 SETTINGS_MANAGER = SettingsManager.get_settings()
 DATABASE = AgentDB(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5a1b01fca89ae29d68b4eceb3fc3bc0c15e8982c  | 
|--------|--------|

### Summary:
Moved `ddtrace` tracer configuration to `skyvern/__init__.py` for centralized initialization.

**Key points**:
- Moved `ddtrace` tracer configuration from `skyvern/forge/app.py` to `skyvern/__init__.py`.
- Ensures tracer is configured during `skyvern` module initialization.
- Removed redundant tracer configuration from `skyvern/forge/app.py`.
- Affects `skyvern/__init__.py` and `skyvern/forge/app.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->