### PR TITLE
fix chain click bug

### DIFF
--- a/skyvern/exceptions.py
+++ b/skyvern/exceptions.py
@@ -355,8 +355,8 @@ class InputActionOnSelect2Dropdown(SkyvernException):
 
 
 class FailToClick(SkyvernException):
-    def __init__(self, element_id: str):
-        super().__init__(f"Failed to click. element_id={element_id}")
+    def __init__(self, element_id: str, anchor: str = "self"):
+        super().__init__(f"Failed to click({anchor}). element_id={element_id}")
 
 
 class FailToSelectByLabel(SkyvernException):

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -1073,7 +1073,7 @@ async def chain_click(
                     dom=DomUtil(scraped_page=scraped_page, page=page)
                 ):
                     await bound_element.get_locator().click(timeout=timeout)
-                    action_results.extend(ActionSuccess())
+                    action_results.append(ActionSuccess())
                     return action_results
             except Exception:
                 action_results.append(

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -1060,9 +1060,33 @@ async def chain_click(
                 javascript_triggered=javascript_triggered,
             )
         ]
-        if await is_input_element(locator):
+
+        if skyvern_element.get_tag_name() == "label":
+            LOG.info(
+                "Chain click: it's a label element. going to try for-click",
+                task_id=task.task_id,
+                action=action,
+                locator=locator,
+            )
+            try:
+                if bound_element := await skyvern_element.find_label_for(
+                    dom=DomUtil(scraped_page=scraped_page, page=page)
+                ):
+                    await bound_element.get_locator().click(timeout=timeout)
+                    action_results.extend(ActionSuccess())
+                    return action_results
+            except Exception:
+                action_results.append(
+                    ActionFailure(
+                        FailToClick(action.element_id, anchor="for"),
+                        javascript_triggered=javascript_triggered,
+                    )
+                )
+
+        if skyvern_element.get_tag_name() == InteractiveElement.INPUT:
             LOG.info(
                 "Chain click: it's an input element. going to try sibling click",
+                task_id=task.task_id,
                 action=action,
                 locator=locator,
             )
@@ -1100,7 +1124,7 @@ async def chain_click(
             )
             action_results.append(
                 ActionFailure(
-                    FailToClick(action.element_id),
+                    FailToClick(action.element_id, anchor="parent"),
                     javascript_triggered=javascript_triggered,
                     interacted_with_parent=True,
                 )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `FailToClick` exception and `chain_click` function to improve handling and logging of click actions on label elements.
> 
>   - **Behavior**:
>     - Update `FailToClick` exception in `exceptions.py` to include `anchor` parameter for more context.
>     - Enhance `chain_click` in `handler.py` to handle label elements by attempting 'for-click' on associated elements.
>   - **Logging**:
>     - Add logging in `chain_click` to indicate attempts and failures for label and input elements.
>   - **Error Handling**:
>     - Improve error handling in `chain_click` for label and input elements by adding specific failure cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c9559255a6ff02d257e5af625f67cffca228673c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->