### PR TITLE
incress max press text

### DIFF
--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -34,7 +34,7 @@ from skyvern.webeye.utils.page import SkyvernFrame
 LOG = structlog.get_logger()
 
 TEXT_INPUT_DELAY = 10  # 10ms between each character input
-TEXT_PRESS_MAX_LENGTH = 10
+TEXT_PRESS_MAX_LENGTH = 20
 
 
 async def resolve_locator(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 61e1d037c6d4eab5db222856e604b05a07367b9a  | 
|--------|--------|

### Summary:
Increased `TEXT_PRESS_MAX_LENGTH` from 10 to 20 in `skyvern/webeye/utils/dom.py`, affecting text input handling in `SkyvernElement.input_sequentially`.

**Key points**:
- Increased `TEXT_PRESS_MAX_LENGTH` from 10 to 20 in `skyvern/webeye/utils/dom.py`.
- Affects `SkyvernElement.input_sequentially` method, allowing longer text input to be processed sequentially.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->