### PR TITLE
Add scrollable for nodes panel

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
@@ -13,6 +13,7 @@ import {
 import { WorkflowBlockNode } from "../nodes";
 import { AddNodeProps } from "../FlowRenderer";
 import { ClickIcon } from "@/components/icons/ClickIcon";
+import { ScrollArea, ScrollAreaViewport } from "@/components/ui/scroll-area";
 
 const nodeLibraryItems: Array<{
   nodeType: NonNullable<WorkflowBlockNode["type"]>;
@@ -118,46 +119,53 @@ function WorkflowNodeLibraryPanel({ onNodeClick, first }: Props) {
               : "Click on the node type you want to add"}
           </span>
         </header>
-        <div className="space-y-2">
-          {nodeLibraryItems.map((item) => {
-            if (workflowPanelData?.disableLoop && item.nodeType === "loop") {
-              return null;
-            }
-            return (
-              <div
-                key={item.nodeType}
-                className="flex cursor-pointer items-center justify-between rounded-sm bg-slate-elevation4 p-4 hover:bg-slate-elevation5"
-                onClick={() => {
-                  onNodeClick({
-                    nodeType: item.nodeType,
-                    next: workflowPanelData?.next ?? null,
-                    parent: workflowPanelData?.parent,
-                    previous: workflowPanelData?.previous ?? null,
-                    connectingEdgeType:
-                      workflowPanelData?.connectingEdgeType ??
-                      "edgeWithAddButton",
-                  });
-                  closeWorkflowPanel();
-                }}
-              >
-                <div className="flex gap-2">
-                  <div className="flex h-[2.75rem] w-[2.75rem] items-center justify-center rounded border border-slate-600">
-                    {item.icon}
+        <ScrollArea>
+          <ScrollAreaViewport className="max-h-[28rem]">
+            <div className="space-y-2">
+              {nodeLibraryItems.map((item) => {
+                if (
+                  workflowPanelData?.disableLoop &&
+                  item.nodeType === "loop"
+                ) {
+                  return null;
+                }
+                return (
+                  <div
+                    key={item.nodeType}
+                    className="flex cursor-pointer items-center justify-between rounded-sm bg-slate-elevation4 p-4 hover:bg-slate-elevation5"
+                    onClick={() => {
+                      onNodeClick({
+                        nodeType: item.nodeType,
+                        next: workflowPanelData?.next ?? null,
+                        parent: workflowPanelData?.parent,
+                        previous: workflowPanelData?.previous ?? null,
+                        connectingEdgeType:
+                          workflowPanelData?.connectingEdgeType ??
+                          "edgeWithAddButton",
+                      });
+                      closeWorkflowPanel();
+                    }}
+                  >
+                    <div className="flex gap-2">
+                      <div className="flex h-[2.75rem] w-[2.75rem] items-center justify-center rounded border border-slate-600">
+                        {item.icon}
+                      </div>
+                      <div className="flex flex-col gap-1">
+                        <span className="max-w-64 truncate text-base">
+                          {item.title}
+                        </span>
+                        <span className="text-xs text-slate-400">
+                          {item.description}
+                        </span>
+                      </div>
+                    </div>
+                    <PlusIcon className="size-6" />
                   </div>
-                  <div className="flex flex-col gap-1">
-                    <span className="max-w-64 truncate text-base">
-                      {item.title}
-                    </span>
-                    <span className="text-xs text-slate-400">
-                      {item.description}
-                    </span>
-                  </div>
-                </div>
-                <PlusIcon className="size-6" />
-              </div>
-            );
-          })}
-        </div>
+                );
+              })}
+            </div>
+          </ScrollAreaViewport>
+        </ScrollArea>
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds scrollable functionality to `WorkflowNodeLibraryPanel.tsx` using `ScrollArea` and `ScrollAreaViewport` for improved UI.
> 
>   - **UI Enhancement**:
>     - Adds `ScrollArea` and `ScrollAreaViewport` to `WorkflowNodeLibraryPanel.tsx` to make the node library panel scrollable.
>     - Sets maximum height of `ScrollAreaViewport` to `28rem` to limit the visible area and enable scrolling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ae52c3e8a31a91b60b12608e73bfafd3af66eee1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->