### PR TITLE
wrap page evaluate with timeout

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -777,17 +777,6 @@ class ForgeAgent:
                         action=action,
                         action_result=results,
                     )
-                    # if the action triggered javascript calls
-                    # this action should be the last action this round and do not take more actions.
-                    # for now, we're being optimistic and assuming that
-                    # js call doesn't have impact on the following actions
-                    if results[-1].javascript_triggered:
-                        LOG.info(
-                            "Action triggered javascript. Stop executing reamaining actions.",
-                            action=action,
-                        )
-                        # stop executing the rest actions
-                        break
                 elif results and not results[-1].success and not results[-1].stop_execution_on_failure:
                     LOG.warning(
                         "Action failed, but not stopping execution",
@@ -1198,7 +1187,9 @@ class ForgeAgent:
         navigation_goal = task.navigation_goal
         starting_url = task.url
         page = await browser_state.get_working_page()
-        current_url = await page.evaluate("() => document.location.href") if page else starting_url
+        current_url = (
+            await SkyvernFrame.evaluate(frame=page, expression="() => document.location.href") if page else starting_url
+        )
         final_navigation_payload = self._build_navigation_payload(
             task, expire_verification_code=expire_verification_code
         )

--- a/skyvern/webeye/actions/responses.py
+++ b/skyvern/webeye/actions/responses.py
@@ -13,7 +13,6 @@ class ActionResult(BaseModel):
     data: dict[str, Any] | list | str | None = None
     step_retry_number: int | None = None
     step_order: int | None = None
-    javascript_triggered: bool = False
     download_triggered: bool | None = None
     # None is used for old data so that we can differentiate between old and new data which only has boolean
     interacted_with_sibling: bool | None = None
@@ -30,8 +29,6 @@ class ActionResult(BaseModel):
             results.append(f"step_order={self.step_order}")
         if self.step_retry_number:
             results.append(f"step_retry_number={self.step_retry_number}")
-        if self.javascript_triggered:
-            results.append(f"javascript_triggered={self.javascript_triggered}")
         if self.download_triggered is not None:
             results.append(f"download_triggered={self.download_triggered}")
         if self.interacted_with_sibling is not None:
@@ -49,7 +46,6 @@ class ActionSuccess(ActionResult):
     def __init__(
         self,
         data: dict[str, Any] | list | str | None = None,
-        javascript_triggered: bool = False,
         download_triggered: bool | None = None,
         interacted_with_sibling: bool = False,
         interacted_with_parent: bool = False,
@@ -57,7 +53,6 @@ class ActionSuccess(ActionResult):
         super().__init__(
             success=True,
             data=data,
-            javascript_triggered=javascript_triggered,
             download_triggered=download_triggered,
             interacted_with_sibling=interacted_with_sibling,
             interacted_with_parent=interacted_with_parent,
@@ -69,7 +64,6 @@ class ActionFailure(ActionResult):
         self,
         exception: Exception,
         stop_execution_on_failure: bool = True,
-        javascript_triggered: bool = False,
         download_triggered: bool | None = None,
         interacted_with_sibling: bool = False,
         interacted_with_parent: bool = False,
@@ -79,7 +73,6 @@ class ActionFailure(ActionResult):
             exception_type=type(exception).__name__,
             stop_execution_on_failure=stop_execution_on_failure,
             exception_message=remove_whitespace(str(exception)),
-            javascript_triggered=javascript_triggered,
             download_triggered=download_triggered,
             interacted_with_sibling=interacted_with_sibling,
             interacted_with_parent=interacted_with_parent,
@@ -91,14 +84,12 @@ class ActionFailure(ActionResult):
 class ActionAbort(ActionResult):
     def __init__(
         self,
-        javascript_triggered: bool = False,
         download_triggered: bool | None = None,
         interacted_with_sibling: bool = False,
         interacted_with_parent: bool = False,
     ):
         super().__init__(
             success=True,
-            javascript_triggered=javascript_triggered,
             download_triggered=download_triggered,
             interacted_with_sibling=interacted_with_sibling,
             interacted_with_parent=interacted_with_parent,

--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -419,7 +419,7 @@ class BrowserState:
     async def stop_page_loading(self) -> None:
         page = await self.__assert_page()
         try:
-            await page.evaluate("window.stop()")
+            await SkyvernFrame.evaluate(frame=page, expression="window.stop()")
         except Exception as e:
             LOG.exception(f"Error while stop loading the page: {repr(e)}")
             raise FailedToStopLoadingPage(url=page.url, error_message=repr(e))

--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -213,6 +213,9 @@ class SkyvernElement:
 
         return False
 
+    async def is_file_input(self) -> bool:
+        return self.get_tag_name() == InteractiveElement.INPUT and await self.get_attr("type") == "file"
+
     def is_interactable(self) -> bool:
         return self.__static_element.get("interactable", False)
 
@@ -507,7 +510,9 @@ class SkyvernElement:
         await page.mouse.click(click_x, click_y)
 
     async def blur(self) -> None:
-        await self.get_frame().evaluate("(element) => element.blur()", await self.get_element_handler())
+        await SkyvernFrame.evaluate(
+            frame=self.get_frame(), expression="(element) => element.blur()", arg=await self.get_element_handler()
+        )
 
     async def scroll_into_view(self, timeout: float = SettingsManager.get_settings().BROWSER_ACTION_TIMEOUT_MS) -> None:
         element_handler = await self.get_element_handler(timeout=timeout)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Wraps page evaluations with a timeout using `SkyvernFrame.evaluate()` and removes deprecated JavaScript-triggered handling.
> 
>   - **Behavior**:
>     - Wraps page evaluations with a timeout using `SkyvernFrame.evaluate()` in `agent.py`, `handler.py`, `scraper.py`, and `browser_factory.py`.
>     - Removes handling of `javascript_triggered` in `agent.py` and `handler.py`.
>   - **Functions**:
>     - Adds `SkyvernFrame.evaluate()` to handle timeouts for page evaluations.
>     - Removes `is_javascript_triggered()` and related logic.
>   - **Misc**:
>     - Removes `javascript_triggered` attribute from `ActionResult` and related classes in `responses.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ba3fc14759c7e2588447e19756164f361bbf9edc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->