### PR TITLE
More visibility into attached files and duplicate status

### DIFF
--- a/skyvern/forge/sdk/api/files.py
+++ b/skyvern/forge/sdk/api/files.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import tempfile
 import zipfile
@@ -86,3 +87,12 @@ def get_number_of_files_in_directory(directory: Path, recursive: bool = False) -
             break
         count += len(files)
     return count
+
+
+def calculate_sha256(file_path: str) -> str:
+    """Helper function to calculate SHA256 hash of a file."""
+    sha256_hash = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        for byte_block in iter(lambda: f.read(4096), b""):
+            sha256_hash.update(byte_block)
+    return sha256_hash.hexdigest()


### PR DESCRIPTION
```
2024-09-06T08:04:25.224790Z [info     ] SendEmailBlock: Total files attached total_files=6
2024-09-06T08:04:25.224827Z [info     ] SendEmailBlock: Unique files (based on content) attached unique_files=3
2024-09-06T08:04:25.224841Z [info     ] SendEmailBlock: Duplicate files (based on content) attached duplicate_files_list=[['/var/folders/hf/6fclkl_17fv_bqbbbx76hjww0000gn/T/tmp0eqd6zu0', '/var/folders/hf/6fclkl_17fv_bqbbbx76hjww0000gn/T/tmpc1vkrtoo', '/var/folders/hf/6fclkl_17fv_bqbbbx76hjww0000gn/T/tmpth672jt8'], ['/var/folders/hf/6fclkl_17fv_bqbbbx76hjww0000gn/T/skyvern_downloads_aq9zfvi4/photo-1510812431401-41d2bd2722f3', '/var/folders/hf/6fclkl_17fv_bqbbbx76hjww0000gn/T/skyvern_downloads_5wj28q45/3wszrhkc']]

```
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 733a1203757d8737b8231ace0701a7073054b2f7  | 
|--------|--------|

### Summary:
Enhanced `SendEmailBlock` to log total, unique, and duplicate file attachments using SHA256 hashes in `_build_email_message`.

**Key points**:
- Added `calculate_sha256` function in `skyvern/forge/sdk/api/files.py` to compute SHA256 hash of files.
- Modified `SendEmailBlock` in `skyvern/forge/sdk/workflow/models/block.py` to log total, unique, and duplicate file attachments.
- Utilized `defaultdict` to group file paths by their SHA256 hash in `_build_email_message` method.
- Logs include total files, unique files, and lists of duplicate files based on content.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->