### PR TITLE
fix custom selection bug

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -1740,9 +1740,12 @@ async def locate_dropdown_menu(
                     exc_info=True,
                 )
 
+        # sometimes taking screenshot might scroll away, need to scroll back after the screenshot
+        x, y = await skyvern_frame.get_scroll_x_y()
         screenshot = await head_element.get_locator().screenshot(
             timeout=SettingsManager.get_settings().BROWSER_SCREENSHOT_TIMEOUT_MS
         )
+        await skyvern_frame.scroll_to_x_y(x, y)
 
         # TODO: better to send untrimmed HTML without skyvern attributes in the future
         dropdown_confirm_prompt = prompt_engine.load_prompt("opened-dropdown-confirm")

--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1476,6 +1476,14 @@ function scrollToTop(draw_boxes) {
   return window.scrollY;
 }
 
+function getScrollXY() {
+  return [window.scrollX, window.scrollY];
+}
+
+function scrollToXY(x, y) {
+  window.scroll({ left: x, top: y, behavior: "instant" });
+}
+
 function scrollToNextPage(draw_boxes) {
   // remove bounding boxes, scroll to next page with 200px overlap, then draw bounding boxes again
   // return true if there is a next page, false otherwise

--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -160,6 +160,14 @@ class SkyvernFrame:
         async with asyncio.timeout(timeout):
             return await self.frame.content()
 
+    async def get_scroll_x_y(self) -> tuple[int, int]:
+        js_script = "() => getScrollXY()"
+        return await self.frame.evaluate(js_script)
+
+    async def scroll_to_x_y(self, x: int, y: int) -> None:
+        js_script = "([x, y]) => scrollToXY(x, y)"
+        return await self.frame.evaluate(js_script, [x, y])
+
     async def scroll_to_element_bottom(self, element: ElementHandle, page_by_page: bool = False) -> None:
         js_script = "([element, page_by_page]) => scrollToElementBottom(element, page_by_page)"
         return await self.frame.evaluate(js_script, [element, page_by_page])


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes custom selection bug by restoring scroll position after screenshots in `handler.py` using new scroll functions in `domUtils.js` and `page.py`.
> 
>   - **Behavior**:
>     - Fixes custom selection bug by restoring scroll position after taking a screenshot in `locate_dropdown_menu()` in `handler.py`.
>   - **Functions**:
>     - Adds `getScrollXY()` and `scrollToXY(x, y)` in `domUtils.js` to get and set scroll positions.
>     - Adds `get_scroll_x_y()` and `scroll_to_x_y(x, y)` in `SkyvernFrame` in `page.py` to interface with new JS functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5fd432524086afb59b725ce9ad31f9f9f307c5bc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->