### PR TITLE
support to parse pseudo content

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -617,7 +617,11 @@ const isAngularDropdown = (element) => {
 };
 
 function getPseudoContent(element, pseudo) {
-  const content = getElementComputedStyle(element, pseudo)
+  const pseudoStyle = getElementComputedStyle(element, pseudo);
+  if (!pseudoStyle) {
+    return null;
+  }
+  const content = pseudoStyle
     .getPropertyValue("content")
     .replace(/"/g, "")
     .trim();

--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -616,6 +616,26 @@ const isAngularDropdown = (element) => {
   return false;
 };
 
+function getPseudoContent(element, pseudo) {
+  const content = getElementComputedStyle(element, pseudo)
+    .getPropertyValue("content")
+    .replace(/"/g, "")
+    .trim();
+
+  if (content === "none" || !content) {
+    return null;
+  }
+
+  return content;
+}
+
+function hasBeforeOrAfterPseudoContent(element) {
+  return (
+    getPseudoContent(element, "::before") != null ||
+    getPseudoContent(element, "::after") != null
+  );
+}
+
 const checkParentClass = (className) => {
   const targetParentClasses = ["field", "entry"];
   for (let i = 0; i < targetParentClasses.length; i++) {
@@ -876,7 +896,9 @@ function buildElementObject(frame, element, interactable, purgeable = false) {
     interactable: interactable,
     tagName: elementTagNameLower,
     attributes: attrs,
+    beforePseudoText: getPseudoContent(element, "::before"),
     text: getElementContent(element),
+    afterPseudoText: getPseudoContent(element, "::after"),
     children: [],
     rect: DomUtils.getVisibleClientRect(element, true),
     // if purgeable is True, which means this element is only used for building the tree relationship
@@ -1019,6 +1041,8 @@ function buildElementTree(starter = document.body, frame, full_tree = false) {
         } else if (isTableRelatedElement(element)) {
           // build all table related elements into skyvern element
           // we need these elements to preserve the DOM structure
+          elementObj = buildElementObject(frame, element, false);
+        } else if (hasBeforeOrAfterPseudoContent(element)) {
           elementObj = buildElementObject(frame, element, false);
         } else if (full_tree) {
           // when building full tree, we only get text from element itself

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -122,11 +122,20 @@ def json_to_html(element: dict, need_skyvern_attrs: bool = True) -> str:
     if element.get("purgeable", False):
         return children_html + option_html
 
+    before_pseudo_text = element.get("beforePseudoText", "")
+    after_pseudo_text = element.get("afterPseudoText", "")
+
     # Check if the element is self-closing
-    if tag in ["img", "input", "br", "hr", "meta", "link"] and not option_html and not children_html:
+    if (
+        tag in ["img", "input", "br", "hr", "meta", "link"]
+        and not option_html
+        and not children_html
+        and not before_pseudo_text
+        and not after_pseudo_text
+    ):
         return f'<{tag}{attributes_html if not attributes_html else " "+attributes_html}>'
     else:
-        return f'<{tag}{attributes_html if not attributes_html else " "+attributes_html}>{text}{children_html+option_html}</{tag}>'
+        return f'<{tag}{attributes_html if not attributes_html else " "+attributes_html}>{before_pseudo_text}{text}{children_html+option_html}{after_pseudo_text}</{tag}>'
 
 
 def clean_element_before_hashing(element: dict) -> dict:
@@ -602,6 +611,13 @@ def trim_element(element: dict) -> dict:
             element_text = str(queue_ele["text"]).strip()
             if not element_text:
                 del queue_ele["text"]
+
+        if "beforePseudoText" in queue_ele and not queue_ele.get("beforePseudoText"):
+            del queue_ele["beforePseudoText"]
+
+        if "afterPseudoText" in queue_ele and not queue_ele.get("afterPseudoText"):
+            del queue_ele["afterPseudoText"]
+
     return element
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for parsing `::before` and `::after` pseudo-element content in DOM processing and HTML generation.
> 
>   - **Behavior**:
>     - Add `getPseudoContent()` and `hasBeforeOrAfterPseudoContent()` in `domUtils.js` to extract content from `::before` and `::after` pseudo-elements.
>     - Modify `buildElementObject()` in `domUtils.js` to include `beforePseudoText` and `afterPseudoText` in element objects.
>     - Update `buildElementTree()` in `domUtils.js` to process elements with pseudo content.
>     - Enhance `json_to_html()` in `scraper.py` to include pseudo content in HTML output.
>   - **Misc**:
>     - Update `trim_element()` in `scraper.py` to remove empty pseudo content fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2e449e59ea472994eef3a6de2fea8b328b79b05f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->