### PR TITLE
update scraped_page references when it's refreshed

### DIFF
--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -242,13 +242,25 @@ class ScrapedPage(BaseModel):
         raise UnknownElementTreeFormat(fmt=fmt)
 
     async def refresh(self, with_screenshot: bool = True) -> Self:
-        return await scrape_website(
+        refreshed_page = await scrape_website(
             browser_state=self._browser_state,
             url=self.url,
             cleanup_element_tree=self._clean_up_func,
             scrape_exclude=self._scrape_exclude,
             with_screenshot=with_screenshot,
         )
+        self.elements = refreshed_page.elements
+        self.id_to_css_dict = refreshed_page.id_to_css_dict
+        self.id_to_element_dict = refreshed_page.id_to_element_dict
+        self.id_to_frame_dict = refreshed_page.id_to_frame_dict
+        self.id_to_element_hash = refreshed_page.id_to_element_hash
+        self.hash_to_element_ids = refreshed_page.hash_to_element_ids
+        self.element_tree = refreshed_page.element_tree
+        self.element_tree_trimmed = refreshed_page.element_tree_trimmed
+        self.screenshots = refreshed_page.screenshots or self.screenshots
+        self.html = refreshed_page.html
+        self.extracted_text = refreshed_page.extracted_text
+        return self
 
 
 async def scrape_website(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `refresh()` in `scraper.py` to update all relevant `ScrapedPage` attributes when refreshed, ensuring consistency with refreshed data.
> 
>   - **Behavior**:
>     - Update `refresh()` in `scraper.py` to update all relevant attributes of `ScrapedPage` when refreshed.
>     - Attributes updated include `elements`, `id_to_css_dict`, `id_to_element_dict`, `id_to_frame_dict`, `id_to_element_hash`, `hash_to_element_ids`, `element_tree`, `element_tree_trimmed`, `screenshots`, `html`, and `extracted_text`.
>     - Ensures `screenshots` are retained if not available in refreshed data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e2bc0baf756c7054ed107ba0f71b1fc5e4b781bc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->