### PR TITLE
get rid of org id, task id, step id, step order and action order from the action history

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1217,7 +1217,18 @@ class ForgeAgent:
         return json.dumps(
             [
                 {
-                    "action": action.model_dump(exclude_none=True, exclude={"text", "confidence_float"}),
+                    "action": action.model_dump(
+                        exclude_none=True,
+                        exclude={
+                            "text",
+                            "confidence_float",
+                            "organization_id",
+                            "task_id",
+                            "step_id",
+                            "step_order",
+                            "action_order",
+                        },
+                    ),
                     "results": [
                         result.model_dump(
                             exclude_none=True,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `organization_id`, `task_id`, `step_id`, `step_order`, and `action_order` from action history serialization in `agent.py`.
> 
>   - **Behavior**:
>     - In `agent.py`, `_get_action_results()` now excludes `organization_id`, `task_id`, `step_id`, `step_order`, and `action_order` from action history serialization.
>   - **Misc**:
>     - No other files or functions are affected by this change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c775b99cf01d92105b9436bcba3b280d34fad547. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->