### PR TITLE
Dont refetch workflow parameters on window focus

### DIFF
--- a/skyvern-frontend/src/routes/workflows/WorkflowRunParameters.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRunParameters.tsx
@@ -19,6 +19,7 @@ function WorkflowRunParameters() {
         .get(`/workflows/${workflowPermanentId}`)
         .then((response) => response.data);
     },
+    refetchOnWindowFocus: false,
   });
 
   const workflowParameters = workflow?.workflow_definition.parameters.filter(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Prevent refetching workflow data on window focus in `WorkflowRunParameters` by setting `refetchOnWindowFocus: false`.
> 
>   - **Behavior**:
>     - Set `refetchOnWindowFocus: false` in `useQuery` in `WorkflowRunParameters` to prevent refetching workflow data on window focus.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ff8d27d019cd8b0b10989bca1859aaf813520cdb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->