### PR TITLE
Fix a problem with duplicate edge created

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -543,10 +543,6 @@ function getElements(blocks: Array<WorkflowBlock>): {
     nodes.push(nodeAdderNode(adderNodeId));
     edges.push(defaultEdge(startNodeId, adderNodeId));
   } else {
-    const firstNode = data.find(
-      (d) => d.previous === null && d.parentId === null,
-    );
-    edges.push(edgeWithAddButton(startNodeId, firstNode!.id));
     const lastNode = data.find((d) => d.next === null && d.parentId === null)!;
     edges.push(defaultEdge(lastNode.id, adderNodeId));
     nodes.push(nodeAdderNode(adderNodeId));


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove duplicate edge creation in `getElements()` in `workflowEditorUtils.ts` to ensure only one edge is created between the start node and the first node.
> 
>   - **Behavior**:
>     - Remove duplicate edge creation in `getElements()` in `workflowEditorUtils.ts` by deleting the line that adds an edge from `startNodeId` to `firstNode.id`.
>     - Ensures only one edge is created between the start node and the first node in the workflow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 3c7cd65bed8ac377b592cd8f09f631681d074c2e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->