### PR TITLE
fix spinbutton issue

### DIFF
--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -197,6 +197,22 @@ class SkyvernElement:
         button_type = await self.get_attr("type")
         return button_type == "radio"
 
+    async def is_spinbtn_input(self) -> bool:
+        """
+        confirm the element is:
+        1. <input> element
+        2. role=spinbutton
+
+        Usage of <input role="spinbutton">, https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/spinbutton_role
+        """
+        if self.get_tag_name() != InteractiveElement.INPUT:
+            return False
+
+        if await self.get_attr("role") == "spinbutton":
+            return True
+
+        return False
+
     def is_interactable(self) -> bool:
         return self.__static_element.get("interactable", False)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit e7a45754d00b11f46b5cdf54fdbbda4220aa4b6b  | 
|--------|--------|

### Summary:
Fixes spin button handling in `handle_input_text_action` by adding `is_spinbtn_input` check in `SkyvernElement`.

**Key points**:
- Updated `handle_input_text_action` in `skyvern/webeye/actions/handler.py` to check for spin buttons using `is_spinbtn_input`.
- Added `is_spinbtn_input` method in `SkyvernElement` class in `skyvern/webeye/utils/dom.py` to identify `<input>` elements with `role="spinbutton"`.
- Prevented clearing of spin button inputs to avoid cursor issues.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->