### PR TITLE
fix hack input trigger

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -660,7 +660,7 @@ async def handle_input_text_action(
         return [ActionSuccess()]
     finally:
         # HACK: force to finish missing auto completion input
-        if auto_complete_hacky_flag:
+        if auto_complete_hacky_flag and not await skyvern_element.is_raw_input():
             LOG.debug(
                 "Trigger input-selection hack, pressing Tab to choose one",
                 action=action,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add condition in `handle_input_text_action` to check for raw input before triggering auto-completion hack.
> 
>   - **Behavior**:
>     - In `handle_input_text_action` in `handler.py`, add a condition to check `not await skyvern_element.is_raw_input()` before triggering the auto-completion hack.
>   - **Logging**:
>     - Add debug log in `handle_input_text_action` to indicate when the input-selection hack is triggered.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 22af91cdc6b2a2548a0eb81382dcaa367254cb17. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->