### PR TITLE
wait until animation ends after scrolling

### DIFF
--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -112,6 +112,9 @@ class SkyvernFrame:
             if draw_boxes:
                 await skyvern_page.remove_bounding_boxes()
             await skyvern_page.scroll_to_top(draw_boxes=False)
+            # wait until animation ends, which is triggered by scrolling
+            LOG.debug("Waiting for 2 seconds until animation ends.")
+            await asyncio.sleep(2)
         else:
             if draw_boxes:
                 await skyvern_page.build_elements_and_draw_bounding_boxes()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 26a5f33ed97e7ad83eb02b236fd5d3c3df597a07  | 
|--------|--------|

fix: add delay after scrolling to wait for animations to end

### Summary:
Adds a 2-second delay after scrolling in `take_split_screenshots()` in `page.py` to wait for animations to end.

**Key points**:
- **Behavior**:
  - Adds a 2-second delay after scrolling in `take_split_screenshots()` in `page.py` to wait for animations to end.
  - Logs a debug message indicating the wait for animations.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->