### PR TITLE
skip unnecessary select-dropdown check for input

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -416,7 +416,7 @@ async def handle_input_text_action(
 
     incremental_element: list[dict] = []
     # check if it's selectable
-    if skyvern_element.get_tag_name() == InteractiveElement.INPUT and not await skyvern_element.is_spinbtn_input():
+    if skyvern_element.get_tag_name() == InteractiveElement.INPUT and not await skyvern_element.is_raw_input():
         await skyvern_element.scroll_into_view()
         select_action = SelectOptionAction(
             reasoning=action.reasoning,

--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -84,6 +84,8 @@ class InteractiveElement(StrEnum):
 
 
 SELECTABLE_ELEMENT = [InteractiveElement.INPUT, InteractiveElement.SELECT]
+RAW_INPUT_TYPE_VALUE = ["number", "url", "tel", "email", "username", "password"]
+RAW_INPUT_NAME_VALUE = ["name", "email", "username", "password", "phone"]
 
 
 class SkyvernOptionType(typing.TypedDict):
@@ -196,6 +198,23 @@ class SkyvernElement:
 
         button_type = await self.get_attr("type")
         return button_type == "radio"
+
+    async def is_raw_input(self) -> bool:
+        if self.get_tag_name() != InteractiveElement.INPUT:
+            return False
+
+        if await self.is_spinbtn_input():
+            return True
+
+        input_type = str(await self.get_attr("type"))
+        if input_type.lower() in RAW_INPUT_TYPE_VALUE:
+            return True
+
+        name = str(await self.get_attr("name"))
+        if name.lower() in RAW_INPUT_NAME_VALUE:
+            return True
+
+        return False
 
     async def is_spinbtn_input(self) -> bool:
         """


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by adc92d2bf60484b8f8e793e9c91963fe52af5f63  | 
|--------|--------|

refactor: skip unnecessary select-dropdown check for raw inputs

### Summary:
Replace `is_spinbtn_input()` with `is_raw_input()` in `handle_input_text_action()` to skip unnecessary select-dropdown checks for raw inputs.

**Key points**:
- **Behavior**:
  - In `handle_input_text_action()` in `handler.py`, replace `is_spinbtn_input()` with `is_raw_input()` to determine if an input is raw, skipping unnecessary select-dropdown checks.
- **Functions**:
  - Add `is_raw_input()` to `SkyvernElement` in `dom.py`, checking for input types `number`, `url`, `tel`, `email`, `username`, `password` and names `name`, `email`, `username`, `password`, `phone`.
- **Constants**:
  - Define `RAW_INPUT_TYPE_VALUE` and `RAW_INPUT_NAME_VALUE` in `dom.py` for use in `is_raw_input()`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->