### PR TITLE
ObserverThought reproduce migration script

### DIFF
--- a/alembic/versions/2024_12_06_0852-4d51ed4719d5_introduce_observercruise_and_.py
+++ b/alembic/versions/2024_12_06_0852-4d51ed4719d5_introduce_observercruise_and_.py
@@ -1,8 +1,8 @@
 """Introduce ObserverCruise and ObserverThought. Add workflow_run_block_id and observer_cruise_id to artifacts
 
-Revision ID: 5e266217e9d9
+Revision ID: 4d51ed4719d5
 Revises: de0254717601
-Create Date: 2024-12-06 07:25:50.080125+00:00
+Create Date: 2024-12-06 08:52:52.111448+00:00
 
 """
 
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "5e266217e9d9"
+revision: str = "4d51ed4719d5"
 down_revision: Union[str, None] = "de0254717601"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
@@ -48,6 +48,7 @@ def upgrade() -> None:
         sa.Column("organization_id", sa.String(), nullable=True),
         sa.Column("observer_cruise_id", sa.String(), nullable=False),
         sa.Column("workflow_run_id", sa.String(), nullable=True),
+        sa.Column("workflow_run_block_id", sa.String(), nullable=True),
         sa.Column("workflow_id", sa.String(), nullable=True),
         sa.Column("thought", sa.String(), nullable=True),
         sa.Column("answer", sa.String(), nullable=True),
@@ -62,6 +63,10 @@ def upgrade() -> None:
         sa.ForeignKeyConstraint(
             ["workflow_id"],
             ["workflows.workflow_id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["workflow_run_block_id"],
+            ["workflow_run_blocks.workflow_run_block_id"],
         ),
         sa.ForeignKeyConstraint(
             ["workflow_run_id"],

--- a/skyvern/forge/sdk/db/models.py
+++ b/skyvern/forge/sdk/db/models.py
@@ -522,6 +522,7 @@ class ObserverThought(Base):
     organization_id = Column(String, ForeignKey("organizations.organization_id"), nullable=True)
     observer_cruise_id = Column(String, ForeignKey("observer_cruises.observer_cruise_id"), nullable=False)
     workflow_run_id = Column(String, ForeignKey("workflow_runs.workflow_run_id"), nullable=True)
+    workflow_run_block_id = Column(String, ForeignKey("workflow_run_blocks.workflow_run_block_id"), nullable=True)
     workflow_id = Column(String, ForeignKey("workflows.workflow_id"), nullable=True)
     thought = Column(String, nullable=True)
     answer = Column(String, nullable=True)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `ObserverCruise` and `ObserverThought` entities with new columns and foreign keys to support enhanced artifact tracking.
> 
>   - **Database Schema**:
>     - Adds `workflow_run_block_id` and `observer_cruise_id` columns to `artifacts` table in Alembic migration script.
>     - Creates `observer_cruises` and `observer_thoughts` tables with relevant foreign key constraints in Alembic migration script.
>     - Updates foreign key constraints in `artifacts` table to reference new tables.
>   - **Models**:
>     - Adds `workflow_run_block_id` to `ObserverThought` class in `models.py`.
>     - Introduces `ObserverCruise` and `ObserverThought` classes in `models.py` with appropriate fields and foreign keys.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 94aebe637080cda2d66d39a86ff7bc9880971c35. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->