### PR TITLE
download with file extension

### DIFF
--- a/skyvern/constants.py
+++ b/skyvern/constants.py
@@ -9,6 +9,7 @@ REPO_ROOT_DIR = SKYVERN_DIR.parent
 INPUT_TEXT_TIMEOUT = 120000  # 2 minutes
 PAGE_CONTENT_TIMEOUT = 300  # 5 mins
 BROWSER_CLOSE_TIMEOUT = 180  # 3 minute
+BROWSER_DOWNLOAD_TIMEOUT = 600  # 10 minute
 
 # reserved fields for navigation payload
 SPECIAL_FIELD_VERIFICATION_CODE = "verification_code"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds automatic file extension handling for downloads in `browser_factory.py` using `set_download_file_listener()` and introduces `BROWSER_DOWNLOAD_TIMEOUT`.
> 
>   - **Behavior**:
>     - Adds `set_download_file_listener()` in `browser_factory.py` to automatically add file extensions to downloads if missing.
>     - Uses `download.suggested_filename` and `download.url` to determine file extension.
>     - Cancels download if it exceeds `BROWSER_DOWNLOAD_TIMEOUT`.
>   - **Constants**:
>     - Adds `BROWSER_DOWNLOAD_TIMEOUT` in `constants.py` set to 600 seconds.
>   - **Logging**:
>     - Logs actions and errors related to file extension handling in `set_download_file_listener()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5b63c07c0a700ba3794576c67a526a561b998d20. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->