### PR TITLE
Avoid overflow in running workflow sidebar

### DIFF
--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -365,7 +365,7 @@ function WorkflowRun() {
           <div className="w-3/4 shrink-0">
             <AspectRatio ratio={16 / 9}>{getStream()}</AspectRatio>
           </div>
-          <div className="flex w-full flex-col gap-4 rounded-md bg-slate-elevation1 p-4">
+          <div className="flex w-full min-w-0 flex-col gap-4 rounded-md bg-slate-elevation1 p-4">
             <header className="text-lg">Current Task</header>
             {workflowRunIsLoading || !currentRunningTask ? (
               <div>Waiting for a task to start...</div>
@@ -377,7 +377,10 @@ function WorkflowRun() {
                 </div>
                 <div className="flex gap-2 rounded-sm bg-slate-elevation3 p-2">
                   <Label className="text-sm text-slate-400">URL</Label>
-                  <span className="text-sm">
+                  <span
+                    className="truncate text-sm"
+                    title={currentRunningTask.request.url}
+                  >
                     {currentRunningTask.request.url}
                   </span>
                 </div>
@@ -389,7 +392,10 @@ function WorkflowRun() {
                 </div>
                 <div className="flex gap-2 rounded-sm bg-slate-elevation3 p-2">
                   <Label className="text-sm text-slate-400">Created</Label>
-                  <span className="text-sm">
+                  <span
+                    className="truncate text-sm"
+                    title={basicLocalTimeFormat(currentRunningTask.created_at)}
+                  >
                     {currentRunningTask &&
                       timeFormatWithShortDate(currentRunningTask.created_at)}
                   </span>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Prevent text overflow in `WorkflowRun.tsx` sidebar by adding `min-w-0` and `truncate` attributes.
> 
>   - **UI Improvements**:
>     - Add `min-w-0` to the sidebar `div` in `WorkflowRun.tsx` to prevent overflow.
>     - Add `truncate` and `title` attributes to `span` elements displaying `currentRunningTask.request.url` and `currentRunningTask.created_at` to handle text overflow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ef118a56dfdba1a20eae8d95f4870d6f99e42a53. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->