### PR TITLE
remove 'Child frame' log

### DIFF
--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -53,7 +53,6 @@ async def resolve_locator(
         if not parent_frame:
             raise SkyvernException(f"element without frame: {frame_element}")
 
-        LOG.info(f"{frame} is a child frame of {parent_frame}")
         frame = parent_frame
 
     current_page: Page | FrameLocator = page


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 33aacadcd4290500b1c8cc330716c4857d9152f4  | 
|--------|--------|

### Summary:
Removed a log statement in `skyvern/webeye/utils/dom.py` to reduce verbosity in the `resolve_locator` function.

**Key points**:
- Removed log statement in `skyvern/webeye/utils/dom.py`.
- Deleted `LOG.info` call that logged child frame and parent frame relationship.
- Affects `resolve_locator` function, reducing log verbosity.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->