### PR TITLE
Email params should use str when injecting into the body

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -917,7 +917,7 @@ class SendEmailBlock(Block):
         if self.body and workflow_run_context.has_parameter(self.body) and workflow_run_context.has_value(self.body):
             # We're purposely not decrypting the body parameter value here because we don't want to expose secrets
             body_parameter_value = workflow_run_context.get_value(self.body)
-            msg.set_content(body_parameter_value)
+            msg.set_content(str(body_parameter_value))
         else:
             msg.set_content(self.body)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit c5ff582908b32a84236ed251f4c463f8ebb371fd  | 
|--------|--------|

fix: ensure email body content is string in SendEmailBlock

### Summary:
Fixes email body content handling in `SendEmailBlock` by converting `body_parameter_value` to string in `_build_email_message()`.

**Key points**:
- **Behavior**:
  - Fixes email body content handling in `SendEmailBlock` by converting `body_parameter_value` to string in `_build_email_message()`.
  - Ensures email body is always a string, preventing potential errors when setting content.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->