### PR TITLE
revert 'add elements to dropdown confirm prompt'

### DIFF
--- a/skyvern/forge/prompts/skyvern/opened-dropdown-confirm.j2
+++ b/skyvern/forge/prompts/skyvern/opened-dropdown-confirm.j2
@@ -11,8 +11,3 @@ Reply in JSON format with the following keys:
     "reasoning": str, // the reason why it's a dropdown menu or not a dropdown menu
     "is_opened_dropdown_menu": bool, // true if it's a opened dropdown menu, otherwise false.
 }
-
-Elements on the screenshot:
-```
-{{ elements }}
-```

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -1661,11 +1661,8 @@ async def locate_dropdown_menu(
             timeout=SettingsManager.get_settings().BROWSER_SCREENSHOT_TIMEOUT_MS
         )
 
-        # only for detecting the dropdown menu, better to send untrimmed HTML without skyvern attributes
-        dropdown_confirm_prompt = prompt_engine.load_prompt(
-            "opened-dropdown-confirm",
-            elements=head_element.build_HTML(need_trim_element=False, need_skyvern_attrs=False),
-        )
+        # TODO: better to send untrimmed HTML without skyvern attributes in the future
+        dropdown_confirm_prompt = prompt_engine.load_prompt("opened-dropdown-confirm")
         LOG.debug(
             "Confirm if it's an opened dropdown menu",
             step_id=step.step_id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 13dc2d09372dc571b60209269faff3f4a024dda0  | 
|--------|--------|

### Summary:
Reverted changes to remove HTML elements from dropdown confirmation prompt and adjusted handler function accordingly.

**Key points**:
- Reverted changes in `skyvern/forge/prompts/skyvern/opened-dropdown-confirm.j2` to remove elements from the JSON response.
- Updated `skyvern/webeye/actions/handler.py` to stop passing HTML elements to the `opened-dropdown-confirm` prompt in `locate_dropdown_menu` function.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->