### PR TITLE
add observer_cruise_index to observer_thoughts table

### DIFF
--- a/alembic/versions/2024_12_18_0537-f81d59b4aed5_add_observer_cruise_index_to_the_.py
+++ b/alembic/versions/2024_12_18_0537-f81d59b4aed5_add_observer_cruise_index_to_the_.py
@@ -1,8 +1,8 @@
-"""add index to ObserverThoughtModel db table
+"""add observer_cruise_index to the observer_thoughts table
 
-Revision ID: cf45479f484c
-Revises: 411dd89f3df9
-Create Date: 2024-12-17 06:51:04.086890+00:00
+Revision ID: f81d59b4aed5
+Revises: 282b0548d443
+Create Date: 2024-12-18 05:37:23.366137+00:00
 
 """
 
@@ -11,8 +11,8 @@ from typing import Sequence, Union
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "cf45479f484c"
-down_revision: Union[str, None] = "411dd89f3df9"
+revision: str = "f81d59b4aed5"
+down_revision: Union[str, None] = "282b0548d443"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `observer_cruise_index` to `observer_thoughts` table for improved query performance.
> 
>   - **Database Migration**:
>     - Adds `observer_cruise_index` to `observer_thoughts` table on `organization_id` and `observer_cruise_id` columns in `2024_12_18_0537-f81d59b4aed5_add_observer_cruise_index_to_the_.py`.
>     - Updates `upgrade()` to create the index and `downgrade()` to drop the index.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 938225f8efd9624188099086688154924c54599c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->