### PR TITLE
Fix support bot link

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ We welcome PRs and suggestions! Don't hesitate to open a PR/issue or to reach ou
 Please have a look at our [contribution guide](CONTRIBUTING.md) and
 ["Help Wanted" issues](https://github.com/skyvern-ai/skyvern/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) to get started!
 
-If you want to chat with the skyvern repository to get a high level overview of how it is structured, how to build off it, and how to resolve usage questions, check out [Code Sage](https://storia.ai?utm_source=github&utm_medium=referral&utm_campaign=skyvern-readme).
+If you want to chat with the skyvern repository to get a high level overview of how it is structured, how to build off it, and how to resolve usage questions, check out [Code Sage](https://sage.storia.ai?utm_source=github&utm_medium=referral&utm_campaign=skyvern-readme).
 
 # Telemetry
 


### PR DESCRIPTION
this fixes the support bot link so it actually points to the bot
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 73f28771a1f1492967168b44eb886e88d19ba4b4  | 
|--------|--------|

### Summary:
Updated the support bot link in `README.md` to point to `https://sage.storia.ai`.

**Key points**:
- Updated the support bot link in `README.md`.
- Changed URL from `https://storia.ai` to `https://sage.storia.ai`.
- Ensures the link correctly points to the support bot.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->