### PR TITLE
Revert "Add ability to use observer in the prompt section (#3194)"

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -233,15 +233,3 @@ export type ActionsApiResponse = {
   intention: string | null;
   response: string | null;
 };
-
-export type ObserverCruise = {
-  observer_cruise_id: string;
-  status: Status;
-  workflow_run_id: string | null;
-  workflow_id: string | null;
-  workflow_permanent_id: string | null;
-  prompt: string | null;
-  url: string | null;
-  created_at: string;
-  modified_at: string;
-};

--- a/skyvern-frontend/src/components/ui/select.tsx
+++ b/skyvern-frontend/src/components/ui/select.tsx
@@ -114,30 +114,6 @@ const SelectLabel = React.forwardRef<
 ));
 SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
-const CustomSelectItem = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Item
-    ref={ref}
-    className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      className,
-    )}
-    {...props}
-  >
-    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
-      <SelectPrimitive.ItemIndicator>
-        <CheckIcon className="h-4 w-4" />
-      </SelectPrimitive.ItemIndicator>
-    </span>
-    {children}
-  </SelectPrimitive.Item>
-));
-CustomSelectItem.displayName = SelectPrimitive.Item.displayName;
-
-const SelectItemText = SelectPrimitive.ItemText;
-
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
@@ -183,6 +159,4 @@ export {
   SelectSeparator,
   SelectScrollUpButton,
   SelectScrollDownButton,
-  CustomSelectItem,
-  SelectItemText,
 };

--- a/skyvern-frontend/src/util/env.ts
+++ b/skyvern-frontend/src/util/env.ts
@@ -19,13 +19,4 @@ if (!artifactApiBaseUrl) {
   console.warn("artifactApiBaseUrl environment variable was not set");
 }
 
-const observerEnabled = import.meta.env.VITE_OBSERVER_ENABLED as string;
-const observerFeatureEnabled = observerEnabled === "true";
-
-export {
-  apiBaseUrl,
-  environment,
-  envCredential,
-  artifactApiBaseUrl,
-  observerFeatureEnabled,
-};
+export { apiBaseUrl, environment, envCredential, artifactApiBaseUrl };


### PR DESCRIPTION
This reverts commit a43c00f520d281184685bae8a99cd6268ef8a5a1.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reverts observer feature in the prompt section by removing related types, components, and logic.
> 
>   - **Revert Observer Feature**:
>     - Remove `ObserverCruise` type from `types.ts`.
>     - Remove `CustomSelectItem` and `SelectItemText` components from `select.tsx`.
>     - Remove observer-related logic and UI elements from `PromptBox.tsx`.
>     - Remove `observerFeatureEnabled` export from `env.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6a706631e408fa7c3717d4e44daacce9dae4296b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->