### PR TITLE
fix no exist browser log error

### DIFF
--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -178,6 +178,9 @@ class BrowserArtifacts(BaseModel):
             return b""
 
         async with self._browser_console_log_lock:
+            if not os.path.exists(self.browser_console_log_path):
+                return b""
+
             async with aiofiles.open(self.browser_console_log_path, "rb") as f:
                 return await f.read()
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add file existence check in `read_browser_console_log()` in `browser_factory.py` to prevent errors.
> 
>   - **Behavior**:
>     - In `read_browser_console_log()` in `browser_factory.py`, added a check to return an empty byte string if `browser_console_log_path` does not exist, preventing file read errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 671ade5bea7bb4eaaff6ff3a8e9954a05675b1d2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->