### PR TITLE
Make CollectionID or OrganizationID required

### DIFF
--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -184,6 +184,9 @@ class BitwardenService:
             elif collection_id:
                 LOG.info("Collection ID is provided, filtering items by collection ID", collection_id=collection_id)
                 list_command.extend(["--collectionid", collection_id])
+            else:
+                LOG.error("No collection ID or organization ID provided -- this is required")
+                raise BitwardenListItemsError("No collection ID or organization ID provided -- this is required")
             items_result = BitwardenService.run_command(list_command)
 
             if items_result.stderr and "Event post failed" not in items_result.stderr:


### PR DESCRIPTION
- **Make collection_id required**
- **Make collection_id required**

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Require `collection_id` or `organization_id` in `_get_secret_value_from_url()` in `bitwarden.py`, raising an error if neither is provided.
> 
>   - **Behavior**:
>     - In `bitwarden.py`, `_get_secret_value_from_url()` now requires either `collection_id` or `organization_id`.
>     - Logs an error and raises `BitwardenListItemsError` if neither ID is provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 308cf68aae52c769fe37d098ab564a14b19658d9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->