### PR TITLE
Change the default font size in code editor to be 12

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -293,7 +293,6 @@ function CreateNewTaskForm({ initialValues }: Props) {
                                 <CodeEditor
                                   {...field}
                                   language="json"
-                                  fontSize={12}
                                   minHeight="96px"
                                   maxHeight="500px"
                                   value={
@@ -388,7 +387,6 @@ function CreateNewTaskForm({ initialValues }: Props) {
                             <CodeEditor
                               {...field}
                               language="json"
-                              fontSize={12}
                               minHeight="96px"
                               maxHeight="500px"
                               value={field.value === null ? "" : field.value}
@@ -509,7 +507,6 @@ function CreateNewTaskForm({ initialValues }: Props) {
                             <CodeEditor
                               {...field}
                               language="json"
-                              fontSize={12}
                               minHeight="96px"
                               maxHeight="500px"
                               value={field.value === null ? "" : field.value}

--- a/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
@@ -462,7 +462,6 @@ function SavedTaskForm({ initialValues }: Props) {
                                 <CodeEditor
                                   {...field}
                                   language="json"
-                                  fontSize={12}
                                   minHeight="96px"
                                   maxHeight="500px"
                                   value={
@@ -557,7 +556,6 @@ function SavedTaskForm({ initialValues }: Props) {
                             <CodeEditor
                               {...field}
                               language="json"
-                              fontSize={14}
                               minHeight="96px"
                               maxHeight="500px"
                               value={
@@ -683,7 +681,6 @@ function SavedTaskForm({ initialValues }: Props) {
                             <CodeEditor
                               {...field}
                               language="json"
-                              fontSize={12}
                               minHeight="96px"
                               maxHeight="500px"
                               value={field.value === null ? "" : field.value}

--- a/skyvern-frontend/src/routes/tasks/detail/TaskDetails.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/TaskDetails.tsx
@@ -125,7 +125,6 @@ function TaskDetails() {
         language="json"
         value={JSON.stringify(task.extracted_information, null, 2)}
         readOnly
-        fontSize={12}
         minHeight={"96px"}
         maxHeight={"500px"}
         className="w-full"
@@ -149,7 +148,6 @@ function TaskDetails() {
         language="json"
         value={JSON.stringify(task.failure_reason, null, 2)}
         readOnly
-        fontSize={12}
         minHeight={"96px"}
         maxHeight={"500px"}
         className="w-full"

--- a/skyvern-frontend/src/routes/tasks/detail/TaskParameters.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/TaskParameters.tsx
@@ -76,7 +76,6 @@ function TaskParameters() {
           readOnly
           minHeight="96px"
           maxHeight="500px"
-          fontSize={12}
         />
       </div>
       <div className="flex gap-16">
@@ -113,7 +112,6 @@ function TaskParameters() {
           readOnly
           minHeight="96px"
           maxHeight="500px"
-          fontSize={12}
         />
       </div>
     </section>

--- a/skyvern-frontend/src/routes/workflows/WorkflowParameterInput.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowParameterInput.tsx
@@ -21,7 +21,6 @@ function WorkflowParameterInput({ type, value, onChange }: Props) {
         value={
           typeof value === "string" ? value : JSON.stringify(value, null, 2)
         }
-        fontSize={12}
       />
     );
   }

--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -494,7 +494,6 @@ function WorkflowRun() {
                     value={JSON.stringify(value, null, 2)}
                     readOnly
                     language="json"
-                    fontSize={12}
                     minHeight="96px"
                     maxHeight="500px"
                   />

--- a/skyvern-frontend/src/routes/workflows/components/CodeEditor.tsx
+++ b/skyvern-frontend/src/routes/workflows/components/CodeEditor.tsx
@@ -23,7 +23,7 @@ function CodeEditor({
   language,
   className,
   readOnly = false,
-  fontSize = 8,
+  fontSize = 12,
 }: Props) {
   const extensions =
     language === "json"

--- a/skyvern-frontend/src/routes/workflows/components/DataSchema.tsx
+++ b/skyvern-frontend/src/routes/workflows/components/DataSchema.tsx
@@ -41,6 +41,7 @@ function DataSchema({ value, onChange }: Props) {
             // TODO
           }}
           className="nowheel nopan"
+          fontSize={8}
         />
       </div>
     </div>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/CodeBlockNode/CodeBlockNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/CodeBlockNode/CodeBlockNode.tsx
@@ -70,6 +70,7 @@ function CodeBlockNode({ id, data }: NodeProps<CodeBlockNode>) {
               updateNodeData(id, { code: value });
             }}
             className="nopan"
+            fontSize={8}
           />
         </div>
       </div>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/TaskNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/TaskNode.tsx
@@ -223,6 +223,7 @@ function TaskNode({ id, data }: NodeProps<TaskNode>) {
                           handleChange("dataSchema", value);
                         }}
                         className="nowheel nopan"
+                        fontSize={8}
                       />
                     </div>
                   )}
@@ -324,6 +325,7 @@ function TaskNode({ id, data }: NodeProps<TaskNode>) {
                           handleChange("errorCodeMapping", value);
                         }}
                         className="nowheel nopan"
+                        fontSize={8}
                       />
                     </div>
                   )}

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TextPromptNode/TextPromptNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TextPromptNode/TextPromptNode.tsx
@@ -115,6 +115,7 @@ function TextPromptNode({ id, data }: NodeProps<TextPromptNode>) {
                   updateNodeData(id, { jsonSchema: value });
                 }}
                 className="nowheel nopan"
+                fontSize={8}
               />
             </div>
           )}


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change default font size in `CodeEditor` to 12 and adjust explicit font size settings across various files.
> 
>   - **CodeEditor Component**:
>     - Change default `fontSize` from 8 to 12 in `CodeEditor`.
>   - **Affected Files**:
>     - Remove explicit `fontSize={12}` in `CreateNewTaskForm.tsx`, `SavedTaskForm.tsx`, `TaskDetails.tsx`, `TaskParameters.tsx`, `WorkflowParameterInput.tsx`, and `WorkflowRun.tsx`.
>     - Add explicit `fontSize={8}` in `DataSchema.tsx`, `CodeBlockNode.tsx`, `TaskNode.tsx`, and `TextPromptNode.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 985a7ede60ad349e9300bd12f9fbfba6632d2b6e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->