### PR TITLE
fixing potential bug

### DIFF
--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -442,7 +442,7 @@ class IncrementalScrapePage:
         js_script = "() => window.globalOneTimeIncrementElements.length"
         return await self.skyvern_frame.get_frame().evaluate(js_script)
 
-    def build_html_tree(self, element_tree: list[dict] = []) -> str:
+    def build_html_tree(self, element_tree: list[dict] | None = None) -> str:
         return "".join([json_to_html(element) for element in (element_tree or self.element_tree_trimmed)])
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 346299c4f0add335bff1a06a249446c8ca3fd50d  | 
|--------|--------|

### Summary:
Fixes potential bug in `build_html_tree` by allowing `None` as default for `element_tree` in `skyvern/webeye/scraper/scraper.py`.

**Key points**:
- Updated `build_html_tree` in `skyvern/webeye/scraper/scraper.py` to accept `None` as default for `element_tree`.
- Ensures `element_tree` defaults to `self.element_tree_trimmed` if not provided.
- Fixes potential bug when `element_tree` is not passed to `build_html_tree`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->