### PR TITLE
Disable panning when focused on node title

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/components/EditableNodeTitle.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/components/EditableNodeTitle.tsx
@@ -32,7 +32,7 @@ function EditableNodeTitle({ value, editable, onChange, className }: Props) {
     <Input
       disabled={!editable}
       ref={ref}
-      className={cn("w-fit min-w-fit max-w-64 border-0 px-0", className)}
+      className={cn("nopan w-fit min-w-fit max-w-64 border-0 px-0", className)}
       onBlur={(event) => {
         if (!editable) {
           event.currentTarget.value = value;


### PR DESCRIPTION
	<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 18d48b42e7a42541eef597232efc5ba9eb768b48  | 
|--------|--------|

feat: disable panning when focused on node title

### Summary:
Adds `nopan` class to disable panning when focused on node title for improved UI/UX.

**Key points**:
- Adds `nopan` class to `Input` in `EditableNodeTitle` to disable panning when focused on node title.
- UI/UX Improvement: Disables panning when focused on node title.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->