### PR TITLE
fix get latest step

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -380,6 +380,7 @@ class AgentDB:
                         .filter_by(task_id=task_id)
                         .filter_by(organization_id=organization_id)
                         .order_by(StepModel.order.desc())
+                        .order_by(StepModel.retry_index.desc())
                     )
                 ).first():
                     return convert_to_step(step, debug_enabled=self.debug_enabled)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `get_latest_step` in `client.py` to correctly order by `retry_index` after `order` to retrieve the latest step.
> 
>   - **Behavior**:
>     - Fix `get_latest_step` in `client.py` to order by `StepModel.retry_index.desc()` after `StepModel.order.desc()` to correctly retrieve the latest step considering retries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1f85d4767767266259470755b2b47d726e53c6ab. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->