### PR TITLE
Put play icon in front of Run in workflow header

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
@@ -75,8 +75,8 @@ function WorkflowHeader({
             navigate(`/workflows/${workflowPermanentId}/run`);
           }}
         >
-          <span className="mr-2">Run</span>
-          <PlayIcon className="h-6 w-6" />
+          <PlayIcon className="mr-2 h-6 w-6" />
+          Run
         </Button>
       </div>
     </div>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Move `PlayIcon` before 'Run' text in `WorkflowHeader.tsx` for improved button layout.
> 
>   - **UI Change**:
>     - In `WorkflowHeader.tsx`, moved `PlayIcon` to precede 'Run' text in the 'Run' button for better visual alignment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 14f04646173fcd9638a3d87497d83134e735ea6c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->