### PR TITLE
remove empty newline char in extract-action prompt

### DIFF
--- a/skyvern/forge/prompts/skyvern/extract-action.j2
+++ b/skyvern/forge/prompts/skyvern/extract-action.j2
@@ -61,7 +61,6 @@ User Data Extraction Goal:
 {{ data_extraction_goal }}
 ```
 {% endif %}
-
 User details:
 ```
 {{ navigation_payload_str }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 514bc53c105afb71f1b2b0cbafd26d6fdec77955  | 
|--------|--------|

### Summary:
Removed an unnecessary newline character in `skyvern/forge/prompts/skyvern/extract-action.j2` for improved readability.

**Key points**:
- Removed an unnecessary newline character in `skyvern/forge/prompts/skyvern/extract-action.j2`.
- The change is purely cosmetic and does not affect the functionality of the template.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->