### PR TITLE
fix LiteLLMParams

### DIFF
--- a/skyvern/forge/sdk/api/llm/models.py
+++ b/skyvern/forge/sdk/api/llm/models.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Literal, Optional, Protocol
+from typing import Any, Awaitable, Literal, Optional, Protocol, TypedDict
 
 from litellm import AllowedFailsPolicy
 
@@ -7,12 +7,11 @@ from skyvern.forge.sdk.models import Step
 from skyvern.forge.sdk.settings_manager import SettingsManager
 
 
-@dataclass
-class LiteLLMParams:
+class LiteLLMParams(TypedDict):
     api_key: str | None
     api_version: str | None
     api_base: str | None
-    model_info: dict[str, Any] = field(default_factory=dict)
+    model_info: dict[str, Any] | None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Convert `LiteLLMParams` from `dataclass` to `TypedDict` and allow `None` for `model_info`.
> 
>   - **Type Change**:
>     - Change `LiteLLMParams` from `dataclass` to `TypedDict` in `models.py`.
>     - `model_info` in `LiteLLMParams` now allows `None` values.
>   - **Imports**:
>     - Add `TypedDict` to imports in `models.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for faf9597853e18515c976f625e29e9a5319971d6e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->