### PR TITLE
workflow run streaming API

### DIFF
--- a/skyvern/forge/sdk/routes/streaming.py
+++ b/skyvern/forge/sdk/routes/streaming.py
@@ -10,7 +10,7 @@ from websockets.exceptions import ConnectionClosedOK
 from skyvern.forge import app
 from skyvern.forge.sdk.schemas.tasks import TaskStatus
 from skyvern.forge.sdk.services.org_auth_service import get_current_org
-from skyvern.forge.sdk.workflow.models.workflow import WorkflowRun, WorkflowRunStatus
+from skyvern.forge.sdk.workflow.models.workflow import WorkflowRunStatus
 
 LOG = structlog.get_logger()
 websocket_router = APIRouter()
@@ -204,7 +204,7 @@ async def workflow_run_streaming(
                 )
                 return
 
-            if WorkflowRun.status == WorkflowRunStatus.running:
+            if workflow_run.status == WorkflowRunStatus.running:
                 file_name = f"{workflow_run_id}.png"
                 screenshot = await app.STORAGE.get_streaming_file(organization_id, file_name)
                 if screenshot:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `workflow_run_streaming` WebSocket endpoint in `streaming.py` for authenticated streaming of workflow run data with error handling.
> 
>   - **New Feature**:
>     - Adds `workflow_run_streaming` WebSocket endpoint in `streaming.py` for streaming workflow run data.
>   - **Authentication**:
>     - Validates `apikey` or `token` for organization access.
>     - Sends error message if credentials are invalid.
>   - **Streaming Logic**:
>     - Streams workflow run data if status is `running`.
>     - Sends base64-encoded screenshot if available.
>     - Closes connection if no activity for 5 minutes or if workflow run is in a final state.
>   - **Error Handling**:
>     - Handles `ValidationError`, `WebSocketDisconnect`, and `ConnectionClosedOK` exceptions with appropriate logging and messaging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e932ccc94da7bc14256c420b59b53119f8c35b79. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->