### PR TITLE
fix workflow can't save browser console log

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -884,6 +884,7 @@ class WorkflowService:
         if not last_step:
             return
 
+        await self.persist_browser_console_log(browser_state, last_step, workflow, workflow_run)
         await self.persist_har_data(browser_state, last_step, workflow, workflow_run)
         await self.persist_tracing_data(browser_state, last_step, workflow_run)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds call to `persist_browser_console_log()` in `persist_debug_artifacts()` to save browser console logs.
> 
>   - **Behavior**:
>     - Adds call to `persist_browser_console_log()` in `persist_debug_artifacts()` in `service.py` to save browser console logs during workflow execution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ec64fe8f61d062849e700d19c797cd667482306a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->