### PR TITLE
Add TOTP stuff to task node

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/TaskNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/TaskNode.tsx
@@ -71,7 +71,7 @@ function TaskNode({ id, data }: NodeProps<TaskNode>) {
     <>
       <Accordion
         type="multiple"
-        defaultValue={["content", "extraction", "limits"]}
+        defaultValue={["content", "extraction", "limits", "totp"]}
       >
         <AccordionItem value="content">
           <AccordionTrigger>Content</AccordionTrigger>
@@ -257,6 +257,47 @@ function TaskNode({ id, data }: NodeProps<TaskNode>) {
                     />
                   </div>
                 )}
+              </div>
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="totp">
+          <AccordionTrigger>TOTP</AccordionTrigger>
+          <AccordionContent className="pl-[1.5rem] pr-1">
+            <div className="space-y-4">
+              <div className="space-y-1">
+                <Label className="text-xs text-slate-300">
+                  TOTP Verification URL
+                </Label>
+                <AutoResizingTextarea
+                  onChange={(event) => {
+                    if (!editable) {
+                      return;
+                    }
+                    updateNodeData(id, {
+                      totpVerificationUrl: event.target.value,
+                    });
+                  }}
+                  value={data.totpVerificationUrl ?? ""}
+                  placeholder="https://"
+                  className="nopan"
+                />
+              </div>
+              <div className="space-y-1">
+                <Label className="text-xs text-slate-300">
+                  TOTP Identifier
+                </Label>
+                <AutoResizingTextarea
+                  onChange={(event) => {
+                    if (!editable) {
+                      return;
+                    }
+                    updateNodeData(id, { totpIdentifier: event.target.value });
+                  }}
+                  value={data.totpIdentifier ?? ""}
+                  placeholder="Identifier"
+                  className="nopan"
+                />
               </div>
             </div>
           </AccordionContent>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/types.ts
@@ -12,6 +12,8 @@ export type TaskNodeData = {
   editable: boolean;
   label: string;
   parameterKeys: Array<string>;
+  totpVerificationUrl: string | null;
+  totpIdentifier: string | null;
 };
 
 export type TaskNode = Node<TaskNodeData, "task">;
@@ -30,4 +32,6 @@ export const taskNodeDefaultData: TaskNodeData = {
   editable: true,
   label: "",
   parameterKeys: [],
+  totpVerificationUrl: null,
+  totpIdentifier: null,
 } as const;

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -112,6 +112,8 @@ function convertToNode(
           maxRetries: block.max_retries ?? null,
           maxStepsOverride: block.max_steps_per_run ?? null,
           parameterKeys: block.parameters.map((p) => p.key),
+          totpIdentifier: block.totp_identifier ?? null,
+          totpVerificationUrl: block.totp_verification_url ?? null,
         },
       };
     }
@@ -402,6 +404,8 @@ function getWorkflowBlock(
         max_steps_per_run: node.data.maxStepsOverride,
         complete_on_download: node.data.allowDownloads,
         parameter_keys: node.data.parameterKeys,
+        totp_identifier: node.data.totpIdentifier,
+        totp_verification_url: node.data.totpVerificationUrl,
       };
     }
     case "sendEmail": {

--- a/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
@@ -134,6 +134,8 @@ export type TaskBlock = WorkflowBlockBase & {
   max_steps_per_run?: number | null;
   parameters: Array<WorkflowParameter>;
   complete_on_download?: boolean;
+  totp_verification_url?: string | null;
+  totp_identifier?: string | null;
 };
 
 export type ForLoopBlock = WorkflowBlockBase & {

--- a/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
@@ -79,6 +79,8 @@ export type TaskBlockYAML = BlockYAMLBase & {
   max_steps_per_run?: number | null;
   parameter_keys?: Array<string> | null;
   complete_on_download?: boolean;
+  totp_verification_url?: string | null;
+  totp_identifier?: string | null;
 };
 
 export type CodeBlockYAML = BlockYAMLBase & {


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ebf7a6d09084e5d850f0e422ce4946c175102c6e  | 
|--------|--------|

### Summary:
This PR adds TOTP fields to the TaskNode component, updating types, default data, and utility functions to support TOTP verification URL and identifier.

**Key points**:
- Added `TOTP` section to `Accordion` in `TaskNode` component in `skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/TaskNode.tsx`.
- Introduced `totpVerificationUrl` and `totpIdentifier` fields in `TaskNodeData` type in `skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/types.ts`.
- Updated `taskNodeDefaultData` to include `totpVerificationUrl` and `totpIdentifier`.
- Modified `convertToNode` and `getWorkflowBlock` functions in `skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts` to handle TOTP fields.
- Updated `TaskBlock` type in `skyvern-frontend/src/routes/workflows/types/workflowTypes.ts` to include TOTP fields.
- Added TOTP fields to `TaskBlockYAML` type in `skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->