### PR TITLE
make task failure log more consistent with 'marking task as failed'

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -382,7 +382,7 @@ class ForgeAgent:
             raise
         except StepTerminationError as e:
             LOG.warning(
-                "Step cannot be executed. Task failed.",
+                "Step cannot be executed, marking task as failed",
                 task_id=task.task_id,
                 step_id=step.step_id,
                 exc_info=True,
@@ -442,7 +442,7 @@ class ForgeAgent:
             return step, detailed_output, None
         except Exception as e:
             LOG.exception(
-                "Got an unexpected exception in step, fail the task",
+                "Got an unexpected exception in step, marking task as failed",
                 task_id=task.task_id,
                 step_id=step.step_id,
             )

--- a/skyvern/forge/sdk/routes/streaming.py
+++ b/skyvern/forge/sdk/routes/streaming.py
@@ -104,12 +104,12 @@ async def task_stream(
     except ValidationError as e:
         await websocket.send_text(f"Invalid data: {e}")
     except WebSocketDisconnect:
-        LOG.info("WebSocket connection closed")
+        LOG.info("WebSocket connection closed", task_id=task_id, organization_id=organization_id)
     except ConnectionClosedOK:
-        LOG.info("ConnectionClosedOK error while streaming", exc_info=True)
+        LOG.info("ConnectionClosedOK error while streaming", task_id=task_id, organization_id=organization_id)
         return
     except Exception:
-        LOG.warning("Error while streaming", exc_info=True)
+        LOG.warning("Error while streaming", task_id=task_id, organization_id=organization_id)
         return
-    LOG.info("WebSocket connection closed successfully")
+    LOG.info("WebSocket connection closed successfully", task_id=task_id, organization_id=organization_id)
     return


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e27bf4c70756769bfb00757d6433837c80174a75  | 
|--------|--------|

### Summary:
Improved logging in `skyvern/forge/agent.py` and `task_stream` for better traceability and error indication.

**Key points**:
- Updated log messages in `skyvern/forge/agent.py` to indicate task failure.
- Enhanced logging in `task_stream` function by adding `task_id` and `organization_id`.
- Affected log messages include WebSocket disconnection and error handling scenarios.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->