### PR TITLE
handle case where we don't get title suggested from LLM

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/TaskTemplates.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/TaskTemplates.tsx
@@ -67,7 +67,7 @@ function createTemplateTaskFromTaskGenerationParameters(
   values: TaskGenerationApiResponse,
 ) {
   return {
-    title: values.suggested_title ?? "Untitled",
+    title: values.suggested_title ?? "Untitled Task",
     description: "",
     is_saved_task: true,
     webhook_callback_url: null,
@@ -84,7 +84,7 @@ function createTemplateTaskFromTaskGenerationParameters(
       blocks: [
         {
           block_type: "task",
-          label: values.suggested_title,
+          label: values.suggested_title ?? "Untitled Task",
           url: values.url,
           navigation_goal: values.navigation_goal,
           data_extraction_goal: values.data_extraction_goal,
@@ -153,7 +153,7 @@ function TaskTemplates() {
     onError: (error: AxiosError) => {
       toast({
         variant: "destructive",
-        title: "Error creating task from prompt",
+        title: "Error saving task",
         description: error.message,
       });
     },
@@ -174,7 +174,7 @@ function TaskTemplates() {
     onError: (error: AxiosError) => {
       toast({
         variant: "destructive",
-        title: "Error creating task from prompt",
+        title: "Error running task",
         description: error.message,
       });
     },


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c4bcd61007f1acba9cf03a1f7adf64493b3e84eb  | 
|--------|--------|

### Summary:
Set default task title to "Untitled Task" and updated error messages in `TaskTemplates.tsx`.

**Key points**:
- Set default task title to "Untitled Task" if `suggested_title` is missing.
- Updated `createTemplateTaskFromTaskGenerationParameters` in `TaskTemplates.tsx`.
- Updated `label` in `workflow_definition.blocks` to use "Untitled Task".
- Changed error toast titles for clarity: "Error creating task from prompt" to "Error saving task" and "Error running task".


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->