### PR TITLE
update chrome args

### DIFF
--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -67,6 +67,7 @@ class BrowserContextFactory:
             "user_data_dir": tempfile.mkdtemp(prefix="skyvern_browser_"),
             "locale": SettingsManager.get_settings().BROWSER_LOCALE,
             "timezone_id": SettingsManager.get_settings().BROWSER_TIMEZONE,
+            "color_scheme": "no-preference",
             "args": [
                 "--disable-blink-features=AutomationControlled",
                 "--disk-cache-size=1",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b90d83df31419e210cdcbccfdd9c24e8d7fb4e98  | 
|--------|--------|

### Summary:
Added `"color_scheme": "no-preference"` to `build_browser_args` in `skyvern/webeye/browser_factory.py` to set the browser's color scheme.

**Key points**:
- Added `"color_scheme": "no-preference"` to the dictionary returned by `build_browser_args` in `skyvern/webeye/browser_factory.py`.
- This change sets the browser's color scheme to "no-preference" when building browser arguments.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->