### PR TITLE
optimize svg cache and add retry

### DIFF
--- a/skyvern/exceptions.py
+++ b/skyvern/exceptions.py
@@ -293,6 +293,11 @@ class StepUnableToExecuteError(SkyvernException):
         super().__init__(f"Step {step_id} cannot be executed and task execution is stopped. Reason: {reason}")
 
 
+class SVGConversionFailed(SkyvernException):
+    def __init__(self, svg_html: str) -> None:
+        super().__init__(f"Failed to convert SVG after max retries. svg_html={svg_html}")
+
+
 class UnsupportedActionType(SkyvernException):
     def __init__(self, action_type: str):
         super().__init__(f"Unsupport action type: {action_type}")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e4af6224dcc2cda1e56a97313a785d5d1f8bda1b  | 
|--------|--------|

### Summary:
This PR optimizes SVG conversion by caching results and retrying failed conversions up to 3 times, introducing a new exception for handling conversion failures.

**Key points**:
- Added `SVGConversionFailed` exception in `skyvern/exceptions.py` for handling failed SVG conversions.
- Introduced `USELESS_SVG_ATTRIBUTE` and `SVG_RETRY_ATTEMPT` constants in `skyvern/forge/agent_functions.py`.
- Modified `_remove_skyvern_attributes` to remove unnecessary SVG attributes.
- Updated `_convert_svg_to_string` to retry SVG conversion up to 3 times before raising `SVGConversionFailed`.
- Improved logging for SVG conversion attempts and failures.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->