### PR TITLE
Ensure Task Clenup - add timeout to browser context close

### DIFF
--- a/skyvern/constants.py
+++ b/skyvern/constants.py
@@ -8,6 +8,7 @@ REPO_ROOT_DIR = SKYVERN_DIR.parent
 
 INPUT_TEXT_TIMEOUT = 120000  # 2 minutes
 PAGE_CONTENT_TIMEOUT = 300  # 5 mins
+BROWSER_CLOSE_TIMEOUT = 60  # 1 minute
 
 # reserved fields for navigation payload
 SPECIAL_FIELD_VERIFICATION_CODE = "verification_code"


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b8dc27d40eafb68397e45c904816b114d2e9db1f  | 
|--------|--------|

### Summary:
Introduced `task_cleanup` methods and browser context timeout for efficient Chrome process and browser state management, with enhanced error handling and updates across multiple files.

**Key points**:
- Introduced `task_cleanup` methods for Chrome process and browser state management.
- Added `task_cleanup` in `cloud/agent_functions.py` to terminate Chrome processes.
- Implemented `task_cleanup` in `skyvern/forge/agent_functions.py` for browser state handling.
- Updated `skyvern/forge/agent.py` to call `task_cleanup` during `send_task_response`.
- Enhanced `skyvern/webeye/browser_manager.py` to handle `TimeoutError` during task cleanup.
- Added `BROWSER_CLOSE_TIMEOUT` constant in `skyvern/constants.py` for browser context close timeout.
- Updated `BrowserManager.cleanup_for_task` to use `asyncio.timeout` for closing browser contexts.
- Added handling for `TimeoutError` in `cleanup_for_task` to log a warning if timeout occurs.
- Integrated `cleanup_browser_and_create_artifacts` into `task_cleanup`.
- Moved Chrome process termination to `workers/temporal_workflows.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->