### PR TITLE
Change file names to file 1,2,3.. for now

### DIFF
--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -635,12 +635,12 @@ function WorkflowRun() {
           </header>
           <div className="space-y-2">
             {fileUrls.length > 0 ? (
-              fileUrls.map((url) => {
+              fileUrls.map((url, index) => {
                 return (
-                  <div key={url} className="flex gap-2">
+                  <div key={url} title={url} className="flex gap-2">
                     <FileIcon className="size-6" />
                     <a href={url} className="underline underline-offset-4">
-                      <span>{url}</span>
+                      <span>{`File ${index + 1}`}</span>
                     </a>
                   </div>
                 );


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Renames file URLs to `File 1`, `File 2`, etc., in `WorkflowRun.tsx` for improved UI clarity.
> 
>   - **UI Changes**:
>     - In `WorkflowRun.tsx`, file URLs are now displayed as `File 1`, `File 2`, etc., instead of the full URL.
>     - Adds `title` attribute to the file link div to retain the full URL for hover display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1b6ef424005f1afb3291f115efef679bc8f3e141. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->