### PR TITLE
[WIP] fail docker build if environments are not set up correctly

### DIFF
--- a/entrypoint-skyvern.sh
+++ b/entrypoint-skyvern.sh
@@ -35,5 +35,7 @@ xvfb=$!
 DISPLAY=:99 xterm 2>/dev/null &
 python run_streaming.py > /dev/null &
 
+# TODO: fail if environments are not set correctly
+#
 # Run the command and pass in all three arguments
 python -m skyvern.forge


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add TODO comment in `entrypoint-skyvern.sh` to fail Docker build if environments are not set correctly.
> 
>   - **Misc**:
>     - Add TODO comment in `entrypoint-skyvern.sh` to fail Docker build if environments are not set correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 08a63397c8bc0fecaeec347df6014bbeb967656a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->