### PR TITLE
fallback to press arrowdown to trigger dropdown menu

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -839,6 +839,22 @@ async def handle_select_option_action(
         incremental_element = await incremental_scraped.get_incremental_element_tree(
             clean_and_remove_element_tree_factory(task=task, step=step, check_exist_funcs=[dom.check_id_in_dom]),
         )
+
+        if len(incremental_element) == 0 and skyvern_element.get_tag_name() == InteractiveElement.INPUT:
+            LOG.info(
+                "No incremental elements detected for the input element, trying to press Arrowdown to trigger the dropdown",
+                element_id=skyvern_element.get_id(),
+                task_id=task.task_id,
+                step_id=step.step_id,
+            )
+            await skyvern_element.scroll_into_view()
+            await skyvern_element.press_key("ArrowDown")
+            # wait 5s for options to load
+            await asyncio.sleep(5)
+            incremental_element = await incremental_scraped.get_incremental_element_tree(
+                clean_and_remove_element_tree_factory(task=task, step=step, check_exist_funcs=[dom.check_id_in_dom]),
+            )
+
         if len(incremental_element) == 0:
             raise NoIncrementalElementFoundForCustomSelection(element_id=action.element_id)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds fallback in `handle_select_option_action` to press 'ArrowDown' for input elements to trigger dropdown if no incremental elements are detected.
> 
>   - **Behavior**:
>     - In `handle_select_option_action` in `handler.py`, added fallback to press 'ArrowDown' if no incremental elements are detected for input elements to trigger dropdown.
>     - Waits 5 seconds after pressing 'ArrowDown' for options to load.
>   - **Logging**:
>     - Logs information when 'ArrowDown' is pressed due to no incremental elements detected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2708015a0906393ed9e685b010af46d7c64c4c38. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->