### PR TITLE
use workflow_run_id screenshot when task has the workflow_run_id

### DIFF
--- a/skyvern/forge/sdk/routes/streaming.py
+++ b/skyvern/forge/sdk/routes/streaming.py
@@ -89,6 +89,8 @@ async def task_stream(
 
             if task.status == TaskStatus.running:
                 file_name = f"{task_id}.png"
+                if task.workflow_run_id:
+                    file_name = f"{task.workflow_run_id}.png"
                 screenshot = await app.STORAGE.get_streaming_file(organization_id, file_name)
                 if screenshot:
                     encoded_screenshot = base64.b64encode(screenshot).decode("utf-8")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 968cd077d48a5fc45bebb0888705cad368744900  | 
|--------|--------|

### Summary:
The `task_stream` function now uses `workflow_run_id` for screenshot file names if available, affecting screenshot retrieval during task running status.

**Key points**:
- Modified `task_stream` function in `skyvern/forge/sdk/routes/streaming.py`.
- Uses `workflow_run_id` for screenshot file name if `task.workflow_run_id` is present.
- Falls back to `task_id` for screenshot file name if `workflow_run_id` is not available.
- Affects screenshot retrieval during task running status.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->