### PR TITLE
remove /tmp persistant volumn in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - ./videos:/data/videos
       - ./har:/data/har
       - ./.streamlit:/app/.streamlit
-      - ./files:/tmp
     environment:
       - DATABASE_STRING=postgresql+psycopg://skyvern:skyvern@postgres:5432/skyvern
       - BROWSER_TYPE=chromium-headful


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove persistent volume mapping `./files:/tmp` from `skyvern` service in `docker-compose.yml`.
> 
>   - **Docker Compose Configuration**:
>     - Removed persistent volume mapping `./files:/tmp` from the `skyvern` service in `docker-compose.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e473394ef5ed8722aea6d0c59c96dd21d35b832b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->