### PR TITLE
Also add local version of short date time format

### DIFF
--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -35,6 +35,7 @@ import { apiBaseUrl, envCredential } from "@/util/env";
 import {
   basicLocalTimeFormat,
   basicTimeFormat,
+  localTimeFormatWithShortDate,
   timeFormatWithShortDate,
 } from "@/util/timeFormat";
 import { cn } from "@/util/utils";
@@ -475,10 +476,14 @@ function WorkflowRun() {
                   <Label className="text-sm text-slate-400">Created</Label>
                   <span
                     className="truncate text-sm"
-                    title={basicLocalTimeFormat(currentRunningTask.created_at)}
+                    title={timeFormatWithShortDate(
+                      currentRunningTask.created_at,
+                    )}
                   >
                     {currentRunningTask &&
-                      timeFormatWithShortDate(currentRunningTask.created_at)}
+                      localTimeFormatWithShortDate(
+                        currentRunningTask.created_at,
+                      )}
                   </span>
                 </div>
                 <div className="mt-auto flex justify-end">

--- a/skyvern-frontend/src/util/timeFormat.ts
+++ b/skyvern-frontend/src/util/timeFormat.ts
@@ -42,7 +42,34 @@ function timeFormatWithShortDate(time: string): string {
   const dateString =
     date.getMonth() + 1 + "/" + date.getDate() + "/" + date.getFullYear();
   const timeString = date.toLocaleTimeString("en-US");
+  return `${dateString} at ${timeString} UTC`;
+}
+
+function localTimeFormatWithShortDate(time: string): string {
+  // Adjust the fractional seconds to milliseconds (3 digits)
+  time = time.replace(/\.(\d{3})\d*/, ".$1");
+
+  // Append 'Z' to indicate UTC time if not already present
+  if (!time.endsWith("Z")) {
+    time += "Z";
+  }
+
+  const date = new Date(time);
+  const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  const dateString =
+    date.getMonth() + 1 + "/" + date.getDate() + "/" + date.getFullYear();
+
+  const timeString = date.toLocaleTimeString("en-US", {
+    timeZone: localTimezone,
+  });
+
   return `${dateString} at ${timeString}`;
 }
 
-export { basicLocalTimeFormat, basicTimeFormat, timeFormatWithShortDate };
+export {
+  basicLocalTimeFormat,
+  basicTimeFormat,
+  timeFormatWithShortDate,
+  localTimeFormatWithShortDate,
+};


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `localTimeFormatWithShortDate` for local timezone formatting and update `WorkflowRun.tsx` to use it for task creation times.
> 
>   - **Behavior**:
>     - Adds `localTimeFormatWithShortDate` to `timeFormat.ts` for local timezone short date formatting.
>     - Updates `WorkflowRun.tsx` to use `localTimeFormatWithShortDate` for displaying `created_at` of `currentRunningTask`.
>   - **Functions**:
>     - `localTimeFormatWithShortDate` handles fractional seconds and appends 'Z' if missing, formats date and time in local timezone.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 75ab65e2d42c4603b3d4a442a249cb1f986aa8e2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->