### PR TITLE
send webhook when task or workflow run is canceled

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -285,7 +285,7 @@ class ForgeAgent:
                 task=task,
                 last_step=step,
                 api_key=api_key,
-                need_call_webhook=False,
+                need_call_webhook=True,
             )
             return step, None, None
 
@@ -1544,7 +1544,7 @@ class ForgeAgent:
     async def execute_task_webhook(
         self,
         task: Task,
-        last_step: Step,
+        last_step: Step | None,
         api_key: str | None,
     ) -> None:
         if not api_key:

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -284,6 +284,7 @@ async def get_task(
 async def cancel_task(
     task_id: str,
     current_org: Organization = Depends(org_auth_service.get_current_org),
+    x_api_key: Annotated[str | None, Header()] = None,
 ) -> None:
     analytics.capture("skyvern-oss-agent-task-get")
     task_obj = await app.DATABASE.get_task(task_id, organization_id=current_org.organization_id)
@@ -292,7 +293,11 @@ async def cancel_task(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Task not found {task_id}",
         )
-    await app.agent.update_task(task_obj, status=TaskStatus.canceled)
+    task = await app.agent.update_task(task_obj, status=TaskStatus.canceled)
+    # get latest step
+    latest_step = await app.DATABASE.get_latest_step(task_id, organization_id=current_org.organization_id)
+    # retry the webhook
+    await app.agent.execute_task_webhook(task=task, last_step=latest_step, api_key=x_api_key)
 
 
 @base_router.post("/workflows/runs/{workflow_run_id}/cancel")
@@ -300,8 +305,16 @@ async def cancel_task(
 async def cancel_workflow_run(
     workflow_run_id: str,
     current_org: Organization = Depends(org_auth_service.get_current_org),
+    x_api_key: Annotated[str | None, Header()] = None,
 ) -> None:
+    workflow_run = await app.DATABASE.get_workflow_run(workflow_run_id=workflow_run_id)
+    if not workflow_run:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Workflow run not found {workflow_run_id}",
+        )
     await app.WORKFLOW_SERVICE.mark_workflow_run_as_canceled(workflow_run_id)
+    await app.WORKFLOW_SERVICE.execute_workflow_webhook(workflow_run, api_key=x_api_key)
 
 
 @base_router.post(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Send webhooks when tasks or workflow runs are canceled by updating `execute_step()`, `execute_workflow()`, and related functions to handle webhook execution.
> 
>   - **Behavior**:
>     - Send webhook when task or workflow run is canceled by setting `need_call_webhook=True` in `execute_step()` in `agent.py` and `execute_workflow()` in `service.py`.
>     - Modify `cancel_task()` and `cancel_workflow_run()` in `agent_protocol.py` to include `x_api_key` for webhook execution.
>   - **Functions**:
>     - Update `execute_task_webhook()` in `agent.py` to accept `last_step` as `Step | None`.
>     - Add `execute_workflow_webhook()` in `service.py` to handle webhook execution for workflow runs.
>   - **Misc**:
>     - Minor logging adjustments in `service.py` for webhook execution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ac4a400e563063a02d3253c5d70f0d153fec6c5f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->