### PR TITLE
make task block title empty string by default; use task_block.label for the running task.title if task_block.title is empty

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -131,7 +131,7 @@ class ForgeAgent:
         task_url = validate_url(task_url)
         task = await app.DATABASE.create_task(
             url=task_url,
-            title=task_block.title,
+            title=task_block.title or task_block.label,
             webhook_callback_url=None,
             totp_verification_url=task_block.totp_verification_url,
             totp_identifier=task_block.totp_identifier,

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -170,7 +170,7 @@ class TaskBlock(Block):
     block_type: Literal[BlockType.TASK] = BlockType.TASK
 
     url: str | None = None
-    title: str = "Untitled Task"
+    title: str = ""
     navigation_goal: str | None = None
     data_extraction_goal: str | None = None
     data_schema: dict[str, Any] | list | None = None

--- a/skyvern/forge/sdk/workflow/models/yaml.py
+++ b/skyvern/forge/sdk/workflow/models/yaml.py
@@ -117,7 +117,7 @@ class TaskBlockYAML(BlockYAML):
     block_type: Literal[BlockType.TASK] = BlockType.TASK  # type: ignore
 
     url: str | None = None
-    title: str = "Untitled Task"
+    title: str = ""
     navigation_goal: str | None = None
     data_extraction_goal: str | None = None
     data_schema: dict[str, Any] | list | None = None


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Default task title changed to empty string, using label if title is empty in `TaskBlock` and `TaskBlockYAML`.
> 
>   - **Behavior**:
>     - In `agent.py`, `create_task_and_step_from_block()` now uses `task_block.label` if `task_block.title` is empty.
>   - **Models**:
>     - In `block.py`, `TaskBlock` default `title` changed from "Untitled Task" to an empty string.
>     - In `yaml.py`, `TaskBlockYAML` default `title` changed from "Untitled Task" to an empty string.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0f139d3ae1ccc0c026f08446f50f74acd4b53cf2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->