### PR TITLE
support custom select serach

### DIFF
--- a/skyvern/forge/prompts/skyvern/custom-select.j2
+++ b/skyvern/forge/prompts/skyvern/custom-select.j2
@@ -1,4 +1,4 @@
-You are performing a {{ "multi-level selection" if select_history else "selection" }} action on an HTML page. Assist the user in selecting the most appropriate option to advance toward their goal, considering the context, user details, and the DOM elements provided in the list.
+You are performing a {{ "multi-level selection" if select_history else "selection" }} action on an HTML page. Assist the user in selecting the most appropriate option(or typing some values to search if neccesary) to advance toward their goal, considering the context, user details, and the DOM elements provided in the list.
 
 You can identify the matching element based on the following guidelines:
   1. Select the most suitable element based on the user goal, user details, and the context.
@@ -16,6 +16,7 @@ Reply in JSON format with the following keys:
     "reasoning": str, // The reasoning behind the action. Be specific, referencing the value and the element id in your reasoning. Mention why you chose the element id. Keep the reasoning short and to the point.
     "confidence_float": float, // The confidence of the action. Pick a number between 0.0 and 1.0. 0.0 means no confidence, 1.0 means full confidence
     "id": str, // The id of the element to take action on. The id has to be one from the elements list
+    "action_type": str, // It's a string enum: "CLICK", "INPUT_TEXT". "CLICK" is an option you'd like to click to choose. "INPUT_TEXT" is an element you'd like to input text into for searching, but it only should be used when there's no valid option to click.
     "value": str, // The value to select.{% if target_value %}
     "relevant": bool, // True if the value you select is relevant to the target value, otherwise False.{% endif %}
 }

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -1734,7 +1734,7 @@ async def select_from_dropdown(
             )
             return single_select_result
 
-    if action_type == "INPUT_TEXT":
+    if value is not None and action_type == "INPUT_TEXT":
         LOG.info(
             "No clickable option found, but found input element to search",
             element_id=element_id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds support for custom select search by introducing `INPUT_TEXT` action type and handling it in `select_from_dropdown()` in `handler.py`.
> 
>   - **Behavior**:
>     - Adds `action_type` key in JSON response in `custom-select.j2` with values "CLICK" or "INPUT_TEXT".
>     - Handles `INPUT_TEXT` action type in `select_from_dropdown()` in `handler.py` to input text when no clickable option is available.
>   - **Error Handling**:
>     - Raises `NoAvailableOptionFoundForCustomSelection` if `action_type` is not "CLICK" or "INPUT_TEXT" in `select_from_dropdown()`.
>   - **Logging**:
>     - Logs when no clickable option is found but an input element is available for search in `select_from_dropdown()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for cbc2a200d5241ad891e7db3d2bdb8b43826ca52e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->