### PR TITLE
set default PRESIGNED_URL_EXPIRATION 24 hours

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -61,6 +61,7 @@ class Settings(BaseSettings):
     AWS_REGION: str = "us-east-1"
     AWS_S3_BUCKET_UPLOADS: str = "skyvern-uploads"
     MAX_UPLOAD_FILE_SIZE: int = 10 * 1024 * 1024  # 10 MB
+    PRESIGNED_URL_EXPIRATION: int = 60 * 60 * 24  # 24 hours
 
     SKYVERN_TELEMETRY: bool = True
     ANALYTICS_ID: str = "anonymous"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add default `PRESIGNED_URL_EXPIRATION` of 24 hours to `Settings` in `config.py`.
> 
>   - **Configuration**:
>     - Add `PRESIGNED_URL_EXPIRATION` to `Settings` in `config.py`, defaulting to 24 hours (60 * 60 * 24 seconds).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 95274f2245e7da7941156f95a816722887b76719. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->