### PR TITLE
Allow p tags in cursor pointer detection

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -672,7 +672,8 @@ function isInteractable(element) {
     tagName === "span" ||
     tagName === "a" ||
     tagName === "i" ||
-    tagName === "li"
+    tagName === "li" ||
+    tagName === "p"
   ) {
     const computedStyle = window.getComputedStyle(element);
     if (computedStyle.cursor === "pointer") {


### PR DESCRIPTION
Done with @wintonzheng 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `isInteractable` in `domUtils.js` to consider `<p>` tags interactable if cursor is 'pointer'.
> 
>   - **Behavior**:
>     - Update `isInteractable` function in `domUtils.js` to include `<p>` tags in cursor pointer detection.
>     - `<p>` tags are now considered interactable if their computed style cursor is 'pointer'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 8a7853611ce1b7cc13aea1eec869c8ca2e32a25e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->