### PR TITLE
Require loop parameter key

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/LoopNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/LoopNode/types.ts
@@ -13,3 +13,7 @@ export const loopNodeDefaultData: LoopNodeData = {
   label: "",
   loopValue: "",
 } as const;
+
+export function isLoopNode(node: Node): node is LoopNode {
+  return node.type === "loop";
+}


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Require non-empty `loopValue` for loop nodes in `FlowRenderer.tsx` to save workflows, with error handling and utility function `isLoopNode()` added.
> 
>   - **Behavior**:
>     - In `FlowRenderer.tsx`, loop nodes must have a non-empty `loopValue` to save a workflow. Displays error toast if empty.
>   - **Functions**:
>     - Adds `isLoopNode()` in `types.ts` to check if a node is a loop node.
>   - **Misc**:
>     - Updates `FlowRenderer.tsx` to clear `loopValue` if it matches a deleted node's output parameter key.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 228de88267601b154a9f29075cbc3751537640fb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->