### PR TITLE
revert settings manager change in skyvern/forge/app.py

### DIFF
--- a/skyvern/forge/app.py
+++ b/skyvern/forge/app.py
@@ -2,7 +2,6 @@ from typing import Awaitable, Callable
 
 from fastapi import FastAPI
 
-from skyvern.config import settings
 from skyvern.forge.agent import ForgeAgent
 from skyvern.forge.agent_functions import AgentFunction
 from skyvern.forge.sdk.api.llm.api_handler_factory import LLMAPIHandlerFactory
@@ -13,24 +12,25 @@ from skyvern.forge.sdk.cache.factory import CacheFactory
 from skyvern.forge.sdk.db.client import AgentDB
 from skyvern.forge.sdk.experimentation.providers import BaseExperimentationProvider, NoOpExperimentationProvider
 from skyvern.forge.sdk.models import Organization
+from skyvern.forge.sdk.settings_manager import SettingsManager
 from skyvern.forge.sdk.workflow.context_manager import WorkflowContextManager
 from skyvern.forge.sdk.workflow.service import WorkflowService
 from skyvern.webeye.browser_manager import BrowserManager
 from skyvern.webeye.scraper.scraper import ScrapeExcludeFunc
 
-SETTINGS_MANAGER = settings
+SETTINGS_MANAGER = SettingsManager.get_settings()
 DATABASE = AgentDB(
-    settings.DATABASE_STRING,
-    debug_enabled=settings.DEBUG_MODE,
+    SettingsManager.get_settings().DATABASE_STRING,
+    debug_enabled=SettingsManager.get_settings().DEBUG_MODE,
 )
-if settings.SKYVERN_STORAGE_TYPE == "s3":
+if SettingsManager.get_settings().SKYVERN_STORAGE_TYPE == "s3":
     StorageFactory.set_storage(S3Storage())
 STORAGE = StorageFactory.get_storage()
 CACHE = CacheFactory.get_cache()
 ARTIFACT_MANAGER = ArtifactManager()
 BROWSER_MANAGER = BrowserManager()
 EXPERIMENTATION_PROVIDER: BaseExperimentationProvider = NoOpExperimentationProvider()
-LLM_API_HANDLER = LLMAPIHandlerFactory.get_llm_api_handler(settings.LLM_KEY)
+LLM_API_HANDLER = LLMAPIHandlerFactory.get_llm_api_handler(SettingsManager.get_settings().LLM_KEY)
 SECONDARY_LLM_API_HANDLER = LLMAPIHandlerFactory.get_llm_api_handler(
     SETTINGS_MANAGER.SECONDARY_LLM_KEY if SETTINGS_MANAGER.SECONDARY_LLM_KEY else SETTINGS_MANAGER.LLM_KEY
 )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reverts settings manager change in `skyvern/forge/app.py` to use `SettingsManager.get_settings()` for configuration access.
> 
>   - **Revert Settings Manager Change**:
>     - Replace `settings` with `SettingsManager.get_settings()` in `skyvern/forge/app.py`.
>     - Affects `DATABASE`, `STORAGE`, `LLM_API_HANDLER`, and `SECONDARY_LLM_API_HANDLER` initialization.
>     - Ensures consistent access to configuration values using `SettingsManager`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 7421e0e3cc6e5da7bbddc41727dbbf30b6b8fa2e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->