### PR TITLE
Double Bitwarden call timeout for each retry

### DIFF
--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -82,13 +82,14 @@ class BitwardenService:
         url: str,
         collection_id: str | None = None,
         remaining_retries: int = settings.BITWARDEN_MAX_RETRIES,
+        timeout: int = settings.BITWARDEN_TIMEOUT_SECONDS,
         fail_reasons: list[str] = [],
     ) -> dict[str, str]:
         """
         Get the secret value from the Bitwarden CLI.
         """
         try:
-            async with asyncio.timeout(settings.BITWARDEN_TIMEOUT_SECONDS):
+            async with asyncio.timeout(timeout):
                 return await BitwardenService._get_secret_value_from_url(
                     client_id=client_id,
                     client_secret=client_secret,
@@ -111,6 +112,8 @@ class BitwardenService:
                 url=url,
                 collection_id=collection_id,
                 remaining_retries=remaining_retries,
+                # Double the timeout for the next retry
+                timeout=timeout * 2,
                 fail_reasons=fail_reasons + [f"{type(e).__name__}: {str(e)}"],
             )
 
@@ -207,13 +210,14 @@ class BitwardenService:
         identity_key: str,
         identity_fields: list[str],
         remaining_retries: int = settings.BITWARDEN_MAX_RETRIES,
+        timeout: int = settings.BITWARDEN_TIMEOUT_SECONDS,
         fail_reasons: list[str] = [],
     ) -> dict[str, str]:
         """
         Get the secret value from the Bitwarden CLI.
         """
         try:
-            async with asyncio.timeout(settings.BITWARDEN_TIMEOUT_SECONDS):
+            async with asyncio.timeout(timeout):
                 return await BitwardenService._get_sensitive_information_from_identity(
                     client_id=client_id,
                     client_secret=client_secret,
@@ -238,6 +242,8 @@ class BitwardenService:
                 identity_key=identity_key,
                 identity_fields=identity_fields,
                 remaining_retries=remaining_retries,
+                # Double the timeout for the next retry
+                timeout=timeout * 2,
                 fail_reasons=fail_reasons + [f"{type(e).__name__}: {str(e)}"],
             )
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Double the timeout for each retry in Bitwarden CLI calls in `get_secret_value_from_url` and `get_sensitive_information_from_identity`.
> 
>   - **Behavior**:
>     - Double timeout for each retry in `get_secret_value_from_url` and `get_sensitive_information_from_identity` in `bitwarden.py`.
>     - Initial timeout set to `settings.BITWARDEN_TIMEOUT_SECONDS` and doubles on each retry.
>   - **Functions**:
>     - Modify `get_secret_value_from_url` to accept `timeout` parameter and double it on retry.
>     - Modify `get_sensitive_information_from_identity` to accept `timeout` parameter and double it on retry.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 72fb96f11b304602736bdbcac01ff4bbc9292f28. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->