### PR TITLE
Revert "refactor loopblock value"

### DIFF
--- a/skyvern/forge/sdk/workflow/exceptions.py
+++ b/skyvern/forge/sdk/workflow/exceptions.py
@@ -110,17 +110,5 @@ class WorkflowParameterMissingRequiredValue(BaseWorkflowHTTPException):
 
 
 class InvalidWaitBlockTime(SkyvernException):
-    def __init__(self, max_sec: int) -> None:
+    def __init__(self, max_sec: int):
         super().__init__(f"Invalid wait time for wait block, it should be a number between 0 and {max_sec}.")
-
-
-class FailedToFormatJinjaStyleParameter(SkyvernException):
-    def __init__(self, template: str, msg: str) -> None:
-        super().__init__(
-            f"Failed to format Jinja style parameter {template}. Please make sure the variable reference is correct. reason: {msg}"
-        )
-
-
-class NoIterableValueFound(SkyvernException):
-    def __init__(self) -> None:
-        super().__init__("No iterable value found for the loop block")

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -47,10 +47,8 @@ from skyvern.forge.sdk.db.enums import TaskType
 from skyvern.forge.sdk.schemas.tasks import Task, TaskOutput, TaskStatus
 from skyvern.forge.sdk.workflow.context_manager import BlockMetadata, WorkflowRunContext
 from skyvern.forge.sdk.workflow.exceptions import (
-    FailedToFormatJinjaStyleParameter,
     InvalidEmailClientConfiguration,
     InvalidFileType,
-    NoIterableValueFound,
     NoValidEmailRecipient,
 )
 from skyvern.forge.sdk.workflow.models.parameter import (
@@ -578,17 +576,14 @@ class LoopBlockExecutedResult(BaseModel):
 class ForLoopBlock(Block):
     block_type: Literal[BlockType.FOR_LOOP] = BlockType.FOR_LOOP
 
-    loop_over: PARAMETER_TYPE | None
-    loop_variable_reference: str | None
+    loop_over: PARAMETER_TYPE
     loop_blocks: list[BlockTypeVar]
 
     def get_all_parameters(
         self,
         workflow_run_id: str,
     ) -> list[PARAMETER_TYPE]:
-        parameters = set()
-        if self.loop_over is not None:
-            parameters.add(self.loop_over)
+        parameters = {self.loop_over}
 
         for loop_block in self.loop_blocks:
             for parameter in loop_block.get_all_parameters(workflow_run_id):
@@ -604,9 +599,6 @@ class ForLoopBlock(Block):
             for parameter in all_parameters:
                 if isinstance(parameter, ContextParameter):
                     context_parameters.append(parameter)
-
-        if self.loop_over is None:
-            return context_parameters
 
         for context_parameter in context_parameters:
             if context_parameter.source.key != self.loop_over.key:
@@ -628,44 +620,29 @@ class ForLoopBlock(Block):
         return context_parameters
 
     def get_loop_over_parameter_values(self, workflow_run_context: WorkflowRunContext) -> list[Any]:
-        # parse the value from self.loop_variable_reference and then from self.loop_over
-        if self.loop_variable_reference:
-            value_template = f'{{{{ {self.loop_variable_reference.strip(" {}")} | tojson }}}}'
-            try:
-                value_json = self.format_block_parameter_template_from_workflow_run_context(
-                    value_template, workflow_run_context
-                )
-            except Exception as e:
-                raise FailedToFormatJinjaStyleParameter(value_template, str(e))
-            parameter_value = json.loads(value_json)
-
-        elif self.loop_over is not None:
-            if isinstance(self.loop_over, WorkflowParameter):
-                parameter_value = workflow_run_context.get_value(self.loop_over.key)
-            elif isinstance(self.loop_over, OutputParameter):
-                # If the output parameter is for a TaskBlock, it will be a TaskOutput object. We need to extract the
-                # value from the TaskOutput object's extracted_information field.
-                output_parameter_value = workflow_run_context.get_value(self.loop_over.key)
-                if isinstance(output_parameter_value, dict) and "extracted_information" in output_parameter_value:
-                    parameter_value = output_parameter_value["extracted_information"]
-                else:
-                    parameter_value = output_parameter_value
-            elif isinstance(self.loop_over, ContextParameter):
-                parameter_value = self.loop_over.value
-                if not parameter_value:
-                    source_parameter_value = workflow_run_context.get_value(self.loop_over.source.key)
-                    if isinstance(source_parameter_value, dict):
-                        if "extracted_information" in source_parameter_value:
-                            parameter_value = source_parameter_value["extracted_information"].get(self.loop_over.key)
-                        else:
-                            parameter_value = source_parameter_value.get(self.loop_over.key)
-                    else:
-                        raise ValueError("ContextParameter source value should be a dict")
+        if isinstance(self.loop_over, WorkflowParameter):
+            parameter_value = workflow_run_context.get_value(self.loop_over.key)
+        elif isinstance(self.loop_over, OutputParameter):
+            # If the output parameter is for a TaskBlock, it will be a TaskOutput object. We need to extract the
+            # value from the TaskOutput object's extracted_information field.
+            output_parameter_value = workflow_run_context.get_value(self.loop_over.key)
+            if isinstance(output_parameter_value, dict) and "extracted_information" in output_parameter_value:
+                parameter_value = output_parameter_value["extracted_information"]
             else:
-                raise NotImplementedError()
-
+                parameter_value = output_parameter_value
+        elif isinstance(self.loop_over, ContextParameter):
+            parameter_value = self.loop_over.value
+            if not parameter_value:
+                source_parameter_value = workflow_run_context.get_value(self.loop_over.source.key)
+                if isinstance(source_parameter_value, dict):
+                    if "extracted_information" in source_parameter_value:
+                        parameter_value = source_parameter_value["extracted_information"].get(self.loop_over.key)
+                    else:
+                        parameter_value = source_parameter_value.get(self.loop_over.key)
+                else:
+                    raise ValueError("ContextParameter source value should be a dict")
         else:
-            raise NoIterableValueFound()
+            raise NotImplementedError
 
         if isinstance(parameter_value, list):
             return parameter_value
@@ -748,15 +725,7 @@ class ForLoopBlock(Block):
 
     async def execute(self, workflow_run_id: str, **kwargs: dict) -> BlockResult:
         workflow_run_context = self.get_workflow_run_context(workflow_run_id)
-        try:
-            loop_over_values = self.get_loop_over_parameter_values(workflow_run_context)
-        except Exception as e:
-            return self.build_block_result(
-                success=False,
-                failure_reason=f"failed to get loop values: {str(e)}",
-                status=BlockStatus.failed,
-            )
-
+        loop_over_values = self.get_loop_over_parameter_values(workflow_run_context)
         LOG.info(
             f"Number of loop_over values: {len(loop_over_values)}",
             block_type=self.block_type,

--- a/skyvern/forge/sdk/workflow/models/yaml.py
+++ b/skyvern/forge/sdk/workflow/models/yaml.py
@@ -142,7 +142,6 @@ class ForLoopBlockYAML(BlockYAML):
 
     loop_over_parameter_key: str
     loop_blocks: list["BLOCK_YAML_SUBCLASSES"]
-    loop_variable_reference: str | None = None
 
 
 class CodeBlockYAML(BlockYAML):

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -1319,27 +1319,10 @@ class WorkflowService:
                 await WorkflowService.block_yaml_to_block(workflow, loop_block, parameters)
                 for loop_block in block_yaml.loop_blocks
             ]
-
-            loop_over_parameter: Parameter | None = None
-            if block_yaml.loop_over_parameter_key:
-                loop_over_parameter = parameters[block_yaml.loop_over_parameter_key]
-
-            if block_yaml.loop_variable_reference:
-                # it's backaward compatible with jinja style parameter and context paramter
-                # we trim the format like {{ loop_key }} into loop_key to initialize the context parater,
-                # otherwise it might break the context parameter initialization chain, blow up the worklofw parameters
-                # TODO: consider remove this if we totally give up context parameter
-                trimmed_key = block_yaml.loop_variable_reference.strip(" {}")
-                if trimmed_key in parameters:
-                    loop_over_parameter = parameters[trimmed_key]
-
-            if loop_over_parameter is None and not block_yaml.loop_variable_reference:
-                raise Exception("empty loop value parameter")
-
+            loop_over_parameter = parameters[block_yaml.loop_over_parameter_key]
             return ForLoopBlock(
                 label=block_yaml.label,
                 loop_over=loop_over_parameter,
-                loop_variable_reference=block_yaml.loop_variable_reference,
                 loop_blocks=loop_blocks,
                 output_parameter=output_parameter,
                 continue_on_failure=block_yaml.continue_on_failure,


### PR DESCRIPTION
Reverts Skyvern-AI/skyvern-cloud#3153
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reverts loop block value refactoring by removing specific exceptions and simplifying `ForLoopBlock` parameter handling.
> 
>   - **Exceptions**:
>     - Removed `FailedToFormatJinjaStyleParameter` and `NoIterableValueFound` exceptions from `exceptions.py`.
>   - **ForLoopBlock**:
>     - Reverted `loop_over` to be non-optional in `block.py`.
>     - Removed `loop_variable_reference` handling in `block.py` and `yaml.py`.
>     - Simplified `get_loop_over_parameter_values()` in `block.py` by removing Jinja template parsing.
>   - **Service**:
>     - Removed handling of `loop_variable_reference` in `service.py`.
>     - Adjusted `block_yaml_to_block()` to not consider `loop_variable_reference` in `service.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6000febbf8d03829eeb3d338c6ffce6dc8051332. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->