### PR TITLE
litellm cooldown config

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -46,6 +46,10 @@ class LLMAPIHandlerFactory:
             ),
             num_retries=llm_config.num_retries,
             retry_after=llm_config.retry_delay_seconds,
+            disable_cooldowns=llm_config.disable_cooldowns,
+            allowed_fails=llm_config.allowed_fails,
+            allowed_fails_policy=llm_config.allowed_fails_policy,
+            cooldown_time=llm_config.cooldown_time,
             set_verbose=(False if SettingsManager.get_settings().is_cloud_environment() else llm_config.set_verbose),
             enable_pre_call_checks=True,
         )

--- a/skyvern/forge/sdk/api/llm/models.py
+++ b/skyvern/forge/sdk/api/llm/models.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Literal, Optional, Protocol, TypedDict
 
+from litellm import AllowedFailsPolicy
+
 from skyvern.forge.sdk.models import Step
 from skyvern.forge.sdk.settings_manager import SettingsManager
 
@@ -62,6 +64,10 @@ class LLMRouterConfig(LLMConfigBase):
     num_retries: int = 1
     retry_delay_seconds: int = 15
     set_verbose: bool = False
+    disable_cooldowns: bool | None = None
+    allowed_fails: int | None = None
+    allowed_fails_policy: AllowedFailsPolicy | None = None
+    cooldown_time: float | None = None
 
 
 class LLMAPIHandler(Protocol):


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 50ea313466c75883de0f63ba351df75e122ee5dc  | 
|--------|--------|

### Summary:
This PR introduces cooldown and failure handling configurations to the LLM API handler in `skyvern/forge/sdk/api/llm` by updating `LLMRouterConfig` and `get_llm_api_handler_with_router`.

**Key points**:
- Added `disable_cooldowns`, `allowed_fails`, `allowed_fails_policy`, and `cooldown_time` to `LLMRouterConfig` in `skyvern/forge/sdk/api/llm/models.py`.
- Updated `get_llm_api_handler_with_router` in `skyvern/forge/sdk/api/llm/api_handler_factory.py` to use new cooldown configurations.
- Integrated `AllowedFailsPolicy` from `litellm` for handling failure policies.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->