### PR TITLE
Add support for the latest sonnet 3.5

### DIFF
--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -133,7 +133,7 @@ if SettingsManager.get_settings().ENABLE_ANTHROPIC:
     LLMConfigRegistry.register_config(
         "ANTHROPIC_CLAUDE3.5_SONNET",
         LLMConfig(
-            "anthropic/claude-3-5-sonnet-20240620",
+            "anthropic/claude-3-5-sonnet-latest",
             ["ANTHROPIC_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=True,
@@ -172,7 +172,7 @@ if SettingsManager.get_settings().ENABLE_BEDROCK:
     LLMConfigRegistry.register_config(
         "BEDROCK_ANTHROPIC_CLAUDE3.5_SONNET",
         LLMConfig(
-            "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
+            "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
             ["AWS_REGION"],
             supports_vision=True,
             add_assistant_prefix=True,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `ANTHROPIC_CLAUDE3.5_SONNET` and `BEDROCK_ANTHROPIC_CLAUDE3.5_SONNET` configurations to support the latest sonnet versions in `config_registry.py`.
> 
>   - **Behavior**:
>     - Update `ANTHROPIC_CLAUDE3.5_SONNET` config in `config_registry.py` to use `anthropic/claude-3-5-sonnet-latest`.
>     - Update `BEDROCK_ANTHROPIC_CLAUDE3.5_SONNET` config in `config_registry.py` to use `bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2903708bd6c186fdf362bb268ec04fc4508f19d0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->