### PR TITLE
Add continue on failure as passthrough and cache_actions property

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/CodeBlockNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/CodeBlockNode/types.ts
@@ -1,9 +1,9 @@
 import type { Node } from "@xyflow/react";
+import { NodeBaseData } from "../types";
 
-export type CodeBlockNodeData = {
+export type CodeBlockNodeData = NodeBaseData & {
   code: string;
   editable: boolean;
-  label: string;
 };
 
 export type CodeBlockNode = Node<CodeBlockNodeData, "codeBlock">;
@@ -12,4 +12,5 @@ export const codeBlockNodeDefaultData: CodeBlockNodeData = {
   editable: true,
   label: "",
   code: `# To assign a value to the output of this block,\n# assign the value to the variable 'result'\n# The final value of 'result' will be used as the output of this block\n\nresult = 5`,
+  continueOnFailure: false,
 } as const;

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/DownloadNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/DownloadNode/types.ts
@@ -1,10 +1,10 @@
 import type { Node } from "@xyflow/react";
 import { SKYVERN_DOWNLOAD_DIRECTORY } from "../../constants";
+import { NodeBaseData } from "../types";
 
-export type DownloadNodeData = {
+export type DownloadNodeData = NodeBaseData & {
   url: string;
   editable: boolean;
-  label: string;
 };
 
 export type DownloadNode = Node<DownloadNodeData, "download">;
@@ -13,6 +13,7 @@ export const downloadNodeDefaultData: DownloadNodeData = {
   editable: true,
   label: "",
   url: SKYVERN_DOWNLOAD_DIRECTORY,
+  continueOnFailure: false,
 } as const;
 
 export const helpTooltipContent = {

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/FileParserNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/FileParserNode/types.ts
@@ -1,9 +1,9 @@
 import type { Node } from "@xyflow/react";
+import { NodeBaseData } from "../types";
 
-export type FileParserNodeData = {
+export type FileParserNodeData = NodeBaseData & {
   fileUrl: string;
   editable: boolean;
-  label: string;
 };
 
 export type FileParserNode = Node<FileParserNodeData, "fileParser">;
@@ -12,6 +12,7 @@ export const fileParserNodeDefaultData: FileParserNodeData = {
   editable: true,
   label: "",
   fileUrl: "",
+  continueOnFailure: false,
 } as const;
 
 export const helpTooltipContent = {

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/LoopNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/LoopNode/types.ts
@@ -1,9 +1,9 @@
 import type { Node } from "@xyflow/react";
+import { NodeBaseData } from "../types";
 
-export type LoopNodeData = {
+export type LoopNodeData = NodeBaseData & {
   loopValue: string;
   editable: boolean;
-  label: string;
 };
 
 export type LoopNode = Node<LoopNodeData, "loop">;
@@ -12,6 +12,7 @@ export const loopNodeDefaultData: LoopNodeData = {
   editable: true,
   label: "",
   loopValue: "",
+  continueOnFailure: false,
 } as const;
 
 export function isLoopNode(node: Node): node is LoopNode {

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/SendEmailNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/SendEmailNode/types.ts
@@ -7,14 +7,14 @@ import {
   SMTP_PORT_PARAMETER_KEY,
   SMTP_USERNAME_PARAMETER_KEY,
 } from "../../constants";
+import { NodeBaseData } from "../types";
 
-export type SendEmailNodeData = {
+export type SendEmailNodeData = NodeBaseData & {
   recipients: string;
   subject: string;
   body: string;
   fileAttachments: string;
   editable: boolean;
-  label: string;
   sender: string;
   smtpHostSecretParameterKey?: string;
   smtpPortSecretParameterKey?: string;
@@ -36,6 +36,7 @@ export const sendEmailNodeDefaultData: SendEmailNodeData = {
   smtpPortSecretParameterKey: SMTP_PORT_PARAMETER_KEY,
   smtpUsernameSecretParameterKey: SMTP_USERNAME_PARAMETER_KEY,
   smtpPasswordSecretParameterKey: SMTP_PASSWORD_PARAMETER_KEY,
+  continueOnFailure: false,
 } as const;
 
 export const helpTooltipContent = {

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/types.ts
@@ -1,6 +1,7 @@
 import type { Node } from "@xyflow/react";
+import { NodeBaseData } from "../types";
 
-export type TaskNodeData = {
+export type TaskNodeData = NodeBaseData & {
   url: string;
   navigationGoal: string;
   dataExtractionGoal: string;
@@ -11,11 +12,10 @@ export type TaskNodeData = {
   allowDownloads: boolean;
   downloadSuffix: string | null;
   editable: boolean;
-  label: string;
   parameterKeys: Array<string>;
   totpVerificationUrl: string | null;
   totpIdentifier: string | null;
-  continueOnFailure: boolean;
+  cacheActions: boolean;
 };
 
 export type TaskNode = Node<TaskNodeData, "task">;
@@ -38,6 +38,7 @@ export const taskNodeDefaultData: TaskNodeData = {
   totpVerificationUrl: null,
   totpIdentifier: null,
   continueOnFailure: false,
+  cacheActions: false,
 } as const;
 
 export function isTaskNode(node: Node): node is TaskNode {

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TextPromptNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TextPromptNode/types.ts
@@ -1,6 +1,7 @@
 import type { Node } from "@xyflow/react";
+import { NodeBaseData } from "../types";
 
-export type TextPromptNodeData = {
+export type TextPromptNodeData = NodeBaseData & {
   prompt: string;
   jsonSchema: string;
   editable: boolean;
@@ -14,6 +15,7 @@ export const textPromptNodeDefaultData: TextPromptNodeData = {
   label: "",
   prompt: "",
   jsonSchema: "null",
+  continueOnFailure: false,
 } as const;
 
 export const helpTooltipContent = {

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/UploadNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/UploadNode/types.ts
@@ -1,10 +1,10 @@
 import type { Node } from "@xyflow/react";
 import { SKYVERN_DOWNLOAD_DIRECTORY } from "../../constants";
+import { NodeBaseData } from "../types";
 
-export type UploadNodeData = {
+export type UploadNodeData = NodeBaseData & {
   path: string;
   editable: boolean;
-  label: string;
 };
 
 export type UploadNode = Node<UploadNodeData, "upload">;
@@ -13,6 +13,7 @@ export const uploadNodeDefaultData: UploadNodeData = {
   editable: true,
   label: "",
   path: SKYVERN_DOWNLOAD_DIRECTORY,
+  continueOnFailure: false,
 } as const;
 
 export const helpTooltipContent = {

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/types.ts
@@ -1,0 +1,4 @@
+export type NodeBaseData = {
+  label: string;
+  continueOnFailure: boolean;
+};

--- a/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
@@ -137,6 +137,7 @@ export type TaskBlock = WorkflowBlockBase & {
   download_suffix?: string | null;
   totp_verification_url?: string | null;
   totp_identifier?: string | null;
+  cache_actions: boolean;
 };
 
 export type ForLoopBlock = WorkflowBlockBase & {

--- a/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
@@ -110,6 +110,7 @@ export type TaskBlockYAML = BlockYAMLBase & {
   download_suffix?: string | null;
   totp_verification_url?: string | null;
   totp_identifier?: string | null;
+  cache_actions: boolean;
 };
 
 export type CodeBlockYAML = BlockYAMLBase & {


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `continueOnFailure` and `cacheActions` properties to node types and update workflow editor utilities for enhanced failure handling and action caching.
> 
>   - **Node Types**:
>     - Introduce `NodeBaseData` type with `label` and `continueOnFailure` properties in `types.ts`.
>     - Extend `NodeBaseData` in `CodeBlockNodeData`, `DownloadNodeData`, `FileParserNodeData`, `LoopNodeData`, `SendEmailNodeData`, `TaskNodeData`, `TextPromptNodeData`, and `UploadNodeData`.
>     - Add `continueOnFailure: false` to default data in `CodeBlockNode`, `DownloadNode`, `FileParserNode`, `LoopNode`, `SendEmailNode`, `TaskNode`, `TextPromptNode`, and `UploadNode`.
>     - Add `cacheActions: false` to `TaskNodeData` and default data in `TaskNode`.
>   - **Workflow Editor Utils**:
>     - Update `convertToNode()` and `getWorkflowBlock()` in `workflowEditorUtils.ts` to handle `continueOnFailure` and `cacheActions` properties.
>     - Use `NodeBaseData` for common node data handling in `convertToNode()`.
>   - **Types**:
>     - Add `cache_actions` to `TaskBlock` in `workflowTypes.ts` and `TaskBlockYAML` in `workflowYamlTypes.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ca4d80bfdc1407be02843273723da6279798498b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->