### PR TITLE
create_empty_workflow interface in workflow service

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -70,7 +70,12 @@ from skyvern.forge.sdk.workflow.models.workflow import (
     WorkflowRunStatus,
     WorkflowRunStatusResponse,
 )
-from skyvern.forge.sdk.workflow.models.yaml import BLOCK_YAML_TYPES, ForLoopBlockYAML, WorkflowCreateYAMLRequest
+from skyvern.forge.sdk.workflow.models.yaml import (
+    BLOCK_YAML_TYPES,
+    ForLoopBlockYAML,
+    WorkflowCreateYAMLRequest,
+    WorkflowDefinitionYAML,
+)
 from skyvern.webeye.browser_factory import BrowserState
 
 LOG = structlog.get_logger()
@@ -1501,3 +1506,20 @@ class WorkflowService:
             )
 
         raise ValueError(f"Invalid block type {block_yaml.block_type}")
+
+    async def create_empty_workflow(self, organization: Organization, title: str) -> Workflow:
+        """
+        Create a blank workflow with no blocks
+        """
+        # create a new workflow
+        workflow_create_request = WorkflowCreateYAMLRequest(
+            title=title,
+            workflow_definition=WorkflowDefinitionYAML(
+                parameters=[],
+                blocks=[],
+            ),
+        )
+        return await app.WORKFLOW_SERVICE.create_workflow_from_request(
+            organization=organization,
+            request=workflow_create_request,
+        )


### PR DESCRIPTION
- observer api
- register cruise router & build observer_service

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces an Observer API for cruise workflows with new routes, executors, services, AWS Batch job definitions, and a method to create empty workflows.
> 
>   - **Observer API**:
>     - Adds `observer_router` to `app.py` and registers it under `/api/v1/cruise`.
>     - Implements `run_observer` endpoint in `observer.py` to initiate cruise workflows.
>   - **Executors**:
>     - Adds `execute_cruise` method in `CloudAsyncExecutor` to submit observer jobs to AWS Batch.
>   - **Services**:
>     - Introduces `initialize_observer_metadata` in `observer_service.py` to generate metadata for observer workflows.
>   - **Schemas**:
>     - Defines `ObserverMetadata` and `CruiseRequest` in `observers.py` for handling observer data.
>   - **Infrastructure**:
>     - Adds `observer-definition-production.json` and `observer-definition-staging.json` for AWS Batch job definitions.
>   - **Scripts**:
>     - Updates `run_observer.py` and adds `run_observer_wrapper.sh` to handle observer execution.
>   - **Misc**:
>     - Updates `update_job_def.sh` to include observer job definitions.
>     - Adds `create_empty_workflow` method in `service.py` to create a blank workflow with no blocks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 06343fcf63065d3bba4a4bfc497076df6e26ca68. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->