### PR TITLE
Fix actions API order, only order by created_at

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -281,7 +281,7 @@ class AgentDB:
                     select(ActionModel)
                     .filter(ActionModel.organization_id == organization_id)
                     .filter(ActionModel.task_id == task_id)
-                    .order_by(ActionModel.step_order, ActionModel.action_order, ActionModel.created_at)
+                    .order_by(ActionModel.created_at)
                 )
 
                 actions = (await session.scalars(query)).all()


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modify `get_task_actions` in `client.py` to order actions by `created_at` only, removing `step_order` and `action_order`.
> 
>   - **Behavior**:
>     - Modify `get_task_actions` in `client.py` to order actions by `created_at` only, removing `step_order` and `action_order` from the ordering criteria.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 98fe8051ebcb1852fbf89313734bac2fe0337983. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->