### PR TITLE
remove scheduler

### DIFF
--- a/skyvern/forge/api_app.py
+++ b/skyvern/forge/api_app.py
@@ -19,7 +19,6 @@ from skyvern.forge.sdk.db.exceptions import NotFoundError
 from skyvern.forge.sdk.routes.agent_protocol import base_router
 from skyvern.forge.sdk.routes.streaming import websocket_router
 from skyvern.forge.sdk.settings_manager import SettingsManager
-from skyvern.scheduler import SCHEDULER
 
 LOG = structlog.get_logger()
 
@@ -64,8 +63,6 @@ def get_agent_app() -> FastAPI:
     @app.on_event("startup")
     def start_scheduler() -> None:
         LOG.info("Starting the skyvern scheduler.")
-        SCHEDULER.start()
-
         LOG.info("Server startup complete. Skyvern is now online")
 
     @app.exception_handler(NotFoundError)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove scheduler functionality from `skyvern/forge/api_app.py` by deleting `SCHEDULER` import and `SCHEDULER.start()` call.
> 
>   - **Scheduler Removal**:
>     - Remove `SCHEDULER` import from `skyvern/forge/api_app.py`.
>     - Delete `SCHEDULER.start()` call in `start_scheduler()` function in `skyvern/forge/api_app.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c56dd6256c021357a95e2d1ef71f28d9575b2a74. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->