### PR TITLE
Navigate to task form when generating task from prompt

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
@@ -16,19 +16,6 @@ import {
   ScrollBar,
 } from "@/components/ui/scroll-area";
 
-function createTaskFromTaskGenerationParameters(
-  values: TaskGenerationApiResponse,
-) {
-  return {
-    url: values.url,
-    navigation_goal: values.navigation_goal,
-    data_extraction_goal: values.data_extraction_goal,
-    proxy_location: "RESIDENTIAL",
-    navigation_payload: values.navigation_payload,
-    extracted_information_schema: values.extracted_information_schema,
-  };
-}
-
 function createTemplateTaskFromTaskGenerationParameters(
   values: TaskGenerationApiResponse,
 ) {
@@ -120,27 +107,6 @@ function PromptBox() {
     },
   });
 
-  const runTaskMutation = useMutation({
-    mutationFn: async (params: TaskGenerationApiResponse) => {
-      const client = await getClient(credentialGetter);
-      const data = createTaskFromTaskGenerationParameters(params);
-      return client.post<
-        ReturnType<typeof createTaskFromTaskGenerationParameters>,
-        { data: { task_id: string } }
-      >("/tasks", data);
-    },
-    onSuccess: (response) => {
-      navigate(`/tasks/${response.data.task_id}/actions`);
-    },
-    onError: (error: AxiosError) => {
-      toast({
-        variant: "destructive",
-        title: "Error running task",
-        description: error.message,
-      });
-    },
-  });
-
   return (
     <div>
       <div
@@ -163,8 +129,7 @@ function PromptBox() {
             />
             <div className="h-full">
               {getTaskFromPromptMutation.isPending ||
-              saveTaskMutation.isPending ||
-              runTaskMutation.isPending ? (
+              saveTaskMutation.isPending ? (
                 <ReloadIcon className="h-6 w-6 animate-spin" />
               ) : (
                 <PaperPlaneIcon
@@ -173,7 +138,11 @@ function PromptBox() {
                     const taskGenerationResponse =
                       await getTaskFromPromptMutation.mutateAsync(prompt);
                     await saveTaskMutation.mutateAsync(taskGenerationResponse);
-                    await runTaskMutation.mutateAsync(taskGenerationResponse);
+                    navigate("/create/from-prompt", {
+                      state: {
+                        data: taskGenerationResponse,
+                      },
+                    });
                   }}
                 />
               )}


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Navigate to a pre-filled task form when generating a task from a prompt, instead of executing it immediately, by updating `CreateNewTaskFormPage.tsx` and `PromptBox.tsx`.
> 
>   - **Behavior**:
>     - In `CreateNewTaskFormPage.tsx`, added logic to handle `from-prompt` template by navigating to a form with pre-filled data from `location.state.data`.
>     - In `PromptBox.tsx`, removed `runTaskMutation` and replaced it with navigation to `/create/from-prompt` with task data in state.
>   - **Functions**:
>     - Removed `createTaskFromTaskGenerationParameters()` and `runTaskMutation` from `PromptBox.tsx`.
>     - Updated `onClick` handler in `PromptBox.tsx` to navigate with state instead of running a task.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 7469206551abce7c0c900cae0cc77114ae2d59fb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->