### PR TITLE
fix fastapi docs

### DIFF
--- a/skyvern/forge/sdk/artifact/models.py
+++ b/skyvern/forge/sdk/artifact/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from enum import StrEnum
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_serializer
 
 
 class ArtifactType(StrEnum):
@@ -47,14 +47,17 @@ class Artifact(BaseModel):
         ...,
         description="The creation datetime of the task.",
         examples=["2023-01-01T00:00:00Z"],
-        json_encoders={datetime: lambda v: v.isoformat()},
     )
     modified_at: datetime = Field(
         ...,
         description="The modification datetime of the task.",
         examples=["2023-01-01T00:00:00Z"],
-        json_encoders={datetime: lambda v: v.isoformat()},
     )
+
+    @field_serializer('created_at', 'modified_at', when_used='json')
+    def serialize_datetime_to_isoformat(value: datetime) -> str:
+        return value.isoformat()
+
     artifact_id: str = Field(
         ...,
         description="The ID of the task artifact.",

--- a/skyvern/forge/sdk/artifact/models.py
+++ b/skyvern/forge/sdk/artifact/models.py
@@ -55,7 +55,7 @@ class Artifact(BaseModel):
     )
 
     @field_serializer('created_at', 'modified_at', when_used='json')
-    def serialize_datetime_to_isoformat(value: datetime) -> str:
+    def serialize_datetime_to_isoformat(self, value: datetime) -> str:
         return value.isoformat()
 
     artifact_id: str = Field(

--- a/skyvern/forge/sdk/artifact/models.py
+++ b/skyvern/forge/sdk/artifact/models.py
@@ -54,7 +54,7 @@ class Artifact(BaseModel):
         examples=["2023-01-01T00:00:00Z"],
     )
 
-    @field_serializer('created_at', 'modified_at', when_used='json')
+    @field_serializer("created_at", "modified_at", when_used="json")
     def serialize_datetime_to_isoformat(self, value: datetime) -> str:
         return value.isoformat()
 


### PR DESCRIPTION
https://github.com/Skyvern-AI/skyvern/issues/745
Fix the doc problem. 
I used  field_serializer because json_encoders is going to be deprecated .
 
(https://docs.pydantic.dev/latest/api/config/#pydantic.config.ConfigDict.json_encoders)

<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 13ea375d02e37cdbd9e1c0cd72802b5f23e3e200  | 
|--------|--------|

### Summary:
Replaced deprecated `json_encoders` with `field_serializer` for `datetime` serialization in `Artifact` class in `skyvern/forge/sdk/artifact/models.py`.

**Key points**:
- Replaced `json_encoders` with `field_serializer` in `skyvern/forge/sdk/artifact/models.py`.
- Updated `Artifact` class to use `field_serializer` for `created_at` and `modified_at` fields.
- Serializes `datetime` fields to ISO format using `serialize_datetime_to_isoformat` method.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->