### PR TITLE
extend interactable coverage

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -484,6 +484,10 @@ function isInteractable(element) {
     return true;
   }
 
+  if (tagName === "span" && element.closest("div[id^='dropdown-container']")) {
+    return true;
+  }
+
   if (
     tagName === "div" ||
     tagName === "img" ||


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Extend `isInteractable` function to include `span` elements within `div[id^='dropdown-container']` as interactable.
> 
>   - **Behavior**:
>     - Extend `isInteractable` function in `domUtils.js` to return `true` for `span` elements within `div` elements with IDs starting with `dropdown-container`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5f0286f4000cd5edab0ad55a6c4cd7fcdd86249f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->