### PR TITLE
dont let users add loop node in another loop node for now

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/edges/EdgeWithAddButton.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/edges/EdgeWithAddButton.tsx
@@ -56,6 +56,7 @@ function EdgeWithAddButton({
             size="icon"
             className="h-4 w-4 rounded-full transition-all hover:scale-150"
             onClick={() => {
+              const disableLoop = Boolean(sourceNode?.parentId);
               setWorkflowPanelState({
                 active: true,
                 content: "nodeLibrary",
@@ -63,6 +64,7 @@ function EdgeWithAddButton({
                   previous: source,
                   next: target,
                   parent: sourceNode?.parentId,
+                  disableLoop,
                 },
               });
             }}

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/NodeAdderNode/NodeAdderNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/NodeAdderNode/NodeAdderNode.tsx
@@ -27,6 +27,7 @@ function NodeAdderNode({ id, parentId }: NodeProps<NodeAdderNode>) {
         className="rounded-full bg-slate-50 p-2"
         onClick={() => {
           const previous = edges.find((edge) => edge.target === id)?.source;
+          const disableLoop = Boolean(parentId);
           setWorkflowPanelState({
             active: true,
             content: "nodeLibrary",
@@ -35,6 +36,7 @@ function NodeAdderNode({ id, parentId }: NodeProps<NodeAdderNode>) {
               next: id,
               parent: parentId,
               connectingEdgeType: "default",
+              disableLoop,
             },
           });
         }}

--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
@@ -106,6 +106,9 @@ function WorkflowNodeLibraryPanel({ onNodeClick, first }: Props) {
         </header>
         <div className="space-y-2">
           {nodeLibraryItems.map((item) => {
+            if (workflowPanelData?.disableLoop && item.nodeType === "loop") {
+              return null;
+            }
             return (
               <div
                 key={item.nodeType}

--- a/skyvern-frontend/src/store/WorkflowPanelStore.ts
+++ b/skyvern-frontend/src/store/WorkflowPanelStore.ts
@@ -8,6 +8,7 @@ type WorkflowPanelState = {
     next?: string | null;
     parent?: string;
     connectingEdgeType?: string;
+    disableLoop?: boolean;
   };
 };
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces `disableLoop` flag to prevent adding loop nodes within other loop nodes in the workflow editor.
> 
>   - **Behavior**:
>     - Prevents adding loop nodes within other loop nodes using `disableLoop` flag in `EdgeWithAddButton.tsx` and `NodeAdderNode.tsx`.
>     - `WorkflowNodeLibraryPanel.tsx` checks `disableLoop` flag to conditionally render loop nodes.
>   - **State Management**:
>     - Adds `disableLoop` boolean to `WorkflowPanelState` in `WorkflowPanelStore.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 75eea15a2d2516bcc6ba7aca52470fd4e3749b3b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->