### PR TITLE
add default timeout to wait_for_task

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -337,7 +337,6 @@ class ForgeAgent:
                         api_key=api_key,
                         close_browser_on_completion=close_browser_on_completion,
                     )
-                    await self.async_operation_pool.remove_task(task.task_id)
                     return step, detailed_output, None
             elif step.status == StepStatus.completed:
                 # TODO (kerem): keep the task object uptodate at all times so that clean_up_task can just use it
@@ -1402,6 +1401,7 @@ class ForgeAgent:
             )
             return
 
+        await self.async_operation_pool.remove_task(task.task_id)
         await self.cleanup_browser_and_create_artifacts(close_browser_on_completion, last_step, task)
 
         # Wait for all tasks to complete before generating the links for the artifacts

--- a/skyvern/forge/sdk/core/asyncio_helper.py
+++ b/skyvern/forge/sdk/core/asyncio_helper.py
@@ -1,0 +1,5 @@
+import asyncio
+
+
+def is_aio_task_running(aio_task: asyncio.Task) -> bool:
+    return not aio_task.done() and not aio_task.cancelled()


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add default 30-second timeout to `wait_for_task()` and introduce `is_aio_task_running()` for task status checking.
> 
>   - **Behavior**:
>     - Add default `timeout` parameter (30 seconds) to `wait_for_task()` in `async_operations.py`.
>     - Update calls to `wait_for_task()` in `actions.py`, `action_input.py`, and `click.py` to use the new default timeout.
>   - **Helper Function**:
>     - Introduce `is_aio_task_running()` in `asyncio_helper.py` to check if an asyncio task is running.
>     - Use `is_aio_task_running()` in `async_operations.py` to replace direct checks of `aio_task.done()`.
>   - **Misc**:
>     - Import `settings` in `async_operations.py` to access `BROWSER_ACTION_TIMEOUT_MS`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 31c5ba33a21220d5270a4650331622167f7824a3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->