### PR TITLE
general selection bugfix

### DIFF
--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -172,6 +172,10 @@ class SkyvernFrame:
         js_script = "([frame, element, interactable]) => buildElementObject(frame, element, interactable)"
         return await self.frame.evaluate(js_script, [frame, element, interactable])
 
+    async def get_element_scrollable(self, element: ElementHandle) -> bool:
+        js_script = "(element) => isScrollable(element)"
+        return await self.frame.evaluate(js_script, element)
+
     async def scroll_to_top(self, draw_boxes: bool) -> float:
         """
         Scroll to the top of the page and take a screenshot.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ca7cdce4a6d31c4f77f56fe9ab2c1bb91cfd381b  | 
|--------|--------|

### Summary:
This pull request fixes a selection bug by refining dropdown handling and element interaction in the `skyvern/webeye` module, including updates to DOM observation and manipulation methods.

**Key points**:
- **`skyvern/webeye/actions/handler.py`**: 
  - Added `dom` parameter to `select_from_dropdown` calls.
  - Replaced `get_locator().press` with `press_key` and added `blur` in `handle_input_text_action` and `handle_select_option_action`.
- **`skyvern/webeye/scraper/domUtils.js`**:
  - Removed `isScrollable` from `buildElementObject`.
  - Added `addIncrementalNodeToMap` for DOM depth tracking.
  - Modified `scrollToElementBottom` to use `smooth` behavior.
- **`skyvern/webeye/scraper/scraper.py`**:
  - Updated `IncrementalScrapePage` to initialize dictionaries and lists in `__init__`.
  - Changed `get_incremental_element_tree` to use `getIncrementElements`.
- **`skyvern/webeye/utils/dom.py`**:
  - Added `get_element_handler` and `press_key` methods to `SkyvernElement`.
  - Removed `get_scrollable` method.
- **`skyvern/webeye/utils/page.py`**:
  - Added `get_element_scrollable` method to `SkyvernFrame`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->