### PR TITLE
fix json workflow parameter validation bug

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -569,13 +569,14 @@ class WorkflowService:
         workflow_parameter: WorkflowParameter,
         value: Any,
     ) -> WorkflowRunParameter:
+        value = json.dumps(value) if isinstance(value, (dict, list)) else value
         # InvalidWorkflowParameter will be raised if the validation fails
         workflow_parameter.workflow_parameter_type.convert_value(value)
 
         return await app.DATABASE.create_workflow_run_parameter(
             workflow_run_id=workflow_run_id,
             workflow_parameter=workflow_parameter,
-            value=json.dumps(value) if isinstance(value, (dict, list)) else value,
+            value=value,
         )
 
     async def get_workflow_run_parameter_tuples(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix redundant JSON serialization in `create_workflow_run_parameter()` in `service.py` by moving `json.dumps()` to the start of the function.
> 
>   - **Bug Fix**:
>     - Fix redundant JSON serialization in `create_workflow_run_parameter()` in `service.py`.
>     - Move `json.dumps()` call to the start of the function to ensure single serialization for `dict` and `list` types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 83193f728c7a3d171958f8d9ab858b9cec490f9b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->