### PR TITLE
re-add several label element to the element tree

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1548,7 +1548,8 @@ function buildElementTree(starter = document.body, frame, full_tree = false) {
         if (
           labelElement &&
           labelElement.childElementCount === 0 &&
-          !labelElement.getAttribute("for")
+          !labelElement.getAttribute("for") &&
+          !element.text
         ) {
           continue;
         }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `domUtils.js`, `buildElementTree()` now skips label elements without text or 'for' attribute.
> 
>   - **Behavior**:
>     - In `buildElementTree()` in `domUtils.js`, skip label elements without text or 'for' attribute when building the element tree.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 242150634d7261ac294687c89ad801ea265d7fa9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->