### PR TITLE
mark readonly elements as non-interactable

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -270,6 +270,25 @@ function isScriptOrStyle(element) {
   return tagName === "script" || tagName === "style";
 }
 
+function isReadonlyElement(element) {
+  if (element.readOnly) {
+    return true;
+  }
+
+  if (element.hasAttribute("readonly")) {
+    return true;
+  }
+
+  if (element.hasAttribute("aria-readonly")) {
+    // only aria-readonly="false" should be considered as "not readonly"
+    return (
+      element.getAttribute("aria-readonly").toLowerCase().trim() !== "false"
+    );
+  }
+
+  return false;
+}
+
 function hasAngularClickBinding(element) {
   return (
     element.hasAttribute("ng-click") || element.hasAttribute("data-ng-click")
@@ -283,6 +302,10 @@ function hasWidgetRole(element) {
   }
   // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles#2._widget_roles
   // Not all roles make sense for the time being so we only check for the ones that do
+  if (role.toLowerCase().trim() === "textbox") {
+    return !isReadonlyElement(element);
+  }
+
   const widgetRoles = [
     "button",
     "link",
@@ -293,7 +316,6 @@ function hasWidgetRole(element) {
     "radio",
     "tab",
     "combobox",
-    "textbox",
     "searchbox",
     "slider",
     "spinbutton",
@@ -326,6 +348,11 @@ function isInteractableInput(element) {
     // let other checks decide
     return false;
   }
+
+  if (type.toLowerCase().trim() === "text") {
+    return !isReadonlyElement(element);
+  }
+
   const clickableTypes = [
     "button",
     "checkbox",
@@ -343,7 +370,6 @@ function isInteractableInput(element) {
     "search",
     "submit",
     "tel",
-    "text",
     "time",
     "url",
     "week",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7fba9a5f113b202a311f52707fe887ec4e6763aa  | 
|--------|--------|

### Summary:
This PR updates `skyvern/webeye/scraper/domUtils.js` to mark readonly elements as non-interactable by modifying `isReadonlyElement`, `hasWidgetRole`, and `isInteractableInput` functions.

**Key points**:
- Added `isReadonlyElement` function in `skyvern/webeye/scraper/domUtils.js` to check for `readonly`, `aria-readonly`, and `readOnly` attributes.
- Updated `hasWidgetRole` function to exclude readonly textboxes.
- Updated `isInteractableInput` function to exclude readonly text inputs.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->