### PR TITLE
workflow run streaming

### DIFF
--- a/skyvern/forge/sdk/routes/streaming.py
+++ b/skyvern/forge/sdk/routes/streaming.py
@@ -89,6 +89,8 @@ async def task_stream(
 
             if task.status == TaskStatus.running:
                 file_name = f"{task_id}.png"
+                if task.workflow_run_id:
+                    file_name = f"{task.workflow_run_id}.png"
                 screenshot = await app.STORAGE.get_streaming_file(organization_id, file_name)
                 if screenshot:
                     encoded_screenshot = base64.b64encode(screenshot).decode("utf-8")


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 1a9fa3e387ccc826643625b21374dd491a62e983  | 
|--------|--------|

### Summary:
Introduced a script for capturing workflow run screenshots and updated streaming routes to handle workflow run IDs.

**Key points**:
- Added `scripts/take_screenshot_workflow.py` for capturing and uploading workflow run screenshots.
- Excluded billed organizations from screenshot capture in `take_screenshot_workflow.py`.
- Implemented timeout mechanisms in `take_screenshot_workflow.py` for total and activity durations.
- Updated `scripts/run_workflow_wrapper.sh` to run the screenshot script concurrently with the main workflow.
- Modified `skyvern/forge/sdk/routes/streaming.py` to handle workflow run IDs for screenshot retrieval.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->