### PR TITLE
Check error existance for the context manager handling

### DIFF
--- a/skyvern/forge/sdk/workflow/context_manager.py
+++ b/skyvern/forge/sdk/workflow/context_manager.py
@@ -294,6 +294,7 @@ class WorkflowRunContext:
                 and parameter.source.key == output_parameter.key
             ):
                 if isinstance(value, dict) and "errors" in value and value["errors"]:
+                    # Is this the correct way to handle errors from task blocks?
                     LOG.error(
                         f"Output parameter {output_parameter.key} has errors. Setting ContextParameter {parameter.key} value to None"
                     )

--- a/skyvern/forge/sdk/workflow/context_manager.py
+++ b/skyvern/forge/sdk/workflow/context_manager.py
@@ -293,7 +293,7 @@ class WorkflowRunContext:
                 and isinstance(parameter.source, OutputParameter)
                 and parameter.source.key == output_parameter.key
             ):
-                if isinstance(value, dict) and "errors" in value:
+                if isinstance(value, dict) and "errors" in value and value["errors"]:
                     LOG.error(
                         f"Output parameter {output_parameter.key} has errors. Setting ContextParameter {parameter.key} value to None"
                     )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3bb5946ebc206ba171412f00ff62e1e36e2783ad  | 
|--------|--------|

### Summary:
Added a check for non-empty 'errors' in `set_parameter_values_for_output_parameter_dependent_blocks` to ensure logging and setting `ContextParameter` to `None` only when errors are present.

**Key points**:
- Added a check for non-empty 'errors' in `set_parameter_values_for_output_parameter_dependent_blocks`.
- Modified `skyvern/forge/sdk/workflow/context_manager.py`.
- Ensures logging and setting `ContextParameter` to `None` only if 'errors' is non-empty.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->