### PR TITLE
Fix a navigation bug with saved tasks

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/SavedTaskCard.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTaskCard.tsx
@@ -156,7 +156,7 @@ function SavedTaskCard({ workflowId, title, url, description }: Props) {
           },
         )}
         onClick={() => {
-          navigate(workflowId);
+          navigate(`/tasks/create/${workflowId}`);
         }}
       >
         {description}


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes navigation bug in `SavedTaskCard` by updating `navigate` call to use correct path format.
> 
>   - **Bug Fix**:
>     - Fixes navigation bug in `SavedTaskCard` by updating `navigate` call to use `/tasks/create/${workflowId}` instead of just `workflowId`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for cc770113251c0950a42151c3aef7bb3eaa6e5cef. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->