### PR TITLE
extend auto completion to support google address

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -477,6 +477,24 @@ function isInteractable(element) {
   }
 
   if (
+    tagName === "li" &&
+    element.className.toString().includes("ui-menu-item")
+  ) {
+    return true;
+  }
+
+  // google map address auto complete
+  // https://developers.google.com/maps/documentation/javascript/place-autocomplete#style-autocomplete
+  // demo: https://developers.google.com/maps/documentation/javascript/examples/places-autocomplete-addressform
+  if (
+    tagName === "div" &&
+    element.className.toString().includes("pac-item") &&
+    element.closest('div[class*="pac-container"]')
+  ) {
+    return true;
+  }
+
+  if (
     tagName === "div" &&
     element.hasAttribute("aria-disabled") &&
     element.getAttribute("aria-disabled").toLowerCase() === "false"
@@ -484,7 +502,7 @@ function isInteractable(element) {
     return true;
   }
 
-  if (tagName === "span" && element.closest("div[id^='dropdown-container']")) {
+  if (tagName === "span" && element.closest('div[id*="dropdown-container"]')) {
     return true;
   }
 

--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -143,6 +143,10 @@ class SkyvernElement:
         if autocomplete and autocomplete == "list":
             return True
 
+        class_name: str = await self.get_attr("class")
+        if "autocomplete-input" in class_name:
+            return True
+
         return False
 
     async def is_custom_option(self) -> bool:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Extend auto-completion to support Google address by updating `isInteractable()` in `domUtils.js` and `is_auto_completion_input()` in `dom.py`.
> 
>   - **Behavior**:
>     - Extend `isInteractable()` in `domUtils.js` to recognize Google Maps auto-complete elements (`div.pac-item` within `div.pac-container`) as interactable.
>     - Update `is_auto_completion_input()` in `dom.py` to return `True` for elements with class `autocomplete-input`.
>   - **Misc**:
>     - Modify `isInteractable()` in `domUtils.js` to use `div[id*="dropdown-container"]` instead of `div[id^="dropdown-container"]`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e6da81dd16d1c43a7c8df222d1bb3652105093e7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->