### PR TITLE
Remove confidence score from UI

### DIFF
--- a/skyvern-frontend/src/routes/tasks/detail/ScrollableActionList.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/ScrollableActionList.tsx
@@ -2,12 +2,6 @@ import { getClient } from "@/api/AxiosClient";
 import { Action, ActionTypes } from "@/api/types";
 import { ScrollArea, ScrollAreaViewport } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
 import { cn } from "@/util/utils";
 import {
@@ -117,24 +111,8 @@ function ScrollableActionList({
                     <span className="text-xs">Fail</span>
                   </div>
                 )}
-                {typeof action.confidence === "number" && (
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger>
-                        <div className="flex gap-1 rounded-sm bg-slate-elevation5 px-2 py-1">
-                          <span className="text-xs text-success">
-                            {action.confidence}
-                          </span>
-                          <span className="text-xs">CS</span>
-                        </div>
-                      </TooltipTrigger>
-                      <TooltipContent>Confidence Score</TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                )}
               </div>
             </div>
-
             <div className="text-xs text-slate-400">{action.reasoning}</div>
             {action.type === ActionTypes.InputText && (
               <>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove confidence score display and related tooltip components from `ScrollableActionList` in the frontend.
> 
>   - **UI Changes**:
>     - Remove confidence score display from `ScrollableActionList` in `ScrollableActionList.tsx`.
>     - Delete `Tooltip`, `TooltipContent`, `TooltipProvider`, and `TooltipTrigger` imports and usage related to confidence score.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 91205ad5ecc072d32749237db85fdb01048e8596. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->