### PR TITLE
try to fix mult-level selection trigger

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -1351,6 +1351,8 @@ async def sequentially_select_from_dropdown(
             should_relevant=should_relevant,
         )
         values.append(single_select_result.value)
+        # wait 1s until DOM finished updating
+        await asyncio.sleep(1)
 
         if await single_select_result.is_done():
             return single_select_result.action_result, values[-1] if len(values) > 0 else None
@@ -1384,6 +1386,12 @@ async def sequentially_select_from_dropdown(
             )
         )
         if len(secondary_increment_element) == 0:
+            LOG.info(
+                "No incremental element detected for the next level selection, going to quit the custom select mode",
+                selected_time=i + 1,
+                task_id=task.task_id,
+                step_id=step.step_id,
+            )
             return single_select_result.action_result, values[-1] if len(values) > 0 else None
 
     return single_select_result.action_result, values[-1] if len(values) > 0 else None


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 2198aea48685a5e27d6aed49dd8c4bfb400beeff  | 
|--------|--------|

### Summary:
Added a delay and logging in `sequentially_select_from_dropdown` to improve handling of multi-level dropdown selections in `skyvern/webeye/actions/handler.py`.

**Key points**:
- Added a 1-second delay in `sequentially_select_from_dropdown` in `skyvern/webeye/actions/handler.py` to ensure DOM updates.
- Introduced logging to indicate when no incremental elements are detected for further selection levels.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->