### PR TITLE
increase redis cache for svg and css from 1 week to 4 weeks

### DIFF
--- a/skyvern/forge/sdk/cache/base.py
+++ b/skyvern/forge/sdk/cache/base.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from datetime import timedelta
 from typing import Any
 
-CACHE_EXPIRE_TIME = timedelta(weeks=1)
+CACHE_EXPIRE_TIME = timedelta(weeks=4)
 MAX_CACHE_ITEM = 1000
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase `CACHE_EXPIRE_TIME` from 1 week to 4 weeks in `base.py` to extend cache duration for SVG and CSS files.
> 
>   - **Behavior**:
>     - Increase `CACHE_EXPIRE_TIME` from 1 week to 4 weeks in `base.py` to extend cache duration for SVG and CSS files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 678403172543d95aaff3b522179b9fe24f89d71c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->