### PR TITLE
fix domutils potential bugs

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1639,7 +1639,7 @@ if (window.globalDomDepthMap === undefined) {
 
 function isClassNameIncludesHidden(className) {
   // some hidden elements are with the classname like `class="select-items select-hide"`
-  return className.includes("hide");
+  return className.toLowerCase().includes("hide");
 }
 
 function addIncrementalNodeToMap(parentNode, childrenNode) {
@@ -1669,7 +1669,7 @@ if (window.globalObserverForDOMIncrement === undefined) {
       if (mutation.type === "attributes") {
         if (mutation.attributeName === "style") {
           // TODO: need to confirm that elemnent is hidden previously
-          node = mutation.target;
+          const node = mutation.target;
           if (node.nodeType === Node.TEXT_NODE) continue;
           const newStyle = window.getComputedStyle(node);
           const newDisplay = newStyle.display;
@@ -1682,7 +1682,7 @@ if (window.globalObserverForDOMIncrement === undefined) {
           }
         }
         if (mutation.attributeName === "class") {
-          node = mutation.target;
+          const node = mutation.target;
           if (
             !mutation.oldValue ||
             !isClassNameIncludesHidden(mutation.oldValue)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit af8f884c5a1c529c2877b411f080d94b4dc008df  | 
|--------|--------|

### Summary:
Fixes potential bugs in `skyvern/webeye/scraper/domUtils.js` by ensuring case-insensitive class name checks and using `const` for variable declarations in `MutationObserver`.

**Key points**:
- Updated `isClassNameIncludesHidden` in `skyvern/webeye/scraper/domUtils.js` to use `toLowerCase()` for case-insensitive checks.
- Changed variable declaration to `const` for `node` in `MutationObserver` callback to prevent accidental reassignment.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->