### PR TITLE
use primpary llm api for user goal check

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -886,11 +886,9 @@ class ForgeAgent:
                 navigation_payload=task.navigation_payload,
                 elements=scraped_page.build_element_tree(ElementTreeFormat.HTML),
             )
-            verification_llm_api_handler = app.SECONDARY_LLM_API_HANDLER
 
-            verification_response = await verification_llm_api_handler(
-                prompt=verification_prompt, step=step, screenshots=None
-            )
+            # this prompt is critical to our agent so let's use the primary LLM API handler
+            verification_response = await app.LLM_API_HANDLER(prompt=verification_prompt, step=step, screenshots=None)
             if "user_goal_achieved" not in verification_response or "thoughts" not in verification_response:
                 LOG.error(
                     "Invalid LLM response for user goal success verification, skipping verification",


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Switch `check_user_goal_success()` in `agent.py` to use primary LLM API for critical user goal verification prompts.
> 
>   - **Behavior**:
>     - In `check_user_goal_success()` in `agent.py`, switch from `SECONDARY_LLM_API_HANDLER` to `LLM_API_HANDLER` for the `verification_prompt`.
>     - Ensures critical prompts use the primary LLM API for user goal verification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0ec5e78c994382ec57466780b43506f557aa17c0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->