### PR TITLE
Implement cancel workflow run endpoint

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -345,6 +345,15 @@ async def cancel_task(
     await app.agent.update_task(task_obj, status=TaskStatus.canceled)
 
 
+@base_router.post("/workflows/runs/{workflow_run_id}/cancel")
+@base_router.post("/workflows/runs/{workflow_run_id}/cancel/", include_in_schema=False)
+async def cancel_workflow_run(
+    workflow_run_id: str,
+    current_org: Organization = Depends(org_auth_service.get_current_org),
+) -> None:
+    await app.WORKFLOW_SERVICE.mark_workflow_run_as_canceled(workflow_run_id)
+
+
 @base_router.post(
     "/tasks/{task_id}/retry_webhook",
     tags=["agent"],

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -335,7 +335,6 @@ class TaskBlock(Block):
                     organization=organization,
                     task=task,
                     step=step,
-                    workflow_run=workflow_run,
                     task_block=self,
                 )
             except Exception as e:

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -188,6 +188,24 @@ class WorkflowService:
         for block_idx, block in enumerate(blocks):
             is_last_block = block_idx + 1 == blocks_cnt
             try:
+                refreshed_workflow_run = await app.DATABASE.get_workflow_run(
+                    workflow_run_id=workflow_run.workflow_run_id
+                )
+                if refreshed_workflow_run and refreshed_workflow_run.status == WorkflowRunStatus.canceled:
+                    LOG.info(
+                        "Workflow run is canceled, stopping execution inside workflow execution loop",
+                        workflow_run_id=workflow_run.workflow_run_id,
+                        block_idx=block_idx,
+                        block_type=block.block_type,
+                        block_label=block.label,
+                    )
+                    await self.clean_up_workflow(
+                        workflow=workflow,
+                        workflow_run=workflow_run,
+                        api_key=api_key,
+                        need_call_webhook=False,
+                    )
+                    return workflow_run
                 parameters = block.get_all_parameters(workflow_run_id)
                 await app.WORKFLOW_CONTEXT_MANAGER.register_block_parameters_for_workflow_run(
                     workflow_run_id, parameters, organization
@@ -197,6 +215,8 @@ class WorkflowService:
                     block_type=block.block_type,
                     workflow_run_id=workflow_run.workflow_run_id,
                     block_idx=block_idx,
+                    block_type_var=block.block_type,
+                    block_label=block.label,
                 )
                 block_result = await block.execute_safe(workflow_run_id=workflow_run_id)
                 if block_result.status == BlockStatus.canceled:
@@ -206,6 +226,8 @@ class WorkflowService:
                         workflow_run_id=workflow_run.workflow_run_id,
                         block_idx=block_idx,
                         block_result=block_result,
+                        block_type_var=block.block_type,
+                        block_label=block.label,
                     )
                     await self.mark_workflow_run_as_canceled(workflow_run_id=workflow_run.workflow_run_id)
                     # We're not sending a webhook here because the workflow run is manually marked as canceled.
@@ -223,6 +245,8 @@ class WorkflowService:
                         workflow_run_id=workflow_run.workflow_run_id,
                         block_idx=block_idx,
                         block_result=block_result,
+                        block_type_var=block.block_type,
+                        block_label=block.label,
                     )
                     if block.continue_on_failure and not is_last_block:
                         LOG.warning(
@@ -232,6 +256,8 @@ class WorkflowService:
                             block_idx=block_idx,
                             block_result=block_result,
                             continue_on_failure=block.continue_on_failure,
+                            block_type_var=block.block_type,
+                            block_label=block.label,
                         )
                     else:
                         await self.mark_workflow_run_as_failed(workflow_run_id=workflow_run.workflow_run_id)
@@ -248,6 +274,8 @@ class WorkflowService:
                         workflow_run_id=workflow_run.workflow_run_id,
                         block_idx=block_idx,
                         block_result=block_result,
+                        block_type_var=block.block_type,
+                        block_label=block.label,
                     )
                     if block.continue_on_failure and not is_last_block:
                         LOG.warning(
@@ -257,6 +285,8 @@ class WorkflowService:
                             block_idx=block_idx,
                             block_result=block_result,
                             continue_on_failure=block.continue_on_failure,
+                            block_type_var=block.block_type,
+                            block_label=block.label,
                         )
                     else:
                         await self.mark_workflow_run_as_terminated(workflow_run_id=workflow_run.workflow_run_id)
@@ -270,6 +300,9 @@ class WorkflowService:
                 LOG.exception(
                     f"Error while executing workflow run {workflow_run.workflow_run_id}",
                     workflow_run_id=workflow_run.workflow_run_id,
+                    block_idx=block_idx,
+                    block_type=block.block_type,
+                    block_label=block.label,
                 )
                 await self.mark_workflow_run_as_failed(workflow_run_id=workflow_run.workflow_run_id)
                 await self.clean_up_workflow(workflow=workflow, workflow_run=workflow_run, api_key=api_key)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `cancel_workflow_run` endpoint and update execution logic to handle canceled workflow runs in `agent.py` and `service.py`.
> 
>   - **Endpoints**:
>     - Add `cancel_workflow_run` endpoint in `agent_protocol.py` to cancel a workflow run.
>   - **Execution Logic**:
>     - In `agent.py`, `execute_step()` checks if `workflow_run` is canceled and stops execution if true.
>     - In `service.py`, `execute_workflow()` checks if `workflow_run` is canceled and stops execution if true.
>   - **Database**:
>     - Use `mark_workflow_run_as_canceled()` in `service.py` to update workflow run status to canceled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 5d0cc44835b696430d6304064cc49c6851e03603. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->