### PR TITLE
try to fix radio button check

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -843,11 +843,7 @@ function buildElementObject(frame, element, interactable, purgeable = false) {
   }
 
   if (elementTagNameLower === "input" || elementTagNameLower === "textarea") {
-    if (element.type === "radio") {
-      attrs["value"] = "" + element.checked + "";
-    } else {
-      attrs["value"] = element.value;
-    }
+    attrs["value"] = element.value;
   }
 
   let elementObj = {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `domUtils.js`, the `buildElementObject` function now sets the `value` attribute for `input` elements to `element.value`, removing special handling for radio buttons.
> 
>   - **Behavior**:
>     - In `buildElementObject` function in `domUtils.js`, the `value` attribute for `input` elements is now always set to `element.value`, removing special handling for radio buttons.
>   - **Misc**:
>     - Removed conditional check for `element.type === "radio"` when setting `attrs["value"]`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 62e2840c17e00f44ac1b8179504d23d85d90c31b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->