### PR TITLE
shu/do not raise TargetClosedError in cleanup

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1414,7 +1414,13 @@ class ForgeAgent:
             return
 
         await self.async_operation_pool.remove_task(task.task_id)
-        await self.cleanup_browser_and_create_artifacts(close_browser_on_completion, last_step, task)
+        try:
+            await self.cleanup_browser_and_create_artifacts(close_browser_on_completion, last_step, task)
+        except TargetClosedError:
+            LOG.warning(
+                "Failed to close the browser. Browser might have been closed",
+                task_id=task.task_id,
+            )
 
         # Wait for all tasks to complete before generating the links for the artifacts
         await app.ARTIFACT_MANAGER.wait_for_upload_aiotasks_for_task(task.task_id)

--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1414,13 +1414,7 @@ class ForgeAgent:
             return
 
         await self.async_operation_pool.remove_task(task.task_id)
-        try:
-            await self.cleanup_browser_and_create_artifacts(close_browser_on_completion, last_step, task)
-        except TargetClosedError:
-            LOG.warning(
-                "Failed to close the browser. Browser might have been closed",
-                task_id=task.task_id,
-            )
+        await self.cleanup_browser_and_create_artifacts(close_browser_on_completion, last_step, task)
 
         # Wait for all tasks to complete before generating the links for the artifacts
         await app.ARTIFACT_MANAGER.wait_for_upload_aiotasks_for_task(task.task_id)
@@ -1548,6 +1542,11 @@ class ForgeAgent:
     async def cleanup_browser_and_create_artifacts(
         self, close_browser_on_completion: bool, last_step: Step, task: Task
     ) -> None:
+        """
+        Developer notes: we should not expect any exception to be raised here.
+        This function should handle exceptions gracefully.
+        If errors are raised and not caught inside this function, please catch and handle them.
+        """
         # We need to close the browser even if there is no webhook callback url or api key
         browser_state = await app.BROWSER_MANAGER.cleanup_for_task(task.task_id, close_browser_on_completion)
         if browser_state:

--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -514,20 +514,29 @@ class BrowserState:
             async with asyncio.timeout(BROWSER_CLOSE_TIMEOUT):
                 if self.browser_context and close_browser_on_completion:
                     LOG.info("Closing browser context and its pages")
-                    await self.browser_context.close()
+                    try:
+                        await self.browser_context.close()
+                    except Exception:
+                        LOG.warning("Failed to close browser context", exc_info=True)
                     LOG.info("Main browser context and all its pages are closed")
                     if self.browser_cleanup is not None:
-                        self.browser_cleanup()
-                        LOG.info("Main browser cleanup is excuted")
+                        try:
+                            self.browser_cleanup()
+                            LOG.info("Main browser cleanup is excuted")
+                        except Exception:
+                            LOG.warning("Failed to execute browser cleanup", exc_info=True)
         except asyncio.TimeoutError:
             LOG.error("Timeout to close browser context, going to stop playwright directly")
 
         try:
             async with asyncio.timeout(BROWSER_CLOSE_TIMEOUT):
                 if self.pw and close_browser_on_completion:
-                    LOG.info("Stopping playwright")
-                    await self.pw.stop()
-                    LOG.info("Playwright is stopped")
+                    try:
+                        LOG.info("Stopping playwright")
+                        await self.pw.stop()
+                        LOG.info("Playwright is stopped")
+                    except Exception:
+                        LOG.warning("Failed to stop playwright", exc_info=True)
         except asyncio.TimeoutError:
             LOG.error("Timeout to close playwright, might leave the broswer opening forever")
 

--- a/skyvern/webeye/browser_manager.py
+++ b/skyvern/webeye/browser_manager.py
@@ -202,6 +202,10 @@ class BrowserManager:
         LOG.info("BrowserManger is closed")
 
     async def cleanup_for_task(self, task_id: str, close_browser_on_completion: bool = True) -> BrowserState | None:
+        """
+        Developer notes: handle errors here. Do not raise error from this function.
+        If error occurs, log it and address the cleanup error.
+        """
         LOG.info("Cleaning up for task")
         browser_state_to_close = self.pages.pop(task_id, None)
         if browser_state_to_close:


### PR DESCRIPTION
- do not raise TargetClosedError in task cleanup when target has been closed
- better error handling: make sure browser clean up won't raise error that breaks other cleanup progress (like artifact upload)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve error handling in task cleanup by logging and handling exceptions without raising `TargetClosedError` in `agent.py`, `browser_factory.py`, and `browser_manager.py`.
> 
>   - **Error Handling**:
>     - In `agent.py`, `cleanup_browser_and_create_artifacts()` now includes a note to handle exceptions gracefully without raising them.
>     - In `browser_factory.py`, `close()` method now logs and handles exceptions during browser context and Playwright closure.
>     - In `browser_manager.py`, `cleanup_for_task()` and `cleanup_for_workflow_run()` now log errors instead of raising them during cleanup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e44f363ec22c17fb826f3fae6284c324d49c1205. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->