### PR TITLE
Use domain while getting totp instead of url

### DIFF
--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -193,7 +193,7 @@ class BitwardenService:
 
             # TODO (kerem): To make this more robust, we need to store the item id of the totp login item
             # and use it here to get the TOTP code for that specific item
-            totp_command = ["bw", "get", "totp", url, "--session", session_key]
+            totp_command = ["bw", "get", "totp", domain, "--session", session_key]
             if bw_organization_id:
                 # We need to add this filter because the TOTP command fails if there are multiple results
                 # For now, we require that the bitwarden organization id has only one totp login item for the domain


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `_get_secret_value_from_url()` in `bitwarden.py` to use `domain` instead of `url` for TOTP retrieval.
> 
>   - **Behavior**:
>     - Change in `_get_secret_value_from_url()` in `bitwarden.py` to use `domain` instead of `url` for TOTP retrieval.
>     - This change aims to improve the specificity of TOTP code retrieval by focusing on domain rather than full URL.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6ffd306ba228e8dd24fe676774ba491823abe37a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->