### PR TITLE
fix zipcode triggers auto completion

### DIFF
--- a/skyvern/forge/prompts/skyvern/parse-input-or-select-context.j2
+++ b/skyvern/forge/prompts/skyvern/parse-input-or-select-context.j2
@@ -8,7 +8,7 @@ Reply in the following JSON format:
     "field": str, // Which field is this action intended to fill out?
     "is_required": bool, // True if this is a required field, otherwise false.
     "is_search_bar": bool, // True if the element to take the action is a search bar, otherwise false.
-    "is_location_input": bool, // True if the element is asking user to input where he lives, otherwise false. For example, it is asking for location, or address, or other similar information.
+    "is_location_input": bool, // True if the element is asking user to input where he lives, otherwise false. For example, it is asking for location, or address, or other similar information. Output False if it only requires ZIP code.
 }
 
 Existing reasoning context:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates `is_location_input` condition in `parse-input-or-select-context.j2` to output `False` if only ZIP code is required.
> 
>   - **Behavior**:
>     - Updates `is_location_input` condition in `parse-input-or-select-context.j2` to output `False` if only ZIP code is required.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d4e7ddad191f5b68e76ac4d9de975449f7d57356. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->