### PR TITLE
remove run_streaming.sh

### DIFF
--- a/run_streaming.sh
+++ b/run_streaming.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-echo "Starting streaming..."
-
-while true; do
-    xwd -root | xwdtopnm | pnmtopng > /tmp/skyvern_screenshot.png
-    sleep 1
-done


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a6f62630e371e6146f9bc5cc934283eede5b92aa  | 
|--------|--------|

### Summary:
Removes `run_streaming.sh` script, which captured and saved root window screenshots every second.

**Key points**:
- Removes `run_streaming.sh` script.
- Script captured root window screenshots every second.
- Used `xwd`, `xwdtopnm`, and `pnmtopng` for image processing.
- Saved screenshots to `/tmp/skyvern_screenshot.png`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->