### PR TITLE
Make collection id required

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParameterAddPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParameterAddPanel.tsx
@@ -205,7 +205,7 @@ function WorkflowParameterAddPanel({ type, onClose, onSave }: Props) {
                 } catch (e) {
                   toast({
                     variant: "destructive",
-                    title: "Failed to save parameters",
+                    title: "Failed to add parameter",
                     description: "Invalid JSON for default value",
                   });
                   return;
@@ -227,6 +227,14 @@ function WorkflowParameterAddPanel({ type, onClose, onSave }: Props) {
               });
             }
             if (type === "credential") {
+              if (!collectionId) {
+                toast({
+                  variant: "destructive",
+                  title: "Failed to add parameter",
+                  description: "Collection ID is required",
+                });
+                return;
+              }
               onSave({
                 key,
                 parameterType: "credential",
@@ -239,7 +247,7 @@ function WorkflowParameterAddPanel({ type, onClose, onSave }: Props) {
               if (!sourceParameterKey) {
                 toast({
                   variant: "destructive",
-                  title: "Failed to save parameters",
+                  title: "Failed to add parameter",
                   description: "Source parameter key is required",
                 });
                 return;

--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParameterEditPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParameterEditPanel.tsx
@@ -238,7 +238,7 @@ function WorkflowParameterEditPanel({
                 } catch (e) {
                   toast({
                     variant: "destructive",
-                    title: "Failed to save parameters",
+                    title: "Failed to save parameter",
                     description: "Invalid JSON for default value",
                   });
                   return;
@@ -260,6 +260,14 @@ function WorkflowParameterEditPanel({
               });
             }
             if (type === "credential") {
+              if (!collectionId) {
+                toast({
+                  variant: "destructive",
+                  title: "Failed to save parameter",
+                  description: "Collection ID is required",
+                });
+                return;
+              }
               onSave({
                 key,
                 parameterType: "credential",
@@ -272,7 +280,7 @@ function WorkflowParameterEditPanel({
               if (!sourceParameterKey) {
                 toast({
                   variant: "destructive",
-                  title: "Failed to save parameters",
+                  title: "Failed to save parameter",
                   description: "Source parameter key is required",
                 });
                 return;


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enforce `collectionId` requirement for `credential` parameters in `WorkflowParameterAddPanel` and `WorkflowParameterEditPanel`, with updated error handling and toast messages.
> 
>   - **Behavior**:
>     - Enforce `collectionId` requirement for `credential` type in `WorkflowParameterAddPanel` and `WorkflowParameterEditPanel`.
>     - Display error toast if `collectionId` is missing when saving.
>   - **UI**:
>     - Update toast titles from "Failed to save parameters" to "Failed to add parameter" or "Failed to save parameter" for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 7b97d1dc20129c8e64b9d51482daf2b46741a784. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->