### PR TITLE
add timezone support

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1310,6 +1310,7 @@ class ForgeAgent:
         if not template:
             raise UnsupportedTaskType(task_type=task_type)
 
+        context = skyvern_context.ensure_context()
         return prompt_engine.load_prompt(
             template=template,
             navigation_goal=navigation_goal,
@@ -1320,7 +1321,7 @@ class ForgeAgent:
             data_extraction_goal=task.data_extraction_goal,
             action_history=actions_and_results_str,
             error_code_mapping_str=(json.dumps(task.error_code_mapping) if task.error_code_mapping else None),
-            utc_datetime=datetime.utcnow().strftime("%Y-%m-%d %H:%M"),
+            local_datetime=datetime.now(context.tz_info).isoformat(),
             verification_code_check=verification_code_check,
             complete_criterion=task.complete_criterion,
             terminate_criterion=task.terminate_criterion,

--- a/skyvern/forge/prompts/skyvern/custom-select.j2
+++ b/skyvern/forge/prompts/skyvern/custom-select.j2
@@ -51,7 +51,7 @@ Select History:
 {{ select_history }}
 ```
 {% endif %}
-Current datetime in UTC, YYYY-MM-DD HH:MM format:
+Current datetime, ISO format:
 ```
-{{ utc_datetime }}
+{{ local_datetime }}
 ```

--- a/skyvern/forge/prompts/skyvern/decisive-criterion-validate.j2
+++ b/skyvern/forge/prompts/skyvern/decisive-criterion-validate.j2
@@ -49,7 +49,7 @@ User details:
 {{ navigation_payload_str }}
 ```
 
-Current datetime in UTC, YYYY-MM-DD HH:MM format:
+Current datetime, ISO format:
 ```
-{{ utc_datetime }}
+{{ local_datetime }}
 ```

--- a/skyvern/forge/prompts/skyvern/extract-action.j2
+++ b/skyvern/forge/prompts/skyvern/extract-action.j2
@@ -73,7 +73,7 @@ User details:
 Action results from previous steps: (note: even if the action history suggests goal is achieved, check the screenshot and the DOM elements to make sure the goal is achieved)
 {{ action_history }}
 {% endif %}
-Current datetime in UTC, YYYY-MM-DD HH:MM format:
+Current datetime, ISO format:
 ```
-{{ utc_datetime }}
+{{ local_datetime }}
 ```

--- a/skyvern/forge/prompts/skyvern/extract-information.j2
+++ b/skyvern/forge/prompts/skyvern/extract-information.j2
@@ -26,7 +26,7 @@ Text extracted from the webpage: {{ extracted_text }}
 
 User Navigation Payload: {{ navigation_payload }}
 
-Current datetime in UTC, YYYY-MM-DD HH:MM format:
+Current datetime, ISO format:
 ```
-{{ utc_datetime }}
+{{ local_datetime }}
 ```

--- a/skyvern/forge/prompts/skyvern/single-click-action.j2
+++ b/skyvern/forge/prompts/skyvern/single-click-action.j2
@@ -35,7 +35,7 @@ User details:
 {{ navigation_payload_str }}
 ```
 
-Current datetime in UTC, YYYY-MM-DD HH:MM format:
+Current datetime, ISO format:
 ```
-{{ utc_datetime }}
+{{ local_datetime }}
 ```

--- a/skyvern/forge/prompts/skyvern/single-input-action.j2
+++ b/skyvern/forge/prompts/skyvern/single-input-action.j2
@@ -37,7 +37,7 @@ User details:
 {{ navigation_payload_str }}
 ```
 
-Current datetime in UTC, YYYY-MM-DD HH:MM format:
+Current datetime, ISO format:
 ```
-{{ utc_datetime }}
+{{ local_datetime }}
 ```

--- a/skyvern/forge/prompts/skyvern/single-select-action.j2
+++ b/skyvern/forge/prompts/skyvern/single-select-action.j2
@@ -39,7 +39,7 @@ User details:
 {{ navigation_payload_str }}
 ```
 
-Current datetime in UTC, YYYY-MM-DD HH:MM format:
+Current datetime, ISO format:
 ```
-{{ utc_datetime }}
+{{ local_datetime }}
 ```

--- a/skyvern/forge/prompts/skyvern/single-upload-action.j2
+++ b/skyvern/forge/prompts/skyvern/single-upload-action.j2
@@ -35,7 +35,7 @@ User details:
 {{ navigation_payload_str }}
 ```
 
-Current datetime in UTC, YYYY-MM-DD HH:MM format:
+Current datetime, ISO format:
 ```
-{{ utc_datetime }}
+{{ local_datetime }}
 ```

--- a/skyvern/forge/sdk/core/skyvern_context.py
+++ b/skyvern/forge/sdk/core/skyvern_context.py
@@ -1,5 +1,6 @@
 from contextvars import ContextVar
 from dataclasses import dataclass, field
+from zoneinfo import ZoneInfo
 
 
 @dataclass
@@ -10,6 +11,7 @@ class SkyvernContext:
     workflow_id: str | None = None
     workflow_run_id: str | None = None
     max_steps_override: int | None = None
+    tz_info: ZoneInfo | None = None
     totp_codes: dict[str, str | None] = field(default_factory=dict)
 
     def __repr__(self) -> str:

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from enum import StrEnum
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -24,6 +25,46 @@ class ProxyLocation(StrEnum):
     RESIDENTIAL_IN = "RESIDENTIAL_IN"
     RESIDENTIAL_JP = "RESIDENTIAL_JP"
     NONE = "NONE"
+
+
+def get_tzinfo_from_proxy(proxy_location: ProxyLocation) -> ZoneInfo | None:
+    if proxy_location == ProxyLocation.NONE:
+        return None
+
+    if proxy_location == ProxyLocation.US_CA:
+        return ZoneInfo("America/Los_Angeles")
+
+    if proxy_location == ProxyLocation.US_NY:
+        return ZoneInfo("America/New_York")
+
+    if proxy_location == ProxyLocation.US_TX:
+        return ZoneInfo("America/Chicago")
+
+    if proxy_location == ProxyLocation.US_FL:
+        return ZoneInfo("America/New_York")
+
+    if proxy_location == ProxyLocation.US_WA:
+        return ZoneInfo("America/New_York")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL:
+        return ZoneInfo("America/New_York")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_ES:
+        return ZoneInfo("Europe/Madrid")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_IE:
+        return ZoneInfo("Europe/Dublin")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_GB:
+        return ZoneInfo("Europe/London")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_IN:
+        return ZoneInfo("Asia/Kolkata")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_JP:
+        return ZoneInfo("Asia/Kolkata")
+
+    return None
 
 
 class TaskBase(BaseModel):


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add timezone support by using local time in datetime operations and configuring timezone based on proxy location.
> 
>   - **Behavior**:
>     - Replaces `utc_datetime` with `local_datetime` in `agent.py` and multiple `.j2` template files to use local timezone.
>     - Adds `tz_info` to `SkyvernContext` in `skyvern_context.py` to store timezone information.
>     - Updates `get_tzinfo_from_proxy()` in `tasks.py` to map `ProxyLocation` to `ZoneInfo`.
>   - **Context Management**:
>     - Uses `ensure_context()` in `agent.py` and `handler.py` to ensure timezone context is available.
>   - **Browser Configuration**:
>     - Modifies `build_browser_args()` in `browser_factory.py` to set `timezone_id` based on `proxy_location`.
>     - Updates `create_browser_context()` in `browser_factory.py` to set `tz_info` in context based on `proxy_location`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ff642f44ee1ff7b5379d72108ff0c383f0bc54f7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->