### PR TITLE
infer action type from instruction

### DIFF
--- a/skyvern/forge/prompts/skyvern/infer-action-type.j2
+++ b/skyvern/forge/prompts/skyvern/infer-action-type.j2
@@ -1,0 +1,16 @@
+You are a browser agent performing actions on the web. You are instructed to take a single action. Help to identify which action type should be taken according to the action instruction.
+
+MAKE SURE YOU OUTPUT VALID JSON. No text before or after JSON, no trailing commas, no comments (//), no unnecessary quotes, etc.
+
+Reply in the following JSON format:
+{
+    "thought": str, // A string to describe how to infer the action type from the action instruction.
+    "confidence_float": float, // The confidence of the action. Pick a number between 0.0 and 1.0. 0.0 means no confidence, 1.0 means full confidence
+    "action_type": str, // It's a string enum: "CLICK", "INPUT_TEXT", "UPLOAD_FILE", "SELECT_OPTION". "CLICK" means user wants to click. "INPUT_TEXT" means user wants to input text. "UPLOAD_FILE" means user wants to upload a file. "SELECT_OPTION" means user wants to select an option.
+    "error": str, // It's a string enum to describe error. Null if you can identify the action as one of the defined action type. Use "UNKNOWN_ACTION" if none of the defined action type matched. Use "MULTIPLE_ACTIONS" if the instruction includes multiple actions.
+}
+
+Action instruction
+```
+{{ navigation_goal }}
+```

--- a/skyvern/forge/sdk/workflow/exceptions.py
+++ b/skyvern/forge/sdk/workflow/exceptions.py
@@ -107,3 +107,10 @@ class WorkflowParameterMissingRequiredValue(BaseWorkflowHTTPException):
             f"Missing required value for workflow parameter. Workflow parameter type: {workflow_parameter_type}. workflow_parameter_key: {workflow_parameter_key}. Required value: {required_value}",
             status_code=status.HTTP_400_BAD_REQUEST,
         )
+
+
+class FailedToParseActionInstruction(SkyvernException):
+    def __init__(self, reason: str | None, error_type: str | None):
+        super().__init__(
+            f"Failed to parse the action instruction as '{reason}({error_type})'",
+        )

--- a/skyvern/forge/sdk/workflow/models/yaml.py
+++ b/skyvern/forge/sdk/workflow/models/yaml.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel, Field
 from skyvern.forge.sdk.schemas.tasks import ProxyLocation
 from skyvern.forge.sdk.workflow.models.block import BlockType, FileType
 from skyvern.forge.sdk.workflow.models.parameter import ParameterType, WorkflowParameterType
-from skyvern.webeye.actions.actions import ActionType
 
 
 class ParameterYAML(BaseModel, abc.ABC):
@@ -219,7 +218,6 @@ class ValidationBlockYAML(BlockYAML):
 
 
 class ActionBlockYAML(BlockYAML):
-    action_type: ActionType
     block_type: Literal[BlockType.ACTION] = BlockType.ACTION  # type: ignore
 
     url: str | None = None


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add action type inference from instructions using a new prompt template and update workflow service to handle parsing errors.
> 
>   - **Behavior**:
>     - Introduces `infer-action-type.j2` template to infer action types from instructions, outputting JSON with `thought`, `confidence_float`, `action_type`, and `error`.
>     - Updates `block_yaml_to_block()` in `service.py` to use the new template for determining action types, raising `FailedToParseActionInstruction` on errors.
>   - **Exceptions**:
>     - Adds `FailedToParseActionInstruction` in `exceptions.py` for handling parsing failures with `reason` and `error_type`.
>   - **Models**:
>     - Removes `action_type` attribute from `ActionBlockYAML` in `yaml.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2e1d51dd08ae6265a0d7d160b394973b822ab165. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->