### PR TITLE
Remove override for container in tailwind config

### DIFF
--- a/skyvern-frontend/tailwind.config.js
+++ b/skyvern-frontend/tailwind.config.js
@@ -12,9 +12,6 @@ module.exports = {
     container: {
       center: true,
       padding: "2rem",
-      screens: {
-        "2xl": "1400px",
-      },
     },
     extend: {
       colors: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `2xl` screen size override from `container` in `tailwind.config.js`.
> 
>   - **Configuration**:
>     - Removed `2xl` screen size override from `container` in `tailwind.config.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 000be608d086e599c1e37544ec43a5e1c3ecca06. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->