### PR TITLE
if bitwarden TOTP is not defined, do not pass totp as part of the credential to llm

### DIFF
--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -177,11 +177,13 @@ class BitwardenService:
                 {
                     BitwardenConstants.USERNAME: item["login"]["username"],
                     BitwardenConstants.PASSWORD: item["login"]["password"],
-                    BitwardenConstants.TOTP: totp_code,
                 }
                 for item in items
                 if "login" in item
             ]
+            if totp_code:
+                for credential in credentials:
+                    credential[BitwardenConstants.TOTP] = totp_code
 
             if len(credentials) == 0:
                 return {}

--- a/skyvern/forge/sdk/workflow/context_manager.py
+++ b/skyvern/forge/sdk/workflow/context_manager.py
@@ -182,15 +182,16 @@ class WorkflowRunContext:
                     # password secret
                     password_secret_id = f"{random_secret_id}_password"
                     self.secrets[password_secret_id] = secret_credentials[BitwardenConstants.PASSWORD]
-
-                    totp_secret_id = f"{random_secret_id}_totp"
-                    self.secrets[totp_secret_id] = BitwardenConstants.TOTP
-
                     self.values[parameter.key] = {
                         "username": username_secret_id,
                         "password": password_secret_id,
-                        "totp": totp_secret_id,
                     }
+
+                    if BitwardenConstants.TOTP in secret_credentials and secret_credentials[BitwardenConstants.TOTP]:
+                        totp_secret_id = f"{random_secret_id}_totp"
+                        self.secrets[totp_secret_id] = BitwardenConstants.TOTP
+                        self.values[parameter.key]["totp"] = totp_secret_id
+
             except BitwardenBaseError as e:
                 LOG.error(f"Failed to get secret from Bitwarden. Error: {e}")
                 raise e


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Conditionally include TOTP in Bitwarden credentials only when defined in `bitwarden.py` and `context_manager.py`.
> 
>   - **Behavior**:
>     - In `bitwarden.py`, TOTP is only added to credentials if `totp_code` is defined.
>     - In `context_manager.py`, TOTP secret is only registered if present in `secret_credentials`.
>   - **Functions**:
>     - `_get_secret_value_from_url()` in `bitwarden.py` now conditionally adds TOTP to credentials.
>     - `register_parameter_value()` in `context_manager.py` conditionally registers TOTP secret.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d1e8f61b839ddb28ee02914fcd6165b83acbe176. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->