### PR TITLE
Warn the user when they are quitting the workflow page

### DIFF
--- a/skyvern-frontend/src/hooks/useShouldNotifyWhenClosingTab.ts
+++ b/skyvern-frontend/src/hooks/useShouldNotifyWhenClosingTab.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+
+function useShouldNotifyWhenClosingTab() {
+  useEffect(() => {
+    function f(event: BeforeUnloadEvent) {
+      // this function is here to have a stable reference only
+
+      // Recommended
+      event.preventDefault();
+
+      // Included for legacy support, e.g. Chrome/Edge < 119
+      // refer to https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event
+      event.returnValue = true;
+    }
+
+    window.addEventListener("beforeunload", f);
+
+    return () => {
+      window.removeEventListener("beforeunload", f);
+    };
+  }, []);
+}
+
+export { useShouldNotifyWhenClosingTab };

--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -67,6 +67,7 @@ import { Button } from "@/components/ui/button";
 import { ReloadIcon } from "@radix-ui/react-icons";
 import { isLoopNode, LoopNode } from "./nodes/LoopNode/types";
 import { isTaskNode } from "./nodes/TaskNode/types";
+import { useShouldNotifyWhenClosingTab } from "@/hooks/useShouldNotifyWhenClosingTab";
 
 function convertToParametersYAML(
   parameters: ParametersState,
@@ -190,6 +191,7 @@ function FlowRenderer({
   const [title, setTitle] = useState(initialTitle);
   const nodesInitialized = useNodesInitialized();
   const { hasChanges, setHasChanges } = useWorkflowHasChangesStore();
+  useShouldNotifyWhenClosingTab();
   const blocker = useBlocker(({ currentLocation, nextLocation }) => {
     return hasChanges && nextLocation.pathname !== currentLocation.pathname;
   });


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `useShouldNotifyWhenClosingTab` hook to warn users of unsaved changes when closing the workflow page, integrated into `FlowRenderer`.
> 
>   - **Behavior**:
>     - Adds `useShouldNotifyWhenClosingTab` hook to warn users when closing the tab with unsaved changes.
>     - Integrates `useShouldNotifyWhenClosingTab` in `FlowRenderer` to trigger warning on unsaved changes.
>   - **Hooks**:
>     - New `useShouldNotifyWhenClosingTab` hook in `useShouldNotifyWhenClosingTab.ts` using `beforeunload` event to prevent tab closing.
>   - **Components**:
>     - Uses `useShouldNotifyWhenClosingTab` in `FlowRenderer` to ensure user is warned about unsaved changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for dc2946f95fd025e8e6ef7d6a0d1f6b68ab4be569. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->