### PR TITLE
extend select2

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -219,7 +219,10 @@ function isElementVisible(element) {
   )
     return element.parentElement && isElementVisible(element.parentElement);
 
-  if (element.className.toString().includes("select2-offscreen")) {
+  if (
+    element.className.toString().includes("select2-offscreen") ||
+    element.className.toString().includes("select2-hidden")
+  ) {
     return false;
   }
 
@@ -468,10 +471,21 @@ const isComboboxDropdown = (element) => {
 };
 
 const isSelect2Dropdown = (element) => {
-  return (
-    element.tagName.toLowerCase() === "a" &&
-    element.className.toString().includes("select2-choice")
-  );
+  const tagName = element.tagName.toLowerCase();
+  const className = element.className.toString();
+  const role = element.getAttribute("role")
+    ? element.getAttribute("role").toLowerCase()
+    : "";
+
+  if (tagName === "a") {
+    return className.includes("select2-choice");
+  }
+
+  if (tagName === "span") {
+    return className.includes("select2-selection") && role === "combobox";
+  }
+
+  return false;
 };
 
 const isSelect2MultiChoice = (element) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4c09a96a3dc689c1225c9043056b16d9a12f7ac1  | 
|--------|--------|

### Summary:
Extended `select2` dropdown detection in `skyvern/webeye/scraper/domUtils.js` by updating `isElementVisible` and `isSelect2Dropdown` functions.

**Key points**:
- Updated `isElementVisible` in `skyvern/webeye/scraper/domUtils.js` to return `false` for elements with class `select2-hidden`.
- Enhanced `isSelect2Dropdown` to detect `span` elements with class `select2-selection` and role `combobox`.
- Improved detection of `select2` dropdowns for better interaction handling.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->