### PR TITLE
Auto minimize the sidebar in workflow editor

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowEditor.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowEditor.tsx
@@ -23,14 +23,23 @@ import {
   BitwardenSensitiveInformationParameter,
   ContextParameter,
 } from "../types/workflowTypes";
+import { useSidebarStore } from "@/store/SidebarStore";
+import { useMountEffect } from "@/hooks/useMountEffect";
 
 function WorkflowEditor() {
   const { workflowPermanentId } = useParams();
   const credentialGetter = useCredentialGetter();
   const queryClient = useQueryClient();
+  const setCollapsed = useSidebarStore((state) => {
+    return state.setCollapsed;
+  });
 
   const { data: workflow, isLoading } = useWorkflowQuery({
     workflowPermanentId,
+  });
+
+  useMountEffect(() => {
+    setCollapsed(true);
   });
 
   const saveWorkflowMutation = useMutation({

--- a/skyvern-frontend/src/store/SidebarStore.ts
+++ b/skyvern-frontend/src/store/SidebarStore.ts
@@ -1,0 +1,15 @@
+import { create } from "zustand";
+
+type SidebarStore = {
+  collapsed: boolean;
+  setCollapsed: (collapsed: boolean) => void;
+};
+
+const useSidebarStore = create<SidebarStore>((set) => {
+  return {
+    collapsed: false,
+    setCollapsed: (collapsed: boolean) => set({ collapsed }),
+  };
+});
+
+export { useSidebarStore };


### PR DESCRIPTION
	<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f55115a63cacc22b25ff0052ac08cadb3b716010  | 
|--------|--------|

feat: auto minimize sidebar in workflow editor using SidebarStore

### Summary:
Introduces `SidebarStore` for managing sidebar state and updates `RootLayout` and `WorkflowEditor` to use it, auto-collapsing the sidebar in the workflow editor.

**Key points**:
- **State Management**:
- Introduces `SidebarStore` in `SidebarStore.ts` using `zustand` to manage sidebar collapsed state.
- **RootLayout Component**:
- Replaces local `useState` with `useSidebarStore` for `collapsed` state.
- Updates sidebar width and icon logic to use `collapsed` from `SidebarStore`.
- **WorkflowEditor Component**:
- Uses `useSidebarStore` to set `collapsed` to `true` on mount using `useMountEffect`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->