### PR TITLE
make totp code fetch more reliable

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -119,6 +119,7 @@ class Settings(BaseSettings):
 
     # TOTP Settings
     TOTP_LIFESPAN_MINUTES: int = 10
+    VERIFICATION_CODE_INITIAL_WAIT_TIME_SECS: int = 40
     VERIFICATION_CODE_POLLING_TIMEOUT_MINS: int = 5
 
     def is_cloud_environment(self) -> bool:

--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1617,7 +1617,7 @@ class ForgeAgent:
                 browser_state,
                 element_tree_in_prompt,
                 verification_code_check=False,
-                expire_verification_code=False,
+                expire_verification_code=True,
             )
             return await app.LLM_API_HANDLER(
                 prompt=extract_action_prompt,

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -2118,6 +2118,8 @@ async def poll_verification_code(
     if not org_token:
         LOG.error("Failed to get organization token when trying to get verification code")
         return None
+    # wait for 40 seconds to get the verification code before actually polling
+    await asyncio.sleep(SettingsManager.get_settings().VERIFICATION_CODE_INITIAL_WAIT_TIME_SECS)
     while True:
         # check timeout
         if datetime.utcnow() > timeout_datetime:

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -2118,7 +2118,7 @@ async def poll_verification_code(
     if not org_token:
         LOG.error("Failed to get organization token when trying to get verification code")
         return None
-    # wait for 40 seconds to get the verification code before actually polling
+    # wait for 40 seconds to let the verification code comes in before polling
     await asyncio.sleep(SettingsManager.get_settings().VERIFICATION_CODE_INITIAL_WAIT_TIME_SECS)
     while True:
         # check timeout


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ecc60c2aa778775a86a04cb7d49fcef80fd45c6a  | 
|--------|--------|

### Summary:
Enhanced TOTP code fetching reliability by adding initial wait time and ensuring code expiration.

**Key points**:
- Improved TOTP code fetching reliability.
- Added `VERIFICATION_CODE_INITIAL_WAIT_TIME_SECS` in `skyvern/config.py`.
- Set `expire_verification_code=True` in `skyvern/forge/agent.py`.
- Introduced a 40-second wait in `poll_verification_code` in `skyvern/webeye/actions/handler.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->