### PR TITLE
fix unclosed browser when navigation error

### DIFF
--- a/skyvern/webeye/browser_manager.py
+++ b/skyvern/webeye/browser_manager.py
@@ -78,16 +78,15 @@ class BrowserManager:
             task_id=task.task_id,
             organization_id=task.organization_id,
         )
+        self.pages[task.task_id] = browser_state
+        if task.workflow_run_id:
+            self.pages[task.workflow_run_id] = browser_state
 
         # The URL here is only used when creating a new page, and not when using an existing page.
         # This will make sure browser_state.page is not None.
         await browser_state.get_or_create_page(
             url=task.url, proxy_location=task.proxy_location, task_id=task.task_id, organization_id=task.organization_id
         )
-
-        self.pages[task.task_id] = browser_state
-        if task.workflow_run_id:
-            self.pages[task.workflow_run_id] = browser_state
         return browser_state
 
     async def get_or_create_for_workflow_run(self, workflow_run: WorkflowRun, url: str | None = None) -> BrowserState:
@@ -105,6 +104,7 @@ class BrowserManager:
             workflow_run_id=workflow_run.workflow_run_id,
             organization_id=workflow_run.organization_id,
         )
+        self.pages[workflow_run.workflow_run_id] = browser_state
 
         # The URL here is only used when creating a new page, and not when using an existing page.
         # This will make sure browser_state.page is not None.
@@ -114,8 +114,6 @@ class BrowserManager:
             workflow_run_id=workflow_run.workflow_run_id,
             organization_id=workflow_run.organization_id,
         )
-
-        self.pages[workflow_run.workflow_run_id] = browser_state
         return browser_state
 
     def get_for_workflow_run(self, workflow_run_id: str) -> BrowserState | None:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes unclosed browser issue by reordering operations in `get_or_create_for_task` and `get_or_create_for_workflow_run` in `browser_manager.py`.
> 
>   - **Behavior**:
>     - Fixes unclosed browser issue by reordering operations in `get_or_create_for_task` and `get_or_create_for_workflow_run` in `browser_manager.py`.
>     - Assigns `browser_state` to `self.pages` before calling `get_or_create_page()` to ensure proper cleanup in case of errors.
>   - **Misc**:
>     - No changes to logging or error handling logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 4f31c39a071f3618ccdf6b99d766d54c46339d4b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->