### PR TITLE
add gpt4o mini support

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -75,6 +75,7 @@ class Settings(BaseSettings):
     ENABLE_OPENAI: bool = False
     ENABLE_ANTHROPIC: bool = False
     ENABLE_AZURE: bool = False
+    ENABLE_AZURE_GPT4O_MINI: bool = False
     ENABLE_BEDROCK: bool = False
     # OPENAI
     OPENAI_API_KEY: str | None = None
@@ -85,6 +86,12 @@ class Settings(BaseSettings):
     AZURE_API_KEY: str | None = None
     AZURE_API_BASE: str | None = None
     AZURE_API_VERSION: str | None = None
+
+    # AZURE GPT-4o mini
+    AZURE_GPT4O_MINI_DEPLOYMENT: str | None = None
+    AZURE_GPT4O_MINI_API_KEY: str | None = None
+    AZURE_GPT4O_MINI_API_BASE: str | None = None
+    AZURE_GPT4O_MINI_API_VERSION: str | None = None
 
     def is_cloud_environment(self) -> bool:
         """

--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -15,7 +15,7 @@ from skyvern.forge.sdk.api.llm.exceptions import (
     InvalidLLMConfigError,
     LLMProviderError,
 )
-from skyvern.forge.sdk.api.llm.models import LLMAPIHandler, LLMRouterConfig
+from skyvern.forge.sdk.api.llm.models import LLMAPIHandler, LLMConfig, LLMRouterConfig
 from skyvern.forge.sdk.api.llm.utils import llm_messages_builder, parse_api_response
 from skyvern.forge.sdk.artifact.models import ArtifactType
 from skyvern.forge.sdk.models import Step
@@ -147,6 +147,8 @@ class LLMAPIHandlerFactory:
         if LLMConfigRegistry.is_router_config(llm_key):
             return LLMAPIHandlerFactory.get_llm_api_handler_with_router(llm_key)
 
+        assert isinstance(llm_config, LLMConfig)
+
         async def llm_api_handler(
             prompt: str,
             step: Step | None = None,
@@ -158,6 +160,8 @@ class LLMAPIHandlerFactory:
                 parameters = LLMAPIHandlerFactory.get_api_parameters()
 
             active_parameters.update(parameters)
+            if llm_config.litellm_params:
+                active_parameters.update(llm_config.litellm_params)
 
             if step:
                 await app.ARTIFACT_MANAGER.create_artifact(

--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -160,8 +160,8 @@ class LLMAPIHandlerFactory:
                 parameters = LLMAPIHandlerFactory.get_api_parameters()
 
             active_parameters.update(parameters)
-            if llm_config.litellm_params:
-                active_parameters.update(llm_config.litellm_params)
+            if llm_config.litellm_params:  # type: ignore
+                active_parameters.update(llm_config.litellm_params)  # type: ignore
 
             if step:
                 await app.ARTIFACT_MANAGER.create_artifact(

--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -6,7 +6,7 @@ from skyvern.forge.sdk.api.llm.exceptions import (
     MissingLLMProviderEnvVarsError,
     NoProviderEnabledError,
 )
-from skyvern.forge.sdk.api.llm.models import LLMConfig, LLMRouterConfig
+from skyvern.forge.sdk.api.llm.models import LiteLLMParams, LLMConfig, LLMRouterConfig
 from skyvern.forge.sdk.settings_manager import SettingsManager
 
 LOG = structlog.get_logger()
@@ -49,6 +49,7 @@ if not any(
         SettingsManager.get_settings().ENABLE_OPENAI,
         SettingsManager.get_settings().ENABLE_ANTHROPIC,
         SettingsManager.get_settings().ENABLE_AZURE,
+        SettingsManager.get_settings().ENABLE_AZURE_GPT4O_MINI,
         SettingsManager.get_settings().ENABLE_BEDROCK,
     ]
 ):
@@ -185,6 +186,27 @@ if SettingsManager.get_settings().ENABLE_AZURE:
                 "AZURE_API_BASE",
                 "AZURE_API_VERSION",
             ],
+            supports_vision=True,
+            add_assistant_prefix=False,
+        ),
+    )
+
+if SettingsManager.get_settings().ENABLE_AZURE_GPT4O_MINI:
+    LLMConfigRegistry.register_config(
+        "AZURE_OPENAI_GPT4O_MINI",
+        LLMConfig(
+            f"azure/{SettingsManager.get_settings().AZURE_GPT4O_MINI_DEPLOYMENT}",
+            [
+                "AZURE_GPT4O_MINI_DEPLOYMENT",
+                "AZURE_GPT4O_MINI_API_KEY",
+                "AZURE_GPT4O_MINI_API_BASE",
+                "AZURE_GPT4O_MINI_API_VERSION",
+            ],
+            litellm_params=LiteLLMParams(
+                api_base=SettingsManager.get_settings().AZURE_GPT4O_MINI_API_BASE,
+                api_key=SettingsManager.get_settings().AZURE_GPT4O_MINI_API_KEY,
+                api_version=SettingsManager.get_settings().AZURE_GPT4O_MINI_API_VERSION,
+            ),
             supports_vision=True,
             add_assistant_prefix=False,
         ),

--- a/skyvern/forge/sdk/api/llm/models.py
+++ b/skyvern/forge/sdk/api/llm/models.py
@@ -1,12 +1,18 @@
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Literal, Protocol
+from typing import Any, Awaitable, Literal, Optional, Protocol, TypedDict
 
 from skyvern.forge.sdk.models import Step
 from skyvern.forge.sdk.settings_manager import SettingsManager
 
 
+class LiteLLMParams(TypedDict):
+    api_key: str
+    api_version: str
+    api_base: str
+
+
 @dataclass(frozen=True)
-class LLMConfig:
+class LLMConfigBase:
     model_name: str
     required_env_vars: list[str]
     supports_vision: bool
@@ -23,6 +29,11 @@ class LLMConfig:
 
 
 @dataclass(frozen=True)
+class LLMConfig(LLMConfigBase):
+    litellm_params: Optional[LiteLLMParams] = field(default=None)
+
+
+@dataclass(frozen=True)
 class LLMRouterModelConfig:
     model_name: str
     # https://litellm.vercel.app/docs/routing
@@ -33,7 +44,7 @@ class LLMRouterModelConfig:
 
 
 @dataclass(frozen=True)
-class LLMRouterConfig(LLMConfig):
+class LLMRouterConfig(LLMConfigBase):
     model_list: list[LLMRouterModelConfig]
     # All three redis parameters are required. Even if there isn't a password, it should be an empty string.
     main_model_group: str

--- a/skyvern/forge/sdk/api/llm/models.py
+++ b/skyvern/forge/sdk/api/llm/models.py
@@ -6,9 +6,9 @@ from skyvern.forge.sdk.settings_manager import SettingsManager
 
 
 class LiteLLMParams(TypedDict):
-    api_key: str
-    api_version: str
-    api_base: str
+    api_key: str | None
+    api_version: str | None
+    api_base: str | None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ae7a6d96eb34ee9e2bc2d684e55050dcc4bd1c75  | 
|--------|--------|

### Summary:
Added support for Azure GPT-4o mini by updating configuration settings, API handler factory, and LLM configuration registry.

**Key points**:
- Added `ENABLE_AZURE_GPT4O_MINI` flag in `skyvern/config.py`.
- Introduced Azure GPT-4o mini specific environment variables in `skyvern/config.py`.
- Updated `LLMConfig` and `LLMConfigBase` in `skyvern/forge/sdk/api/llm/models.py` to include `litellm_params`.
- Modified `LLMAPIHandlerFactory.get_llm_api_handler` in `skyvern/forge/sdk/api/llm/api_handler_factory.py` to handle `litellm_params`.
- Registered Azure GPT-4o mini configuration in `skyvern/forge/sdk/api/llm/config_registry.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->