### PR TITLE
add browser console log artifact

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,7 @@ repos:
           - alembic
           - "sqlalchemy[mypy]"
           - types-PyYAML
+          - types-aiofiles
         exclude: |
           (?x)(
             ^tests.*|

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ COPY . /app
 ENV PYTHONPATH="/app:$PYTHONPATH"
 ENV VIDEO_PATH=/data/videos
 ENV HAR_PATH=/data/har
+ENV LOG_PATH=/data/log
 ENV ARTIFACT_STORAGE_PATH=/data/artifacts
 
 COPY ./entrypoint-skyvern.sh /app/entrypoint-skyvern.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - ./artifacts:/data/artifacts
       - ./videos:/data/videos
       - ./har:/data/har
+      - ./log:/data/log
       - ./.streamlit:/app/.streamlit
     environment:
       - DATABASE_STRING=postgresql+psycopg://skyvern:skyvern@postgres:5432/skyvern

--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -13,6 +13,7 @@ class Settings(BaseSettings):
     MAX_SCRAPING_RETRIES: int = 0
     VIDEO_PATH: str | None = None
     HAR_PATH: str | None = "./har"
+    LOG_PATH: str = "./log"
     BROWSER_ACTION_TIMEOUT_MS: int = 5000
     BROWSER_SCREENSHOT_TIMEOUT_MS: int = 20000
     BROWSER_LOADING_TIMEOUT_MS: int = 120000

--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1517,6 +1517,16 @@ class ForgeAgent:
                     data=har_data,
                 )
 
+            browser_log = await app.BROWSER_MANAGER.get_browser_console_log(
+                task_id=task.task_id, browser_state=browser_state
+            )
+            if browser_log:
+                await app.ARTIFACT_MANAGER.create_artifact(
+                    step=last_step,
+                    artifact_type=ArtifactType.BROWSER_CONSOLE_LOG,
+                    data=browser_log,
+                )
+
             if browser_state.browser_context and browser_state.browser_artifacts.traces_dir:
                 trace_path = f"{browser_state.browser_artifacts.traces_dir}/{task.task_id}.zip"
                 await app.ARTIFACT_MANAGER.create_artifact(

--- a/skyvern/forge/sdk/artifact/models.py
+++ b/skyvern/forge/sdk/artifact/models.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, field_serializer
 
 class ArtifactType(StrEnum):
     RECORDING = "recording"
+    BROWSER_CONSOLE_LOG = "browser_console_log"
 
     # DEPRECATED. pls use SCREENSHOT_LLM, SCREENSHOT_ACTION or SCREENSHOT_FINAL
     SCREENSHOT = "screenshot"

--- a/skyvern/forge/sdk/artifact/storage/base.py
+++ b/skyvern/forge/sdk/artifact/storage/base.py
@@ -6,6 +6,7 @@ from skyvern.forge.sdk.models import Step
 # TODO: This should be a part of the ArtifactType model
 FILE_EXTENTSION_MAP: dict[ArtifactType, str] = {
     ArtifactType.RECORDING: "webm",
+    ArtifactType.BROWSER_CONSOLE_LOG: "log",
     ArtifactType.SCREENSHOT_LLM: "png",
     ArtifactType.SCREENSHOT_ACTION: "png",
     ArtifactType.SCREENSHOT_FINAL: "png",

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -843,6 +843,25 @@ class WorkflowService:
                 data=har_data,
             )
 
+    async def persist_browser_console_log(
+        self,
+        browser_state: BrowserState,
+        last_step: Step,
+        workflow: Workflow,
+        workflow_run: WorkflowRun,
+    ) -> None:
+        browser_log = await app.BROWSER_MANAGER.get_browser_console_log(
+            workflow_id=workflow.workflow_id,
+            workflow_run_id=workflow_run.workflow_run_id,
+            browser_state=browser_state,
+        )
+        if browser_log:
+            await app.ARTIFACT_MANAGER.create_artifact(
+                step=last_step,
+                artifact_type=ArtifactType.BROWSER_CONSOLE_LOG,
+                data=browser_log,
+            )
+
     async def persist_tracing_data(
         self, browser_state: BrowserState, last_step: Step, workflow_run: WorkflowRun
     ) -> None:

--- a/skyvern/webeye/browser_manager.py
+++ b/skyvern/webeye/browser_manager.py
@@ -169,6 +169,24 @@ class BrowserManager:
         )
         return b""
 
+    async def get_browser_console_log(
+        self,
+        browser_state: BrowserState,
+        task_id: str = "",
+        workflow_id: str = "",
+        workflow_run_id: str = "",
+    ) -> bytes:
+        if browser_state.browser_artifacts.browser_console_log_path is None:
+            LOG.warning(
+                "browser console log not found for task",
+                task_id=task_id,
+                workflow_id=workflow_id,
+                workflow_run_id=workflow_run_id,
+            )
+            return b""
+
+        return await browser_state.browser_artifacts.read_browser_console_log()
+
     @classmethod
     async def close(cls) -> None:
         LOG.info("Closing BrowserManager")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add browser console log capture as an artifact in the Skyvern system, including new artifact type and storage handling.
> 
>   - **Behavior**:
>     - Adds browser console log capture in `cleanup_browser_and_create_artifacts()` in `agent.py` and `persist_browser_console_log()` in `service.py`.
>     - New artifact type `BROWSER_CONSOLE_LOG` added to `ArtifactType` in `models.py`.
>   - **Artifact Management**:
>     - Updates `FILE_EXTENTSION_MAP` in `storage/base.py` to include `BROWSER_CONSOLE_LOG` with `.log` extension.
>     - Implements `append_browser_console_log()` and `read_browser_console_log()` in `BrowserArtifacts` in `browser_factory.py`.
>   - **Configuration**:
>     - Adds `LOG_PATH` environment variable in `Dockerfile` and `docker-compose.yml` for log storage.
>     - Updates `config.py` to include `LOG_PATH` setting.
>   - **Misc**:
>     - Adds `types-aiofiles` to `additional_dependencies` in `.pre-commit-config.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b2953794687ef680702afb14121a1457aa5bf108. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->