### PR TITLE
Fix tooltip weird behavior in editable titles

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/components/EditableNodeTitle.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/components/EditableNodeTitle.tsx
@@ -25,11 +25,11 @@ function EditableNodeTitle({
 }: Props) {
   const [editing, setEditing] = useState(false);
 
-  return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          {!editing ? (
+  if (!editing) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
             <h1
               className={cn("cursor-text", titleClassName)}
               onClick={() => {
@@ -38,41 +38,43 @@ function EditableNodeTitle({
             >
               {value}
             </h1>
-          ) : (
-            <HorizontallyResizingInput
-              disabled={!editable}
-              size={1}
-              autoFocus
-              className={cn("nopan w-min border-0 p-0", inputClassName)}
-              onBlur={(event) => {
-                if (!editable) {
-                  event.currentTarget.value = value;
-                  return;
-                }
-                if (event.currentTarget.value !== value) {
-                  onChange(event.target.value);
-                }
-                setEditing(false);
-              }}
-              onKeyDown={(event) => {
-                if (!editable) {
-                  return;
-                }
-                if (event.key === "Enter") {
-                  event.currentTarget.blur();
-                }
-                if (event.key === "Escape") {
-                  event.currentTarget.value = value;
-                  event.currentTarget.blur();
-                }
-              }}
-              defaultValue={value}
-            />
-          )}
-        </TooltipTrigger>
-        <TooltipContent>Click to edit</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+          </TooltipTrigger>
+          <TooltipContent>Click to edit</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  return (
+    <HorizontallyResizingInput
+      disabled={!editable}
+      size={1}
+      autoFocus
+      className={cn("nopan w-min border-0 p-0", inputClassName)}
+      onBlur={(event) => {
+        if (!editable) {
+          event.currentTarget.value = value;
+          return;
+        }
+        if (event.currentTarget.value !== value) {
+          onChange(event.target.value);
+        }
+        setEditing(false);
+      }}
+      onKeyDown={(event) => {
+        if (!editable) {
+          return;
+        }
+        if (event.key === "Enter") {
+          event.currentTarget.blur();
+        }
+        if (event.key === "Escape") {
+          event.currentTarget.value = value;
+          event.currentTarget.blur();
+        }
+      }}
+      defaultValue={value}
+    />
   );
 }
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `EditableNodeTitle` to fix tooltip behavior by separating editing and non-editing rendering logic.
> 
>   - **Behavior**:
>     - Refactor `EditableNodeTitle` in `EditableNodeTitle.tsx` to separate rendering logic for editing and non-editing states.
>     - Tooltip is only rendered when `editing` is `false`, fixing weird behavior during title editing.
>   - **Components**:
>     - Uses `TooltipProvider`, `Tooltip`, `TooltipTrigger`, and `TooltipContent` for non-editing state.
>     - Uses `HorizontallyResizingInput` for editing state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 7101faad85d7d3edfd580ab52f63ea6d2c9bc91d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->