### PR TITLE
Move navigation payload inside advanced accordion

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -324,46 +324,46 @@ function CreateNewTaskForm({ initialValues }: Props) {
             </FormItem>
           )}
         />
-        <FormField
-          control={form.control}
-          name="navigationPayload"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>
-                <div className="flex gap-2">
-                  Navigation Payload
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <InfoCircledIcon />
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-[250px]">
-                        <p>{navigationPayloadDescription}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-              </FormLabel>
-              <FormDescription>
-                Any context Skyvern needs to complete its actions (ex. text that
-                may be required to fill out forms)
-              </FormDescription>
-              <FormControl>
-                <Textarea
-                  rows={5}
-                  placeholder="Navigation Payload"
-                  {...field}
-                  value={field.value === null ? "" : field.value}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
         <Accordion type="single" collapsible>
           <AccordionItem value="advanced-settings">
             <AccordionTrigger>Advanced Settings</AccordionTrigger>
             <AccordionContent className="space-y-8 px-1 py-4">
+              <FormField
+                control={form.control}
+                name="navigationPayload"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      <div className="flex gap-2">
+                        Navigation Payload
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <InfoCircledIcon />
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-[250px]">
+                              <p>{navigationPayloadDescription}</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      </div>
+                    </FormLabel>
+                    <FormDescription>
+                      Any context Skyvern needs to complete its actions (ex.
+                      text that may be required to fill out forms)
+                    </FormDescription>
+                    <FormControl>
+                      <Textarea
+                        rows={5}
+                        placeholder="Navigation Payload"
+                        {...field}
+                        value={field.value === null ? "" : field.value}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
               <FormField
                 control={form.control}
                 name="extractedInformationSchema"

--- a/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
@@ -451,46 +451,46 @@ function SavedTaskForm({ initialValues }: Props) {
             </FormItem>
           )}
         />
-        <FormField
-          control={form.control}
-          name="navigationPayload"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>
-                <div className="flex gap-2">
-                  Navigation Payload
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <InfoCircledIcon />
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-[250px]">
-                        <p>{navigationPayloadDescription}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </div>
-              </FormLabel>
-              <FormDescription>
-                Any context Skyvern needs to complete its actions (ex. text that
-                may be required to fill out forms)
-              </FormDescription>
-              <FormControl>
-                <Textarea
-                  rows={5}
-                  placeholder="Navigation Payload"
-                  {...field}
-                  value={field.value === null ? "" : field.value}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
         <Accordion type="single" collapsible>
           <AccordionItem value="advanced-settings">
             <AccordionTrigger>Advanced Settings</AccordionTrigger>
             <AccordionContent className="space-y-8 px-1 py-4">
+              <FormField
+                control={form.control}
+                name="navigationPayload"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      <div className="flex gap-2">
+                        Navigation Payload
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <InfoCircledIcon />
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-[250px]">
+                              <p>{navigationPayloadDescription}</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      </div>
+                    </FormLabel>
+                    <FormDescription>
+                      Any context Skyvern needs to complete its actions (ex.
+                      text that may be required to fill out forms)
+                    </FormDescription>
+                    <FormControl>
+                      <Textarea
+                        rows={5}
+                        placeholder="Navigation Payload"
+                        {...field}
+                        value={field.value === null ? "" : field.value}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
               <FormField
                 control={form.control}
                 name="extractedInformationSchema"


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2798365ce74f5e8a6b92313b86c9f019bf0d1cc4  | 
|--------|--------|

### Summary:
Moved `navigationPayload` form field into 'Advanced Settings' accordion in task creation forms.

**Key points**:
- Moved `navigationPayload` form field into 'Advanced Settings' accordion in `CreateNewTaskForm.tsx`.
- Moved `navigationPayload` form field into 'Advanced Settings' accordion in `SavedTaskForm.tsx`.
- Ensures `navigationPayload` is treated as an advanced setting in both task creation forms.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->