### PR TITLE
Remove Proxy Location None from Proxy selector

### DIFF
--- a/skyvern-frontend/src/components/ProxySelector.tsx
+++ b/skyvern-frontend/src/components/ProxySelector.tsx
@@ -32,7 +32,6 @@ function ProxySelector({ value, onChange }: Props) {
         <SelectItem value={ProxyLocation.ResidentialJP}>
           Residential (Japan)
         </SelectItem>
-        <SelectItem value={ProxyLocation.None}>None</SelectItem>
       </SelectContent>
     </Select>
   );


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove 'None' option from proxy location selector in `ProxySelector.tsx`, disallowing users from selecting it.
> 
>   - **Behavior**:
>     - Removed `SelectItem` with value `ProxyLocation.None` from `ProxySelector` in `ProxySelector.tsx`.
>     - Users can no longer select 'None' as a proxy location.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ffbc5e7b0c5e444e607e444d2aa2fe8339761217. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->