### PR TITLE
add support bot link

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ We welcome PRs and suggestions! Don't hesitate to open a PR/issue or to reach ou
 Please have a look at our [contribution guide](CONTRIBUTING.md) and
 ["Help Wanted" issues](https://github.com/skyvern-ai/skyvern/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) to get started!
 
-If you want to chat with the skyvern repository to get a high level overview of how it is structured, how to build off it, and how to resolve usage questions, check out [Sage](https://sage.storia.ai).
+If you want to chat with the skyvern repository to get a high level overview of how it is structured, how to build off it, and how to resolve usage questions, check out [Code Sage](https://storia.ai?utm_source=github&utm_medium=referral&utm_campaign=skyvern-readme).
 
 # Telemetry
 

--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ We welcome PRs and suggestions! Don't hesitate to open a PR/issue or to reach ou
 Please have a look at our [contribution guide](CONTRIBUTING.md) and
 ["Help Wanted" issues](https://github.com/skyvern-ai/skyvern/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) to get started!
 
+If you want to chat with the skyvern repository to get a high level overview of how it is structured, how to build off it, and how to resolve usage questions, check out [Sage](https://sage.storia.ai).
+
 # Telemetry
 
 By Default, Skyvern collects basic usage statistics to help us understand how Skyvern is being used. If you would like to opt-out of telemetry, please set the `SKYVERN_TELEMETRY` environment variable to `false`.


### PR DESCRIPTION
skyvern is publicly indexed and available for chat on [Storia Sage](https://sage.storia.ai). I thought this would be helpful for users of skyvern to get support questions answered quickly.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d2ddfbc7b2a9e5c22e1e3b4b1bac6be12c026fd2  | 
|--------|--------|

### Summary:
Added a support bot link to [Sage](https://sage.storia.ai) in the `README.md` for user assistance and project understanding.

**Key points**:
- Added a link to [Sage](https://sage.storia.ai) in `README.md`.
- The link provides users with a way to chat with the Skyvern repository for support and understanding.
- Located under the contribution section of the `README.md`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->