### PR TITLE
Use replace when navigating between task detail page tabs

### DIFF
--- a/skyvern-frontend/src/routes/tasks/detail/TaskDetails.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/TaskDetails.tsx
@@ -277,6 +277,7 @@ function TaskDetails() {
       <div className="flex w-fit gap-2 rounded-sm border border-slate-700 p-2">
         <NavLink
           to="actions"
+          replace
           className={({ isActive }) => {
             return cn(
               "cursor-pointer rounded-sm px-3 py-2 hover:bg-slate-700",
@@ -290,6 +291,7 @@ function TaskDetails() {
         </NavLink>
         <NavLink
           to="recording"
+          replace
           className={({ isActive }) => {
             return cn(
               "cursor-pointer rounded-sm px-3 py-2 hover:bg-slate-700",
@@ -303,6 +305,7 @@ function TaskDetails() {
         </NavLink>
         <NavLink
           to="parameters"
+          replace
           className={({ isActive }) => {
             return cn(
               "cursor-pointer rounded-sm px-3 py-2 hover:bg-slate-700",
@@ -316,6 +319,7 @@ function TaskDetails() {
         </NavLink>
         <NavLink
           to="diagnostics"
+          replace
           className={({ isActive }) => {
             return cn(
               "cursor-pointer rounded-sm px-3 py-2 hover:bg-slate-700",


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `replace` prop to `NavLink` components in `TaskDetails.tsx` to prevent new history entries when switching tabs.
> 
>   - **Behavior**:
>     - Add `replace` prop to `NavLink` components in `TaskDetails.tsx` for tabs `actions`, `recording`, `parameters`, and `diagnostics` to prevent adding new history entries when navigating between them.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0f3210da6ef5d08a6566c293e84a6f6d01111ef7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->