### PR TITLE
Add workflows settings in start node

### DIFF
--- a/skyvern-frontend/src/components/ProxySelector.tsx
+++ b/skyvern-frontend/src/components/ProxySelector.tsx
@@ -10,12 +10,13 @@ import {
 type Props = {
   value: ProxyLocation | null;
   onChange: (value: ProxyLocation) => void;
+  className?: string;
 };
 
-function ProxySelector({ value, onChange }: Props) {
+function ProxySelector({ value, onChange, className }: Props) {
   return (
     <Select value={value ?? ""} onValueChange={onChange}>
-      <SelectTrigger className="w-48">
+      <SelectTrigger className={className}>
         <SelectValue placeholder="Proxy Location" />
       </SelectTrigger>
       <SelectContent>

--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -514,6 +514,7 @@ function CreateNewTaskForm({ initialValues }: Props) {
                               <ProxySelector
                                 value={field.value}
                                 onChange={field.onChange}
+                                className="w-48"
                               />
                             </FormControl>
                             <FormMessage />

--- a/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
@@ -686,6 +686,7 @@ function SavedTaskForm({ initialValues }: Props) {
                               <ProxySelector
                                 value={field.value}
                                 onChange={field.onChange}
+                                className="w-48"
                               />
                             </FormControl>
                             <FormMessage />

--- a/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
+++ b/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
@@ -1,4 +1,7 @@
 import { getClient } from "@/api/AxiosClient";
+import { ProxyLocation } from "@/api/types";
+import { ProxySelector } from "@/components/ProxySelector";
+import { Button } from "@/components/ui/button";
 import {
   Form,
   FormControl,
@@ -7,28 +10,29 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { useCredentialGetter } from "@/hooks/useCredentialGetter";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useForm } from "react-hook-form";
-import { Link, useParams } from "react-router-dom";
-import { WorkflowParameterInput } from "./WorkflowParameterInput";
-import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { toast } from "@/components/ui/use-toast";
+import { useApiCredential } from "@/hooks/useApiCredential";
+import { useCredentialGetter } from "@/hooks/useCredentialGetter";
+import { copyText } from "@/util/copyText";
+import { apiBaseUrl } from "@/util/env";
 import { CopyIcon, PlayIcon, ReloadIcon } from "@radix-ui/react-icons";
 import { ToastAction } from "@radix-ui/react-toast";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import fetchToCurl from "fetch-to-curl";
-import { apiBaseUrl } from "@/util/env";
-import { useApiCredential } from "@/hooks/useApiCredential";
-import { copyText } from "@/util/copyText";
-import { WorkflowParameter } from "./types/workflowTypes";
-import { Input } from "@/components/ui/input";
+import { useForm } from "react-hook-form";
+import { Link, useParams } from "react-router-dom";
 import { z } from "zod";
-import { ProxyLocation } from "@/api/types";
-import { ProxySelector } from "@/components/ProxySelector";
+import { WorkflowParameter } from "./types/workflowTypes";
+import { WorkflowParameterInput } from "./WorkflowParameterInput";
 
 type Props = {
   workflowParameters: Array<WorkflowParameter>;
   initialValues: Record<string, unknown>;
+  initialSettings: {
+    proxyLocation: ProxyLocation;
+    webhookCallbackUrl: string;
+  };
 };
 
 function parseValuesForWorkflowRun(
@@ -92,19 +96,23 @@ function getRunWorkflowRequestBody(
 }
 
 type RunWorkflowFormType = Record<string, unknown> & {
-  webhookCallbackUrl: string | null;
-  proxyLocation: ProxyLocation | null;
+  webhookCallbackUrl: string;
+  proxyLocation: ProxyLocation;
 };
 
-function RunWorkflowForm({ workflowParameters, initialValues }: Props) {
+function RunWorkflowForm({
+  workflowParameters,
+  initialValues,
+  initialSettings,
+}: Props) {
   const { workflowPermanentId } = useParams();
   const credentialGetter = useCredentialGetter();
   const queryClient = useQueryClient();
   const form = useForm<RunWorkflowFormType>({
     defaultValues: {
       ...initialValues,
-      webhookCallbackUrl: null,
-      proxyLocation: ProxyLocation.Residential,
+      webhookCallbackUrl: initialSettings.webhookCallbackUrl,
+      proxyLocation: initialSettings.proxyLocation,
     },
   });
   const apiCredential = useApiCredential();
@@ -313,6 +321,7 @@ function RunWorkflowForm({ workflowParameters, initialValues }: Props) {
                         <ProxySelector
                           value={field.value}
                           onChange={field.onChange}
+                          className="w-48"
                         />
                       </FormControl>
                       <FormMessage />

--- a/skyvern-frontend/src/routes/workflows/WorkflowRunParameters.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRunParameters.tsx
@@ -5,6 +5,7 @@ import { useLocation, useParams } from "react-router-dom";
 import { RunWorkflowForm } from "./RunWorkflowForm";
 import { WorkflowApiResponse } from "./types/workflowTypes";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ProxyLocation } from "@/api/types";
 
 function WorkflowRunParameters() {
   const credentialGetter = useCredentialGetter();
@@ -93,6 +94,10 @@ function WorkflowRunParameters() {
       <RunWorkflowForm
         initialValues={initialValues}
         workflowParameters={workflowParameters}
+        initialSettings={{
+          proxyLocation: workflow.proxy_location ?? ProxyLocation.Residential,
+          webhookCallbackUrl: workflow.webhook_callback_url ?? "",
+        }}
       />
     </div>
   );

--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowEditor.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowEditor.tsx
@@ -7,6 +7,7 @@ import { useWorkflowQuery } from "../hooks/useWorkflowQuery";
 import { FlowRenderer } from "./FlowRenderer";
 import { getElements } from "./workflowEditorUtils";
 import { LogoMinimized } from "@/components/LogoMinimized";
+import { WorkflowSettings } from "../types/workflowTypes";
 
 function WorkflowEditor() {
   const { workflowPermanentId } = useParams();
@@ -39,7 +40,13 @@ function WorkflowEditor() {
     return null;
   }
 
-  const elements = getElements(workflow.workflow_definition.blocks);
+  const settings: WorkflowSettings = {
+    persistBrowserSession: workflow.persist_browser_session,
+    proxyLocation: workflow.proxy_location,
+    webhookCallbackUrl: workflow.webhook_callback_url,
+  };
+
+  const elements = getElements(workflow.workflow_definition.blocks, settings);
 
   return (
     <div className="h-screen w-full">

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
@@ -1,6 +1,109 @@
-import { Handle, Position } from "@xyflow/react";
+import { Handle, NodeProps, Position, useReactFlow } from "@xyflow/react";
+import type { StartNode } from "./types";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { useState } from "react";
+import { ProxyLocation } from "@/api/types";
+import { Label } from "@/components/ui/label";
+import { HelpTooltip } from "@/components/HelpTooltip";
+import { Input } from "@/components/ui/input";
+import { ProxySelector } from "@/components/ProxySelector";
+import { Switch } from "@/components/ui/switch";
+import { Separator } from "@/components/ui/separator";
 
-function StartNode() {
+function StartNode({ id, data }: NodeProps<StartNode>) {
+  const { updateNodeData } = useReactFlow();
+  const [inputs, setInputs] = useState({
+    webhookCallbackUrl: data.withWorkflowSettings
+      ? data.webhookCallbackUrl
+      : "",
+    proxyLocation: data.withWorkflowSettings
+      ? data.proxyLocation
+      : ProxyLocation.Residential,
+    persistBrowserSession: data.withWorkflowSettings
+      ? data.persistBrowserSession
+      : false,
+  });
+
+  function handleChange(key: string, value: unknown) {
+    setInputs({ ...inputs, [key]: value });
+    updateNodeData(id, { [key]: value });
+  }
+
+  if (data.withWorkflowSettings) {
+    return (
+      <div>
+        <Handle
+          type="source"
+          position={Position.Bottom}
+          id="a"
+          className="opacity-0"
+        />
+        <div className="w-[30rem] rounded-lg bg-slate-elevation3 px-6 py-4 text-center">
+          <div className="space-y-4">
+            <header>Start</header>
+            <Separator />
+            <Accordion type="single" collapsible>
+              <AccordionItem value="settings" className="border-b-0">
+                <AccordionTrigger className="py-2">
+                  Workflow Settings
+                </AccordionTrigger>
+                <AccordionContent className="pl-6 pr-1 pt-1">
+                  <div className="space-y-4">
+                    <div className="space-y-2">
+                      <div className="flex gap-2">
+                        <Label>Webhook Callback URL</Label>
+                        <HelpTooltip content="The URL of a webhook endpoint to send the workflow results" />
+                      </div>
+                      <Input
+                        value={inputs.webhookCallbackUrl}
+                        placeholder="https://"
+                        onChange={(event) => {
+                          handleChange(
+                            "webhookCallbackUrl",
+                            event.target.value,
+                          );
+                        }}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <div className="flex gap-2">
+                        <Label>Proxy Location</Label>
+                        <HelpTooltip content="Route Skyvern through one of our available proxies." />
+                      </div>
+                      <ProxySelector
+                        value={inputs.proxyLocation}
+                        onChange={(value) => {
+                          handleChange("proxyLocation", value);
+                        }}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-2">
+                        <Label>Persist Browser Session</Label>
+                        <HelpTooltip content="Persist session information across workflow runs" />
+                        <Switch
+                          checked={inputs.persistBrowserSession}
+                          onCheckedChange={(value) => {
+                            handleChange("persistBrowserSession", value);
+                          }}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div>
       <Handle

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/types.ts
@@ -1,5 +1,28 @@
+import { ProxyLocation } from "@/api/types";
 import type { Node } from "@xyflow/react";
+import { AppNode } from "..";
 
-export type StartNodeData = Record<string, never>;
+export type WorkflowStartNodeData = {
+  withWorkflowSettings: true;
+  webhookCallbackUrl: string;
+  proxyLocation: ProxyLocation;
+  persistBrowserSession: boolean;
+};
+
+export type OtherStartNodeData = {
+  withWorkflowSettings: false;
+};
+
+export type StartNodeData = WorkflowStartNodeData | OtherStartNodeData;
 
 export type StartNode = Node<StartNodeData, "start">;
+
+export function isStartNode(node: AppNode): node is StartNode {
+  return node.type === "start";
+}
+
+export function isWorkflowStartNodeData(
+  data: StartNodeData,
+): data is WorkflowStartNodeData {
+  return data.withWorkflowSettings;
+}

--- a/skyvern-frontend/src/routes/workflows/hooks/useLabelChangeHandler.ts
+++ b/skyvern-frontend/src/routes/workflows/hooks/useLabelChangeHandler.ts
@@ -1,5 +1,5 @@
 import { useNodes, useReactFlow } from "@xyflow/react";
-import { AppNode } from "../editor/nodes";
+import { AppNode, isWorkflowBlockNode } from "../editor/nodes";
 import {
   getUniqueLabelForExistingNode,
   getUpdatedNodesAfterLabelUpdateForParameterKeys,
@@ -21,7 +21,9 @@ function useNodeLabelChangeHandler({ id, initialValue }: Props) {
     useWorkflowParametersState();
 
   function handleLabelChange(value: string) {
-    const existingLabels = nodes.map((n) => n.data.label);
+    const existingLabels = nodes
+      .filter(isWorkflowBlockNode)
+      .map((n) => n.data.label);
     const labelWithoutWhitespace = value.replace(/\s+/g, "_");
     const newLabel = getUniqueLabelForExistingNode(
       labelWithoutWhitespace,

--- a/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
@@ -1,3 +1,5 @@
+import { ProxyLocation } from "@/api/types";
+
 export type WorkflowParameterBase = {
   parameter_type: WorkflowParameterType;
   key: string;
@@ -296,12 +298,20 @@ export type WorkflowApiResponse = {
   version: number;
   description: string;
   workflow_definition: WorkflowDefinition;
-  proxy_location: string;
-  webhook_callback_url: string;
-  totp_verification_url: string;
+  proxy_location: ProxyLocation | null;
+  webhook_callback_url: string | null;
+  persist_browser_session: boolean;
+  totp_verification_url: string | null;
+  totp_identifier: string | null;
   created_at: string;
   modified_at: string;
   deleted_at: string | null;
+};
+
+export type WorkflowSettings = {
+  proxyLocation: ProxyLocation | null;
+  webhookCallbackUrl: string | null;
+  persistBrowserSession: boolean;
 };
 
 export function isOutputParameter(

--- a/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
@@ -3,6 +3,7 @@ export type WorkflowCreateYAMLRequest = {
   description?: string | null;
   proxy_location?: string | null;
   webhook_callback_url?: string | null;
+  persist_browser_session?: boolean;
   totp_verification_url?: string | null;
   workflow_definition: WorkflowDefinitionYAML;
   is_saved_task?: boolean;


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add workflow settings to the start node, enabling configuration of `webhookCallbackUrl`, `proxyLocation`, and `persistBrowserSession`.
> 
>   - **Behavior**:
>     - Add `webhookCallbackUrl`, `proxyLocation`, and `persistBrowserSession` settings to the start node in `StartNode.tsx`.
>     - Update `RunWorkflowForm`, `CreateNewTaskForm`, and `SavedTaskForm` to include `proxyLocation` and `persistBrowserSession` settings.
>     - Modify `getRunWorkflowRequestBody()` in `RunWorkflowForm.tsx` to handle new settings.
>   - **Workflow Editor**:
>     - Update `FlowRenderer` and `WorkflowEditor` to handle new workflow settings.
>     - Add `getWorkflowSettings()` in `workflowEditorUtils.ts` to extract settings from nodes.
>   - **Types**:
>     - Add `WorkflowSettings` type in `workflowTypes.ts` and `workflowYamlTypes.ts`.
>     - Update `StartNodeData` in `types.ts` to include workflow settings.
>   - **Misc**:
>     - Add `className` prop to `ProxySelector` component.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f9a71563ae65548aa1163d345b70c0c7eecc8fb3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->