### PR TITLE
Use search params for diagnostics step and artifact

### DIFF
--- a/skyvern-frontend/src/routes/tasks/detail/StepArtifacts.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/StepArtifacts.tsx
@@ -7,7 +7,7 @@ import {
 import { StatusBadge } from "@/components/StatusBadge";
 import { Label } from "@/components/ui/label";
 import { useQuery } from "@tanstack/react-query";
-import { useParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ZoomableImage } from "@/components/ZoomableImage";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -23,6 +23,8 @@ type Props = {
 };
 
 function StepArtifacts({ id, stepProps }: Props) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const artifact = searchParams.get("artifact") ?? "info";
   const { taskId } = useParams();
   const credentialGetter = useCredentialGetter();
   const {
@@ -78,7 +80,22 @@ function StepArtifacts({ id, stepProps }: Props) {
   );
 
   return (
-    <Tabs defaultValue="info" className="w-full">
+    <Tabs
+      value={artifact}
+      onValueChange={(value) => {
+        setSearchParams(
+          (params) => {
+            const newParams = new URLSearchParams(params);
+            newParams.set("artifact", value);
+            return newParams;
+          },
+          {
+            replace: true,
+          },
+        );
+      }}
+      className="w-full"
+    >
       <TabsList className="grid h-16 w-full grid-cols-5">
         <TabsTrigger value="info">Info</TabsTrigger>
         <TabsTrigger value="screenshot_llm">Annotated Screenshots</TabsTrigger>

--- a/skyvern-frontend/src/routes/tasks/detail/StepArtifactsLayout.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/StepArtifactsLayout.tsx
@@ -1,14 +1,14 @@
-import { useState } from "react";
 import { StepNavigation } from "./StepNavigation";
 import { StepArtifacts } from "./StepArtifacts";
 import { useQuery } from "@tanstack/react-query";
 import { StepApiResponse } from "@/api/types";
-import { useParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 import { getClient } from "@/api/AxiosClient";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
 
 function StepArtifactsLayout() {
-  const [activeIndex, setActiveIndex] = useState(0);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const step = Number(searchParams.get("step")) || 0;
   const credentialGetter = useCredentialGetter();
   const { taskId } = useParams();
 
@@ -30,14 +30,25 @@ function StepArtifactsLayout() {
     return <div>Error: {error?.message}</div>;
   }
 
-  const activeStep = steps?.[activeIndex];
+  const activeStep = steps?.[step];
 
   return (
     <div className="flex">
       <aside className="w-64 shrink-0">
         <StepNavigation
-          activeIndex={activeIndex}
-          onActiveIndexChange={setActiveIndex}
+          activeIndex={step}
+          onActiveIndexChange={(index) => {
+            setSearchParams(
+              (params) => {
+                const newParams = new URLSearchParams(params);
+                newParams.set("step", String(index));
+                return newParams;
+              },
+              {
+                replace: true,
+              },
+            );
+          }}
         />
       </aside>
       <main className="w-full px-4">


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Use URL search parameters for managing `artifact` and `step` states in `StepArtifacts` and `StepArtifactsLayout` components.
> 
>   - **Behavior**:
>     - `StepArtifacts.tsx`: Uses `useSearchParams` to manage the `artifact` state, replacing the default tab value with the URL search parameter.
>     - `StepArtifactsLayout.tsx`: Uses `useSearchParams` to manage the `step` state, replacing the local state with the URL search parameter.
>   - **Components**:
>     - `Tabs` in `StepArtifacts.tsx` now updates the URL search parameter `artifact` on tab change.
>     - `StepNavigation` in `StepArtifactsLayout.tsx` now updates the URL search parameter `step` on step change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 771d3db3e4ba034f3d89fae67fb9ff7f2a116f82. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->