### PR TITLE
fix no exist artifact read

### DIFF
--- a/skyvern/webeye/browser_manager.py
+++ b/skyvern/webeye/browser_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 
 import structlog
 from playwright.async_api import async_playwright
@@ -127,13 +128,10 @@ class BrowserManager:
 
         for i, video_artifact in enumerate(browser_state.browser_artifacts.video_artifacts):
             path = video_artifact.video_path
-            if path:
-                try:
-                    with open(path, "rb") as f:
-                        browser_state.browser_artifacts.video_artifacts[i].video_data = f.read()
+            if path and os.path.exists(path=path):
+                with open(path, "rb") as f:
+                    browser_state.browser_artifacts.video_artifacts[i].video_data = f.read()
 
-                except FileNotFoundError:
-                    pass
         return browser_state.browser_artifacts.video_artifacts
 
     async def get_har_data(
@@ -145,7 +143,7 @@ class BrowserManager:
     ) -> bytes:
         if browser_state:
             path = browser_state.browser_artifacts.har_path
-            if path:
+            if path and os.path.exists(path=path):
                 with open(path, "rb") as f:
                     return f.read()
         LOG.warning(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f5d58560215970720ccdabd1ebd79adf12984777  | 
|--------|--------|

### Summary:
Improved file existence checks in `get_video_artifacts` and `get_har_data` in `skyvern/webeye/browser_manager.py` to handle non-existent artifact files gracefully.

**Key points**:
- Updated `get_video_artifacts` in `skyvern/webeye/browser_manager.py` to check if `video_path` exists before reading.
- Removed `FileNotFoundError` exception handling in `get_video_artifacts`.
- Updated `get_har_data` in `skyvern/webeye/browser_manager.py` to check if `har_path` exists before reading.
- Ensures non-existent artifact files are handled gracefully without exceptions.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->