### PR TITLE
add browser console log

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -277,6 +277,15 @@ async def get_task(
     if recording_artifact:
         recording_url = await app.ARTIFACT_MANAGER.get_share_link(recording_artifact)
 
+    browser_console_log = await app.DATABASE.get_latest_artifact(
+        task_id=task_obj.task_id,
+        artifact_types=[ArtifactType.BROWSER_CONSOLE_LOG],
+        organization_id=current_org.organization_id,
+    )
+    browser_console_log_url = None
+    if browser_console_log:
+        browser_console_log_url = await app.ARTIFACT_MANAGER.get_share_link(browser_console_log)
+
     # get the artifact of the last  screenshot and get the screenshot_url
     latest_action_screenshot_artifacts = await app.DATABASE.get_latest_n_artifacts(
         task_id=task_obj.task_id,
@@ -315,6 +324,7 @@ async def get_task(
         action_screenshot_urls=latest_action_screenshot_urls,
         screenshot_url=screenshot_url,
         recording_url=recording_url,
+        browser_console_log_url=browser_console_log_url,
         failure_reason=failure_reason,
     )
 

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -235,6 +235,7 @@ class Task(TaskBase):
         action_screenshot_urls: list[str] | None = None,
         screenshot_url: str | None = None,
         recording_url: str | None = None,
+        browser_console_log_url: str | None = None,
         failure_reason: str | None = None,
     ) -> TaskResponse:
         return TaskResponse(
@@ -248,6 +249,7 @@ class Task(TaskBase):
             action_screenshot_urls=action_screenshot_urls,
             screenshot_url=screenshot_url,
             recording_url=recording_url,
+            browser_console_log_url=browser_console_log_url,
             errors=self.errors,
             max_steps_per_run=self.max_steps_per_run,
             workflow_run_id=self.workflow_run_id,
@@ -264,6 +266,7 @@ class TaskResponse(BaseModel):
     action_screenshot_urls: list[str] | None = None
     screenshot_url: str | None = None
     recording_url: str | None = None
+    browser_console_log_url: str | None = None
     failure_reason: str | None = None
     errors: list[dict[str, Any]] = []
     max_steps_per_run: int | None = None


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add browser console log URL retrieval and inclusion in task response in `agent_protocol.py` and `tasks.py`.
> 
>   - **Behavior**:
>     - `get_task` in `agent_protocol.py` now retrieves the latest browser console log artifact for a task and generates a shareable URL.
>     - The URL is included in the task response as `browser_console_log_url`.
>   - **Models**:
>     - `TaskResponse` in `tasks.py` updated to include `browser_console_log_url` field.
>     - `to_task_response` method in `Task` class updated to handle `browser_console_log_url`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a63690aeb54a007e522c5c43c21ef1903cb0a168. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->