### PR TITLE
extend the raw input scope

### DIFF
--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -178,6 +178,10 @@ class SkyvernElement:
         if name.lower() in RAW_INPUT_NAME_VALUE:
             return True
 
+        # if input has these attrs, it expects user to type and input sth
+        if await self.get_attr("min") or await self.get_attr("max") or await self.get_attr("step"):
+            return True
+
         return False
 
     async def is_spinbtn_input(self) -> bool:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Extends `is_raw_input()` in `dom.py` to consider inputs with `min`, `max`, or `step` attributes as raw inputs.
> 
>   - **Behavior**:
>     - Extends `is_raw_input()` in `dom.py` to return `True` if input has `min`, `max`, or `step` attributes.
>   - **Misc**:
>     - No other files or functions are affected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for fe3a5c42281b5cb7a0418da2633c298f02650af7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->