### PR TITLE
use registered_domain to search in bitwarden

### DIFF
--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -157,7 +157,7 @@ class BitwardenService:
             BitwardenService.sync()
             session_key = BitwardenService.unlock(master_password)
 
-            # Extract the domain from the URL and search for items in Bitwarden with that domain
+            # Extract the domain(with suffix) from the URL and search for items in Bitwarden with that domain
             domain = tldextract.extract(url).registered_domain
             list_command = [
                 "bw",

--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -158,7 +158,7 @@ class BitwardenService:
             session_key = BitwardenService.unlock(master_password)
 
             # Extract the domain from the URL and search for items in Bitwarden with that domain
-            domain = tldextract.extract(url).domain
+            domain = tldextract.extract(url).registered_domain
             list_command = [
                 "bw",
                 "list",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change domain extraction in `bitwarden.py` to use `registered_domain` for Bitwarden searches.
> 
>   - **Behavior**:
>     - In `bitwarden.py`, change domain extraction in `_get_secret_value_from_url()` from `domain` to `registered_domain` using `tldextract`.
>     - This affects how URLs are processed when searching for items in Bitwarden, ensuring the full registered domain is used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2946cdae6ac2461af47915c1b95e927d233b6da6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->