### PR TITLE
close the new page/window opened by file download action

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -397,6 +397,13 @@ async def handle_click_action(
                     step_id=step.step_id,
                     workflow_run_id=task.workflow_run_id,
                 )
+                if page == browser_state.browser_context.pages[-1]:
+                    LOG.warning(
+                        "The extra page is the current page, closing it",
+                        task_id=task.task_id,
+                        step_id=step.step_id,
+                        workflow_run_id=task.workflow_run_id,
+                    )
                 # close the extra page
                 await browser_state.browser_context.pages[-1].close()
     else:

--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -63,10 +63,9 @@ def set_browser_console_log(browser_context: BrowserContext, browser_artifacts: 
 
 def set_download_file_listener(browser_context: BrowserContext, **kwargs: Any) -> None:
     async def listen_to_download(download: Download) -> None:
+        workflow_run_id = kwargs.get("workflow_run_id")
+        task_id = kwargs.get("task_id")
         try:
-            workflow_run_id = kwargs.get("workflow_run_id")
-            task_id = kwargs.get("task_id")
-
             async with asyncio.timeout(BROWSER_DOWNLOAD_TIMEOUT):
                 file_path = await download.path()
                 if file_path.suffix:

--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1134,11 +1134,7 @@ function buildElementObject(frame, element, interactable, purgeable = false) {
   }
 
   if (elementTagNameLower === "input" || elementTagNameLower === "textarea") {
-    if (element.type === "password") {
-      attrs["value"] = element.value ? "*".repeat(element.value.length) : "";
-    } else {
-      attrs["value"] = element.value;
-    }
+    attrs["value"] = element.value;
   }
 
   let elementObj = {

--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1134,7 +1134,11 @@ function buildElementObject(frame, element, interactable, purgeable = false) {
   }
 
   if (elementTagNameLower === "input" || elementTagNameLower === "textarea") {
-    attrs["value"] = element.value;
+    if (element.type === "password") {
+      attrs["value"] = element.value ? "*".repeat(element.value.length) : "";
+    } else {
+      attrs["value"] = element.value;
+    }
   }
 
   let elementObj = {


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds logic in `handle_click_action()` to close extra pages opened during file downloads and refactors `set_download_file_listener()` for clarity.
> 
>   - **Behavior**:
>     - In `handle_click_action()` in `handler.py`, added logic to close any extra page opened during a file download action.
>     - Logs page count before and after download to identify if an extra page was opened.
>   - **Misc**:
>     - Minor refactoring in `set_download_file_listener()` in `browser_factory.py` to improve code clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 03b18fe3ebe2bfd004cd0b54059f916116310c30. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->