### PR TITLE
remove task actions

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -1629,3 +1629,15 @@ class AgentDB:
             )
             actions = (await session.scalars(query)).all()
             return [Action.model_validate(action) for action in actions]
+
+    async def delete_task_actions(self, organization_id: str, task_id: str) -> None:
+        async with self.Session() as session:
+            # delete actions by filtering organization_id and task_id
+            stmt = delete(ActionModel).where(
+                and_(
+                    ActionModel.organization_id == organization_id,
+                    ActionModel.task_id == task_id,
+                )
+            )
+            await session.execute(stmt)
+            await session.commit()


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `nuke_related_objects_for_task` in `cloud/tasks.py` now deletes task actions using the new `delete_task_actions` method in `client.py`.
> 
>   - **Behavior**:
>     - `nuke_related_objects_for_task` in `cloud/tasks.py` now deletes task actions before resetting task status.
>   - **Database**:
>     - Adds `delete_task_actions` method in `client.py` to delete actions by `organization_id` and `task_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 97b56ff7758479730386a7563544be1fe4dae2fd. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->