### PR TITLE
Disable download block

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
@@ -2,7 +2,6 @@ import { useWorkflowPanelStore } from "@/store/WorkflowPanelStore";
 import {
   Cross2Icon,
   CursorTextIcon,
-  DownloadIcon,
   EnvelopeClosedIcon,
   FileIcon,
   ListBulletIcon,
@@ -56,12 +55,13 @@ const nodeLibraryItems: Array<{
     title: "File Parser Block",
     description: "Downloads and parses a file",
   },
-  {
-    nodeType: "download",
-    icon: <DownloadIcon className="h-6 w-6" />,
-    title: "Download Block",
-    description: "Downloads a file from S3",
-  },
+  // disabled
+  // {
+  //   nodeType: "download",
+  //   icon: <DownloadIcon className="h-6 w-6" />,
+  //   title: "Download Block",
+  //   description: "Downloads a file from S3",
+  // },
   {
     nodeType: "upload",
     icon: <UploadIcon className="h-6 w-6" />,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Disables the "Download Block" in `WorkflowNodeLibraryPanel.tsx` by commenting out its entry in `nodeLibraryItems`.
> 
>   - **Behavior**:
>     - Disables the "Download Block" in `WorkflowNodeLibraryPanel.tsx` by commenting out its entry in `nodeLibraryItems`.
>     - The "Download Block" was intended to download files from S3.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 121475905a508763e980fddc6d8a3808ea32da35. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->