### PR TITLE
fix yes/no radio input

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -850,6 +850,16 @@ function buildElementObject(frame, element, interactable, purgeable = false) {
     attrs["required"] = true;
   }
 
+  if (
+    elementTagNameLower === "input" &&
+    (element.type === "radio" || element.type === "checkbox")
+  ) {
+    // if checkbox and radio don't have "checked" and "aria-checked", add a checked="false" to help LLM understand
+    if (!("checked" in attrs) && !("aria-checked" in attrs)) {
+      attrs["checked"] = false;
+    }
+  }
+
   if (elementTagNameLower === "input" || elementTagNameLower === "textarea") {
     attrs["value"] = element.value;
   }

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -573,7 +573,7 @@ def _trimmed_attributes(attributes: dict) -> dict:
     for key in attributes:
         if key == "role" and attributes[key] in ["listbox", "option"]:
             new_attributes[key] = attributes[key]
-        if key in RESERVED_ATTRIBUTES and attributes[key]:
+        if key in RESERVED_ATTRIBUTES:
             new_attributes[key] = attributes[key]
 
     return new_attributes


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes radio/checkbox input handling in `domUtils.js` and simplifies `_trimmed_attributes()` in `scraper.py`.
> 
>   - **Behavior**:
>     - In `domUtils.js`, `buildElementObject()` now sets `checked=false` for radio and checkbox inputs if `checked` and `aria-checked` are absent.
>   - **Code Simplification**:
>     - In `scraper.py`, removed redundant condition in `_trimmed_attributes()` that checked for truthy values in `RESERVED_ATTRIBUTES`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 3cfa10c890a134ec0711197947b89570e7054c42. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->