### PR TITLE
fix missing video recording - recording is stored in the first step

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1633,14 +1633,16 @@ class ForgeAgent:
         if screenshot_artifact:
             screenshot_url = await app.ARTIFACT_MANAGER.get_share_link(screenshot_artifact)
 
-        recording_artifact = await app.DATABASE.get_artifact(
-            task_id=task.task_id,
-            step_id=last_step.step_id,
-            artifact_type=ArtifactType.RECORDING,
-            organization_id=task.organization_id,
-        )
-        if recording_artifact:
-            recording_url = await app.ARTIFACT_MANAGER.get_share_link(recording_artifact)
+        first_step = await app.DATABASE.get_first_step(task_id=task.task_id, organization_id=task.organization_id)
+        if first_step:
+            recording_artifact = await app.DATABASE.get_artifact(
+                task_id=task.task_id,
+                step_id=last_step.step_id,
+                artifact_type=ArtifactType.RECORDING,
+                organization_id=task.organization_id,
+            )
+            if recording_artifact:
+                recording_url = await app.ARTIFACT_MANAGER.get_share_link(recording_artifact)
 
         # get the artifact of the last TASK_RESPONSE_ACTION_SCREENSHOT_COUNT screenshots and get the screenshot_url
         latest_action_screenshot_artifacts = await app.DATABASE.get_latest_n_artifacts(

--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1637,7 +1637,7 @@ class ForgeAgent:
         if first_step:
             recording_artifact = await app.DATABASE.get_artifact(
                 task_id=task.task_id,
-                step_id=last_step.step_id,
+                step_id=first_step.step_id,
                 artifact_type=ArtifactType.RECORDING,
                 organization_id=task.organization_id,
             )

--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -340,8 +340,6 @@ class AgentDB:
             LOG.error("UnexpectedError", exc_info=True)
             raise
 
-
-
     async def get_latest_step(self, task_id: str, organization_id: str | None = None) -> Step | None:
         try:
             async with self.Session() as session:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes video recording storage by retrieving the recording artifact from the first step in `build_task_response()` and adds `get_first_step()` to `client.py`.
> 
>   - **Behavior**:
>     - Fixes video recording storage by retrieving the recording artifact using the first step in `build_task_response()` in `agent.py`.
>   - **Database**:
>     - Adds `get_first_step()` to `client.py` to fetch the first step of a task for recording retrieval.
>   - **Misc**:
>     - Minor logging changes in `client.py` for error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c263b98726de2fb65cb2bd7520f5a7159ec1784a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->