### PR TITLE
Make search a bit bigger in codemirror

### DIFF
--- a/skyvern-frontend/src/index.css
+++ b/skyvern-frontend/src/index.css
@@ -105,3 +105,7 @@ body,
 .cm-gutters {
   @apply rounded-md;
 }
+
+.cm-search.cm-panel {
+  @apply text-sm;
+}


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Increase CodeMirror search panel size by applying `text-sm` in `cloud/index.css` and `src/index.css`.
> 
>   - **CSS Changes**:
>     - Apply `text-sm` to `.cm-search.cm-panel` in `cloud/index.css` and `src/index.css` to increase the search panel size in CodeMirror.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b815e2b9e3eed3ab6a3647d8661fda634c658b7b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->