### PR TITLE
fix saving complete action when there's no navigation goal

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -569,6 +569,13 @@ class ForgeAgent:
                     CompleteAction(
                         reasoning="Task has no navigation goal.",
                         data_extraction_goal=task.data_extraction_goal,
+                        organization_id=task.organization_id,
+                        task_id=task.task_id,
+                        workflow_run_id=task.workflow_run_id,
+                        step_id=step.step_id,
+                        step_order=step.order,
+                        action_order=0,
+                        confidence_float=1.0,
                     )
                 ]
             elif (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `CompleteAction` in `agent_step()` to include necessary identifiers when task lacks navigation goal.
> 
>   - **Behavior**:
>     - Fixes `CompleteAction` in `agent_step()` in `agent.py` to include `organization_id`, `task_id`, `workflow_run_id`, `step_id`, `step_order`, `action_order`, and `confidence_float` when task has no navigation goal.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 94f44aea2ec16979e725f9796a26b729687ddbc9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->