### PR TITLE
Detailed logs for webhook failures

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -729,10 +729,10 @@ class WorkflowService:
                     "Webhook failed",
                     workflow_id=workflow.workflow_id,
                     workflow_run_id=workflow_run.workflow_run_id,
+                    webhook_data=payload,
                     resp=resp,
                     resp_code=resp.status_code,
                     resp_text=resp.text,
-                    resp_json=resp.json(),
                 )
         except Exception as e:
             raise FailedToSendWebhook(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d5e9dd6694f42155851636d3bd96720fb3c15171  | 
|--------|--------|

### Summary:
Remove JSON response logging in `send_workflow_response`, affecting webhook response logging behavior.

**Key points**:
- Remove JSON response logging in `send_workflow_response` function.
- Affects `skyvern/forge/sdk/workflow/service.py`.
- Remove `resp_json=resp.json()` from logging on webhook failure.
- Changes logging behavior for webhook responses.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->