### PR TITLE
Add Start Node to workflows

### DIFF
--- a/skyvern-frontend/src/routes/workflows/components/SourceParameterKeySelector.tsx
+++ b/skyvern-frontend/src/routes/workflows/components/SourceParameterKeySelector.tsx
@@ -1,6 +1,6 @@
 import { useNodes } from "@xyflow/react";
 import { useWorkflowParametersState } from "../editor/useWorkflowParametersState";
-import { AppNode } from "../editor/nodes";
+import { AppNode, isWorkflowBlockNode } from "../editor/nodes";
 import { getOutputParameterKey } from "../editor/workflowEditorUtils";
 import {
   Select,
@@ -22,7 +22,7 @@ function SourceParameterKeySelector({ value, onChange }: Props) {
     .filter((parameter) => parameter.parameterType !== "credential")
     .map((parameter) => parameter.key);
   const outputParameterKeys = nodes
-    .filter((node) => node.type !== "nodeAdder")
+    .filter(isWorkflowBlockNode)
     .map((node) => getOutputParameterKey(node.data.label));
 
   return (

--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -31,18 +31,21 @@ import {
 import { WorkflowHeader } from "./WorkflowHeader";
 import { WorkflowParametersStateContext } from "./WorkflowParametersStateContext";
 import { edgeTypes } from "./edges";
-import { AppNode, nodeTypes } from "./nodes";
+import { AppNode, nodeTypes, WorkflowBlockNode } from "./nodes";
 import { WorkflowNodeLibraryPanel } from "./panels/WorkflowNodeLibraryPanel";
 import { WorkflowParametersPanel } from "./panels/WorkflowParametersPanel";
 import "./reactFlowOverrideStyles.css";
 import {
   convertEchoParameters,
   createNode,
+  defaultEdge,
   generateNodeLabel,
   getAdditionalParametersForEmailBlock,
   getOutputParameterKey,
   getWorkflowBlocks,
   layout,
+  nodeAdderNode,
+  startNode,
 } from "./workflowEditorUtils";
 import { useWorkflowHasChangesStore } from "@/store/WorkflowHasChangesStore";
 import { useBlocker, useParams } from "react-router-dom";
@@ -139,7 +142,7 @@ type Props = {
 };
 
 export type AddNodeProps = {
-  nodeType: Exclude<keyof typeof nodeTypes, "nodeAdder">;
+  nodeType: NonNullable<WorkflowBlockNode["type"]>;
   previous: string | null;
   next: string | null;
   parent?: string;
@@ -316,15 +319,11 @@ function FlowRenderer({
 
     if (nodeType === "loop") {
       // when loop node is first created it needs an adder node so nodes can be added inside the loop
-      newNodes.push({
-        id: nanoid(),
-        type: "nodeAdder",
-        parentId: id,
-        position: { x: 0, y: 0 },
-        data: {},
-        draggable: false,
-        connectable: false,
-      });
+      const startNodeId = nanoid();
+      const adderNodeId = nanoid();
+      newNodes.push(startNode(startNodeId, id));
+      newNodes.push(nodeAdderNode(adderNodeId, id));
+      newEdges.push(defaultEdge(startNodeId, adderNodeId));
     }
 
     const editedEdges = previous
@@ -343,26 +342,6 @@ function FlowRenderer({
       ...nodes.slice(previousNodeIndex + 1),
     ];
 
-    if (nodes.length === 0) {
-      // if there were no nodes before, add a nodeAdder node and connect it to the new node
-      newNodesAfter.push({
-        id: `${id}-nodeAdder`,
-        type: "nodeAdder",
-        position: { x: 0, y: 0 },
-        data: {},
-        draggable: false,
-        connectable: false,
-      });
-      newEdges.push({
-        id: `edge-0-${id}`,
-        type: "default",
-        source: id,
-        target: `${id}-nodeAdder`,
-        style: {
-          strokeWidth: 2,
-        },
-      });
-    }
     setHasChanges(true);
     doLayout(newNodesAfter, [...editedEdges, ...newEdges]);
   }
@@ -617,16 +596,6 @@ function FlowRenderer({
                     }}
                   />
                 )}
-              </Panel>
-            )}
-            {nodes.length === 0 && (
-              <Panel position="top-right">
-                <WorkflowNodeLibraryPanel
-                  onNodeClick={(props) => {
-                    addNode(props);
-                  }}
-                  first
-                />
               </Panel>
             )}
           </ReactFlow>

--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowEditor.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowEditor.tsx
@@ -6,6 +6,7 @@ import { useParams } from "react-router-dom";
 import { useWorkflowQuery } from "../hooks/useWorkflowQuery";
 import { FlowRenderer } from "./FlowRenderer";
 import { getElements } from "./workflowEditorUtils";
+import { LogoMinimized } from "@/components/LogoMinimized";
 
 function WorkflowEditor() {
   const { workflowPermanentId } = useParams();
@@ -29,7 +30,7 @@ function WorkflowEditor() {
   if (isLoading) {
     return (
       <div className="flex h-screen w-full items-center justify-center">
-        Loading...
+        <LogoMinimized />
       </div>
     );
   }

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
@@ -1,0 +1,19 @@
+import { Handle, Position } from "@xyflow/react";
+
+function StartNode() {
+  return (
+    <div>
+      <Handle
+        type="source"
+        position={Position.Bottom}
+        id="a"
+        className="opacity-0"
+      />
+      <div className="w-[30rem] rounded-lg bg-slate-elevation3 px-6 py-4 text-center">
+        Start
+      </div>
+    </div>
+  );
+}
+
+export { StartNode };

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/types.ts
@@ -1,0 +1,5 @@
+import type { Node } from "@xyflow/react";
+
+export type StartNodeData = Record<string, never>;
+
+export type StartNode = Node<StartNodeData, "start">;

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/types.ts
@@ -20,8 +20,6 @@ export type TaskNodeData = NodeBaseData & {
 
 export type TaskNode = Node<TaskNodeData, "task">;
 
-export type TaskNodeDisplayMode = "basic" | "advanced";
-
 export const taskNodeDefaultData: TaskNodeData = {
   url: "",
   navigationGoal: "",

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/index.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/index.ts
@@ -17,8 +17,12 @@ import type { DownloadNode } from "./DownloadNode/types";
 import { DownloadNode as DownloadNodeComponent } from "./DownloadNode/DownloadNode";
 import type { NodeAdderNode } from "./NodeAdderNode/types";
 import { NodeAdderNode as NodeAdderNodeComponent } from "./NodeAdderNode/NodeAdderNode";
+import { StartNode as StartNodeComponent } from "./StartNode/StartNode";
+import type { StartNode } from "./StartNode/types";
 
-export type AppNode =
+export type UtilityNode = StartNode | NodeAdderNode;
+
+export type WorkflowBlockNode =
   | LoopNode
   | TaskNode
   | TextPromptNode
@@ -26,8 +30,17 @@ export type AppNode =
   | CodeBlockNode
   | FileParserNode
   | UploadNode
-  | DownloadNode
-  | NodeAdderNode;
+  | DownloadNode;
+
+export function isUtilityNode(node: AppNode): node is UtilityNode {
+  return node.type === "nodeAdder" || node.type === "start";
+}
+
+export function isWorkflowBlockNode(node: AppNode): node is WorkflowBlockNode {
+  return node.type !== "nodeAdder" && node.type !== "start";
+}
+
+export type AppNode = UtilityNode | WorkflowBlockNode;
 
 export const nodeTypes = {
   loop: memo(LoopNodeComponent),
@@ -39,4 +52,5 @@ export const nodeTypes = {
   upload: memo(UploadNodeComponent),
   download: memo(DownloadNodeComponent),
   nodeAdder: memo(NodeAdderNodeComponent),
+  start: memo(StartNodeComponent),
 };

--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
@@ -10,11 +10,11 @@ import {
   UpdateIcon,
   UploadIcon,
 } from "@radix-ui/react-icons";
-import { nodeTypes } from "../nodes";
+import { WorkflowBlockNode } from "../nodes";
 import { AddNodeProps } from "../FlowRenderer";
 
 const nodeLibraryItems: Array<{
-  nodeType: Exclude<keyof typeof nodeTypes, "nodeAdder">;
+  nodeType: NonNullable<WorkflowBlockNode["type"]>;
   icon: JSX.Element;
   title: string;
   description: string;


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `StartNode` to workflows, updating node management and parameter handling to integrate this new node type.
> 
>   - **Behavior**:
>     - Introduces `StartNode` in `StartNode.tsx` to represent the start of a workflow.
>     - Updates `FlowRenderer.tsx` to add `StartNode` when creating new workflows or loops.
>     - Modifies `getElements()` in `workflowEditorUtils.ts` to include `StartNode` in node and edge generation.
>   - **Node Management**:
>     - Updates `createNode()` and `addNode()` in `workflowEditorUtils.ts` and `FlowRenderer.tsx` to exclude `StartNode` from node addition operations.
>     - Adjusts `getWorkflowBlocks()` in `workflowEditorUtils.ts` to exclude `StartNode` from workflow block generation.
>   - **Parameter Handling**:
>     - Modifies `SourceParameterKeySelector.tsx` to exclude `StartNode` from output parameter key generation.
>   - **Misc**:
>     - Removes unused `TaskNodeDisplayMode` type from `TaskNode/types.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for cd5cd82065620ecdc28cb4636d89be8c42eebcf4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->