### PR TITLE
Add a max height for task form code editor fields

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -295,6 +295,7 @@ function CreateNewTaskForm({ initialValues }: Props) {
                                   language="json"
                                   fontSize={12}
                                   minHeight="96px"
+                                  maxHeight="500px"
                                   value={
                                     field.value === null ? "" : field.value
                                   }
@@ -389,6 +390,7 @@ function CreateNewTaskForm({ initialValues }: Props) {
                               language="json"
                               fontSize={12}
                               minHeight="96px"
+                              maxHeight="500px"
                               value={field.value === null ? "" : field.value}
                             />
                           </FormControl>
@@ -509,6 +511,7 @@ function CreateNewTaskForm({ initialValues }: Props) {
                               language="json"
                               fontSize={12}
                               minHeight="96px"
+                              maxHeight="500px"
                               value={field.value === null ? "" : field.value}
                             />
                           </FormControl>

--- a/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
@@ -464,6 +464,7 @@ function SavedTaskForm({ initialValues }: Props) {
                                   language="json"
                                   fontSize={12}
                                   minHeight="96px"
+                                  maxHeight="500px"
                                   value={
                                     field.value === null ? "" : field.value
                                   }
@@ -558,6 +559,7 @@ function SavedTaskForm({ initialValues }: Props) {
                               language="json"
                               fontSize={14}
                               minHeight="96px"
+                              maxHeight="500px"
                               value={
                                 field.value === null ||
                                 typeof field.value === "undefined"
@@ -683,6 +685,7 @@ function SavedTaskForm({ initialValues }: Props) {
                               language="json"
                               fontSize={12}
                               minHeight="96px"
+                              maxHeight="500px"
                               value={field.value === null ? "" : field.value}
                             />
                           </FormControl>

--- a/skyvern-frontend/src/routes/workflows/components/CodeEditor.tsx
+++ b/skyvern-frontend/src/routes/workflows/components/CodeEditor.tsx
@@ -10,6 +10,7 @@ type Props = {
   language: "python" | "json";
   disabled?: boolean;
   minHeight?: string;
+  maxHeight?: string;
   className?: string;
   fontSize?: number;
 };
@@ -18,6 +19,7 @@ function CodeEditor({
   value,
   onChange,
   minHeight,
+  maxHeight,
   language,
   className,
   fontSize = 8,
@@ -33,6 +35,7 @@ function CodeEditor({
       extensions={extensions}
       theme={tokyoNightStorm}
       minHeight={minHeight}
+      maxHeight={maxHeight}
       className={cn("cursor-auto", className)}
       style={{
         fontSize: fontSize,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Set a maximum height of 500px for `CodeEditor` fields in task forms for UI consistency.
> 
>   - **UI Changes**:
>     - Set `maxHeight` to `500px` for `CodeEditor` in `CreateNewTaskForm.tsx` and `SavedTaskForm.tsx`.
>     - Updated `CodeEditor` component in `CodeEditor.tsx` to accept `maxHeight` prop.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 20430f99ca206c767f38f6e82c8899999785c775. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->