### PR TITLE
Add slate elevation color

### DIFF
--- a/skyvern-frontend/tailwind.config.js
+++ b/skyvern-frontend/tailwind.config.js
@@ -18,6 +18,9 @@ module.exports = {
     },
     extend: {
       colors: {
+        slate: {
+          elevation2: "hsl(var(--slate-elevation-2))",
+        },
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c0cb2b080daf11b0d502a6d5f5dec96cf66e16f8  | 
|--------|--------|

### Summary:
Added `slate.elevation2` color to `skyvern-frontend/tailwind.config.js`.

**Key points**:
- Added `slate.elevation2` color to `skyvern-frontend/tailwind.config.js`.
- `slate.elevation2` is set to `hsl(var(--slate-elevation-2))`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->