### PR TITLE
Only use json.dumps when workflow parameter type is json

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -1123,11 +1123,16 @@ class AgentDB:
     ) -> WorkflowParameter:
         try:
             async with self.Session() as session:
+                default_value = (
+                    json.dumps(default_value)
+                    if workflow_parameter_type == WorkflowParameterType.JSON
+                    else default_value
+                )
                 workflow_parameter = WorkflowParameterModel(
                     workflow_id=workflow_id,
                     workflow_parameter_type=workflow_parameter_type,
                     key=key,
-                    default_value=json.dumps(default_value),
+                    default_value=default_value,
                     description=description,
                 )
                 session.add(workflow_parameter)


### PR DESCRIPTION
	<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by 509f882f354d267206647c5b4aaae0d5d69145d5  | 
|--------|--------|

fix: conditionally apply json.dumps for JSON type parameters in create_workflow_parameter

### Summary:
Conditionally apply `json.dumps` in `create_workflow_parameter()` for JSON type parameters only.

**Key points**:
- Conditionally apply `json.dumps` in `create_workflow_parameter()` for JSON type parameters.
- `json.dumps` is applied only when `workflow_parameter_type` is `WorkflowParameterType.JSON`.
- For non-JSON types, `default_value` is used as-is without serialization.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->