### PR TITLE
fallback to use js click

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -427,10 +427,10 @@ function getBlockElementUniqueID(element) {
   );
 
   if (!hitElement) {
-    return "";
+    return ["", false];
   }
 
-  return hitElement.getAttribute("unique_id") ?? "";
+  return [hitElement.getAttribute("unique_id") ?? "", true];
 }
 
 function isHidden(element) {

--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -320,12 +320,12 @@ class SkyvernElement:
         assert handler is not None
         return handler
 
-    async def find_blocking_element(self, dom: DomUtil) -> SkyvernElement | None:
+    async def find_blocking_element(self, dom: DomUtil) -> tuple[SkyvernElement | None, bool]:
         skyvern_frame = await SkyvernFrame.create_instance(self.get_frame())
-        blocking_element_id = await skyvern_frame.get_blocking_element_id(await self.get_element_handler())
+        blocking_element_id, blocked = await skyvern_frame.get_blocking_element_id(await self.get_element_handler())
         if not blocking_element_id:
-            return None
-        return await dom.get_skyvern_element_by_id(blocking_element_id)
+            return None, blocked
+        return await dom.get_skyvern_element_by_id(blocking_element_id), blocked
 
     async def find_element_in_label_children(
         self, dom: DomUtil, element_type: InteractiveElement
@@ -575,6 +575,10 @@ class SkyvernElement:
         await page.mouse.move(dest_x, dest_y)
 
         return dest_x, dest_y
+
+    async def click_in_javascript(self) -> None:
+        skyvern_frame = await SkyvernFrame.create_instance(self.get_frame())
+        await skyvern_frame.click_element_in_javascript(await self.get_element_handler())
 
     async def coordinate_click(
         self, page: Page, timeout: float = SettingsManager.get_settings().BROWSER_ACTION_TIMEOUT_MS

--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -182,7 +182,7 @@ class SkyvernFrame:
         js_script = "(element) => checkDisabledFromStyle(element)"
         return await self.evaluate(frame=self.frame, expression=js_script, arg=element)
 
-    async def get_blocking_element_id(self, element: ElementHandle) -> str:
+    async def get_blocking_element_id(self, element: ElementHandle) -> tuple[str, bool]:
         js_script = "(element) => getBlockElementUniqueID(element)"
         return await self.evaluate(frame=self.frame, expression=js_script, arg=element)
 
@@ -239,3 +239,7 @@ class SkyvernFrame:
     async def has_ASP_client_control(self) -> bool:
         js_script = "() => hasASPClientControl()"
         return await self.evaluate(frame=self.frame, expression=js_script)
+
+    async def click_element_in_javascript(self, element: ElementHandle) -> None:
+        js_script = "(element) => element.click()"
+        return await self.evaluate(frame=self.frame, expression=js_script, arg=element)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add JavaScript click fallback in `chain_click()` for blocked elements in `handler.py`, with supporting changes in `domUtils.js`, `dom.py`, and `page.py`.
> 
>   - **Behavior**:
>     - In `handler.py`, `chain_click()` now attempts a JavaScript click if the element is blocked by a non-interactable element.
>     - Logs an error and returns `ActionFailure` if JavaScript click fails.
>   - **JavaScript**:
>     - `getBlockElementUniqueID()` in `domUtils.js` now returns a tuple with a boolean indicating if the element is blocked.
>   - **Functions**:
>     - `find_blocking_element()` in `dom.py` and `get_blocking_element_id()` in `page.py` updated to handle new tuple return type.
>     - Added `click_in_javascript()` method to `SkyvernElement` in `dom.py` for executing JavaScript clicks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 52f0c7152d9b0e6d7090f51d70473713bce402a9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->