### PR TITLE
migrate to wait_for_upload_aiotasks for aiotasks cleanup

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1536,7 +1536,7 @@ class ForgeAgent:
         await self.cleanup_browser_and_create_artifacts(close_browser_on_completion, last_step, task)
 
         # Wait for all tasks to complete before generating the links for the artifacts
-        await app.ARTIFACT_MANAGER.wait_for_upload_aiotasks_for_task(task.task_id)
+        await app.ARTIFACT_MANAGER.wait_for_upload_aiotasks([task.task_id])
 
         if need_call_webhook:
             await self.execute_task_webhook(task=task, last_step=last_step, api_key=api_key)

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -859,7 +859,7 @@ class WorkflowService:
                 )
                 LOG.info("Persisted browser session for workflow run", workflow_run_id=workflow_run.workflow_run_id)
 
-        await app.ARTIFACT_MANAGER.wait_for_upload_aiotasks_for_tasks(all_workflow_task_ids)
+        await app.ARTIFACT_MANAGER.wait_for_upload_aiotasks(all_workflow_task_ids)
 
         try:
             async with asyncio.timeout(SAVE_DOWNLOADED_FILES_TIMEOUT):


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Consolidates artifact upload task waiting methods into `wait_for_upload_aiotasks` and updates related code in `agent.py`, `manager.py`, and `service.py`.
> 
>   - **Behavior**:
>     - Replaces `wait_for_upload_aiotasks_for_task` and `wait_for_upload_aiotasks_for_tasks` with `wait_for_upload_aiotasks` in `agent.py` and `service.py`.
>     - Updates `wait_for_upload_aiotasks` in `manager.py` to handle a list of primary keys instead of task IDs.
>   - **Functions**:
>     - Removes `wait_for_upload_aiotasks_for_task` and `wait_for_upload_aiotasks_for_tasks` from `manager.py`.
>     - Modifies `wait_for_upload_aiotasks` in `manager.py` to use `primary_keys` instead of `task_ids`.
>   - **Misc**:
>     - Updates logging messages in `manager.py` to reflect changes in parameter names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 536db4886d1c2883d9bd0f5d3c6b05d0943fab6e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->