### PR TITLE
fix auto complete detect

### DIFF
--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -163,9 +163,8 @@ class SkyvernElement:
         if tag_name != InteractiveElement.INPUT:
             return False
 
-        haspopup = await self.get_attr("aria-haspopup")
         autocomplete = await self.get_attr("aria-autocomplete")
-        if haspopup and autocomplete:
+        if autocomplete and autocomplete == "list":
             return True
 
         element_id = await self.get_attr("id")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a445d432841c1d64d643a55d778bb33acf317d12  | 
|--------|--------|

### Summary:
Updated `is_auto_completion_input` in `skyvern/webeye/utils/dom.py` to only check `aria-autocomplete` for "list" value, removing `aria-haspopup` check.

**Key points**:
- Modified `is_auto_completion_input` in `skyvern/webeye/utils/dom.py`.
- Removed `aria-haspopup` attribute check.
- Now only checks if `aria-autocomplete` is "list" to determine auto-completion input.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->