### PR TITLE
Remove whitespace when blocks are renamed

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/CodeBlockNode/CodeBlockNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/CodeBlockNode/CodeBlockNode.tsx
@@ -14,7 +14,7 @@ import { NodeActionMenu } from "../NodeActionMenu";
 import type { CodeBlockNode } from "./types";
 import { useState } from "react";
 import {
-  getLabelForExistingNode,
+  getUniqueLabelForExistingNode,
   getUpdatedNodesAfterLabelUpdateForParameterKeys,
 } from "../../workflowEditorUtils";
 import { AppNode } from "..";
@@ -54,8 +54,9 @@ function CodeBlockNode({ id, data }: NodeProps<CodeBlockNode>) {
                 editable={data.editable}
                 onChange={(value) => {
                   const existingLabels = nodes.map((n) => n.data.label);
-                  const newLabel = getLabelForExistingNode(
-                    value,
+                  const labelWithoutWhitespace = value.replace(/\s+/g, "_");
+                  const newLabel = getUniqueLabelForExistingNode(
+                    labelWithoutWhitespace,
                     existingLabels,
                   );
                   setLabel(newLabel);

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/DownloadNode/DownloadNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/DownloadNode/DownloadNode.tsx
@@ -14,7 +14,7 @@ import { NodeActionMenu } from "../NodeActionMenu";
 import type { DownloadNode } from "./types";
 import { useState } from "react";
 import {
-  getLabelForExistingNode,
+  getUniqueLabelForExistingNode,
   getUpdatedNodesAfterLabelUpdateForParameterKeys,
 } from "../../workflowEditorUtils";
 import { AppNode } from "..";
@@ -51,8 +51,9 @@ function DownloadNode({ id, data }: NodeProps<DownloadNode>) {
                 editable={data.editable}
                 onChange={(value) => {
                   const existingLabels = nodes.map((n) => n.data.label);
-                  const newLabel = getLabelForExistingNode(
-                    value,
+                  const labelWithoutWhitespace = value.replace(/\s+/g, "_");
+                  const newLabel = getUniqueLabelForExistingNode(
+                    labelWithoutWhitespace,
                     existingLabels,
                   );
                   setLabel(newLabel);

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/FileParserNode/FileParserNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/FileParserNode/FileParserNode.tsx
@@ -13,7 +13,7 @@ import { NodeActionMenu } from "../NodeActionMenu";
 import type { FileParserNode } from "./types";
 import { useState } from "react";
 import {
-  getLabelForExistingNode,
+  getUniqueLabelForExistingNode,
   getUpdatedNodesAfterLabelUpdateForParameterKeys,
 } from "../../workflowEditorUtils";
 import { AppNode } from "..";
@@ -53,8 +53,9 @@ function FileParserNode({ id, data }: NodeProps<FileParserNode>) {
                 editable={data.editable}
                 onChange={(value) => {
                   const existingLabels = nodes.map((n) => n.data.label);
-                  const newLabel = getLabelForExistingNode(
-                    value,
+                  const labelWithoutWhitespace = value.replace(/\s+/g, "_");
+                  const newLabel = getUniqueLabelForExistingNode(
+                    labelWithoutWhitespace,
                     existingLabels,
                   );
                   setLabel(newLabel);

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/LoopNode/LoopNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/LoopNode/LoopNode.tsx
@@ -15,7 +15,7 @@ import { NodeActionMenu } from "../NodeActionMenu";
 import type { LoopNode } from "./types";
 import { useState } from "react";
 import {
-  getLabelForExistingNode,
+  getUniqueLabelForExistingNode,
   getUpdatedNodesAfterLabelUpdateForParameterKeys,
 } from "../../workflowEditorUtils";
 import { AppNode } from "..";
@@ -81,8 +81,9 @@ function LoopNode({ id, data }: NodeProps<LoopNode>) {
                     editable={data.editable}
                     onChange={(value) => {
                       const existingLabels = nodes.map((n) => n.data.label);
-                      const newLabel = getLabelForExistingNode(
-                        value,
+                      const labelWithoutWhitespace = value.replace(/\s+/g, "_");
+                      const newLabel = getUniqueLabelForExistingNode(
+                        labelWithoutWhitespace,
                         existingLabels,
                       );
                       setLabel(newLabel);

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/SendEmailNode/SendEmailNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/SendEmailNode/SendEmailNode.tsx
@@ -15,7 +15,7 @@ import { NodeActionMenu } from "../NodeActionMenu";
 import type { SendEmailNode } from "./types";
 import { useState } from "react";
 import {
-  getLabelForExistingNode,
+  getUniqueLabelForExistingNode,
   getUpdatedNodesAfterLabelUpdateForParameterKeys,
 } from "../../workflowEditorUtils";
 import { AppNode } from "..";
@@ -66,8 +66,9 @@ function SendEmailNode({ id, data }: NodeProps<SendEmailNode>) {
                 editable={data.editable}
                 onChange={(value) => {
                   const existingLabels = nodes.map((n) => n.data.label);
-                  const newLabel = getLabelForExistingNode(
-                    value,
+                  const labelWithoutWhitespace = value.replace(/\s+/g, "_");
+                  const newLabel = getUniqueLabelForExistingNode(
+                    labelWithoutWhitespace,
                     existingLabels,
                   );
                   setLabel(newLabel);

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/TaskNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/TaskNode.tsx
@@ -24,7 +24,7 @@ import {
 import { useState } from "react";
 import { AppNode } from "..";
 import {
-  getLabelForExistingNode,
+  getUniqueLabelForExistingNode,
   getOutputParameterKey,
   getUpdatedNodesAfterLabelUpdateForParameterKeys,
 } from "../../workflowEditorUtils";
@@ -423,8 +423,9 @@ function TaskNode({ id, data }: NodeProps<TaskNode>) {
                 editable={editable}
                 onChange={(value) => {
                   const existingLabels = nodes.map((n) => n.data.label);
-                  const newLabel = getLabelForExistingNode(
-                    value,
+                  const labelWithoutWhitespace = value.replace(/\s+/g, "_");
+                  const newLabel = getUniqueLabelForExistingNode(
+                    labelWithoutWhitespace,
                     existingLabels,
                   );
                   setLabel(newLabel);

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TextPromptNode/TextPromptNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TextPromptNode/TextPromptNode.tsx
@@ -17,7 +17,7 @@ import { NodeActionMenu } from "../NodeActionMenu";
 import type { TextPromptNode } from "./types";
 import { useState } from "react";
 import {
-  getLabelForExistingNode,
+  getUniqueLabelForExistingNode,
   getUpdatedNodesAfterLabelUpdateForParameterKeys,
 } from "../../workflowEditorUtils";
 import { AppNode } from "..";
@@ -59,8 +59,9 @@ function TextPromptNode({ id, data }: NodeProps<TextPromptNode>) {
                 editable={data.editable}
                 onChange={(value) => {
                   const existingLabels = nodes.map((n) => n.data.label);
-                  const newLabel = getLabelForExistingNode(
-                    value,
+                  const labelWithoutWhitespace = value.replace(/\s+/g, "_");
+                  const newLabel = getUniqueLabelForExistingNode(
+                    labelWithoutWhitespace,
                     existingLabels,
                   );
                   setLabel(newLabel);

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/UploadNode/UploadNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/UploadNode/UploadNode.tsx
@@ -14,7 +14,7 @@ import { NodeActionMenu } from "../NodeActionMenu";
 import type { UploadNode } from "./types";
 import { useState } from "react";
 import {
-  getLabelForExistingNode,
+  getUniqueLabelForExistingNode,
   getUpdatedNodesAfterLabelUpdateForParameterKeys,
 } from "../../workflowEditorUtils";
 import { AppNode } from "..";
@@ -51,8 +51,9 @@ function UploadNode({ id, data }: NodeProps<UploadNode>) {
                 editable={data.editable}
                 onChange={(value) => {
                   const existingLabels = nodes.map((n) => n.data.label);
-                  const newLabel = getLabelForExistingNode(
-                    value,
+                  const labelWithoutWhitespace = value.replace(/\s+/g, "_");
+                  const newLabel = getUniqueLabelForExistingNode(
+                    labelWithoutWhitespace,
                     existingLabels,
                   );
                   setLabel(newLabel);

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -30,7 +30,7 @@ import { textPromptNodeDefaultData } from "./nodes/TextPromptNode/types";
 import { uploadNodeDefaultData } from "./nodes/UploadNode/types";
 import type { Node } from "@xyflow/react";
 
-export const NEW_NODE_LABEL_PREFIX = "Block ";
+export const NEW_NODE_LABEL_PREFIX = "block_";
 
 function layoutUtil(
   nodes: Array<AppNode>,
@@ -754,12 +754,15 @@ function getAdditionalParametersForEmailBlock(
   return sendEmailParameters;
 }
 
-function getLabelForExistingNode(label: string, existingLabels: Array<string>) {
+function getUniqueLabelForExistingNode(
+  label: string,
+  existingLabels: Array<string>,
+) {
   if (!existingLabels.includes(label)) {
     return label;
   }
   for (let i = 2; i < existingLabels.length + 1; i++) {
-    const candidate = `${label} (${i})`;
+    const candidate = `${label}_${i}`;
     if (!existingLabels.includes(candidate)) {
       return candidate;
     }
@@ -801,7 +804,7 @@ export {
   getOutputParameterKey,
   getUpdatedNodesAfterLabelUpdateForParameterKeys,
   getAdditionalParametersForEmailBlock,
-  getLabelForExistingNode,
+  getUniqueLabelForExistingNode,
   isOutputParameterKey,
   getBlockNameOfOutputParameterKey,
   getDefaultValueForParameterType,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves node label handling by replacing whitespace with underscores and ensuring uniqueness across multiple node types in the workflow editor.
> 
>   - **Behavior**:
>     - Replaces whitespace with underscores in node labels in `CodeBlockNode.tsx`, `DownloadNode.tsx`, and 6 other node files.
>     - Ensures unique labels using `getUniqueLabelForExistingNode()` in `workflowEditorUtils.ts`.
>   - **Functions**:
>     - Renames `getLabelForExistingNode()` to `getUniqueLabelForExistingNode()` in `workflowEditorUtils.ts`.
>     - Updates `getUniqueLabelForExistingNode()` to append underscores instead of parentheses for duplicate labels.
>   - **Constants**:
>     - Changes `NEW_NODE_LABEL_PREFIX` from `"Block "` to `"block_"` in `workflowEditorUtils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1163cf1259c03b0b40f48ffbce9cb9a2fe6eb5ac. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->