### PR TITLE
Adjust font weight in multi select

### DIFF
--- a/skyvern-frontend/src/components/ui/multi-select.tsx
+++ b/skyvern-frontend/src/components/ui/multi-select.tsx
@@ -238,7 +238,7 @@ export const MultiSelect = React.forwardRef<
               </div>
             ) : (
               <div className="mx-auto flex w-full items-center justify-between">
-                <span className="mx-3 text-sm text-muted-foreground">
+                <span className="mx-3 text-sm font-normal text-muted-foreground">
                   {placeholder}
                 </span>
                 <ChevronDownIcon className="mx-2 h-4 cursor-pointer text-muted-foreground" />


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change font weight to `font-normal` for placeholder text in `MultiSelect` component in `multi-select.tsx`.
> 
>   - **UI Adjustment**:
>     - Change font weight to `font-normal` for placeholder text in `MultiSelect` component in `multi-select.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b3877315b67b3b0e84c2052a883845a1b5dff675. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->