### PR TITLE
Adjust font weight in multi select component

### DIFF
--- a/skyvern-frontend/src/components/ui/multi-select.tsx
+++ b/skyvern-frontend/src/components/ui/multi-select.tsx
@@ -238,7 +238,7 @@ export const MultiSelect = React.forwardRef<
               </div>
             ) : (
               <div className="mx-auto flex w-full items-center justify-between">
-                <span className="mx-3 text-sm text-muted-foreground">
+                <span className="mx-3 text-sm text-muted-foreground font-normal">
                   {placeholder}
                 </span>
                 <ChevronDownIcon className="mx-2 h-4 cursor-pointer text-muted-foreground" />


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adjusts font weight of placeholder text to `font-normal` in `MultiSelect` component.
> 
>   - **UI Change**:
>     - Adjusts font weight of placeholder text to `font-normal` in `MultiSelect` component in `multi-select.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0fc8515fad80e0bcf70f3db1c40b3526e012ebfa. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->