### PR TITLE
catch and log db error in generate_task api

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -18,6 +18,7 @@ from fastapi import (
 )
 from fastapi.responses import ORJSONResponse
 from pydantic import BaseModel
+from sqlalchemy.exc import OperationalError
 
 from skyvern import analytics
 from skyvern.exceptions import StepNotFound
@@ -788,6 +789,9 @@ async def generate_task(
     except LLMProviderError:
         LOG.error("Failed to generate task", exc_info=True)
         raise HTTPException(status_code=400, detail="Failed to generate task. Please try again later.")
+    except OperationalError:
+        LOG.error("Database error when generating task", exc_info=True, user_prompt=data.prompt)
+        raise HTTPException(status_code=500, detail="Failed to generate task. Please try again later.")
 
 
 @base_router.put("/organizations/", include_in_schema=False)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5ce51378573296da907af2f59871035d96eb0afa  | 
|--------|--------|

### Summary:
This PR adds error handling for database operational errors in the `generate_task` API endpoint, logging the error and returning a 500 HTTP response.

**Key points**:
- Added import for `OperationalError` from `sqlalchemy.exc` in `skyvern/forge/sdk/routes/agent_protocol.py`.
- Updated `generate_task` function to catch `OperationalError`.
- Logs database errors with `LOG.error` including `user_prompt`.
- Raises `HTTPException` with status code 500 on database errors.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->