### PR TITLE
Move navigation payload to base content

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -87,6 +87,7 @@ function CreateNewTaskForm({ initialValues }: Props) {
   const [section, setSection] = useState<"base" | "extraction" | "advanced">(
     "base",
   );
+  const [showAdvancedBaseContent, setShowAdvancedBaseContent] = useState(false);
 
   const form = useForm<CreateNewTaskFormValues>({
     resolver: zodResolver(createNewTaskFormSchema),
@@ -233,6 +234,67 @@ function CreateNewTaskForm({ initialValues }: Props) {
                     </FormItem>
                   )}
                 />
+                {showAdvancedBaseContent ? (
+                  <div className="border-t border-dashed pt-4">
+                    <FormField
+                      control={form.control}
+                      name="navigationPayload"
+                      render={({ field }) => (
+                        <FormItem>
+                          <div className="flex gap-16">
+                            <FormLabel>
+                              <div className="w-72">
+                                <h1 className="text-lg">Navigation Payload</h1>
+                                <h2 className="text-base text-slate-400">
+                                  Specify important parameters, routes, or
+                                  states
+                                </h2>
+                              </div>
+                              <Button
+                                className="mt-4"
+                                type="button"
+                                variant="tertiary"
+                                onClick={() => {
+                                  setShowAdvancedBaseContent(false);
+                                }}
+                                size="sm"
+                              >
+                                Hide Advanced Settings
+                              </Button>
+                            </FormLabel>
+                            <div className="w-full">
+                              <FormControl>
+                                <CodeEditor
+                                  {...field}
+                                  language="json"
+                                  fontSize={12}
+                                  minHeight="96px"
+                                  value={
+                                    field.value === null ? "" : field.value
+                                  }
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </div>
+                          </div>
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+                ) : (
+                  <div>
+                    <Button
+                      type="button"
+                      variant="tertiary"
+                      onClick={() => {
+                        setShowAdvancedBaseContent(true);
+                      }}
+                      size="sm"
+                    >
+                      Show Advanced Settings
+                    </Button>
+                  </div>
+                )}
               </div>
             </div>
           )}
@@ -331,36 +393,6 @@ function CreateNewTaskForm({ initialValues }: Props) {
           {section === "advanced" && (
             <div className="space-y-6">
               <div className="space-y-4">
-                <FormField
-                  control={form.control}
-                  name="navigationPayload"
-                  render={({ field }) => (
-                    <FormItem>
-                      <div className="flex gap-16">
-                        <FormLabel>
-                          <div className="w-72">
-                            <h1 className="text-lg">Navigation Payload</h1>
-                            <h2 className="text-base text-slate-400">
-                              Specify important parameters, routes, or states
-                            </h2>
-                          </div>
-                        </FormLabel>
-                        <div className="w-full">
-                          <FormControl>
-                            <CodeEditor
-                              {...field}
-                              language="json"
-                              fontSize={12}
-                              minHeight="96px"
-                              value={field.value === null ? "" : field.value}
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </div>
-                      </div>
-                    </FormItem>
-                  )}
-                />
                 <FormField
                   control={form.control}
                   name="maxStepsOverride"

--- a/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
@@ -138,6 +138,7 @@ function SavedTaskForm({ initialValues }: Props) {
   const [section, setSection] = useState<"base" | "extraction" | "advanced">(
     "base",
   );
+  const [showAdvancedBaseContent, setShowAdvancedBaseContent] = useState(false);
 
   const form = useForm<SavedTaskFormValues>({
     resolver: zodResolver(savedTaskFormSchema),
@@ -398,6 +399,67 @@ function SavedTaskForm({ initialValues }: Props) {
                     </FormItem>
                   )}
                 />
+                {showAdvancedBaseContent ? (
+                  <div className="border-t border-dashed pt-4">
+                    <FormField
+                      control={form.control}
+                      name="navigationPayload"
+                      render={({ field }) => (
+                        <FormItem>
+                          <div className="flex gap-16">
+                            <FormLabel>
+                              <div className="w-72">
+                                <h1 className="text-lg">Navigation Payload</h1>
+                                <h2 className="text-base text-slate-400">
+                                  Specify important parameters, routes, or
+                                  states
+                                </h2>
+                              </div>
+                              <Button
+                                className="mt-4"
+                                type="button"
+                                variant="tertiary"
+                                onClick={() => {
+                                  setShowAdvancedBaseContent(false);
+                                }}
+                                size="sm"
+                              >
+                                Hide Advanced Settings
+                              </Button>
+                            </FormLabel>
+                            <div className="w-full">
+                              <FormControl>
+                                <CodeEditor
+                                  {...field}
+                                  language="json"
+                                  fontSize={12}
+                                  minHeight="96px"
+                                  value={
+                                    field.value === null ? "" : field.value
+                                  }
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </div>
+                          </div>
+                        </FormItem>
+                      )}
+                    />
+                  </div>
+                ) : (
+                  <div>
+                    <Button
+                      type="button"
+                      variant="tertiary"
+                      onClick={() => {
+                        setShowAdvancedBaseContent(true);
+                      }}
+                      size="sm"
+                    >
+                      Show Advanced Settings
+                    </Button>
+                  </div>
+                )}
               </div>
             </div>
           )}
@@ -497,41 +559,6 @@ function SavedTaskForm({ initialValues }: Props) {
           {section === "advanced" && (
             <div className="space-y-6">
               <div className="space-y-4">
-                <FormField
-                  control={form.control}
-                  name="navigationPayload"
-                  render={({ field }) => (
-                    <FormItem>
-                      <div className="flex gap-16">
-                        <FormLabel>
-                          <div className="w-72">
-                            <h1 className="text-lg">Navigation Payload</h1>
-                            <h2 className="text-base text-slate-400">
-                              Specify important parameters, routes, or states
-                            </h2>
-                          </div>
-                        </FormLabel>
-                        <div className="w-full">
-                          <FormControl>
-                            <CodeEditor
-                              {...field}
-                              language="json"
-                              fontSize={12}
-                              minHeight="96px"
-                              value={
-                                field.value === null ||
-                                typeof field.value === "undefined"
-                                  ? ""
-                                  : field.value
-                              }
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </div>
-                      </div>
-                    </FormItem>
-                  )}
-                />
                 <FormField
                   control={form.control}
                   name="maxStepsOverride"


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Move `navigationPayload` field to 'base' section with toggle visibility in `CreateNewTaskForm.tsx` and `SavedTaskForm.tsx`.
> 
>   - **Behavior**:
>     - Move `navigationPayload` field from 'advanced' to 'base' section in `CreateNewTaskForm.tsx` and `SavedTaskForm.tsx`.
>     - Add toggle button to show/hide `navigationPayload` in 'base' section.
>   - **State Management**:
>     - Introduce `showAdvancedBaseContent` state to manage visibility of `navigationPayload` field in 'base' section.
>   - **UI**:
>     - Add 'Show Advanced Settings' and 'Hide Advanced Settings' buttons to toggle `navigationPayload` visibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9c32cbdafff86842333f81d77807047f3dcaf3c1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->