### PR TITLE
Add Timeout to bitwarden subprocess call so it doesn't wait forever for things that don't exist (ie TOTPs)

### DIFF
--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -56,7 +56,7 @@ class BitwardenService:
         try:
             return subprocess.run(command, capture_output=True, text=True, env=env, timeout=60)
         except subprocess.TimeoutExpired as e:
-            LOG.error(f"Bitwarden command timed out after 60 seconds", stdout=e.stdout, stderr=e.stderr)
+            LOG.error("Bitwarden command timed out after 60 seconds", stdout=e.stdout, stderr=e.stderr)
             raise e
 
     @staticmethod

--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -56,7 +56,7 @@ class BitwardenService:
         try:
             return subprocess.run(command, capture_output=True, text=True, env=env, timeout=60)
         except subprocess.TimeoutExpired as e:
-            LOG.error("Bitwarden command timed out", stdout=e.stdout, stderr=e.stderr, timeout=60)
+            LOG.error(f"Bitwarden command timed out after 60 seconds", stdout=e.stdout, stderr=e.stderr)
             raise e
 
     @staticmethod


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 797101caefa16866717023e79e6b7f52dd0f54d8  | 
|--------|--------|

### Summary:
Added timeout, improved logging, updated logic for sensitive information extraction, and updated documentation in `BitwardenService`.

**Key points**:
- Added 60-second timeout to `subprocess.run` in `BitwardenService.run_command`.
- Improved error logging for `subprocess.TimeoutExpired` in `BitwardenService.run_command`.
- Enhanced logging for sensitive information retrieval in `BitwardenService.get_sensitive_information_from_identity`.
- Updated logic for extracting sensitive information in `BitwardenService._get_sensitive_information_from_identity`.
- Removed unnecessary logging in `BitwardenService._get_sensitive_information_from_identity`.
- Added logging for parameter values in `WorkflowRunContext.register_parameter_value`.
- Updated script documentation in `scripts/restart_task.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->