### PR TITLE
Add adder node after the first node is added

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -188,6 +188,27 @@ function FlowRenderer({
       ...newNodes,
       ...nodes.slice(previousNodeIndex + 1),
     ];
+
+    if (nodes.length === 0) {
+      newNodesAfter.push({
+        id: `${id}-nodeAdder`,
+        type: "nodeAdder",
+        position: { x: 0, y: 0 },
+        data: {},
+        draggable: false,
+        connectable: false,
+      });
+      newEdges.push({
+        id: `edge-0-${id}`,
+        type: "default",
+        source: id,
+        target: `${id}-nodeAdder`,
+        style: {
+          strokeWidth: 2,
+        },
+      });
+    }
+
     doLayout(newNodesAfter, [...editedEdges, ...newEdges]);
   }
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a9cfa49a0d1455e7afa9ff5c5a011b920e91f6e0  | 
|--------|--------|

### Summary:
Add `nodeAdder` node and edge in `FlowRenderer.tsx` for the first node in an empty workflow.

**Key points**:
- Add `nodeAdder` node and edge in `FlowRenderer.tsx` when the first node is added to an empty workflow.
- Modify `addNode` function in `skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx`.
- Ensure `nodeAdder` is present for further node additions.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->