### PR TITLE
skip css conversion for span with chidren

### DIFF
--- a/skyvern/forge/agent_functions.py
+++ b/skyvern/forge/agent_functions.py
@@ -36,19 +36,21 @@ def _should_css_shape_convert(element: Dict) -> bool:
     if tag_name not in ["a", "span", "i"]:
         return False
 
-    # if <span> and <i> without any text in the element, we try to convert the shape
-    if tag_name in ["span", "i"] and not element.get("text"):
+    # should be without children
+    if len(element.get("children", [])) > 0:
+        return False
+
+    # should be no text
+    if element.get("text"):
+        return False
+
+    # if <span> and <i>  we try to convert the shape
+    if tag_name in ["span", "i"]:
         return True
 
-    # if <a>, it should be no text, no children, no href/target attribute
+    # if <a>, it should be no text, no href/target attribute
     if tag_name == "a":
         attributes = element.get("attributes", {})
-        if element.get("text"):
-            return False
-
-        if len(element.get("children", [])) > 0:
-            return False
-
         if "href" in attributes:
             return False
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `_should_css_shape_convert` in `agent_functions.py` to skip CSS conversion for `span` and `i` elements with children and simplify logic for `a` elements.
> 
>   - **Behavior**:
>     - Update `_should_css_shape_convert` in `agent_functions.py` to skip CSS conversion for `span` and `i` elements with children.
>     - Simplify logic for `a` elements by removing redundant children check.
>   - **Misc**:
>     - Minor comment adjustments in `agent_functions.py` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for bc99ccc8b8d507c6881fc4dc953f5470a3e515d5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->