### PR TITLE
Fix save as template bug

### DIFF
--- a/skyvern-frontend/src/routes/tasks/list/TaskActions.tsx
+++ b/skyvern-frontend/src/routes/tasks/list/TaskActions.tsx
@@ -50,6 +50,7 @@ function createTaskTemplateRequestObject(
   return {
     title: values.title,
     description: values.description,
+    is_saved_task: true,
     webhook_callback_url: task.request.webhook_callback_url,
     proxy_location: task.request.proxy_location,
     workflow_definition: {


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7b72e3579eab7c6754cb175d1aa7f22db8ae4cda  | 
|--------|--------|

### Summary:
Added `is_saved_task` property to mark tasks as saved when creating a task template in `skyvern-frontend/src/routes/tasks/list/TaskActions.tsx`.

**Key points**:
- Added `is_saved_task` property to mark tasks as saved when creating a task template in `skyvern-frontend/src/routes/tasks/list/TaskActions.tsx`.
- Added `is_saved_task: true` to the object returned by `createTaskTemplateRequestObject` in `skyvern-frontend/src/routes/tasks/list/TaskActions.tsx`.
- Ensures tasks are marked as saved when creating a task template.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->