### PR TITLE
Show only standalone tasks in task pages

### DIFF
--- a/skyvern-frontend/src/routes/tasks/list/TaskHistory.tsx
+++ b/skyvern-frontend/src/routes/tasks/list/TaskHistory.tsx
@@ -49,6 +49,7 @@ function TaskHistory() {
       params.append("task_status", "terminated");
       params.append("task_status", "timed_out");
       params.append("task_status", "canceled");
+      params.append("only_standalone_tasks", "true");
 
       return client
         .get("/tasks", {

--- a/skyvern-frontend/src/routes/tasks/running/QueuedTasks.tsx
+++ b/skyvern-frontend/src/routes/tasks/running/QueuedTasks.tsx
@@ -26,6 +26,7 @@ function QueuedTasks() {
         .get("/tasks", {
           params: {
             task_status: "queued",
+            only_standalone_tasks: "true",
           },
         })
         .then((response) => response.data);

--- a/skyvern-frontend/src/routes/tasks/running/RunningTasks.tsx
+++ b/skyvern-frontend/src/routes/tasks/running/RunningTasks.tsx
@@ -26,6 +26,7 @@ function RunningTasks() {
         .get("/tasks", {
           params: {
             task_status: "running",
+            only_standalone_tasks: "true",
           },
         })
         .then((response) => response.data);


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `only_standalone_tasks` filter to task API requests in `TaskHistory`, `QueuedTasks`, and `RunningTasks`.
> 
>   - **Behavior**:
>     - Add `only_standalone_tasks: "true"` to API requests in `TaskHistory`, `QueuedTasks`, and `RunningTasks` to filter tasks.
>   - **Components**:
>     - `TaskHistory`: Filters completed, failed, terminated, timed out, and canceled tasks.
>     - `QueuedTasks`: Filters queued tasks.
>     - `RunningTasks`: Filters running tasks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 38a154500644d602ece72eaeba7a640d26790261. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->