### PR TITLE
set a DEFAULT_TEXT_PROMPT_LLM_KEY if TextPromptBlock.llm_key is not passed to backend

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -765,10 +765,13 @@ async def user_code():
         return self.build_block_result(success=True, output_parameter_value=result, status=BlockStatus.completed)
 
 
+DEFAULT_TEXT_PROMPT_LLM_KEY = settings.SECONDARY_LLM_KEY or settings.LLM_KEY
+
+
 class TextPromptBlock(Block):
     block_type: Literal[BlockType.TEXT_PROMPT] = BlockType.TEXT_PROMPT
 
-    llm_key: str
+    llm_key: str = DEFAULT_TEXT_PROMPT_LLM_KEY
     prompt: str
     parameters: list[PARAMETER_TYPE] = []
     json_schema: dict[str, Any] | None = None

--- a/skyvern/forge/sdk/workflow/models/yaml.py
+++ b/skyvern/forge/sdk/workflow/models/yaml.py
@@ -3,6 +3,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, Field
 
+from skyvern.config import settings
 from skyvern.forge.sdk.schemas.tasks import ProxyLocation
 from skyvern.forge.sdk.workflow.models.block import BlockType, FileType
 from skyvern.forge.sdk.workflow.models.parameter import ParameterType, WorkflowParameterType
@@ -154,6 +155,9 @@ class CodeBlockYAML(BlockYAML):
     parameter_keys: list[str] | None = None
 
 
+DEFAULT_TEXT_PROMPT_LLM_KEY = settings.SECONDARY_LLM_KEY or settings.LLM_KEY
+
+
 class TextPromptBlockYAML(BlockYAML):
     # There is a mypy bug with Literal. Without the type: ignore, mypy will raise an error:
     # Parameter 1 of Literal[...] cannot be of type "Any"
@@ -161,7 +165,7 @@ class TextPromptBlockYAML(BlockYAML):
     # to infer the type of the parameter_type attribute.
     block_type: Literal[BlockType.TEXT_PROMPT] = BlockType.TEXT_PROMPT  # type: ignore
 
-    llm_key: str
+    llm_key: str = DEFAULT_TEXT_PROMPT_LLM_KEY
     prompt: str
     parameter_keys: list[str] | None = None
     json_schema: dict[str, Any] | None = None


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set default `llm_key` in `TextPromptBlock` and `TextPromptBlockYAML` to `DEFAULT_TEXT_PROMPT_LLM_KEY`.
> 
>   - **Behavior**:
>     - Set `llm_key` default to `DEFAULT_TEXT_PROMPT_LLM_KEY` in `TextPromptBlock` and `TextPromptBlockYAML`.
>     - `DEFAULT_TEXT_PROMPT_LLM_KEY` is derived from `settings.SECONDARY_LLM_KEY` or `settings.LLM_KEY`.
>   - **Constants**:
>     - Add `DEFAULT_TEXT_PROMPT_LLM_KEY` in `block.py` and `yaml.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 61b4371409014b96e57171ca59ebec7c05517951. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->