### PR TITLE
fix unbound log_path

### DIFF
--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -43,8 +43,8 @@ def get_download_dir(workflow_run_id: str | None, task_id: str | None) -> str:
 
 def set_browser_console_log(browser_context: BrowserContext, browser_artifacts: BrowserArtifacts) -> None:
     if browser_artifacts.browser_console_log_path is None:
+        log_path = f"{settings.LOG_PATH}/{datetime.utcnow().strftime('%Y-%m-%d')}/{uuid.uuid4()}.log"
         try:
-            log_path = f"{settings.LOG_PATH}/{datetime.utcnow().strftime('%Y-%m-%d')}/{uuid.uuid4()}.log"
             os.makedirs(os.path.dirname(log_path), exist_ok=True)
             # create the empty log file
             with open(log_path, "w") as _:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes unbound `log_path` variable in `set_browser_console_log()` in `browser_factory.py`.
> 
>   - **Behavior**:
>     - Fixes unbound `log_path` variable in `set_browser_console_log()` in `browser_factory.py` by moving its assignment outside the `try` block.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for bdf4891e589e1e4dc251e6f3e191ca6333b4e098. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->