### PR TITLE
Change terminated status badge color to warning

### DIFF
--- a/skyvern-frontend/src/components/StatusBadge.tsx
+++ b/skyvern-frontend/src/components/StatusBadge.tsx
@@ -11,12 +11,11 @@ function StatusBadge({ status }: Props) {
     variant = "success";
   } else if (
     status === "failed" ||
-    status === "terminated" ||
     status === "timed_out" ||
     status === "canceled"
   ) {
     variant = "destructive";
-  } else if (status === "running") {
+  } else if (status === "running" || status === "terminated") {
     variant = "warning";
   }
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change `terminated` status badge color from `destructive` to `warning` in `StatusBadge.tsx`.
> 
>   - **Behavior**:
>     - Changes `terminated` status badge color from `destructive` to `warning` in `StatusBadge` component in `StatusBadge.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 515f64dbedf84bb4573c2c8cf485465f5424b992. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->