### PR TITLE
fix update organization api

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -867,10 +867,7 @@ async def update_organization(
 ) -> Organization:
     return await app.DATABASE.update_organization(
         current_org.organization_id,
-        organization_name=org_update.organization_name,
-        webhook_callback_url=org_update.webhook_callback_url,
         max_steps_per_run=org_update.max_steps_per_run,
-        max_retries_per_step=org_update.max_retries_per_step,
     )
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove certain parameters from `update_organization` call in `agent_protocol.py`, only updating `max_steps_per_run`.
> 
>   - **Behavior**:
>     - In `update_organization()` in `agent_protocol.py`, removed `organization_name`, `webhook_callback_url`, and `max_retries_per_step` from the `update_organization` call.
>     - Now only updates `max_steps_per_run` for an organization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1d505b7c11be7ebc5231b971368cf39ad31ad5d1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->