### PR TITLE
fix workflow cleanup bug when there are no tasks created for the workflow

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -820,7 +820,8 @@ class WorkflowService:
         )
         if browser_state:
             await self.persist_video_data(browser_state, workflow, workflow_run)
-            await self.persist_debug_artifacts(browser_state, tasks[-1], workflow, workflow_run)
+            if tasks:
+                await self.persist_debug_artifacts(browser_state, tasks[-1], workflow, workflow_run)
             if workflow.persist_browser_session and browser_state.browser_artifacts.browser_session_dir:
                 await app.STORAGE.store_browser_session(
                     workflow.organization_id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes a bug in `clean_up_workflow()` in `service.py` to prevent errors when no tasks are created for a workflow by checking if tasks exist before calling `persist_debug_artifacts()`.
> 
>   - **Bug Fix**:
>     - In `clean_up_workflow()` in `service.py`, added a check to ensure `persist_debug_artifacts()` is only called if `tasks` list is not empty.
>     - Prevents errors when no tasks are created for a workflow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for dc5a4b9726a511abcce6af6edcc86b8b675bec06. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->