### PR TITLE
fix non class name bug

### DIFF
--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -143,8 +143,8 @@ class SkyvernElement:
         if autocomplete and autocomplete == "list":
             return True
 
-        class_name: str = await self.get_attr("class")
-        if "autocomplete-input" in class_name:
+        class_name: str | None = await self.get_attr("class")
+        if class_name and "autocomplete-input" in class_name:
             return True
 
         return False


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `is_auto_completion_input` in `SkyvernElement` to handle `None` for `class_name` in `dom.py`.
> 
>   - **Bug Fix**:
>     - Fix `is_auto_completion_input` in `SkyvernElement` in `dom.py` to handle `None` for `class_name` when checking for 'autocomplete-input'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 140c5912f595afce396a856fa27564b280be81fa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->