### PR TITLE
block urls pointing to internal addresses

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
     LOG_LEVEL: str = "INFO"
     PORT: int = 8000
     ALLOWED_ORIGINS: list[str] = ["*"]
-    BLOCKED_HOSTS: list[str] = ["10.", "192.168.", "172.16.", "169.254.", "localhost"]
+    BLOCKED_HOSTS: list[str] = ["localhost"]
 
     # Secret key for JWT. Please generate your own secret key in production
     SECRET_KEY: str = "PLACEHOLDER"

--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -34,6 +34,7 @@ class Settings(BaseSettings):
     LOG_LEVEL: str = "INFO"
     PORT: int = 8000
     ALLOWED_ORIGINS: list[str] = ["*"]
+    BLOCKED_HOSTS: list[str] = ["10.", "192.168.", "172.16.", "169.254.", "localhost"]
 
     # Secret key for JWT. Please generate your own secret key in production
     SECRET_KEY: str = "PLACEHOLDER"

--- a/skyvern/exceptions.py
+++ b/skyvern/exceptions.py
@@ -502,3 +502,11 @@ class InvalidUrl(SkyvernHTTPException):
         super().__init__(
             f"Invalid URL: {url}. Skyvern supports HTTP and HTTPS urls.", status_code=status.HTTP_400_BAD_REQUEST
         )
+
+
+class BlockedHost(SkyvernHTTPException):
+    def __init__(self, host: str) -> None:
+        super().__init__(
+            f"The host in your url is blocked: {host}",
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )

--- a/skyvern/forge/sdk/core/validators.py
+++ b/skyvern/forge/sdk/core/validators.py
@@ -16,7 +16,7 @@ def validate_url(url: str) -> str:
         raise InvalidUrl(url=url)
 
 
-def is_blocked_ip(host: str) -> bool:
+def is_blocked_host(host: str) -> bool:
     try:
         ip = ipaddress.ip_address(host)
         # Check if the IP is private, link-local, loopback, or reserved

--- a/skyvern/forge/sdk/core/validators.py
+++ b/skyvern/forge/sdk/core/validators.py
@@ -1,5 +1,8 @@
+import ipaddress
+
 from pydantic import HttpUrl, ValidationError, parse_obj_as
 
+from skyvern.config import settings
 from skyvern.exceptions import InvalidUrl
 
 
@@ -11,3 +14,18 @@ def validate_url(url: str) -> str:
     except ValidationError:
         # Handle the validation error
         raise InvalidUrl(url=url)
+
+
+def is_blocked_ip(host: str) -> bool:
+    try:
+        ip = ipaddress.ip_address(host)
+        # Check if the IP is private, link-local, loopback, or reserved
+        return ip.is_private or ip.is_link_local or ip.is_loopback or ip.is_reserved
+    except ValueError:
+        # If the host is not a valid IP address (e.g., it's a domain name like localhost), handle it here
+        for blocked_host in settings.BLOCKED_HOSTS:
+            if blocked_host == host:
+                return True
+        return False
+    except Exception:
+        return False

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -6,9 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field, HttpUrl, field_validator
 
-from skyvern.config import settings
 from skyvern.exceptions import BlockedHost, InvalidTaskStatusTransition, TaskAlreadyCanceled
-from skyvern.forge.sdk.core.validators import is_blocked_ip
+from skyvern.forge.sdk.core.validators import is_blocked_host
 
 
 class ProxyLocation(StrEnum):
@@ -97,7 +96,7 @@ class TaskRequest(TaskBase):
         if not v or not v.host:
             return None
         host = v.host
-        blocked = is_blocked_ip(host)
+        blocked = is_blocked_host(host)
         if blocked:
             raise BlockedHost(host=host)
         return v

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -4,9 +4,10 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, Field, HttpUrl, field_validator
 
-from skyvern.exceptions import InvalidTaskStatusTransition, TaskAlreadyCanceled
+from skyvern.config import settings
+from skyvern.exceptions import BlockedHost, InvalidTaskStatusTransition, TaskAlreadyCanceled
 
 
 class ProxyLocation(StrEnum):
@@ -88,6 +89,18 @@ class TaskRequest(TaskBase):
         examples=["https://my-webhook.com"],
     )
     totp_verification_url: HttpUrl | None = None
+
+    @field_validator("url", "webhook_callback_url", "totp_verification_url")
+    @classmethod
+    def validate_urls(cls, v: HttpUrl | None) -> HttpUrl | None:
+        if not v or not v.host:
+            return None
+        # Disallow internal IP ranges
+        host = v.host
+        for block in settings.BLOCKED_HOSTS:
+            if host.startswith(block):
+                raise BlockedHost(host)
+        return v
 
 
 class TaskStatus(StrEnum):


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add URL validation in `TaskRequest` to block internal IP addresses using `BlockedHost` exception.
> 
>   - **Validation**:
>     - Add `validate_urls` method in `TaskRequest` in `tasks.py` to block internal IP addresses for `url`, `webhook_callback_url`, and `totp_verification_url`.
>     - Implement `is_blocked_host` function in `validators.py` to check if an IP is private, link-local, loopback, or reserved.
>   - **Exceptions**:
>     - Add `BlockedHost` exception in `exceptions.py` for blocked host URLs.
>   - **Configuration**:
>     - Add `BLOCKED_HOSTS` list in `config.py` to specify blocked IP address patterns.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 35e7ac55e4b9d46529a618dc78268edf616c546f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->