### PR TITLE
fix streaming bug

### DIFF
--- a/run_streaming.py
+++ b/run_streaming.py
@@ -5,7 +5,7 @@ import structlog
 import typer
 
 from skyvern.forge import app
-from skyvern.forge.sdk.settings_manager import SettingsManager
+from skyvern.forge.sdk.api.files import get_skyvern_temp_dir
 
 INTERVAL = 1
 LOG = structlog.get_logger()
@@ -13,7 +13,7 @@ LOG = structlog.get_logger()
 
 async def run() -> None:
     file_name = "skyvern_screenshot.png"
-    png_file_path = f"{SettingsManager.get_settings().STREAMING_FILE_BASE_PATH}/{file_name}"
+    png_file_path = f"{get_skyvern_temp_dir()}/{file_name}"
 
     while True:
         # run subprocess to take screenshot

--- a/run_streaming.py
+++ b/run_streaming.py
@@ -21,7 +21,7 @@ async def run() -> None:
             f"xwd -root | xwdtopnm 2>/dev/null | pnmtopng > {png_file_path}", shell=True, env={"DISPLAY": ":99"}
         )
 
-        # upload screenshot to S3
+        # FIXME: upload screenshot to S3 with correct organization id
         try:
             await app.STORAGE.save_streaming_file("placeholder_org", file_name)
         except Exception:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaced file path management in `run_streaming.py` and added a FIXME for correct S3 upload organization ID.
> 
>   - **File Path Management**:
>     - Replaced `SettingsManager.get_settings().STREAMING_FILE_BASE_PATH` with `get_skyvern_temp_dir()` in `run_streaming.py` to determine the directory for saving screenshots.
>   - **TODOs**:
>     - Added FIXME comment to address the need for using the correct organization ID when uploading screenshots to S3 in `run_streaming.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 7e3a4a2238ba319fff1b79b125efc9e8f4480b9e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->