### PR TITLE
shu/do not send llm key for now

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -997,7 +997,6 @@ function getWorkflowBlock(node: WorkflowBlockNode): BlockYAML {
       return {
         ...base,
         block_type: "text_prompt",
-        llm_key: null,
         prompt: node.data.prompt,
         json_schema: JSONParseSafe(node.data.jsonSchema),
         parameter_keys: node.data.parameterKeys,

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -997,7 +997,7 @@ function getWorkflowBlock(node: WorkflowBlockNode): BlockYAML {
       return {
         ...base,
         block_type: "text_prompt",
-        llm_key: "",
+        llm_key: null,
         prompt: node.data.prompt,
         json_schema: JSONParseSafe(node.data.jsonSchema),
         parameter_keys: node.data.parameterKeys,

--- a/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
@@ -221,7 +221,7 @@ export type CodeBlockYAML = BlockYAMLBase & {
 
 export type TextPromptBlockYAML = BlockYAMLBase & {
   block_type: "text_prompt";
-  llm_key: string;
+  llm_key: string | null;
   prompt: string;
   json_schema?: Record<string, unknown> | null;
   parameter_keys?: Array<string> | null;

--- a/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
@@ -221,7 +221,6 @@ export type CodeBlockYAML = BlockYAMLBase & {
 
 export type TextPromptBlockYAML = BlockYAMLBase & {
   block_type: "text_prompt";
-  llm_key: string | null;
   prompt: string;
   json_schema?: Record<string, unknown> | null;
   parameter_keys?: Array<string> | null;


### PR DESCRIPTION
- do not send text_prompt llm_key for now
- remove llm_key for now

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `llm_key` from `text_prompt` blocks in `workflowEditorUtils.ts` and `workflowYamlTypes.ts`.
> 
>   - **Behavior**:
>     - Remove `llm_key` from `text_prompt` blocks in `getWorkflowBlock()` in `workflowEditorUtils.ts`.
>     - Remove `llm_key` from `TextPromptBlockYAML` in `workflowYamlTypes.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e38ac4f0821773d1588a534b535ff8021421e1db. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->