### PR TITLE
add disabled attr to element

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -938,7 +938,8 @@ function buildElementObject(frame, element, interactable, purgeable = false) {
       attr.name === "selected" ||
       attr.name === "aria-selected" ||
       attr.name === "readonly" ||
-      attr.name === "aria-readonly"
+      attr.name === "aria-readonly" ||
+      attr.name === "disabled"
     ) {
       if (attrValue && attrValue.toLowerCase() === "false") {
         attrValue = false;

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -30,6 +30,7 @@ RESERVED_ATTRIBUTES = {
     "checked",
     "data-original-title",  # for bootstrap tooltip
     "data-ui",
+    "disabled",  # for button
     "for",
     "href",  # For a tags
     "maxlength",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by 45c4285ab54a77889994acba1ae3a9287ac70e43  | 
|--------|--------|

feat: add support for `disabled` attribute in element processing

### Summary:
Add support for `disabled` attribute in `domUtils.js` and `scraper.py`.

**Key points**:
- **Behavior**:
  - Add support for `disabled` attribute in `buildElementObject()` in `domUtils.js`.
  - Include `disabled` in `RESERVED_ATTRIBUTES` in `scraper.py` for button elements.
- **Misc**:
  - No changes to existing logic or other attributes.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->