### PR TITLE
fix python style for webhook url and totp url when creating a task

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -184,11 +184,13 @@ class ForgeAgent:
         return task, step
 
     async def create_task(self, task_request: TaskRequest, organization_id: str | None = None) -> Task:
+        webhook_callback_url = str(task_request.webhook_callback_url) if task_request.webhook_callback_url else None
+        totp_verification_url = str(task_request.totp_verification_url) if task_request.totp_verification_url else None
         task = await app.DATABASE.create_task(
             url=str(task_request.url),
             title=task_request.title,
-            webhook_callback_url=str(task_request.webhook_callback_url) if task_request.webhook_callback_url else None,
-            totp_verification_url=str(task_request.totp_verification_url) if task_request.totp_verification_url else None,
+            webhook_callback_url=webhook_callback_url,
+            totp_verification_url=totp_verification_url,
             totp_identifier=task_request.totp_identifier,
             navigation_goal=task_request.navigation_goal,
             data_extraction_goal=task_request.data_extraction_goal,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `create_task()` in `agent.py` to improve readability by assigning URLs to variables before use.
> 
>   - **Refactor**:
>     - In `create_task()` method of `ForgeAgent` class in `agent.py`, refactor to assign `webhook_callback_url` and `totp_verification_url` to variables before passing them to `app.DATABASE.create_task()`.
>     - This change improves code readability without altering functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 879ea477c182f51dbf26cf718e5ee75da25800bd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->