### PR TITLE
fix None string for webhook url and totp url

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -187,8 +187,8 @@ class ForgeAgent:
         task = await app.DATABASE.create_task(
             url=str(task_request.url),
             title=task_request.title,
-            webhook_callback_url=str(task_request.webhook_callback_url),
-            totp_verification_url=str(task_request.totp_verification_url),
+            webhook_callback_url=str(task_request.webhook_callback_url) if task_request.webhook_callback_url else None,
+            totp_verification_url=str(task_request.totp_verification_url) if task_request.totp_verification_url else None,
             totp_identifier=task_request.totp_identifier,
             navigation_goal=task_request.navigation_goal,
             data_extraction_goal=task_request.data_extraction_goal,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `create_task` in `agent.py` to handle `None` values for `webhook_callback_url` and `totp_verification_url` correctly.
> 
>   - **Behavior**:
>     - Fix `create_task` in `agent.py` to handle `None` values for `webhook_callback_url` and `totp_verification_url` by keeping them as `None` instead of converting to string 'None'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 4fa80dfef76a9e9e5fec00dce17929b5d1a089f6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->