### PR TITLE
cleanup_element_tree_factory compatibility without task/step

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -624,7 +624,6 @@ class ForgeAgent:
                 task,
                 step,
                 browser_state,
-                organization,
             )
             detailed_agent_step_output.scraped_page = scraped_page
             detailed_agent_step_output.extract_action_prompt = extract_action_prompt
@@ -1098,7 +1097,6 @@ class ForgeAgent:
         step: Step,
         browser_state: BrowserState,
         scrape_type: ScrapeType,
-        organization: Organization | None = None,
     ) -> ScrapedPage:
         if scrape_type == ScrapeType.NORMAL:
             pass
@@ -1121,7 +1119,7 @@ class ForgeAgent:
         return await scrape_website(
             browser_state,
             task.url,
-            app.AGENT_FUNCTION.cleanup_element_tree_factory(task=task, step=step, organization=organization),
+            app.AGENT_FUNCTION.cleanup_element_tree_factory(task=task, step=step),
             scrape_exclude=app.scrape_exclude,
         )
 
@@ -1130,7 +1128,6 @@ class ForgeAgent:
         task: Task,
         step: Step,
         browser_state: BrowserState,
-        organization: Organization | None = None,
     ) -> tuple[ScrapedPage, str]:
         # start the async tasks while running scrape_website
         self.async_operation_pool.run_operation(task.task_id, AgentPhase.scrape)
@@ -1148,7 +1145,6 @@ class ForgeAgent:
                     step=step,
                     browser_state=browser_state,
                     scrape_type=scrape_type,
-                    organization=organization,
                 )
                 break
             except FailedToTakeScreenshot as e:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `run_observer` function, makes `task` and `step` optional in agent functions, and introduces new prompt templates.
> 
>   - **New Functionality**:
>     - Adds `run_observer()` in `scripts/run_observer.py`, an async function to handle user prompts and create workflows.
>     - Uses `generate_navigation_url.j2` and `observer.j2` templates for prompt generation.
>   - **Agent Functions**:
>     - Modifies `_convert_svg_to_string()` and `_convert_css_shape_to_string()` in `agent_functions.py` to make `task` and `step` parameters optional.
>     - Updates `cleanup_element_tree_factory()` to use modified conversion functions.
>   - **Prompts**:
>     - Adds `generate_navigation_url.j2` for URL generation based on user goals.
>     - Adds `observer.j2` for planning tasks based on DOM elements and user goals.
>   - **Misc**:
>     - Removes `organization` parameter from `_scrape_with_type()` and `_build_and_record_step_prompt()` in `agent.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for face022cd3d9f8d33daa4f72ecbc1ff8707526ea. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->