### PR TITLE
add org id and task id to the max steps override log

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -124,7 +124,12 @@ async def create_agent_task(
 
     created_task = await app.agent.create_task(task, current_org.organization_id)
     if x_max_steps_override:
-        LOG.info("Overriding max steps per run", max_steps_override=x_max_steps_override)
+        LOG.info(
+            "Overriding max steps per run",
+            max_steps_override=x_max_steps_override,
+            organization_id=current_org.organization_id,
+            task_id=created_task.task_id,
+        )
     await AsyncExecutorFactory.get_executor().execute_task(
         request=request,
         background_tasks=background_tasks,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit bddbfbce29d777c9a355caa3ceb45122f6d03bd7  | 
|--------|--------|

### Summary:
Enhanced logging in `create_agent_task` to include `organization_id` and `task_id` when overriding max steps in `skyvern/forge/sdk/routes/agent_protocol.py`.

**Key points**:
- Updated `create_agent_task` function in `skyvern/forge/sdk/routes/agent_protocol.py`.
- Enhanced log message to include `organization_id` and `task_id` when `x_max_steps_override` is used.
- Provides better context for debugging and tracking task execution.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->