### PR TITLE
Invalidate workflow query after save

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowEditor.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowEditor.tsx
@@ -1,7 +1,7 @@
 import { useParams } from "react-router-dom";
 import { useWorkflowQuery } from "../hooks/useWorkflowQuery";
 import { getElements } from "./workflowEditorUtils";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   BlockYAML,
   ParameterYAML,
@@ -18,6 +18,7 @@ import { AxiosError } from "axios";
 function WorkflowEditor() {
   const { workflowPermanentId } = useParams();
   const credentialGetter = useCredentialGetter();
+  const queryClient = useQueryClient();
 
   const { data: workflow, isLoading } = useWorkflowQuery({
     workflowPermanentId,
@@ -59,6 +60,9 @@ function WorkflowEditor() {
         title: "Changes saved",
         description: "Your changes have been saved",
         variant: "success",
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["workflow", workflowPermanentId],
       });
     },
     onError: (error: AxiosError) => {


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit af894fd31d6cc6d79cfed68b6fda45dc1dc35bef  | 
|--------|--------|

### Summary:
Invalidate workflow query cache in `WorkflowEditor` after saving changes to ensure data consistency, using `queryClient.invalidateQueries` with a specific `queryKey`.

**Key points**:
- Invalidate workflow query cache after saving changes in `WorkflowEditor` for data consistency.
- Import `useQueryClient` from `@tanstack/react-query` in `skyvern-frontend/src/routes/workflows/editor/WorkflowEditor.tsx`.
- Initialize `queryClient` using `useQueryClient` in `WorkflowEditor` function.
- Use `queryClient.invalidateQueries` in `saveWorkflowMutation`'s `onSuccess` callback with `queryKey: ["workflow", workflowPermanentId]`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->