### PR TITLE
introduce db timeout

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     MAX_RETRIES_PER_STEP: int = 5
     DEBUG_MODE: bool = False
     DATABASE_STRING: str = "postgresql+psycopg://skyvern@localhost/skyvern"
+    DATABASE_STATEMENT_TIMEOUT_MS: int = 60000
     PROMPT_ACTION_HISTORY_WINDOW: int = 1
     TASK_RESPONSE_ACTION_SCREENSHOT_COUNT: int = 3
 

--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -74,10 +74,11 @@ from skyvern.webeye.actions.models import AgentStepOutput
 
 LOG = structlog.get_logger()
 
-DB_CONNECT_ARGS: dict[str, Any] = {
-    "options": f"-c statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT_MS}",
-}
-if "postgresql+asyncpg" in settings.DATABASE_STRING:
+DB_CONNECT_ARGS: dict[str, Any] = {}
+
+if "postgresql+psycopg" in settings.DATABASE_STRING:
+    DB_CONNECT_ARGS = {"options": f"-c statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT_MS}"}
+elif "postgresql+asyncpg" in settings.DATABASE_STRING:
     DB_CONNECT_ARGS = {"server_settings": {"statement_timeout": str(settings.DATABASE_STATEMENT_TIMEOUT_MS)}}
 
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduce database statement timeout configuration in `config.py` and apply it in `client.py` for database connections.
> 
>   - **Configuration**:
>     - Add `DATABASE_STATEMENT_TIMEOUT_MS` in `config.py` with default 60000 ms.
>   - **Database Client**:
>     - Update `DB_CONNECT_ARGS` in `client.py` to include `statement_timeout` using `DATABASE_STATEMENT_TIMEOUT_MS`.
>     - Modify `create_async_engine` in `AgentDB` to use `DB_CONNECT_ARGS`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 542d30ec8b0f57bee1d9b461e19e06232f38c409. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->