### PR TITLE
remove all the whitespace from the totp secret

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -1085,7 +1085,8 @@ async def get_actual_value_of_parameter_if_secret(task: Task, parameter: str) ->
     if secret_value == BitwardenConstants.TOTP:
         totp_secret_key = workflow_run_context.totp_secret_value_key(parameter)
         totp_secret = workflow_run_context.get_original_secret_value_or_none(totp_secret_key)
-        secret_value = pyotp.TOTP(totp_secret).now()
+        totp_secret_no_whitespace = "".join(totp_secret.split())
+        secret_value = pyotp.TOTP(totp_secret_no_whitespace).now()
     return secret_value if secret_value is not None else parameter
 
 


### PR DESCRIPTION
getting `Error: Non-base32 digit found` when there's a space in the totp secret
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove whitespace from TOTP secret in `get_actual_value_of_parameter_if_secret()` in `handler.py` before generating TOTP code.
> 
>   - **Behavior**:
>     - In `get_actual_value_of_parameter_if_secret()` in `handler.py`, removes all whitespace from `totp_secret` before generating TOTP code using `pyotp.TOTP`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for daa441587fb07bc2920c291f4661c10c5c930e96. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->