### PR TITLE
Failed to convert css shape to string shape by LLM log should be warning

### DIFF
--- a/skyvern/forge/agent_functions.py
+++ b/skyvern/forge/agent_functions.py
@@ -250,11 +250,12 @@ async def _convert_css_shape_to_string(
                 )
                 return None
         except Exception:
-            LOG.exception(
+            LOG.warning(
                 "Failed to convert css shape to string shape by LLM",
                 task_id=task.task_id,
                 step_id=step.step_id,
                 element_id=element_id,
+                exc_info=True,
             )
             return None
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change logging level from `exception` to `warning` in `_convert_css_shape_to_string()` for CSS shape conversion failures.
> 
>   - **Logging**:
>     - Change logging level from `exception` to `warning` in `_convert_css_shape_to_string()` in `agent_functions.py` when CSS shape conversion fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d5cd16979685fd425520309e40c0abeec81df367. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->