### PR TITLE
add some refetching and invalidating logic for workflow runs

### DIFF
--- a/skyvern-frontend/src/routes/tasks/detail/TaskDetails.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/TaskDetails.tsx
@@ -97,6 +97,18 @@ function TaskDetails() {
       queryClient.invalidateQueries({
         queryKey: ["tasks"],
       });
+      if (task?.workflow_run_id) {
+        queryClient.invalidateQueries({
+          queryKey: ["workflowRun", task.workflow_run_id],
+        });
+        queryClient.invalidateQueries({
+          queryKey: [
+            "workflowRun",
+            workflow?.workflow_permanent_id,
+            task.workflow_run_id,
+          ],
+        });
+      }
       toast({
         variant: "success",
         title: "Task Canceled",

--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -97,6 +97,18 @@ function WorkflowRun() {
         return false;
       },
       placeholderData: keepPreviousData,
+      refetchOnMount: (query) => {
+        if (!query.state.data) {
+          return false;
+        }
+        return statusIsRunningOrQueued(query.state.data);
+      },
+      refetchOnWindowFocus: (query) => {
+        if (!query.state.data) {
+          return false;
+        }
+        return statusIsRunningOrQueued(query.state.data);
+      },
     });
 
   const { data: workflowTasks, isLoading: workflowTasksIsLoading } = useQuery<


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add refetching and invalidation logic for workflow runs in `TaskDetails.tsx` and `WorkflowRun.tsx` to ensure data consistency.
> 
>   - **Behavior**:
>     - In `TaskDetails.tsx`, invalidate `workflowRun` queries when a task with a `workflow_run_id` is canceled.
>     - In `WorkflowRun.tsx`, add `refetchOnMount` and `refetchOnWindowFocus` to refetch data if the workflow run status is running or queued.
>   - **Refetching Logic**:
>     - `WorkflowRun.tsx` refetches data every 5 seconds if the workflow run is not finalized.
>     - `TaskDetails.tsx` invalidates `workflowRun` queries on task cancellation.
>   - **Misc**:
>     - Minor adjustments to query configurations in `WorkflowRun.tsx` for data consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 31e8aee83d442de2aa10235717b43098645f245e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->