### PR TITLE
downgrade litellm to 1.42.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2943,13 +2943,13 @@ files = [
 
 [[package]]
 name = "litellm"
-version = "1.43.1"
+version = "1.42.0"
 description = "Library to easily interface with LLM API providers"
 optional = false
 python-versions = "!=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,!=3.7.*,>=3.8"
 files = [
-    {file = "litellm-1.43.1-py3-none-any.whl", hash = "sha256:57a3ce38889782f014f371cd794a1cad4e7d9b97412d75ff8b051bc8fc4f4e4d"},
-    {file = "litellm-1.43.1.tar.gz", hash = "sha256:f7132938b6e2120e40b01b2210087ca05c51f2f90cebf33495adb53e7f9aaaab"},
+    {file = "litellm-1.42.0-py3-none-any.whl", hash = "sha256:e0a0a6481298855557c26ae04f8165bc75d6ac2321daf6d4b27c816979ad32a5"},
+    {file = "litellm-1.42.0.tar.gz", hash = "sha256:c239e27e33c549da7f7a8770c7d6393e16d4e1aeb6e09dc50a259948b0cb432c"},
 ]
 
 [package.dependencies]
@@ -7277,4 +7277,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11,<3.12"
-content-hash = "df83fd6155013c6c72e24e0a24dcb5543ab919001a17492d788cd2ce959edc3b"
+content-hash = "1ab10eda8079403801f277e5239948e0fbad26af36b120e79cfc436b13b650c3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ python-multipart = "^0.0.6"
 toml = "^0.10.2"
 jinja2 = "^3.1.2"
 uvicorn = {extras = ["standard"], version = "^0.24.0.post1"}
-litellm = "1.43.1"
+litellm = "1.42.0"
 duckduckgo-search = "^3.8.0"
 selenium = "^4.13.0"
 bs4 = "^0.0.1"


### PR DESCRIPTION
litellm 1.43.1  is generating a lot of this errors:
```
litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - 'NoneType' object has no attribute 'get'
```