### PR TITLE
skip invisible iframe

### DIFF
--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -249,6 +249,19 @@ async def get_frame_text(iframe: Frame) -> str:
         if child_frame.is_detached():
             continue
 
+        try:
+            child_frame_element = await child_frame.frame_element()
+        except Exception:
+            LOG.warning(
+                "Unable to get child_frame_element",
+                exc_info=True,
+            )
+            continue
+
+        # it will get stuck when we `frame.evaluate()` on an invisible iframe
+        if not await child_frame_element.is_visible():
+            continue
+
         text += await get_frame_text(child_frame)
 
     return text
@@ -339,6 +352,10 @@ async def get_interactable_element_tree_in_frame(
                 "Unable to get frame_element",
                 exc_info=True,
             )
+            continue
+
+        # it will get stuck when we `frame.evaluate()` on an invisible iframe
+        if not await frame_element.is_visible():
             continue
 
         unique_id = await frame_element.get_attribute("unique_id")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Skip invisible iframes in `get_frame_text()` and `get_interactable_element_tree_in_frame()` to prevent scraping issues.
> 
>   - **Behavior**:
>     - Skip invisible iframes in `get_frame_text()` and `get_interactable_element_tree_in_frame()` to prevent getting stuck during `frame.evaluate()`.
>   - **Logging**:
>     - Add warning log in `get_frame_text()` when unable to get `child_frame_element`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 33cfe1b59fd95421cc10c55ae28694ca4bb6a7a6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->