### PR TITLE
Reuse proxy location when set

### DIFF
--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -30,6 +30,7 @@ import { statusIsFinalized, statusIsRunningOrQueued } from "../tasks/types";
 import { useWorkflowQuery } from "./hooks/useWorkflowQuery";
 import { useWorkflowRunQuery } from "./hooks/useWorkflowRunQuery";
 import { cn } from "@/util/utils";
+import { ProxyLocation } from "@/api/types";
 
 function WorkflowRun() {
   const { workflowRunId, workflowPermanentId } = useParams();
@@ -79,6 +80,8 @@ function WorkflowRun() {
   const workflowRunIsFinalized = workflowRun && statusIsFinalized(workflowRun);
 
   const parameters = workflowRun?.parameters ?? {};
+  const proxyLocation =
+    workflowRun?.proxy_location ?? ProxyLocation.Residential;
 
   const title = workflowIsLoading ? (
     <Skeleton className="h-9 w-48" />
@@ -189,6 +192,7 @@ function WorkflowRun() {
                 to={`/workflows/${workflowPermanentId}/run`}
                 state={{
                   data: parameters,
+                  proxyLocation,
                 }}
               >
                 <PlayIcon className="mr-2 h-4 w-4" />

--- a/skyvern-frontend/src/routes/workflows/WorkflowRunParameters.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRunParameters.tsx
@@ -27,6 +27,10 @@ function WorkflowRunParameters() {
     (parameter) => parameter.parameter_type === "workflow",
   );
 
+  const proxyLocation = location.state
+    ? (location.state.proxyLocation as ProxyLocation)
+    : null;
+
   const initialValues = location.state?.data
     ? location.state.data
     : workflowParameters?.reduce(
@@ -95,7 +99,10 @@ function WorkflowRunParameters() {
         initialValues={initialValues}
         workflowParameters={workflowParameters}
         initialSettings={{
-          proxyLocation: workflow.proxy_location ?? ProxyLocation.Residential,
+          proxyLocation:
+            proxyLocation ??
+            workflow.proxy_location ??
+            ProxyLocation.Residential,
           webhookCallbackUrl: workflow.webhook_callback_url ?? "",
         }}
       />


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reuse `proxyLocation` when rerunning workflows, defaulting to `ProxyLocation.Residential` if not set, in `WorkflowRun` and `WorkflowRunParameters`.
> 
>   - **Behavior**:
>     - Reuse `proxyLocation` when rerunning workflows in `WorkflowRun` and `WorkflowRunParameters`.
>     - Default to `ProxyLocation.Residential` if `proxyLocation` is not set.
>   - **State Management**:
>     - Pass `proxyLocation` in `state` when navigating to rerun a workflow in `WorkflowRun`.
>     - Retrieve `proxyLocation` from `location.state` in `WorkflowRunParameters`.
>   - **Initial Settings**:
>     - Set `proxyLocation` in `initialSettings` of `RunWorkflowForm` in `WorkflowRunParameters`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a64da9270065f6b718cff3314e9180582ac29c37. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->