### PR TITLE
Add endpoint to stream HAR file for tasks 

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -781,6 +781,7 @@ async def generate_task(
             navigation_payload=parsed_task_generation_obj.navigation_payload,
             data_extraction_goal=parsed_task_generation_obj.data_extraction_goal,
             extracted_information_schema=parsed_task_generation_obj.extracted_information_schema,
+            suggested_title=parsed_task_generation_obj.suggested_title,
             llm=SettingsManager.get_settings().LLM_KEY,
             llm_prompt=llm_prompt,
             llm_response=str(llm_response),


### PR DESCRIPTION
This is my second PR, first time didn't install pre-commit, but now I do, and the workflow should be able to pass this time.

Original PR: https://github.com/Skyvern-AI/skyvern/pull/712

Quick summary: This PR introduces a new endpoint that allows users to retrieve the HAR (HTTP Archive) file associated with a specific task. This addition is for developers who need access to raw network traffic data.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2f09eb5e37e936335250b055bbb5f7759c53de61  | 
|--------|--------|

### Summary:
Added a new endpoint in `skyvern/forge/sdk/routes/agent_protocol.py` to stream HAR files for tasks, using `StreamingResponse` and handling file retrieval and streaming errors.

**Key points**:
- Added new endpoint `/tasks/{task_id}/har` in `skyvern/forge/sdk/routes/agent_protocol.py`.
- Endpoint streams HAR file content for a given task ID.
- Uses `StreamingResponse` to stream file content.
- Retrieves HAR artifact from database using `app.DATABASE.get_latest_artifact`.
- Handles file reading with `stream_file` function, reading in 1 MB chunks.
- Raises `HTTPException` for file not found or read errors.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->