### PR TITLE
Disable inactive issue closer

### DIFF
--- a/.github/workflows/inactive-issues-and-prs.yml
+++ b/.github/workflows/inactive-issues-and-prs.yml
@@ -1,7 +1,7 @@
 name: Close inactive issues
 on:
-  schedule:
-    - cron: "30 1 * * *"
+   workflow_dispatch:
+
 
 jobs:
   close-issues:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change workflow trigger from scheduled to manual in `inactive-issues-and-prs.yml`.
> 
>   - **Workflow Trigger**:
>     - Changed trigger in `.github/workflows/inactive-issues-and-prs.yml` from `schedule` to `workflow_dispatch`, disabling automatic execution and enabling manual execution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b1f9e835e8dafbcce79784f1674b423be01b6b9e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->