### PR TITLE
fix empty llm_key promblem for the TextPromptBlock

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -783,7 +783,8 @@ class TextPromptBlock(Block):
         return self.parameters
 
     async def send_prompt(self, prompt: str, parameter_values: dict[str, Any]) -> dict[str, Any]:
-        llm_api_handler = LLMAPIHandlerFactory.get_llm_api_handler(self.llm_key)
+        llm_key = self.llm_key or DEFAULT_TEXT_PROMPT_LLM_KEY
+        llm_api_handler = LLMAPIHandlerFactory.get_llm_api_handler(llm_key)
         if not self.json_schema:
             self.json_schema = {
                 "type": "object",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes empty `llm_key` issue in `TextPromptBlock.send_prompt()` by using a default key.
> 
>   - **Behavior**:
>     - In `TextPromptBlock.send_prompt()`, use `DEFAULT_TEXT_PROMPT_LLM_KEY` if `self.llm_key` is empty.
>   - **Misc**:
>     - No other changes or refactors were made.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 37024ebe29dd6bff47aa88e8393295c3b52fd73c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->