### PR TITLE
skip large size svg

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -122,6 +122,8 @@ class Settings(BaseSettings):
     VERIFICATION_CODE_INITIAL_WAIT_TIME_SECS: int = 40
     VERIFICATION_CODE_POLLING_TIMEOUT_MINS: int = 5
 
+    SVG_MAX_LENGTH: int = 100000
+
     def is_cloud_environment(self) -> bool:
         """
         :return: True if env is not local, else False

--- a/skyvern/forge/agent_functions.py
+++ b/skyvern/forge/agent_functions.py
@@ -88,6 +88,7 @@ async def _convert_svg_to_string(task: Task, step: Step, organization: Organizat
         LOG.debug("SVG loaded from cache", element_id=element_id, shape=svg_shape)
     else:
         if len(svg_html) > settings.SVG_MAX_LENGTH:
+            # TODO: implement a fallback solution for "too large" case, maybe convert by screenshot
             LOG.warning(
                 "SVG element is too large to convert, going to drop the svg element.",
                 element_id=element_id,

--- a/skyvern/forge/agent_functions.py
+++ b/skyvern/forge/agent_functions.py
@@ -196,7 +196,6 @@ class AgentFunction:
                 queue_ele = queue.pop(0)
                 _remove_rect(queue_ele)
                 await _convert_svg_to_string(task, step, organization, queue_ele)
-
                 # TODO: we can come back to test removing the unique_id
                 # from element attributes to make sure this won't increase hallucination
                 # _remove_unique_id(queue_ele)

--- a/skyvern/forge/agent_functions.py
+++ b/skyvern/forge/agent_functions.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 import structlog
 from playwright.async_api import Page
 
+from skyvern.config import settings
 from skyvern.constants import SKYVERN_ID_ATTR
 from skyvern.exceptions import StepUnableToExecuteError, SVGConversionFailed
 from skyvern.forge import app
@@ -65,6 +66,9 @@ async def _convert_svg_to_string(task: Task, step: Step, organization: Organizat
     element_id = element.get("id", "")
     svg_element = _remove_skyvern_attributes(element)
     svg_html = json_to_html(svg_element)
+    if len(svg_html) > settings.SVG_MAX_LENGTH:
+        LOG.warning("SVG element is too large to convert", element_id=element_id, length=len(svg_html))
+        return
     hash_object = hashlib.sha256()
     hash_object.update(svg_html.encode("utf-8"))
     svg_hash = hash_object.hexdigest()
@@ -181,7 +185,16 @@ class AgentFunction:
             while queue:
                 queue_ele = queue.pop(0)
                 _remove_rect(queue_ele)
-                await _convert_svg_to_string(task, step, organization, queue_ele)
+
+                # still WIP
+                if queue_ele.get("tagName") == "svg":
+                    element_id = queue_ele.get("id", "")
+                    svg_element = _remove_skyvern_attributes(queue_ele)
+                    svg_html = json_to_html(svg_element)
+                    if len(svg_html) > settings.SVG_MAX_LENGTH:
+                        LOG.warning("SVG element is too large to convert", element_id=element_id, length=len(svg_html))
+                    else:
+                        await _convert_svg_to_string(task, step, organization, queue_ele)
                 # TODO: we can come back to test removing the unique_id
                 # from element attributes to make sure this won't increase hallucination
                 # _remove_unique_id(queue_ele)

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -86,6 +86,12 @@ def build_attribute(key: str, value: Any) -> str:
 
 
 def json_to_html(element: dict, need_skyvern_attrs: bool = True) -> str:
+    """
+    if element is flagged as dropped, the html format is empty
+    """
+    if element.get("isDropped", False):
+        return ""
+
     attributes: dict[str, Any] = copy.deepcopy(element.get("attributes", {}))
 
     if need_skyvern_attrs:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `SVG_MAX_LENGTH` setting to handle large SVGs and update functions to skip conversion and handle dropped elements.
> 
>   - Add `SVG_MAX_LENGTH` setting in `config.py` with default 100000.
>   - Skip SVG conversion in `_convert_svg_to_string()` in `agent_functions.py` if `svg_html` exceeds `SVG_MAX_LENGTH`.
>   - Log warning and mark SVG as dropped if too large.
>   - Update `json_to_html()` in `scraper.py` to return empty string for dropped elements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 44e2e748515d0b614f06acd6a54263ec467ad297. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->