### PR TITLE
Fix a bug with opening and closing sections in task form

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -117,9 +117,9 @@ function CreateNewTaskForm({ initialValues }: Props) {
   const { toast } = useToast();
   const credentialGetter = useCredentialGetter();
   const apiCredential = useApiCredential();
-  const [sections, setSections] = useState<
-    Array<"base" | "extraction" | "advanced">
-  >(["base"]);
+  const [section, setSection] = useState<"base" | "extraction" | "advanced">(
+    "base",
+  );
 
   const form = useForm<CreateNewTaskFormValues>({
     resolver: zodResolver(createNewTaskFormSchema),
@@ -195,37 +195,22 @@ function CreateNewTaskForm({ initialValues }: Props) {
     mutation.mutate(values);
   }
 
-  function toggleSectionVisibility(
-    section: "base" | "extraction" | "advanced",
-  ) {
-    setSections((sections) => {
-      if (sections.includes(section)) {
-        return sections.filter((s) => s !== section);
-      }
-      return [...sections, section];
-    });
-  }
-
-  function isActive(section: "base" | "extraction" | "advanced") {
-    return sections.includes(section);
-  }
-
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
         <TaskFormSection
           index={1}
           title="Base Content"
-          active={isActive("base")}
+          active={section === "base"}
           onClick={() => {
-            toggleSectionVisibility("base");
+            setSection("base");
           }}
           hasError={
             typeof errors.url !== "undefined" ||
             typeof errors.navigationGoal !== "undefined"
           }
         >
-          {isActive("base") && (
+          {section === "base" && (
             <div className="space-y-6">
               <div className="space-y-4">
                 <FormField
@@ -288,16 +273,16 @@ function CreateNewTaskForm({ initialValues }: Props) {
         <TaskFormSection
           index={2}
           title="Extraction"
-          active={isActive("extraction")}
+          active={section === "extraction"}
           onClick={() => {
-            toggleSectionVisibility("extraction");
+            setSection("extraction");
           }}
           hasError={
             typeof errors.dataExtractionGoal !== "undefined" ||
             typeof errors.extractedInformationSchema !== "undefined"
           }
         >
-          {isActive("extraction") && (
+          {section === "extraction" && (
             <div className="space-y-6">
               <div className="space-y-4">
                 <FormField
@@ -370,9 +355,9 @@ function CreateNewTaskForm({ initialValues }: Props) {
         <TaskFormSection
           index={3}
           title="Advanced Settings"
-          active={isActive("advanced")}
+          active={section === "advanced"}
           onClick={() => {
-            toggleSectionVisibility("advanced");
+            setSection("advanced");
           }}
           hasError={
             typeof errors.navigationPayload !== "undefined" ||
@@ -380,7 +365,7 @@ function CreateNewTaskForm({ initialValues }: Props) {
             typeof errors.webhookCallbackUrl !== "undefined"
           }
         >
-          {isActive("advanced") && (
+          {section === "advanced" && (
             <div className="space-y-6">
               <div className="space-y-4">
                 <FormField


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `CreateNewTaskForm.tsx` to use a single state for section visibility, simplifying toggling logic and removing unnecessary functions.
> 
>   - **Behavior**:
>     - Refactor section visibility in `CreateNewTaskForm.tsx` from an array `sections` to a single state `section`.
>     - Simplifies toggling logic by directly setting `section` state instead of filtering an array.
>     - Updates section rendering logic to check `section === "base"`, `section === "extraction"`, and `section === "advanced"`.
>   - **Functions**:
>     - Remove `toggleSectionVisibility()` and `isActive()` functions, replaced by direct state checks.
>   - **Misc**:
>     - Adjust `TaskFormSection` components to use new `section` state for `active` and `onClick` props.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 63dc22c3cab4111cd09e781b4198b0dbdb6edb0c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->