### PR TITLE
add timeout when close browser

### DIFF
--- a/skyvern/webeye/browser_manager.py
+++ b/skyvern/webeye/browser_manager.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-import asyncio
 import os
 
 import structlog
 from playwright.async_api import async_playwright
 
-from skyvern.constants import BROWSER_CLOSE_TIMEOUT
 from skyvern.exceptions import MissingBrowserState
 from skyvern.forge.sdk.schemas.tasks import ProxyLocation, Task
 from skyvern.forge.sdk.workflow.models.workflow import WorkflowRun
@@ -208,18 +206,14 @@ class BrowserManager:
     async def cleanup_for_task(self, task_id: str, close_browser_on_completion: bool = True) -> BrowserState | None:
         LOG.info("Cleaning up for task")
         browser_state_to_close = self.pages.pop(task_id, None)
-        try:
-            if browser_state_to_close:
-                async with asyncio.timeout(BROWSER_CLOSE_TIMEOUT):
-                    # Stop tracing before closing the browser if tracing is enabled
-                    if browser_state_to_close.browser_context and browser_state_to_close.browser_artifacts.traces_dir:
-                        trace_path = f"{browser_state_to_close.browser_artifacts.traces_dir}/{task_id}.zip"
-                        await browser_state_to_close.browser_context.tracing.stop(path=trace_path)
-                        LOG.info("Stopped tracing", trace_path=trace_path)
-                    await browser_state_to_close.close(close_browser_on_completion=close_browser_on_completion)
-            LOG.info("Task is cleaned up")
-        except TimeoutError:
-            LOG.warning("Timeout on task cleanup")
+        if browser_state_to_close:
+            # Stop tracing before closing the browser if tracing is enabled
+            if browser_state_to_close.browser_context and browser_state_to_close.browser_artifacts.traces_dir:
+                trace_path = f"{browser_state_to_close.browser_artifacts.traces_dir}/{task_id}.zip"
+                await browser_state_to_close.browser_context.tracing.stop(path=trace_path)
+                LOG.info("Stopped tracing", trace_path=trace_path)
+            await browser_state_to_close.close(close_browser_on_completion=close_browser_on_completion)
+        LOG.info("Task is cleaned up")
 
         return browser_state_to_close
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add timeout to `BrowserState.close()` to prevent indefinite waiting during browser closure in `browser_factory.py`.
> 
>   - **Behavior**:
>     - Add timeout to `BrowserState.close()` in `browser_factory.py` to prevent indefinite waiting when closing the browser context and Playwright.
>     - Logs error if timeout occurs during browser context or Playwright closure.
>   - **Refactoring**:
>     - Remove timeout handling from `cleanup_for_task()` in `browser_manager.py` as it is now managed in `BrowserState.close()`.
>   - **Constants**:
>     - Import `BROWSER_CLOSE_TIMEOUT` in `browser_factory.py` for timeout duration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 03535ad0119ccc3b6d5d6f06d51decb3c2b30b17. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->