### PR TITLE
Change query invalidation for saved task actions

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/SavedTaskCard.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTaskCard.tsx
@@ -65,7 +65,7 @@ function SavedTaskCard({ workflowId, title, url, description }: Props) {
         description: "Template deleted successfully",
       });
       queryClient.invalidateQueries({
-        queryKey: ["workflows"],
+        queryKey: ["savedTasks"],
       });
       setOpen(false);
       navigate("/create");

--- a/skyvern-frontend/src/routes/tasks/create/SavedTasks.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTasks.tsx
@@ -90,7 +90,7 @@ function SavedTasks() {
         description: "Your template was created successfully",
       });
       queryClient.invalidateQueries({
-        queryKey: ["workflows"],
+        queryKey: ["savedTasks"],
       });
       navigate(`/create/${response.workflow_permanent_id}`);
     },


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 36bfdaeecabd93a242fa5382d2c8696950d02f71  | 
|--------|--------|

### Summary:
Change query invalidation key from `workflows` to `savedTasks` for correct cache invalidation on task actions.

**Key points**:
- Change query invalidation key from `workflows` to `savedTasks` in `SavedTaskCard.tsx` and `SavedTasks.tsx`.
- Affects task deletion and creation actions for correct cache invalidation.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->