### PR TITLE
Show workflow outputs in workflow run screen

### DIFF
--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -611,6 +611,20 @@ function WorkflowRun() {
           </Pagination>
         </div>
       </div>
+      {workflowRunIsFinalized && (
+        <div className="space-y-4">
+          <header>
+            <h2 className="text-lg font-semibold">Block Outputs</h2>
+          </header>
+          <CodeEditor
+            language="json"
+            value={JSON.stringify(workflowRun.outputs, null, 2)}
+            readOnly
+            minHeight="96px"
+            maxHeight="500px"
+          />
+        </div>
+      )}
       {Object.entries(parameters).length > 0 && (
         <div className="space-y-4">
           <header>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add UI section in `WorkflowRun.tsx` to display workflow outputs in JSON format when run is finalized.
> 
>   - **UI Enhancement**:
>     - In `WorkflowRun.tsx`, added a section to display "Block Outputs" using `CodeEditor` when `workflowRunIsFinalized` is true.
>     - Outputs are shown in JSON format, read-only, with a min height of 96px and max height of 500px.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a0936bdd74206156573ad3278b53286d53a509c8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->