### PR TITLE
Fix a bug when first added node is loop type

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -173,7 +173,7 @@ function FlowRenderer({
     if (nodeType === "loop") {
       // when loop node is first created it needs an adder node so nodes can be added inside the loop
       newNodes.push({
-        id: `${id}-nodeAdder`,
+        id: nanoid(),
         type: "nodeAdder",
         parentId: id,
         position: { x: 0, y: 0 },


### PR DESCRIPTION
	<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 335c8c1affd05c99c9660a339ef43d3516eabf26  | 
|--------|--------|

fix: correct ID generation for node adder in loop node in `FlowRenderer.tsx`

### Summary:
Fixes ID generation bug for node adder in `FlowRenderer.tsx` using `nanoid()` for unique IDs.

**Key points**:
- **Bug Fix**: Corrects ID generation for node adder in `FlowRenderer.tsx` when the first node is a 'loop'.
- Uses `nanoid()` for unique ID instead of concatenated string.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->