### PR TITLE
increase lazy loading wait time to 10s

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -1015,7 +1015,7 @@ async def scroll_down_to_load_all_options(
         await page.mouse.wheel(0, -20)
         await page.mouse.wheel(0, 20)
         # wait for while to load new options
-        await asyncio.sleep(5)
+        await asyncio.sleep(10)
 
         current_num = await incremental_scraped.get_incremental_elements_num()
         LOG.info(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 378e28d32c9388f65fb733fbfe5b64b3ea2c38ca  | 
|--------|--------|

### Summary:
Increased wait time for lazy loading options from 5s to 10s in `scroll_down_to_load_all_options` function in `skyvern/webeye/actions/handler.py`.

**Key points**:
- Increased wait time from 5s to 10s in `scroll_down_to_load_all_options` function.
- Affects lazy loading of options in dropdown menus.
- Change made in `skyvern/webeye/actions/handler.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->