### PR TITLE
add support for gpt-4o-2024-08-06

### DIFF
--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -87,6 +87,10 @@ if SettingsManager.get_settings().ENABLE_OPENAI:
             add_assistant_prefix=False,
         ),
     )
+    LLMConfigRegistry.register_config(
+        "OPENAI_GPT-4O-2024-08-06",
+        LLMConfig("gpt-4o-2024-08-06", ["OPENAI_API_KEY"], supports_vision=True, add_assistant_prefix=False),
+    )
 
 
 if SettingsManager.get_settings().ENABLE_ANTHROPIC:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d62efad75c4d0b34705b7453086bbccec12356c3  | 
|--------|--------|

### Summary:
Added support for `gpt-4o-2024-08-06` in `config_registry.py` with vision support and no assistant prefix.

**Key points**:
- Added support for `gpt-4o-2024-08-06` in `skyvern/forge/sdk/api/llm/config_registry.py`.
- Registered new `LLMConfig` with key `OPENAI_GPT-4O-2024-08-06`.
- Configuration includes `supports_vision=True` and `add_assistant_prefix=False`.
- Requires `OPENAI_API_KEY` environment variable.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->