### PR TITLE
urlencode download suffix

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -14,6 +14,7 @@ from email.message import EmailMessage
 from enum import StrEnum
 from pathlib import Path
 from typing import Annotated, Any, Literal, Union
+from urllib.parse import quote
 
 import filetype
 import structlog
@@ -245,6 +246,8 @@ class BaseTaskBlock(Block):
             self.download_suffix = self.format_block_parameter_template_from_workflow_run_context(
                 self.download_suffix, workflow_run_context
             )
+            # encode the suffix to prevent invalid path style
+            self.download_suffix = quote(string=self.download_suffix, safe="")
 
         if self.navigation_goal:
             self.navigation_goal = self.format_block_parameter_template_from_workflow_run_context(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Encode `download_suffix` in `BaseTaskBlock` to prevent invalid path styles.
> 
>   - **Behavior**:
>     - Encode `download_suffix` using `urllib.parse.quote` in `format_potential_template_parameters()` in `BaseTaskBlock` to prevent invalid path styles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 06ab8398146f6dc43c362dbeee3844b9d1e90e7c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->