### PR TITLE
Add a query param to filter out workflow tasks

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -438,6 +438,7 @@ class AgentDB:
         task_status: list[TaskStatus] | None = None,
         workflow_run_id: str | None = None,
         organization_id: str | None = None,
+        only_standalone_tasks: bool = False,
     ) -> list[Task]:
         """
         Get all tasks.
@@ -445,6 +446,7 @@ class AgentDB:
         :param page_size:
         :param task_status:
         :param workflow_run_id:
+        :param only_standalone_tasks:
         :return:
         """
         if page < 1:
@@ -458,6 +460,8 @@ class AgentDB:
                     query = query.filter(TaskModel.status.in_(task_status))
                 if workflow_run_id:
                     query = query.filter(TaskModel.workflow_run_id == workflow_run_id)
+                if only_standalone_tasks:
+                    query = query.filter(TaskModel.workflow_run_id.is_(None))
                 query = query.order_by(TaskModel.created_at.desc()).limit(page_size).offset(db_page * page_size)
                 tasks = (await session.scalars(query)).all()
                 return [convert_to_task(task, debug_enabled=self.debug_enabled) for task in tasks]


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `only_standalone_tasks` query parameter to filter tasks not part of a workflow run in `get_tasks()` and `get_agent_tasks()`.
> 
>   - **Behavior**:
>     - Add `only_standalone_tasks` parameter to `get_tasks()` in `client.py` to filter tasks not part of a workflow run.
>     - In `agent_protocol.py`, add `only_standalone_tasks` query parameter to `get_agent_tasks()`.
>     - Raise `HTTPException` if `only_standalone_tasks` and `workflow_run_id` are used together in `get_agent_tasks()`.
>   - **Misc**:
>     - Update docstring in `get_tasks()` in `client.py` to include `only_standalone_tasks` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 262cc5bf121e0a81c4d567e47b09fe3477b4841a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->