### PR TITLE
trim element tree bugfix

### DIFF
--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -461,7 +461,7 @@ def trim_element_tree(elements: list[dict]) -> list[dict]:
         if "frame" in queue_ele:
             del queue_ele["frame"]
 
-        if not queue_ele.get("interactable"):
+        if "id" in queue_ele and not queue_ele.get("interactable"):
             del queue_ele["id"]
 
         if "attributes" in queue_ele:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit fe5a48e61d0f82c6282cb9055a63a4d56aea77c7  | 
|--------|--------|

### Summary:
Fixes a bug in `trim_element_tree` to ensure `id` is deleted only if it exists and the element is not interactable in `skyvern/webeye/scraper/scraper.py`.

**Key points**:
- **File Modified**: `skyvern/webeye/scraper/scraper.py`
- **Function Affected**: `trim_element_tree`
- **Bug Fix**: Modify condition to delete `id` key only if it exists and element is not interactable.
- **Previous Behavior**: Deleted `id` key if element was not interactable, regardless of `id` existence.
- **New Behavior**: Checks for `id` existence before deletion when element is not interactable.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->