### PR TITLE
handle continue on failure for loop node

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -610,6 +610,7 @@ function getWorkflowBlocksUtil(nodes: Array<AppNode>): Array<BlockYAML> {
         {
           block_type: "for_loop",
           label: node.data.label,
+          continue_on_failure: node.data.continueOnFailure,
           loop_over_parameter_key: node.data.loopValue,
           loop_blocks: nodes
             .filter((n) => n.parentId === node.id)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `continue_on_failure` property to `for_loop` block in `getWorkflowBlocksUtil()` to handle loop nodes that should continue on failure.
> 
>   - **Behavior**:
>     - Adds `continue_on_failure` property to `for_loop` block in `getWorkflowBlocksUtil()` in `workflowEditorUtils.ts` to handle loop nodes that should continue on failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 66c34281c6a3d601c1bcc8fc835ee58655dcc0ee. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->