### PR TITLE
Add proxy location to workflow run screen

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -12,6 +12,8 @@ export const ArtifactType = {
   HTMLScrape: "html_scrape",
 } as const;
 
+export type ArtifactType = (typeof ArtifactType)[keyof typeof ArtifactType];
+
 export const Status = {
   Created: "created",
   Running: "running",
@@ -25,7 +27,16 @@ export const Status = {
 
 export type Status = (typeof Status)[keyof typeof Status];
 
-export type ArtifactType = (typeof ArtifactType)[keyof typeof ArtifactType];
+export const ProxyLocation = {
+  Residential: "RESIDENTIAL",
+  ResidentialIE: "RESIDENTIAL_IE",
+  ResidentialES: "RESIDENTIAL_ES",
+  ResidentialIN: "RESIDENTIAL_IN",
+  ResidentialJP: "RESIDENTIAL_JP",
+  None: "NONE",
+} as const;
+
+export type ProxyLocation = (typeof ProxyLocation)[keyof typeof ProxyLocation];
 
 export type ArtifactApiResponse = {
   created_at: string;
@@ -90,7 +101,7 @@ export type CreateTaskRequest = {
   navigation_payload: Record<string, unknown> | string | null;
   extracted_information_schema: Record<string, unknown> | string | null;
   error_code_mapping: Record<string, string> | null;
-  proxy_location: string | null;
+  proxy_location: ProxyLocation | null;
   totp_verification_url: string | null;
   totp_identifier: string | null;
 };
@@ -184,7 +195,7 @@ export type WorkflowApiResponse = {
     parameters: Array<WorkflowParameter>;
     blocks: Array<WorkflowBlock>;
   };
-  proxy_location: string;
+  proxy_location: ProxyLocation | null;
   webhook_callback_url: string;
   created_at: string;
   modified_at: string;
@@ -248,7 +259,7 @@ export type WorkflowRunApiResponse = {
   workflow_run_id: string;
   workflow_id: string;
   status: Status;
-  proxy_location: string;
+  proxy_location: ProxyLocation | null;
   webhook_callback_url: string;
   created_at: string;
   modified_at: string;
@@ -258,7 +269,7 @@ export type WorkflowRunStatusApiResponse = {
   workflow_id: string;
   workflow_run_id: string;
   status: Status;
-  proxy_location: string;
+  proxy_location: ProxyLocation | null;
   webhook_callback_url: string | null;
   created_at: string;
   modified_at: string;


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add proxy location selection to `RunWorkflowForm` with new `ProxyLocation` type and update related API types.
> 
>   - **Types**:
>     - Add `ProxyLocation` type in `types.ts` with options for various residential proxies and `None`.
>     - Update `proxy_location` fields in `CreateTaskRequest`, `WorkflowApiResponse`, `WorkflowRunApiResponse`, and `WorkflowRunStatusApiResponse` to use `ProxyLocation` type.
>   - **Form**:
>     - Add `proxyLocation` field to `RunWorkflowForm` in `RunWorkflowForm.tsx` with a select input for choosing proxy locations.
>     - Default `proxyLocation` to `Residential` in form initial values.
>     - Update `getRunWorkflowRequestBody` to include `proxyLocation` in the request body.
>   - **Misc**:
>     - Refactor `onSubmit` and cURL generation to use `getRunWorkflowRequestBody`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9980bc519068ef3a8d4f5c046d65785cfea11b33. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->