### PR TITLE
do not pass secrets as the parameter context in text prompt block

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -704,8 +704,8 @@ class TextPromptBlock(Block):
         for parameter in self.parameters:
             value = workflow_run_context.get_value(parameter.key)
             secret_value = workflow_run_context.get_original_secret_value_or_none(value)
-            if secret_value is not None:
-                parameter_values[parameter.key] = secret_value
+            if secret_value:
+                continue
             else:
                 parameter_values[parameter.key] = value
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> In `TextPromptBlock.execute()`, secret values are no longer added to `parameter_values`, enhancing security by preventing secrets from being passed to text prompts.
> 
>   - **Security**:
>     - In `TextPromptBlock.execute()`, skip adding secret values to `parameter_values` to prevent passing secrets to text prompts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 3165d4fa26a89ebbd10edf1e95a3f0c29824fce3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->