### PR TITLE
add continue on failure in task block

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/TaskNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/TaskNode.tsx
@@ -73,6 +73,7 @@ function TaskNode({ id, data }: NodeProps<TaskNode>) {
     maxRetries: data.maxRetries,
     maxStepsOverride: data.maxStepsOverride,
     allowDownloads: data.allowDownloads,
+    continueOnFailure: data.continueOnFailure,
     downloadSuffix: data.downloadSuffix,
     errorCodeMapping: data.errorCodeMapping,
     totpVerificationUrl: data.totpVerificationUrl,
@@ -329,6 +330,24 @@ function TaskNode({ id, data }: NodeProps<TaskNode>) {
                         return;
                       }
                       handleChange("allowDownloads", checked);
+                    }}
+                  />
+                </div>
+              </div>
+              <div className="flex items-center justify-between">
+                <div className="flex gap-2">
+                  <Label className="text-xs font-normal text-slate-300">
+                    Continue on Failure
+                  </Label>
+                </div>
+                <div className="w-52">
+                  <Switch
+                    checked={inputs.continueOnFailure}
+                    onCheckedChange={(checked) => {
+                      if (!editable) {
+                        return;
+                      }
+                      handleChange("continueOnFailure", checked);
                     }}
                   />
                 </div>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/types.ts
@@ -15,6 +15,7 @@ export type TaskNodeData = {
   parameterKeys: Array<string>;
   totpVerificationUrl: string | null;
   totpIdentifier: string | null;
+  continueOnFailure: boolean;
 };
 
 export type TaskNode = Node<TaskNodeData, "task">;
@@ -36,6 +37,7 @@ export const taskNodeDefaultData: TaskNodeData = {
   parameterKeys: [],
   totpVerificationUrl: null,
   totpIdentifier: null,
+  continueOnFailure: false,
 } as const;
 
 export function isTaskNode(node: Node): node is TaskNode {

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -147,6 +147,7 @@ function convertToNode(
           parameterKeys: block.parameters.map((p) => p.key),
           totpIdentifier: block.totp_identifier ?? null,
           totpVerificationUrl: block.totp_verification_url ?? null,
+          continueOnFailure: block.continue_on_failure,
         },
       };
     }
@@ -518,6 +519,7 @@ function getWorkflowBlock(
         parameter_keys: node.data.parameterKeys,
         totp_identifier: node.data.totpIdentifier,
         totp_verification_url: node.data.totpVerificationUrl,
+        continue_on_failure: node.data.continueOnFailure,
       };
     }
     case "sendEmail": {


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `continueOnFailure` option to `TaskNode` to handle task failures, with UI, data model, and workflow conversion updates.
> 
>   - **Behavior**:
>     - Add `continueOnFailure` property to `TaskNode` in `TaskNode.tsx` to allow tasks to proceed on failure.
>     - UI switch added for `continueOnFailure` in `TaskNode.tsx`.
>   - **Data Model**:
>     - Update `TaskNodeData` type in `types.ts` to include `continueOnFailure`.
>     - Set default `continueOnFailure` to `false` in `taskNodeDefaultData` in `types.ts`.
>   - **Workflow Conversion**:
>     - Update `convertToNode` and `getWorkflowBlock` in `workflowEditorUtils.ts` to handle `continueOnFailure`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e4b7c5b7f7926c64b9d2348d112e4136b1f6c425. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->