### PR TITLE
make polling timeout configurable and 5mins by default

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -119,6 +119,7 @@ class Settings(BaseSettings):
 
     # TOTP Settings
     TOTP_LIFESPAN_MINUTES: int = 10
+    VERIFICATION_CODE_POLLING_TIMEOUT_MINS: int = 5
 
     def is_cloud_environment(self) -> bool:
         """

--- a/skyvern/constants.py
+++ b/skyvern/constants.py
@@ -13,8 +13,6 @@ BROWSER_CLOSE_TIMEOUT = 180  # 3 minute
 # reserved fields for navigation payload
 SPECIAL_FIELD_VERIFICATION_CODE = "verification_code"
 
-VERIFICATION_CODE_POLLING_TIMEOUT_MINS = 10
-
 
 class ScrapeType(StrEnum):
     NORMAL = "normal"

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -12,7 +12,7 @@ from deprecation import deprecated
 from playwright.async_api import FileChooser, Locator, Page, TimeoutError
 from pydantic import BaseModel
 
-from skyvern.constants import REPO_ROOT_DIR, SKYVERN_ID_ATTR, VERIFICATION_CODE_POLLING_TIMEOUT_MINS
+from skyvern.constants import REPO_ROOT_DIR, SKYVERN_ID_ATTR
 from skyvern.exceptions import (
     EmptySelect,
     ErrEmptyTweakValue,
@@ -2099,7 +2099,7 @@ async def poll_verification_code(
     totp_verification_url: str | None = None,
     totp_identifier: str | None = None,
 ) -> str | None:
-    timeout = timedelta(minutes=VERIFICATION_CODE_POLLING_TIMEOUT_MINS)
+    timeout = timedelta(minutes=SettingsManager.get_settings().VERIFICATION_CODE_POLLING_TIMEOUT_MINS)
     start_datetime = datetime.utcnow()
     timeout_datetime = start_datetime + timeout
     org_token = await app.DATABASE.get_valid_org_auth_token(organization_id, OrganizationAuthTokenType.api)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ff3b1728cdf1d84199c220c064f3a2322147c917  | 
|--------|--------|

### Summary:
Made verification code polling timeout configurable via `Settings` with a default of 5 minutes, updating its usage in `poll_verification_code`.

**Key points**:
- Added `VERIFICATION_CODE_POLLING_TIMEOUT_MINS` to `Settings` in `skyvern/config.py` with a default of 5 minutes.
- Removed `VERIFICATION_CODE_POLLING_TIMEOUT_MINS` from `skyvern/constants.py`.
- Updated `poll_verification_code` function in `skyvern/webeye/actions/handler.py` to use `SettingsManager.get_settings().VERIFICATION_CODE_POLLING_TIMEOUT_MINS` for timeout configuration.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->