### PR TITLE
re-enable upload block

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
@@ -11,6 +11,7 @@ import {
   PlusIcon,
   StopwatchIcon,
   UpdateIcon,
+  UploadIcon,
 } from "@radix-ui/react-icons";
 import { WorkflowBlockNode } from "../nodes";
 import { AddNodeProps } from "../FlowRenderer";
@@ -93,12 +94,12 @@ const nodeLibraryItems: Array<{
   //   title: "Download Block",
   //   description: "Downloads a file from S3",
   // },
-  // {
-  //   nodeType: "upload",
-  //   icon: <UploadIcon className="size-6" />,
-  //   title: "Upload Block",
-  //   description: "Uploads a file to S3",
-  // },
+  {
+    nodeType: "upload",
+    icon: <UploadIcon className="size-6" />,
+    title: "Upload Block",
+    description: "Uploads a file to S3",
+  },
   {
     nodeType: "fileDownload",
     icon: <DownloadIcon className="size-6" />,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Re-enables the `Upload Block` in `WorkflowNodeLibraryPanel.tsx` to allow file uploads to S3.
> 
>   - **Behavior**:
>     - Re-enables the `Upload Block` in `WorkflowNodeLibraryPanel.tsx`, allowing users to upload files to S3.
>     - Previously commented out, now active with `UploadIcon`, title "Upload Block", and description "Uploads a file to S3".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 75c0e354ffc793d5c4d8144f0112182d4bd1f1cf. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->