### PR TITLE
enforce navigation_goal for Navigation Task

### DIFF
--- a/skyvern/forge/sdk/workflow/models/yaml.py
+++ b/skyvern/forge/sdk/workflow/models/yaml.py
@@ -236,9 +236,9 @@ class ActionBlockYAML(BlockYAML):
 class NavigationBlockYAML(BlockYAML):
     block_type: Literal[BlockType.NAVIGATION] = BlockType.NAVIGATION  # type: ignore
 
+    navigation_goal: str
     url: str | None = None
     title: str = ""
-    navigation_goal: str | None = None
     error_code_mapping: dict[str, str] | None = None
     max_retries: int = 0
     max_steps_per_run: int | None = None


### PR DESCRIPTION
- faile workflow run when the task_type generated is not supported
- Observer: navigation block support

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add navigation task support and fail workflow on unsupported task types in `run_observer()` while refactoring task generation logic.
> 
>   - **Behavior**:
>     - Fail workflow run if unsupported `task_type` is generated in `run_observer()` in `scripts/run_observer.py`.
>     - Add support for `navigate` task type in `run_observer()`.
>   - **Refactoring**:
>     - Extract extraction task generation logic to `_generate_extraction_task()` in `scripts/run_observer.py`.
>     - Extract navigation task generation logic to `_generate_navigation_task()` in `scripts/run_observer.py`.
>   - **Prompts**:
>     - Rename task types in `cloud/prompts/cloud/observer.j2` from `navigation` to `navigate` and `extraction` to `extract`.
>   - **Models**:
>     - Reorder attributes in `NavigationBlockYAML` in `yaml.py` to place `navigation_goal` before `url`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 3ad7b6f8029b618f976f373e5aa154d790651487. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->