### PR TITLE
make default verification wait time 20 seconds

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -119,7 +119,7 @@ class Settings(BaseSettings):
 
     # TOTP Settings
     TOTP_LIFESPAN_MINUTES: int = 10
-    VERIFICATION_CODE_INITIAL_WAIT_TIME_SECS: int = 40
+    VERIFICATION_CODE_INITIAL_WAIT_TIME_SECS: int = 20
     VERIFICATION_CODE_POLLING_TIMEOUT_MINS: int = 5
 
     def is_cloud_environment(self) -> bool:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 63c852b0ecdaa1d2040f25b683ce3b46482f46d2  | 
|--------|--------|

fix: reduce default verification wait time to 20 seconds

### Summary:
Reduce `VERIFICATION_CODE_INITIAL_WAIT_TIME_SECS` from 40 to 20 seconds in `Settings` class in `skyvern/config.py`.

**Key points**:
- **Behavior**:
  - Change `VERIFICATION_CODE_INITIAL_WAIT_TIME_SECS` from 40 to 20 seconds in `Settings` class in `skyvern/config.py`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->