### PR TITLE
Show webhook URL in task parameters

### DIFF
--- a/skyvern-frontend/src/routes/tasks/detail/TaskParameters.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/TaskParameters.tsx
@@ -114,6 +114,15 @@ function TaskParameters() {
           maxHeight="500px"
         />
       </div>
+      <div className="flex gap-16">
+        <div className="w-72">
+          <h1 className="text-lg">Webhook Callback URL</h1>
+          <h2 className="text-base text-slate-400">
+            The URL of a webhook endpoint to send the extracted information
+          </h2>
+        </div>
+        <Input value={task.request.webhook_callback_url ?? ""} readOnly />
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a new section in `TaskParameters` to display `webhook_callback_url` using a read-only `Input` component.
> 
>   - **UI Enhancement**:
>     - Adds a new section in `TaskParameters` component to display `webhook_callback_url`.
>     - Uses `Input` component to show the URL in a read-only format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d3cca2076376e9842b328856e5f429c6a16d5ff8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->