### PR TITLE
remove unused property from multiselect

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/TaskNodeParametersPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/TaskNodeParametersPanel.tsx
@@ -47,7 +47,6 @@ function TaskNodeParametersPanel({
         </TooltipProvider>
       </header>
       <MultiSelect
-        defaultValue={parameters}
         value={parameters}
         onValueChange={onParametersChange}
         options={options}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit ca1bf3ff8181585f6749fe14622007f2c025466d  | 
|--------|--------|

refactor: remove unused defaultValue from MultiSelect in TaskNodeParametersPanel.tsx

### Summary:
Remove unused `defaultValue` property from `MultiSelect` in `TaskNodeParametersPanel.tsx`.

**Key points**:
- **Code Simplification**:
  - Removed unused `defaultValue` property from `MultiSelect` in `TaskNodeParametersPanel.tsx`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->