### PR TITLE
Show downloaded files in workflow run

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -206,6 +206,7 @@ export type WorkflowRunStatusApiResponse = {
   recording_url: string | null;
   outputs: Record<string, unknown> | null;
   failure_reason: string | null;
+  downloaded_file_urls: Array<string> | null;
 };
 
 export type TaskGenerationApiResponse = {

--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -49,6 +49,7 @@ import {
 import { cn } from "@/util/utils";
 import {
   CopyIcon,
+  FileIcon,
   Pencil2Icon,
   PlayIcon,
   ReaderIcon,
@@ -376,6 +377,8 @@ function WorkflowRun() {
     </TableRow>
   );
 
+  const fileUrls = workflowRun?.downloaded_file_urls ?? [];
+
   return (
     <div className="space-y-8">
       <header className="flex justify-between">
@@ -623,6 +626,29 @@ function WorkflowRun() {
             minHeight="96px"
             maxHeight="500px"
           />
+        </div>
+      )}
+      {workflowRunIsFinalized && (
+        <div className="space-y-4">
+          <header>
+            <h2 className="text-lg font-semibold">Downloaded Files</h2>
+          </header>
+          <div className="space-y-2">
+            {fileUrls.length > 0 ? (
+              fileUrls.map((url) => {
+                return (
+                  <div key={url} className="flex gap-2">
+                    <FileIcon className="size-6" />
+                    <a href={url} className="underline underline-offset-4">
+                      <span>{url}</span>
+                    </a>
+                  </div>
+                );
+              })
+            ) : (
+              <div>No files downloaded</div>
+            )}
+          </div>
         </div>
       )}
       {Object.entries(parameters).length > 0 && (


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add display of downloaded files in workflow run UI by updating API response and rendering in `WorkflowRun.tsx`.
> 
>   - **API Changes**:
>     - Add `downloaded_file_urls` to `WorkflowRunStatusApiResponse` in `types.ts`.
>   - **UI Changes**:
>     - In `WorkflowRun.tsx`, display downloaded files section if `workflowRunIsFinalized`.
>     - Render list of file URLs with `FileIcon` and link in `WorkflowRun.tsx`.
>     - Show message "No files downloaded" if `fileUrls` is empty in `WorkflowRun.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9416c591166cabc13e9dcc62953a65beb167a96d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->