### PR TITLE
move action type validate in workflow runtime

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -45,6 +45,7 @@ from skyvern.forge.sdk.schemas.tasks import Task, TaskOutput, TaskStatus
 from skyvern.forge.sdk.settings_manager import SettingsManager
 from skyvern.forge.sdk.workflow.context_manager import WorkflowRunContext
 from skyvern.forge.sdk.workflow.exceptions import (
+    FailedToParseActionInstruction,
     InvalidEmailClientConfiguration,
     InvalidFileType,
     NoValidEmailRecipient,
@@ -56,6 +57,7 @@ from skyvern.forge.sdk.workflow.models.parameter import (
     OutputParameter,
     WorkflowParameter,
 )
+from skyvern.webeye.actions.actions import ActionType
 from skyvern.webeye.browser_factory import BrowserState
 
 LOG = structlog.get_logger()
@@ -1299,6 +1301,38 @@ class ActionBlock(BaseTaskBlock):
     block_type: Literal[BlockType.ACTION] = BlockType.ACTION
 
     async def execute(self, workflow_run_id: str, **kwargs: dict) -> BlockResult:
+        try:
+            prompt = prompt_engine.load_prompt("infer-action-type", navigation_goal=self.navigation_goal)
+            # TODO: no step here, so LLM call won't be saved as an artifact
+            json_response = await app.LLM_API_HANDLER(prompt=prompt)
+            if json_response.get("error"):
+                raise FailedToParseActionInstruction(
+                    reason=json_response.get("thought"), error_type=json_response.get("error")
+                )
+
+            action_type: str = json_response.get("action_type") or ""
+            action_type = ActionType[action_type.upper()]
+
+            prompt_template = ""
+            if action_type == ActionType.CLICK:
+                prompt_template = TaskPromptTemplate.SingleClickAction
+            elif action_type == ActionType.INPUT_TEXT:
+                prompt_template = TaskPromptTemplate.SingleInputAction
+            elif action_type == ActionType.UPLOAD_FILE:
+                prompt_template = TaskPromptTemplate.SingleUploadAction
+            elif action_type == ActionType.SELECT_OPTION:
+                prompt_template = TaskPromptTemplate.SingleSelectAction
+
+            if not prompt_template:
+                raise Exception(
+                    f"Not supported action for action block. Currently we only support [click, input_text, upload_file, select_option], but got [{action_type}]"
+                )
+        except Exception as e:
+            return self.build_block_result(
+                success=False, failure_reason=str(e), output_parameter_value=None, status=BlockStatus.failed
+            )
+
+        self.prompt_template = prompt_template
         return await super().execute(workflow_run_id=workflow_run_id, kwargs=kwargs)
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Move action type validation from `service.py` to `ActionBlock` in `block.py`, centralizing logic and improving modularity.
> 
>   - **Behavior**:
>     - Move action type validation logic from `block_yaml_to_block()` in `service.py` to `execute()` in `ActionBlock` in `block.py`.
>     - `ActionBlock` now determines `prompt_template` based on `ActionType` and handles unsupported actions by raising an exception.
>     - If `LLM_API_HANDLER` returns an error, `ActionBlock` raises `FailedToParseActionInstruction`.
>   - **Imports**:
>     - Add `FailedToParseActionInstruction` and `ActionType` imports to `block.py`.
>     - Remove `FailedToParseActionInstruction` and `ActionType` imports from `service.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a883a2a2461272344af58c942a172c183614f147. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->