### PR TITLE
make totp_identifier parametrized in workflow

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -240,6 +240,20 @@ class TaskBlock(Block):
                 )
                 self.url = task_url_parameter_value
 
+        if (
+            self.totp_identifier
+            and workflow_run_context.has_parameter(self.totp_identifier)
+            and workflow_run_context.has_value(self.totp_identifier)
+        ):
+            totp_identifier_parameter_value = workflow_run_context.get_value(self.totp_identifier)
+            if totp_identifier_parameter_value:
+                LOG.info(
+                    "TOTP identifier is parameterized, using parameter value",
+                    totp_identifier_parameter_value=totp_identifier_parameter_value,
+                    totp_identifier_parameter_key=self.totp_identifier,
+                )
+                self.totp_identifier = totp_identifier_parameter_value
+
         if self.download_suffix and workflow_run_context.has_parameter(self.download_suffix):
             download_suffix_parameter_value = workflow_run_context.get_value(self.download_suffix)
             if download_suffix_parameter_value:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 4d0fe261a12dceedb40c4fbe9da0ccc3d06ed444  | 
|--------|--------|

feat: parameterize totp_identifier in TaskBlock

### Summary:
Parameterizes `totp_identifier` in `TaskBlock` within `block.py`, allowing dynamic setting from workflow context.

**Key points**:
- **Behavior**:
  - `totp_identifier` in `TaskBlock` is now parameterized in `block.py`.
  - If `totp_identifier` is set and exists in the workflow context, it is updated with the context value.
  - Logs the use of parameterized `totp_identifier` value.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->