### PR TITLE
Fix a bug where the first node wouldn't be added correctly

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -317,7 +317,7 @@ function FlowRenderer({
     newNodes.push(node);
     if (previous) {
       const newEdge = {
-        id: `edge-${previous}-${id}`,
+        id: nanoid(),
         type: "edgeWithAddButton",
         source: previous,
         target: id,
@@ -329,7 +329,7 @@ function FlowRenderer({
     }
     if (next) {
       const newEdge = {
-        id: `edge-${id}-${next}`,
+        id: nanoid(),
         type: connectingEdgeType,
         source: id,
         target: next,

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -376,7 +376,10 @@ function getElements(blocks: Array<WorkflowBlock>): {
   const nodes: Array<AppNode> = [];
   const edges: Array<Edge> = [];
 
-  data.forEach((d) => {
+  const startNodeId = nanoid();
+  nodes.push(startNode(startNodeId));
+
+  data.forEach((d, index) => {
     const node = convertToNode(
       {
         id: d.id,
@@ -387,6 +390,9 @@ function getElements(blocks: Array<WorkflowBlock>): {
     nodes.push(node);
     if (d.previous) {
       edges.push(edgeWithAddButton(d.previous, d.id));
+    }
+    if (index === 0) {
+      edges.push(edgeWithAddButton(startNodeId, d.id));
     }
   });
 
@@ -411,18 +417,15 @@ function getElements(blocks: Array<WorkflowBlock>): {
     }
   });
 
-  const startNodeId = nanoid();
   const adderNodeId = nanoid();
 
-  if (nodes.length === 0) {
-    nodes.push(startNode(startNodeId));
+  if (data.length === 0) {
     nodes.push(nodeAdderNode(adderNodeId));
     edges.push(defaultEdge(startNodeId, adderNodeId));
   } else {
     const firstNode = data.find(
       (d) => d.previous === null && d.parentId === null,
     );
-    nodes.push(startNode(startNodeId));
     edges.push(edgeWithAddButton(startNodeId, firstNode!.id));
     const lastNode = data.find((d) => d.next === null && d.parentId === null)!;
     edges.push(defaultEdge(lastNode.id, adderNodeId));


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes node addition bug in workflow editor by using `nanoid()` for unique edge IDs and ensuring the first node is correctly added and connected.
> 
>   - **Behavior**:
>     - Fixes bug in `FlowRenderer.tsx` and `workflowEditorUtils.ts` where the first node was not added correctly by using `nanoid()` for unique edge IDs.
>     - Ensures a start node is added and connected to the first node in `getElements()`.
>   - **Functions**:
>     - Updates `addNode()` in `FlowRenderer.tsx` to use `nanoid()` for edge IDs.
>     - Updates `getElements()` in `workflowEditorUtils.ts` to add a start node and connect it to the first node.
>   - **Misc**:
>     - Minor refactoring in `getElements()` to handle edge creation more robustly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 322aa178ce5f3a8858f47fb682152ebaca0fa5dc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->