### PR TITLE
Timeout and retry mechanism for Bitwarden CLI

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -63,6 +63,12 @@ class Settings(BaseSettings):
     WORKFLOW_DOWNLOAD_DIRECTORY_PARAMETER_KEY: str = "SKYVERN_DOWNLOAD_DIRECTORY"
 
     #####################
+    # Bitwarden Configs #
+    #####################
+    BITWARDEN_TIMEOUT_SECONDS: int = 60
+    BITWARDEN_MAX_RETRIES: int = 1
+
+    #####################
     # LLM Configuration #
     #####################
     # ACTIVE LLM PROVIDER

--- a/skyvern/exceptions.py
+++ b/skyvern/exceptions.py
@@ -278,6 +278,11 @@ class BitwardenLogoutError(BitwardenBaseError):
         super().__init__(f"Error logging out of Bitwarden: {message}")
 
 
+class BitwardenSyncError(BitwardenBaseError):
+    def __init__(self, message: str) -> None:
+        super().__init__(f"Error syncing Bitwarden: {message}")
+
+
 class UnknownElementTreeFormat(SkyvernException):
     def __init__(self, fmt: str) -> None:
         super().__init__(f"Unknown element tree format {fmt}")

--- a/skyvern/forge/sdk/workflow/context_manager.py
+++ b/skyvern/forge/sdk/workflow/context_manager.py
@@ -97,11 +97,11 @@ class WorkflowRunContext:
             return self.secrets.get(secret_id_or_value)
         return None
 
-    def get_secrets_from_password_manager(self) -> dict[str, Any]:
+    async def get_secrets_from_password_manager(self) -> dict[str, Any]:
         """
         Get the secrets from the password manager. The secrets dict will contain the actual secret values.
         """
-        secret_credentials = BitwardenService.get_secret_value_from_url(
+        secret_credentials = await BitwardenService.get_secret_value_from_url(
             url=self.secrets[BitwardenConstants.URL],
             client_secret=self.secrets[BitwardenConstants.CLIENT_SECRET],
             client_id=self.secrets[BitwardenConstants.CLIENT_ID],
@@ -161,7 +161,7 @@ class WorkflowRunContext:
                     collection_id = parameter.bitwarden_collection_id
 
             try:
-                secret_credentials = BitwardenService.get_secret_value_from_url(
+                secret_credentials = await BitwardenService.get_secret_value_from_url(
                     client_id,
                     client_secret,
                     master_password,
@@ -218,7 +218,7 @@ class WorkflowRunContext:
                 collection_id = self.values[parameter.bitwarden_collection_id]
 
             try:
-                sensitive_values = BitwardenService.get_sensitive_information_from_identity(
+                sensitive_values = await BitwardenService.get_sensitive_information_from_identity(
                     client_id,
                     client_secret,
                     master_password,

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -706,7 +706,7 @@ async def get_actual_value_of_parameter_if_secret(task: Task, parameter: str) ->
     secret_value = workflow_run_context.get_original_secret_value_or_none(parameter)
 
     if secret_value == BitwardenConstants.TOTP:
-        secrets = workflow_run_context.get_secrets_from_password_manager()
+        secrets = await workflow_run_context.get_secrets_from_password_manager()
         secret_value = secrets[BitwardenConstants.TOTP]
     return secret_value if secret_value is not None else parameter
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 087d32e34a46559a87b485bf05f789f865dbd369  | 
|--------|--------|

### Summary:
Introduced timeout and retry mechanism for Bitwarden CLI operations with async support and updated relevant methods across the codebase.

**Key points**:
- Added `BITWARDEN_TIMEOUT_SECONDS` and `BITWARDEN_MAX_RETRIES` to `skyvern/config.py` for configuring timeout and retry settings.
- Introduced `BitwardenSyncError` in `skyvern/exceptions.py` for handling sync errors.
- Updated `BitwardenService` methods in `skyvern/forge/sdk/services/bitwarden.py` to support async operations and added retry logic with timeout for `get_secret_value_from_url` and `get_sensitive_information_from_identity`.
- Modified `WorkflowRunContext` methods in `skyvern/forge/sdk/workflow/context_manager.py` to call the updated async `BitwardenService` methods.
- Updated `get_actual_value_of_parameter_if_secret` in `skyvern/webeye/actions/handler.py` to handle TOTP secrets using the new async methods.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->