### PR TITLE
deprecate streamlit ui image in the docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,19 +72,3 @@ services:
     depends_on:
       skyvern:
         condition: service_healthy
-  
-  streamlit:
-    image: public.ecr.aws/skyvern/skyvern:latest
-    restart: on-failure
-    ports:
-      - 8501:8501
-    volumes:
-      - ./artifacts:/data/artifacts
-      - ./videos:/data/videos
-      - ./har:/data/har
-      - ./.streamlit:/app/.streamlit
-    command: ["/bin/bash", "entrypoint-streamlit.sh"]
-    depends_on:
-      skyvern:
-        condition: service_healthy
-


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 276b7780b051137f513c8dbdc4d31b7bccc0b882  | 
|--------|--------|

### Summary:
Deprecates the `streamlit` service in `docker-compose.yml`, removing its configuration and dependencies.

**Key points**:
- Removed `streamlit` service from `docker-compose.yml`.
- `streamlit` service used `public.ecr.aws/skyvern/skyvern:latest` image.
- Removed `streamlit` service configuration including ports, volumes, and command.
- `streamlit` service depended on `skyvern` service health.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->