### PR TITLE
shu/disable organization name change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,9 @@ files/
 node_modules
 .env.backup
 .env.old
+
+# ctags
+tags
+tags.lock
+tags.temp
+tags.temp.tmp

--- a/skyvern/forge/sdk/schemas/organizations.py
+++ b/skyvern/forge/sdk/schemas/organizations.py
@@ -12,7 +12,4 @@ class GetOrganizationAPIKeysResponse(BaseModel):
 
 
 class OrganizationUpdate(BaseModel):
-    organization_name: str | None = None
-    webhook_callback_url: str | None = None
     max_steps_per_run: int | None = None
-    max_retries_per_step: int | None = None


### PR DESCRIPTION
- only allow org update on max steps per run
- ignore tags

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disables updates to `organization_name` and `webhook_callback_url` in `OrganizationUpdate`, allowing only `max_steps_per_run` updates.
> 
>   - **Behavior**:
>     - Disables updates to `organization_name` and `webhook_callback_url` in `OrganizationUpdate` class in `organizations.py`.
>     - Only allows updates to `max_steps_per_run` in `OrganizationUpdate`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 8f8cbeb4a773ceca1c4f2c4a08c1e560559ac22f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->