### PR TITLE
Add GET workflows/runs/run_id endpoint

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -641,6 +641,26 @@ async def get_workflow_run(
     )
 
 
+@base_router.get(
+    "/workflows/runs/{workflow_run_id}",
+    response_model=WorkflowRunStatusResponse,
+)
+@base_router.get(
+    "/workflows/runs/{workflow_run_id}/",
+    response_model=WorkflowRunStatusResponse,
+    include_in_schema=False,
+)
+async def get_workflow_run_by_run_id(
+    workflow_run_id: str,
+    current_org: Organization = Depends(org_auth_service.get_current_org),
+) -> WorkflowRunStatusResponse:
+    analytics.capture("skyvern-oss-agent-workflow-run-get")
+    return await app.WORKFLOW_SERVICE.build_workflow_run_status_response_by_workflow_id(
+        workflow_run_id=workflow_run_id,
+        organization_id=current_org.organization_id,
+    )
+
+
 @base_router.post(
     "/workflows",
     openapi_extra={

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -612,6 +612,22 @@ class WorkflowService:
     async def get_tasks_by_workflow_run_id(self, workflow_run_id: str) -> list[Task]:
         return await app.DATABASE.get_tasks_by_workflow_run_id(workflow_run_id=workflow_run_id)
 
+    async def build_workflow_run_status_response_by_workflow_id(
+        self,
+        workflow_run_id: str,
+        organization_id: str,
+    ) -> WorkflowRunStatusResponse:
+        workflow_run = await self.get_workflow_run(workflow_run_id=workflow_run_id)
+        if workflow_run is None:
+            LOG.error(f"Workflow run {workflow_run_id} not found")
+            raise WorkflowRunNotFound(workflow_run_id=workflow_run_id)
+        workflow_permanent_id = workflow_run.workflow_permanent_id
+        return await self.build_workflow_run_status_response(
+            workflow_permanent_id=workflow_permanent_id,
+            workflow_run_id=workflow_run_id,
+            organization_id=organization_id,
+        )
+
     async def build_workflow_run_status_response(
         self,
         workflow_permanent_id: str,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `GET /workflows/runs/{workflow_run_id}` endpoint to retrieve workflow run status with error handling for not found cases.
> 
>   - **Endpoints**:
>     - Add `GET /workflows/runs/{workflow_run_id}` endpoint in `agent_protocol.py` to retrieve workflow run status by `workflow_run_id`.
>     - Includes a variant with a trailing slash, not included in schema.
>   - **Service Logic**:
>     - Add `build_workflow_run_status_response_by_workflow_id()` in `service.py` to construct response using `workflow_run_id`.
>     - Handles case where workflow run is not found by logging an error and raising `WorkflowRunNotFound`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5084fdf6df8bc03f43397a470c92f24f6bb4a2d7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->