### PR TITLE
fix angular select bug

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -418,8 +418,10 @@ function isInteractable(element) {
     return true;
   }
 
-  if (tagName === "div" && hasAngularClickBinding(element)) {
-    return true;
+  if (tagName === "div" || tagName === "span") {
+    if (hasAngularClickBinding(element)) {
+      return true;
+    }
   }
 
   // support listbox and options underneath it
@@ -562,12 +564,7 @@ const isAngularDropdown = (element) => {
   }
 
   const tagName = element.tagName.toLowerCase();
-  // TODO: some angular might use <span> to trigger dropdown menu
-  // if (tagName === "span") {
-  //   ...
-  // }
-
-  if (tagName === "input") {
+  if (tagName === "input" || tagName === "span") {
     const ariaLabel = element.hasAttribute("aria-label")
       ? element.getAttribute("aria-label").toLowerCase()
       : "";


### PR DESCRIPTION
	<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit a84eb9376f448e7c795114ead7987c9b5051ec59  | 
|--------|--------|

fix: handle Angular select bug for span elements

### Summary:
Fixes Angular select bug by updating `domUtils.js` to handle `span` elements with click bindings and dropdown attributes.

**Key points**:
- Fixes bug in `domUtils.js` for `span` elements with Angular click bindings and dropdown attributes.
- Updates `isInteractable()` to treat `span` elements as interactable.
- Modifies `isAngularDropdown()` to recognize `span` elements as Angular dropdowns.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->