### PR TITLE
Utilize all Workflow Run statuses

### DIFF
--- a/skyvern/forge/sdk/workflow/models/workflow.py
+++ b/skyvern/forge/sdk/workflow/models/workflow.py
@@ -62,10 +62,22 @@ class Workflow(BaseModel):
 
 class WorkflowRunStatus(StrEnum):
     created = "created"
+    queued = "queued"
     running = "running"
     failed = "failed"
     terminated = "terminated"
+    canceled = "canceled"
+    timed_out = "timed_out"
     completed = "completed"
+
+    def is_final(self) -> bool:
+        return self in [
+            WorkflowRunStatus.failed,
+            WorkflowRunStatus.terminated,
+            WorkflowRunStatus.canceled,
+            WorkflowRunStatus.timed_out,
+            WorkflowRunStatus.completed,
+        ]
 
 
 class WorkflowRun(BaseModel):


### PR DESCRIPTION
Added & handled:
- queued
- timed_out
- canceled

Handled:
- terminated
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for `queued`, `timed_out`, `canceled`, and `terminated` workflow run statuses across execution, database, and logging components.
> 
>   - **Workflow Run Statuses**:
>     - Added `queued`, `timed_out`, `canceled`, and `terminated` statuses to `WorkflowRunStatus` in `workflow.py`.
>     - Updated `execute_workflow()` in `service.py` to handle new statuses.
>     - Added `mark_workflow_run_as_canceled()` in `service.py`.
>   - **Database**:
>     - Added `get_workflow_runs_stuck_in_status()` in `db_client.py` to query stuck workflow runs.
>     - Updated `update_stuck_workflow_runs_to_timed_out()` in `tasks.py` to handle new statuses.
>   - **Blocks and Execution**:
>     - Updated `BlockStatus` in `block.py` to include new statuses.
>     - Modified `execute()` in `block.py` to handle `canceled` and `terminated` statuses.
>     - Adjusted `execute_safe()` in `block.py` to log and handle new statuses.
>   - **Miscellaneous**:
>     - Updated constants in `config.py` for stuck workflow run timing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for aa7e9de758d86a0961ffadd73552f957f33c1072. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->