### PR TITLE
Fix the prompt cache window - use settings.PROMPT_CACHE_WINDOW_HOURS

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -1423,7 +1423,7 @@ class AgentDB:
     async def get_task_generation_by_prompt_hash(
         self,
         user_prompt_hash: str,
-        query_window_hours: int = settings.PROMPT_ACTION_HISTORY_WINDOW,
+        query_window_hours: int = settings.PROMPT_CACHE_WINDOW_HOURS,
     ) -> TaskGeneration | None:
         before_time = datetime.utcnow() - timedelta(hours=query_window_hours)
         async with self.Session() as session:

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -55,7 +55,6 @@ from skyvern.forge.sdk.workflow.models.yaml import WorkflowCreateYAMLRequest
 base_router = APIRouter()
 
 LOG = structlog.get_logger()
-PROMPT_CACHE_WINDOW_HOURS = 24
 
 
 @base_router.post("/webhook", tags=["server"])
@@ -775,7 +774,7 @@ async def generate_task(
     # check if there's a same user_prompt within the past x Hours
     # in the future, we can use vector db to fetch similar prompts
     existing_task_generation = await app.DATABASE.get_task_generation_by_prompt_hash(
-        user_prompt_hash=user_prompt_hash, query_window_hours=PROMPT_CACHE_WINDOW_HOURS
+        user_prompt_hash=user_prompt_hash, query_window_hours=SettingsManager.get_settings().PROMPT_CACHE_WINDOW_HOURS
     )
     if existing_task_generation:
         new_task_generation = await app.DATABASE.create_task_generation(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 91fd88629c896e41f1a10dcf5ecfdbef44b23f4a  | 
|--------|--------|

### Summary:
Replaced hardcoded `PROMPT_CACHE_WINDOW_HOURS` with dynamic configuration using `SettingsManager.get_settings()` in `generate_task`, affecting `skyvern/forge/sdk/routes/agent_protocol.py` and `skyvern/forge/sdk/db/client.py`.

**Key points**:
- Replaced hardcoded `PROMPT_CACHE_WINDOW_HOURS` with `SettingsManager.get_settings().PROMPT_CACHE_WINDOW_HOURS` for dynamic configuration.
- Removed hardcoded value from `skyvern/forge/sdk/routes/agent_protocol.py`.
- Updated `generate_task` function to use dynamic configuration.
- Modified `query_window_hours` parameter in `get_task_generation_by_prompt_hash`.
- Changes affect `skyvern/forge/sdk/db/client.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->