### PR TITLE
Add task block back into node library

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
@@ -6,6 +6,7 @@ import {
   DownloadIcon,
   EnvelopeClosedIcon,
   FileIcon,
+  ListBulletIcon,
   LockOpen1Icon,
   PlusIcon,
   StopwatchIcon,
@@ -49,6 +50,12 @@ const nodeLibraryItems: Array<{
     description: "Validate the state of the workflow or terminate",
   },
   {
+    nodeType: "task",
+    icon: <ListBulletIcon className="size-6" />,
+    title: "Task Block",
+    description: "Takes actions or extracts information",
+  },
+  {
     nodeType: "textPrompt",
     icon: <CursorTextIcon className="size-6" />,
     title: "Text Prompt Block",
@@ -60,13 +67,6 @@ const nodeLibraryItems: Array<{
     title: "Send Email Block",
     description: "Sends an email",
   },
-  // legacy
-  // {
-  //   nodeType: "task",
-  //   icon: <ListBulletIcon className="size-6" />,
-  //   title: "Task Block",
-  //   description: "Takes actions or extracts information",
-  // },
   {
     nodeType: "loop",
     icon: <UpdateIcon className="size-6" />,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reintroduces `Task Block` in `WorkflowNodeLibraryPanel.tsx` with `ListBulletIcon` and description.
> 
>   - **Behavior**:
>     - Reintroduces `Task Block` in `nodeLibraryItems` in `WorkflowNodeLibraryPanel.tsx`.
>     - `Task Block` has `nodeType: "task"`, `ListBulletIcon`, and description "Takes actions or extracts information".
>   - **Icons**:
>     - Adds `ListBulletIcon` import from `@radix-ui/react-icons`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 574744e462e0cc064c4b3028fe6f11f18e490bfe. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->