### PR TITLE
support svg-container classes as interactable svg elements

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -448,6 +448,11 @@ function isInteractable(element) {
     if (hasAngularClickBinding(element)) {
       return true;
     }
+    // https://www.oxygenxml.com/dita/1.3/specs/langRef/technicalContent/svg-container.html
+    // svg-container is usually used for clickable elements that wrap SVGs
+    if (element.className.toString().includes("svg-container")) {
+      return true;
+    }
   }
 
   // support listbox and options underneath it


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `isInteractable` in `domUtils.js` to treat elements with class `svg-container` as interactable.
> 
>   - **Behavior**:
>     - Update `isInteractable` in `domUtils.js` to return `true` for elements with class `svg-container`, treating them as interactable.
>   - **Misc**:
>     - Add comment referencing `svg-container` usage for clickable SVG elements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ae1fcdaf529f05516776d0a264f4c32793c8a813. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->