### PR TITLE
Update max output tokens to 16K

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -74,7 +74,7 @@ class LLMAPIHandlerFactory:
                 The response from the LLM router.
             """
             if parameters is None:
-                parameters = LLMAPIHandlerFactory.get_api_parameters()
+                parameters = LLMAPIHandlerFactory.get_api_parameters(llm_config)
 
             if step:
                 await app.ARTIFACT_MANAGER.create_artifact(
@@ -168,7 +168,7 @@ class LLMAPIHandlerFactory:
         ) -> dict[str, Any]:
             active_parameters = base_parameters or {}
             if parameters is None:
-                parameters = LLMAPIHandlerFactory.get_api_parameters()
+                parameters = LLMAPIHandlerFactory.get_api_parameters(llm_config)
 
             active_parameters.update(parameters)
             if llm_config.litellm_params:  # type: ignore
@@ -261,9 +261,9 @@ class LLMAPIHandlerFactory:
         return llm_api_handler
 
     @staticmethod
-    def get_api_parameters() -> dict[str, Any]:
+    def get_api_parameters(llm_config: LLMConfig | LLMRouterConfig) -> dict[str, Any]:
         return {
-            "max_tokens": SettingsManager.get_settings().LLM_CONFIG_MAX_TOKENS,
+            "max_tokens": llm_config.max_output_tokens,
             "temperature": SettingsManager.get_settings().LLM_CONFIG_TEMPERATURE,
         }
 

--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -76,7 +76,10 @@ if SettingsManager.get_settings().ENABLE_OPENAI:
         ),
     )
     LLMConfigRegistry.register_config(
-        "OPENAI_GPT4O", LLMConfig("gpt-4o", ["OPENAI_API_KEY"], supports_vision=True, add_assistant_prefix=False)
+        "OPENAI_GPT4O",
+        LLMConfig(
+            "gpt-4o", ["OPENAI_API_KEY"], supports_vision=True, add_assistant_prefix=False, max_output_tokens=16384
+        ),
     )
     LLMConfigRegistry.register_config(
         "OPENAI_GPT4O_MINI",
@@ -85,11 +88,18 @@ if SettingsManager.get_settings().ENABLE_OPENAI:
             ["OPENAI_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=False,
+            max_output_tokens=16384,
         ),
     )
     LLMConfigRegistry.register_config(
         "OPENAI_GPT-4O-2024-08-06",
-        LLMConfig("gpt-4o-2024-08-06", ["OPENAI_API_KEY"], supports_vision=True, add_assistant_prefix=False),
+        LLMConfig(
+            "gpt-4o-2024-08-06",
+            ["OPENAI_API_KEY"],
+            supports_vision=True,
+            add_assistant_prefix=False,
+            max_output_tokens=16384,
+        ),
     )
 
 
@@ -137,6 +147,7 @@ if SettingsManager.get_settings().ENABLE_ANTHROPIC:
             ["ANTHROPIC_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=True,
+            max_output_tokens=8192,
         ),
     )
 

--- a/skyvern/forge/sdk/api/llm/models.py
+++ b/skyvern/forge/sdk/api/llm/models.py
@@ -34,6 +34,7 @@ class LLMConfigBase:
 @dataclass(frozen=True)
 class LLMConfig(LLMConfigBase):
     litellm_params: Optional[LiteLLMParams] = field(default=None)
+    max_output_tokens: int = SettingsManager.get_settings().LLM_CONFIG_MAX_TOKENS
 
 
 @dataclass(frozen=True)
@@ -69,6 +70,7 @@ class LLMRouterConfig(LLMConfigBase):
     allowed_fails: int | None = None
     allowed_fails_policy: AllowedFailsPolicy | None = None
     cooldown_time: float | None = None
+    max_output_tokens: int = SettingsManager.get_settings().LLM_CONFIG_MAX_TOKENS
 
 
 class LLMAPIHandler(Protocol):


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Increase max output tokens to 16K in LLM configurations and update related logic in handlers and registry.
> 
>   - **Configuration Update**:
>     - Increase `LLM_CONFIG_MAX_TOKENS` from 4096 to 16384 in `Settings` class in `skyvern/config.py`.
>     - Update `max_output_tokens` to 16384 in `LLMConfig` and `LLMRouterConfig` in `models.py`.
>   - **API Handler Changes**:
>     - Modify `get_api_parameters()` in `api_handler_factory.py` to use `llm_config.max_output_tokens`.
>     - Update `llm_api_handler_with_router_and_fallback()` and `llm_api_handler()` to use new token limit.
>   - **Config Registry**:
>     - Set `max_output_tokens` to 16384 for `OPENAI_GPT4O`, `OPENAI_GPT4O_MINI`, and `OPENAI_GPT-4O-2024-08-06` in `config_registry.py`.
>     - Set `max_output_tokens` to 8192 for `ANTHROPIC_CLAUDE3.5_SONNET`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 776cb63f085176df83c5581bf4a169e809f172d9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->