### PR TITLE
Use residential proxy for workflow UI runs by default

### DIFF
--- a/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
+++ b/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
@@ -36,6 +36,7 @@ function RunWorkflowForm({ workflowParameters, initialValues }: Props) {
       return client
         .post(`/workflows/${workflowPermanentId}/run`, {
           data: values,
+          proxy_location: "RESIDENTIAL",
         })
         .then((response) => response.data);
     },


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 6aab2afe8c0badb883f017236fb64e628a1f3251  | 
|--------|--------|

### Summary:
Set residential proxy as default for workflow runs in `RunWorkflowForm`.

**Key points**:
- Set residential proxy as default for workflow runs in `RunWorkflowForm`.
- Updated `skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx`.
- Modified `runWorkflowMutation` in `RunWorkflowForm` to include `proxy_location: "RESIDENTIAL"` in the POST request payload.
- Ensures all workflow runs use a residential proxy by default.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->