### PR TITLE
Left align navigation pills in task details

### DIFF
--- a/skyvern-frontend/src/routes/tasks/detail/TaskDetails.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/TaskDetails.tsx
@@ -274,61 +274,59 @@ function TaskDetails() {
           {failureReason}
         </>
       )}
-      <div className="flex items-center justify-center">
-        <div className="inline-flex rounded border bg-muted p-1">
-          <NavLink
-            to="actions"
-            className={({ isActive }) => {
-              return cn(
-                "cursor-pointer rounded-md px-2 py-1 text-muted-foreground",
-                {
-                  "bg-primary-foreground text-foreground": isActive,
-                },
-              );
-            }}
-          >
-            Actions
-          </NavLink>
-          <NavLink
-            to="recording"
-            className={({ isActive }) => {
-              return cn(
-                "cursor-pointer rounded-md px-2 py-1 text-muted-foreground",
-                {
-                  "bg-primary-foreground text-foreground": isActive,
-                },
-              );
-            }}
-          >
-            Recording
-          </NavLink>
-          <NavLink
-            to="parameters"
-            className={({ isActive }) => {
-              return cn(
-                "cursor-pointer rounded-md px-2 py-1 text-muted-foreground",
-                {
-                  "bg-primary-foreground text-foreground": isActive,
-                },
-              );
-            }}
-          >
-            Parameters
-          </NavLink>
-          <NavLink
-            to="diagnostics"
-            className={({ isActive }) => {
-              return cn(
-                "cursor-pointer rounded-md px-2 py-1 text-muted-foreground",
-                {
-                  "bg-primary-foreground text-foreground": isActive,
-                },
-              );
-            }}
-          >
-            Diagnostics
-          </NavLink>
-        </div>
+      <div className="flex w-fit gap-2 rounded-sm border border-slate-700 p-2">
+        <NavLink
+          to="actions"
+          className={({ isActive }) => {
+            return cn(
+              "cursor-pointer rounded-sm px-3 py-2 hover:bg-slate-700",
+              {
+                "bg-slate-700": isActive,
+              },
+            );
+          }}
+        >
+          Actions
+        </NavLink>
+        <NavLink
+          to="recording"
+          className={({ isActive }) => {
+            return cn(
+              "cursor-pointer rounded-sm px-3 py-2 hover:bg-slate-700",
+              {
+                "bg-slate-700": isActive,
+              },
+            );
+          }}
+        >
+          Recording
+        </NavLink>
+        <NavLink
+          to="parameters"
+          className={({ isActive }) => {
+            return cn(
+              "cursor-pointer rounded-sm px-3 py-2 hover:bg-slate-700",
+              {
+                "bg-slate-700": isActive,
+              },
+            );
+          }}
+        >
+          Parameters
+        </NavLink>
+        <NavLink
+          to="diagnostics"
+          className={({ isActive }) => {
+            return cn(
+              "cursor-pointer rounded-sm px-3 py-2 hover:bg-slate-700",
+              {
+                "bg-slate-700": isActive,
+              },
+            );
+          }}
+        >
+          Diagnostics
+        </NavLink>
       </div>
       <Outlet />
     </div>

--- a/skyvern-frontend/src/routes/tasks/detail/TaskRecording.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/TaskRecording.tsx
@@ -28,10 +28,8 @@ function TaskRecording() {
 
   if (taskIsLoading) {
     return (
-      <div className="mx-auto flex">
-        <div className="h-[450px] w-[800px]">
-          <Skeleton className="h-full" />
-        </div>
+      <div className="h-[450px] w-[800px]">
+        <Skeleton className="h-full" />
       </div>
     );
   }
@@ -41,9 +39,7 @@ function TaskRecording() {
   }
 
   return recordingURL ? (
-    <div className="mx-auto flex">
-      <video width={800} height={450} src={recordingURL} controls />
-    </div>
+    <video width={800} height={450} src={recordingURL} controls />
   ) : (
     <div>No recording available for this task</div>
   );


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Align navigation pills to the left and simplify code in `TaskDetails.tsx` and `TaskRecording.tsx`.
> 
>   - **UI Changes**:
>     - Align navigation pills to the left in `TaskDetails.tsx` by updating parent div to `flex w-fit gap-2`.
>     - Update navigation pill styles to `rounded-sm px-3 py-2 hover:bg-slate-700`.
>   - **Code Simplification**:
>     - Remove unnecessary `div` wrappers around `Skeleton` and `video` elements in `TaskRecording.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5cd0c622d0a02d054ef5e5a5ff76fd3dd126def1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->