### PR TITLE
Try to fix stale queries when tasks and workflows are created

### DIFF
--- a/skyvern-frontend/src/routes/tasks/detail/TaskActions.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/TaskActions.tsx
@@ -6,7 +6,11 @@ import { ZoomableImage } from "@/components/ZoomableImage";
 import { useCostCalculator } from "@/hooks/useCostCalculator";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
 import { envCredential } from "@/util/env";
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import {
+  keepPreviousData,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import {
@@ -41,6 +45,7 @@ function TaskActions() {
     number | "stream" | null
   >(null);
   const costCalculator = useCostCalculator();
+  const queryClient = useQueryClient();
 
   const { data: task, isLoading: taskIsLoading } = useQuery<TaskApiResponse>({
     queryKey: ["task", taskId],
@@ -95,6 +100,9 @@ function TaskActions() {
             message.status === "terminated"
           ) {
             socket?.close();
+            queryClient.invalidateQueries({
+              queryKey: ["tasks"],
+            });
             if (
               message.status === "failed" ||
               message.status === "terminated"
@@ -129,7 +137,7 @@ function TaskActions() {
         socket = null;
       }
     };
-  }, [credentialGetter, taskId, taskIsRunningOrQueued]);
+  }, [credentialGetter, taskId, taskIsRunningOrQueued, queryClient]);
 
   const { data: steps, isLoading: stepsIsLoading } = useQuery<
     Array<StepApiResponse>

--- a/skyvern-frontend/src/routes/tasks/running/QueuedTasks.tsx
+++ b/skyvern-frontend/src/routes/tasks/running/QueuedTasks.tsx
@@ -31,7 +31,7 @@ function QueuedTasks() {
         })
         .then((response) => response.data);
     },
-    refetchOnMount: true,
+    refetchOnMount: "always",
   });
 
   function handleNavigate(event: React.MouseEvent, id: string) {

--- a/skyvern-frontend/src/routes/tasks/running/RunningTasks.tsx
+++ b/skyvern-frontend/src/routes/tasks/running/RunningTasks.tsx
@@ -31,7 +31,7 @@ function RunningTasks() {
         })
         .then((response) => response.data);
     },
-    refetchOnMount: true,
+    refetchOnMount: "always",
   });
 
   if (runningTasks?.length === 0) {

--- a/skyvern-frontend/src/routes/workflows/WorkflowPage.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowPage.tsx
@@ -52,6 +52,7 @@ function WorkflowPage() {
         })
         .then((response) => response.data);
     },
+    refetchOnMount: "always",
   });
 
   const { data: workflow, isLoading: workflowIsLoading } =

--- a/skyvern-frontend/src/routes/workflows/Workflows.tsx
+++ b/skyvern-frontend/src/routes/workflows/Workflows.tsx
@@ -93,6 +93,7 @@ function Workflows() {
         })
         .then((response) => response.data);
     },
+    refetchOnMount: "always",
   });
 
   const createNewWorkflowMutation = useMutation({


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix stale queries by invalidating and refetching data for tasks and workflows upon status changes and component mounts.
> 
>   - **Behavior**:
>     - In `TaskActions.tsx` and `WorkflowRun.tsx`, added `queryClient.invalidateQueries` to refresh queries for tasks and workflows when their status changes to completed, failed, or terminated.
>     - Changed `refetchOnMount` to "always" in `QueuedTasks.tsx`, `RunningTasks.tsx`, `WorkflowPage.tsx`, and `Workflows.tsx` to ensure data is always refetched when components mount.
>   - **Misc**:
>     - Updated dependencies in `TaskActions.tsx` and `WorkflowRun.tsx` to include `queryClient` for useEffect hooks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 11bc2498e939023e4bc1b23a6a0fbab117dc6d43. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->