### PR TITLE
Fix workflow title initial style

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
@@ -56,7 +56,7 @@ function WorkflowHeader({
           editable={true}
           onChange={onTitleChange}
           value={title}
-          className="max-w-96 text-3xl"
+          className="text-3xl"
         />
       </div>
       <div className="flex h-full w-1/3 items-center justify-end gap-4 p-4">

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/components/EditableNodeTitle.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/components/EditableNodeTitle.tsx
@@ -1,4 +1,10 @@
 import { Input } from "@/components/ui/input";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/util/utils";
 import { useLayoutEffect, useRef } from "react";
 
@@ -29,33 +35,41 @@ function EditableNodeTitle({ value, editable, onChange, className }: Props) {
   }
 
   return (
-    <Input
-      disabled={!editable}
-      ref={ref}
-      className={cn("nopan w-fit min-w-fit max-w-64 border-0 px-0", className)}
-      onBlur={(event) => {
-        if (!editable) {
-          event.currentTarget.value = value;
-          return;
-        }
-        onChange(event.target.value);
-      }}
-      onKeyDown={(event) => {
-        if (!editable) {
-          return;
-        }
-        if (event.key === "Enter") {
-          event.currentTarget.blur();
-        }
-        if (event.key === "Escape") {
-          event.currentTarget.value = value;
-          event.currentTarget.blur();
-        }
-        setSize();
-      }}
-      onInput={setSize}
-      defaultValue={value}
-    />
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Input
+            disabled={!editable}
+            ref={ref}
+            size={1}
+            className={cn("nopan w-min border-0 p-0", className)}
+            onBlur={(event) => {
+              if (!editable) {
+                event.currentTarget.value = value;
+                return;
+              }
+              onChange(event.target.value);
+            }}
+            onKeyDown={(event) => {
+              if (!editable) {
+                return;
+              }
+              if (event.key === "Enter") {
+                event.currentTarget.blur();
+              }
+              if (event.key === "Escape") {
+                event.currentTarget.value = value;
+                event.currentTarget.blur();
+              }
+              setSize();
+            }}
+            onInput={setSize}
+            defaultValue={value}
+          />
+        </TooltipTrigger>
+        <TooltipContent>Click to edit</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit b0f20766d48d0801b89f8ccfa6e7532520a11ce2  | 
|--------|--------|

fix: improve workflow title editing UI with tooltip and style adjustments

### Summary:
Improves workflow title editing UI with tooltip and style adjustments in `WorkflowHeader.tsx` and `EditableNodeTitle.tsx`.

**Key points**:
- **UI/UX Enhancements**: Added tooltip to `EditableNodeTitle` to indicate editability with message "Click to edit"; adjusted `Input` component styles in `EditableNodeTitle.tsx` to use `w-min` and `p-0` for better layout control.
- **Style Adjustments**: Removed `max-w-96` from `WorkflowHeader.tsx` to allow flexible width; added `flex-grow` to parent `div` in `WorkflowHeader.tsx` for better layout distribution.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->