### PR TITLE
Fix cyclic import

### DIFF
--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -22,7 +22,6 @@ from skyvern.exceptions import (
     UnknownBrowserType,
     UnknownErrorWhileCreatingBrowserContext,
 )
-from skyvern.forge import app
 from skyvern.forge.sdk.core.skyvern_context import current
 from skyvern.forge.sdk.schemas.tasks import ProxyLocation
 from skyvern.forge.sdk.settings_manager import SettingsManager
@@ -390,9 +389,3 @@ class BrowserState:
     async def take_screenshot(self, full_page: bool = False, file_path: str | None = None) -> bytes:
         page = await self.__assert_page()
         return await SkyvernFrame.take_screenshot(page=page, full_page=full_page, file_path=file_path)
-
-    async def store_browser_session(self, organization_id: str, workflow_permanent_id: str) -> None:
-        if self.browser_artifacts.browser_session_dir:
-            await app.STORAGE.store_browser_session(
-                organization_id, workflow_permanent_id, self.browser_artifacts.browser_session_dir
-            )

--- a/skyvern/webeye/browser_manager.py
+++ b/skyvern/webeye/browser_manager.py
@@ -9,7 +9,7 @@ from playwright.async_api import async_playwright
 from skyvern.constants import BROWSER_CLOSE_TIMEOUT
 from skyvern.exceptions import MissingBrowserState
 from skyvern.forge.sdk.schemas.tasks import ProxyLocation, Task
-from skyvern.forge.sdk.workflow.models.workflow import Workflow, WorkflowRun
+from skyvern.forge.sdk.workflow.models.workflow import WorkflowRun
 from skyvern.webeye.browser_factory import BrowserContextFactory, BrowserState, VideoArtifact
 
 LOG = structlog.get_logger()
@@ -182,7 +182,6 @@ class BrowserManager:
 
     async def cleanup_for_workflow_run(
         self,
-        workflow: Workflow,
         workflow_run_id: str,
         task_ids: list[str],
         close_browser_on_completion: bool = True,
@@ -195,13 +194,6 @@ class BrowserManager:
                 trace_path = f"{browser_state_to_close.browser_artifacts.traces_dir}/{workflow_run_id}.zip"
                 await browser_state_to_close.browser_context.tracing.stop(path=trace_path)
                 LOG.info("Stopped tracing", trace_path=trace_path)
-
-            if workflow.persist_browser_session:
-                await browser_state_to_close.store_browser_session(
-                    organization_id=workflow.organization_id,
-                    workflow_permanent_id=workflow.workflow_permanent_id,
-                )
-                LOG.info("Persisted browser session for workflow run", workflow_run_id=workflow_run_id)
 
             await browser_state_to_close.close(close_browser_on_completion=close_browser_on_completion)
         for task_id in task_ids:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c2e37cccf029b34669d4489a1b365123b0f6bdee  | 
|--------|--------|

### Summary:
Refactored code to fix circular import by adjusting `cleanup_for_workflow_run` and `send_workflow_response` functions.

**Key points**:
- Refactored code to fix circular import issue.
- Removed `workflow` parameter from `cleanup_for_workflow_run` in `skyvern/webeye/browser_manager.py`.
- Moved `persist_browser_session` logic to `send_workflow_response` in `skyvern/forge/sdk/workflow/service.py`.
- Removed import of `Workflow` from `skyvern/webeye/browser_manager.py`.
- Deleted `store_browser_session` method from `skyvern/webeye/browser_factory.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->