### PR TITLE
adjust cache expiration policy

### DIFF
--- a/skyvern/forge/sdk/cache/local.py
+++ b/skyvern/forge/sdk/cache/local.py
@@ -14,7 +14,6 @@ class LocalCache(BaseCache):
         if key not in self.cache:
             return None
         value = self.cache[key]
-        await self.set(key, value)
         return value
 
     async def set(self, key: str, value: Any, ex: Union[int, timedelta, None] = CACHE_EXPIRE_TIME) -> None:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjust cache expiration policy by removing unnecessary refreshes and adding cache keys to log messages in `agent_functions.py` and `local.py`.
> 
>   - **Cache Expiration**:
>     - Removed cache expiration refresh in `get()` method of `LocalCache` in `local.py`.
>     - Added cache expiration refresh after successful SVG and CSS shape conversions in `_convert_svg_to_string()` and `_convert_css_shape_to_string()` in `agent_functions.py`.
>   - **Logging**:
>     - Added `key` to log messages in `_convert_svg_to_string()` and `_convert_css_shape_to_string()` in `agent_functions.py` for better traceability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 528c9e790ec38b0614bcffbc2529f2fa67d749fd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->