### PR TITLE
Add button to rerun workflow in workflow run screen

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -124,7 +124,12 @@ async def create_agent_task(
 
     created_task = await app.agent.create_task(task, current_org.organization_id)
     if x_max_steps_override:
-        LOG.info("Overriding max steps per run", max_steps_override=x_max_steps_override)
+        LOG.info(
+            "Overriding max steps per run",
+            max_steps_override=x_max_steps_override,
+            organization_id=current_org.organization_id,
+            task_id=created_task.task_id,
+        )
     await AsyncExecutorFactory.get_executor().execute_task(
         request=request,
         background_tasks=background_tasks,

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -124,12 +124,7 @@ async def create_agent_task(
 
     created_task = await app.agent.create_task(task, current_org.organization_id)
     if x_max_steps_override:
-        LOG.info(
-            "Overriding max steps per run",
-            max_steps_override=x_max_steps_override,
-            organization_id=current_org.organization_id,
-            task_id=created_task.task_id,
-        )
+        LOG.info("Overriding max steps per run", max_steps_override=x_max_steps_override)
     await AsyncExecutorFactory.get_executor().execute_task(
         request=request,
         background_tasks=background_tasks,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ff0154fb8544ff8e80f323903898d6d52483792d  | 
|--------|--------|

### Summary:
Added a rerun button in `WorkflowRun` with mutation handling, notifications, and enhanced logging in `agent_protocol.py`.

**Key points**:
- Added a button in `WorkflowRun` to rerun workflows using a mutation with success/error notifications and a loading state.
- Utilized `useMutation` from `@tanstack/react-query` in `skyvern-frontend/src/routes/workflows/WorkflowRun.tsx` for rerun functionality.
- Implemented `runWorkflowMutation` to post rerun requests to `/workflows/{workflowPermanentId}/run`.
- Added success and error `toast` notifications for rerun actions.
- Introduced a `Button` with `ReloadIcon` to trigger rerun in `WorkflowRun` component.
- Button is disabled while mutation is pending, showing a loading spinner.
- Enhanced logging in `skyvern/forge/sdk/routes/agent_protocol.py` to include `organization_id` and `task_id`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->