### PR TITLE
Skip updating context params if task has errors in workflow

### DIFF
--- a/skyvern/forge/sdk/workflow/context_manager.py
+++ b/skyvern/forge/sdk/workflow/context_manager.py
@@ -293,6 +293,14 @@ class WorkflowRunContext:
                 and isinstance(parameter.source, OutputParameter)
                 and parameter.source.key == output_parameter.key
             ):
+                if isinstance(value, dict) and "errors" in value:
+                    LOG.error(
+                        f"Output parameter {output_parameter.key} has errors. Setting ContextParameter {parameter.key} value to None"
+                    )
+                    parameter.value = None
+                    self.parameters[parameter.key] = parameter
+                    self.values[parameter.key] = parameter.value
+                    continue
                 value = (
                     value["extracted_information"]
                     if isinstance(value, dict) and "extracted_information" in value


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6b6538f2406163049ae44d7b6e147bd73c5b7137  | 
|--------|--------|

### Summary:
Handles errors in output parameters by setting corresponding context parameter values to `None` in `WorkflowRunContext`.

**Key points**:
- **File Modified**: `skyvern/forge/sdk/workflow/context_manager.py`
- **Class Modified**: `WorkflowRunContext`
- **Function Modified**: `set_parameter_values_for_output_parameter_dependent_blocks`
- **Behavior Change**: If an output parameter contains errors (i.e., `value` is a dict with an `"errors"` key), the corresponding context parameter's value is set to `None`.
- **Logging**: Logs an error message when an output parameter with errors is encountered.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->