### PR TITLE
Fix release build - remove streamlit installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ FROM python:3.11-slim-bookworm
 WORKDIR /app
 COPY --from=requirements-stage /tmp/requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r requirements.txt
-RUN pip install --no-cache-dir streamlit
 RUN playwright install-deps
 RUN playwright install
 RUN apt-get install -y xauth x11-apps netpbm && apt-get clean
@@ -24,8 +23,5 @@ ENV ARTIFACT_STORAGE_PATH=/data/artifacts
 
 COPY ./entrypoint-skyvern.sh /app/entrypoint-skyvern.sh
 RUN chmod +x /app/entrypoint-skyvern.sh
-
-COPY ./entrypoint-streamlit.sh /app/entrypoint-streamlit.sh
-RUN chmod +x /app/entrypoint-streamlit.sh
 
 CMD [ "/bin/bash", "/app/entrypoint-skyvern.sh" ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove Streamlit installation and related entrypoint script from Dockerfile.
> 
>   - **Dockerfile Changes**:
>     - Remove `pip install streamlit` command.
>     - Remove `COPY` and `chmod` commands for `entrypoint-streamlit.sh`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI/skyvern#867)<sup> for 628874e416430d1f6c9015bd4ccea9041b111d93. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->