### PR TITLE
Only log duplicate file line if there are dupe files

### DIFF
--- a/skyvern/forge/sdk/routes/streaming.py
+++ b/skyvern/forge/sdk/routes/streaming.py
@@ -89,8 +89,6 @@ async def task_stream(
 
             if task.status == TaskStatus.running:
                 file_name = f"{task_id}.png"
-                if task.workflow_run_id:
-                    file_name = f"{task.workflow_run_id}.png"
                 screenshot = await app.STORAGE.get_streaming_file(organization_id, file_name)
                 if screenshot:
                     encoded_screenshot = base64.b64encode(screenshot).decode("utf-8")

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -985,9 +985,10 @@ class SendEmailBlock(Block):
         # Log file statistics
         LOG.info("SendEmailBlock: Total files attached", total_files=total_files)
         LOG.info("SendEmailBlock: Unique files (based on content) attached", unique_files=unique_files)
-        LOG.info(
-            "SendEmailBlock: Duplicate files (based on content) attached", duplicate_files_list=duplicate_files_list
-        )
+        if duplicate_files_list:
+            LOG.info(
+                "SendEmailBlock: Duplicate files (based on content) attached", duplicate_files_list=duplicate_files_list
+            )
 
         return msg
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit bba868463fa196ffdc3fced65f5a7565d4344b62  | 
|--------|--------|

### Summary:
This PR modifies logging behavior by removing a conditional file name assignment in `streaming.py` and logging duplicate files only if they exist in `block.py`.

**Key points**:
- Removed conditional `file_name` assignment in `skyvern/forge/sdk/routes/streaming.py`.
- Modified `SendEmailBlock` in `skyvern/forge/sdk/workflow/models/block.py` to log duplicate files only if they exist.
- Changes affect `_build_email_message` function in `SendEmailBlock`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->