### PR TITLE
fix recreate workflow browser

### DIFF
--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -200,6 +200,7 @@ class BrowserState:
         url: str | None = None,
         proxy_location: ProxyLocation | None = None,
         task_id: str | None = None,
+        workflow_run_id: str | None = None,
     ) -> None:
         if self.pw is None:
             LOG.info("Starting playwright")
@@ -216,6 +217,7 @@ class BrowserState:
                 url=url,
                 proxy_location=proxy_location,
                 task_id=task_id,
+                workflow_run_id=workflow_run_id,
             )
             self.browser_context = browser_context
             self.browser_artifacts = browser_artifacts
@@ -276,23 +278,30 @@ class BrowserState:
         url: str | None = None,
         proxy_location: ProxyLocation | None = None,
         task_id: str | None = None,
+        workflow_run_id: str | None = None,
     ) -> Page:
         if self.page is not None:
             return self.page
 
         try:
-            await self.check_and_fix_state(url=url, proxy_location=proxy_location, task_id=task_id)
+            await self.check_and_fix_state(
+                url=url, proxy_location=proxy_location, task_id=task_id, workflow_run_id=workflow_run_id
+            )
         except Exception as e:
             error_message = str(e)
             if "net::ERR" not in error_message:
                 raise e
             await self.close_current_open_page()
-            await self.check_and_fix_state(url=url, proxy_location=proxy_location, task_id=task_id)
+            await self.check_and_fix_state(
+                url=url, proxy_location=proxy_location, task_id=task_id, workflow_run_id=workflow_run_id
+            )
         assert self.page is not None
 
         if not await BrowserContextFactory.validate_browser_context(self.page):
             await self.close_current_open_page()
-            await self.check_and_fix_state(url=url, proxy_location=proxy_location, task_id=task_id)
+            await self.check_and_fix_state(
+                url=url, proxy_location=proxy_location, task_id=task_id, workflow_run_id=workflow_run_id
+            )
             assert self.page is not None
 
         return self.page

--- a/skyvern/webeye/browser_manager.py
+++ b/skyvern/webeye/browser_manager.py
@@ -84,7 +84,9 @@ class BrowserManager:
 
         # The URL here is only used when creating a new page, and not when using an existing page.
         # This will make sure browser_state.page is not None.
-        await browser_state.get_or_create_page(url=url, proxy_location=workflow_run.proxy_location)
+        await browser_state.get_or_create_page(
+            url=url, proxy_location=workflow_run.proxy_location, workflow_run_id=workflow_run.workflow_run_id
+        )
 
         self.pages[workflow_run.workflow_run_id] = browser_state
         return browser_state


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 091daa7bb7bd47fccb9c4f3e7780ab9a9c0f7b68  | 
|--------|--------|

### Summary:
Added `workflow_run_id` parameter to improve browser state handling in workflows.

**Key points**:
- **Added** `workflow_run_id` parameter to `check_and_fix_state` and `get_or_create_page` methods in `skyvern/webeye/browser_factory.py`.
- **Updated** `get_or_create_for_workflow_run` method in `skyvern/webeye/browser_manager.py` to pass `workflow_run_id`.
- **Improved** browser state handling for workflows by associating states with `workflow_run_id`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->