### PR TITLE
Running saved task should save changes

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
@@ -295,7 +295,7 @@ function SavedTaskForm({ initialValues }: Props) {
         description: "Changes saved successfully",
       });
       queryClient.invalidateQueries({
-        queryKey: ["workflows", template],
+        queryKey: ["savedTasks", template],
       });
     },
   });
@@ -315,12 +315,10 @@ function SavedTaskForm({ initialValues }: Props) {
           const submitter = (
             (event.nativeEvent as SubmitEvent).submitter as HTMLButtonElement
           ).value;
-          if (submitter === "save") {
-            form.handleSubmit(handleSave)(event);
-          }
           if (submitter === "create") {
             form.handleSubmit(handleCreate)(event);
           }
+          form.handleSubmit(handleSave)(event);
         }}
         className="space-y-8"
       >


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1978df03d9e7aed9d2dddcc301415c696652af58  | 
|--------|--------|

### Summary:
This PR updates `SavedTaskForm` to ensure changes are saved when running a saved task by modifying form submission logic and query invalidation keys.

**Key points**:
- Update `SavedTaskForm` to ensure changes are saved when running a saved task.
- Modify form submission logic to always call `handleSave`.
- Change `queryKey` in `saveTaskMutation.onSuccess` from `"workflows"` to `"savedTasks"`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->