### PR TITLE
Raise screenshot error earlier when page is closed

### DIFF
--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -39,6 +39,8 @@ class SkyvernFrame:
         file_path: str | None = None,
         timeout: float = SettingsManager.get_settings().BROWSER_LOADING_TIMEOUT_MS,
     ) -> bytes:
+        if page.is_closed():
+            raise FailedToTakeScreenshot(error_message="Page is closed")
         try:
             await page.wait_for_load_state(timeout=SettingsManager.get_settings().BROWSER_LOADING_TIMEOUT_MS)
             LOG.debug("Page is fully loaded, agent is about to take screenshots")


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Raise `FailedToTakeScreenshot` in `take_screenshot()` if `page.is_closed()` in `page.py`.
> 
>   - **Behavior**:
>     - In `take_screenshot()` in `page.py`, raise `FailedToTakeScreenshot` if `page.is_closed()` before attempting to take a screenshot.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 2627a3801b74877c0a64d30a67383f4a7acc901b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->