### PR TITLE
fix prompt punctuation format

### DIFF
--- a/skyvern/forge/prompts/skyvern/custom-select.j2
+++ b/skyvern/forge/prompts/skyvern/custom-select.j2
@@ -4,7 +4,7 @@ You can identify the matching element based on the following guidelines:
   1. Select the most suitable element based on the user goal, user details, and the context.
   2. If no option is a perfect match, and there is a fallback option such as "Others" or "None of the above" in the DOM elements, you can consider it a match.
   3. If a field is required, do not leave it blank.
-  4. If a field is required, do not select a placeholder value, such as "Please select", "-", or "Select…".
+  4. If a field is required, do not select a placeholder value, such as "Please select", "-", or "Select...".
   5. Exclude loading indicators like "loading more results" as valid options.
 
 MAKE SURE YOU OUTPUT VALID JSON. No text before or after JSON, no trailing commas, no comments (//), no unnecessary quotes, etc.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 22e11eba4e1acc5b7ee436e6dc783e52e63c9f4b  | 
|--------|--------|

### Summary:
Fixed punctuation in `skyvern/forge/prompts/skyvern/custom-select.j2` by replacing ellipsis with three dots.

**Key points**:
- Updated `skyvern/forge/prompts/skyvern/custom-select.j2`.
- Changed ellipsis character to three dots in guideline 4.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->