### PR TITLE
Change limit field width and file suffix placeholder

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/TaskNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/TaskNode.tsx
@@ -266,7 +266,7 @@ function TaskNode({ id, data }: NodeProps<TaskNode>) {
                 <Input
                   type="number"
                   placeholder={fieldPlaceholders["maxRetries"]}
-                  className="nopan w-44 text-xs"
+                  className="nopan w-52 text-xs"
                   min="0"
                   value={inputs.maxRetries ?? ""}
                   onChange={(event) => {
@@ -288,7 +288,7 @@ function TaskNode({ id, data }: NodeProps<TaskNode>) {
                 <Input
                   type="number"
                   placeholder={fieldPlaceholders["maxStepsOverride"]}
-                  className="nopan w-44 text-xs"
+                  className="nopan w-52 text-xs"
                   min="0"
                   value={inputs.maxStepsOverride ?? ""}
                   onChange={(event) => {
@@ -307,7 +307,7 @@ function TaskNode({ id, data }: NodeProps<TaskNode>) {
                 <Label className="text-xs font-normal text-slate-300">
                   Complete on Download
                 </Label>
-                <div className="w-44">
+                <div className="w-52">
                   <Switch
                     checked={inputs.allowDownloads}
                     onCheckedChange={(checked) => {
@@ -326,7 +326,7 @@ function TaskNode({ id, data }: NodeProps<TaskNode>) {
                 <Input
                   type="text"
                   placeholder={fieldPlaceholders["downloadSuffix"]}
-                  className="nopan w-44 text-xs"
+                  className="nopan w-52 text-xs"
                   value={inputs.downloadSuffix ?? ""}
                   onChange={(event) => {
                     if (!editable) {

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/types.ts
@@ -57,7 +57,7 @@ export const fieldPlaceholders = {
   dataExtractionGoal: "What data do you need to extract?",
   maxRetries: "Default: 3",
   maxStepsOverride: "Default: 10",
-  downloadSuffix: "Suffix for file downloads",
+  downloadSuffix: "Add an ID for downloaded files",
   label: "Task",
   totpVerificationUrl: "Provide your 2FA endpoint",
   totpIdentifier: "Add an ID that links your TOTP to the task",


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Increase input field widths in `TaskNode.tsx` and update `downloadSuffix` placeholder in `types.ts`.
> 
>   - **UI Changes in `TaskNode.tsx`**:
>     - Increase width of input fields for `maxRetries`, `maxStepsOverride`, `allowDownloads`, and `downloadSuffix` from `w-44` to `w-52`.
>   - **Placeholder Update in `types.ts`**:
>     - Change `downloadSuffix` placeholder from "Suffix for file downloads" to "Add an ID for downloaded files".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9d52848036ad308b4b2151f2f10fc0c855109795. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->