### PR TITLE
Clicking on task title should navigate into task

### DIFF
--- a/skyvern-frontend/src/routes/workflows/WorkflowBlockCollapsibleContent.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowBlockCollapsibleContent.tsx
@@ -79,6 +79,9 @@ function WorkflowBlockCollapsibleContent({ task, onNavigate }: Props) {
           <TableCell
             className="w-1/5 max-w-0 cursor-pointer truncate"
             title={task.request.title ?? undefined}
+            onClick={(event) => {
+              onNavigate(event, task.task_id);
+            }}
           >
             {task.request.title}
           </TableCell>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `onClick` event to task title in `WorkflowBlockCollapsibleContent.tsx` for navigation to task details.
> 
>   - **Behavior**:
>     - Adds `onClick` event to `TableCell` in `WorkflowBlockCollapsibleContent.tsx` to navigate to task details when task title is clicked.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d8ebf991c0be77e05f0a4b98d565515f11e50595. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->