### PR TITLE
Make parameters panel max height shorter for smaller screens

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParametersPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParametersPanel.tsx
@@ -107,7 +107,7 @@ function WorkflowParametersPanel() {
         </DropdownMenu>
 
         <ScrollArea>
-          <ScrollAreaViewport className="max-h-[600px]">
+          <ScrollAreaViewport className="max-h-96">
             <section className="space-y-2">
               {workflowParameters.map((parameter) => {
                 return (


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reduce `ScrollAreaViewport` max height in `WorkflowParametersPanel.tsx` for improved small screen display.
> 
>   - **UI Adjustment**:
>     - In `WorkflowParametersPanel.tsx`, reduce `ScrollAreaViewport` max height from `600px` to `max-h-96` (384px) for better small screen display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ebb8ca0ffd967f93248a34d3aa51a5b7caf59ae8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->