### PR TITLE
Fix a bug where adder node wasnt added to loop children

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -316,6 +316,32 @@ function getElements(blocks: Array<WorkflowBlock>): {
     }
   });
 
+  const loopBlocks = data.filter((d) => d.block.block_type === "for_loop");
+  loopBlocks.forEach((block) => {
+    const children = data.filter((b) => b.parentId === block.id);
+    const lastChild = children.find((c) => c.next === null);
+    nodes.push({
+      id: `${block.id}-nodeAdder`,
+      type: "nodeAdder",
+      position: { x: 0, y: 0 },
+      data: {},
+      draggable: false,
+      connectable: false,
+      parentId: block.id,
+    });
+    if (lastChild) {
+      edges.push({
+        id: `${block.id}-nodeAdder-edge`,
+        type: "default",
+        source: lastChild.id,
+        target: `${block.id}-nodeAdder`,
+        style: {
+          strokeWidth: 2,
+        },
+      });
+    }
+  });
+
   if (nodes.length > 0) {
     const lastNode = data.find((d) => d.next === null && d.parentId === null);
     edges.push({


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3000770dc2e20c90e5d800650c97da99e749dc5f  | 
|--------|--------|

fix: add `nodeAdder` to `for_loop` children in `getElements()`

### Summary:
Fixes bug in `getElements()` to add `nodeAdder` nodes to `for_loop` children in `workflowEditorUtils.ts`.

**Key points**:
- **Bug Fix**: In `getElements()` in `workflowEditorUtils.ts`, added logic to append `nodeAdder` nodes and corresponding edges to the children of `for_loop` blocks. Ensures `nodeAdder` is connected to the last child of each `for_loop` block.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->