### PR TITLE
fix workflow run timeline infinite loop

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -1630,7 +1630,9 @@ class WorkflowService:
 
         result = []
         block_map: dict[str, WorkflowRunTimeline] = {}
+        counter = 0
         while workflow_run_blocks:
+            counter += 1
             block = workflow_run_blocks.pop(0)
             workflow_run_timeline = WorkflowRunTimeline(
                 type=WorkflowRunTimelineType.block,
@@ -1646,5 +1648,10 @@ class WorkflowService:
                     workflow_run_blocks.append(block)
             else:
                 result.append(workflow_run_timeline)
+                block_map[block.workflow_run_block_id] = workflow_run_timeline
+
+            if counter > 1000:
+                LOG.error("Too many blocks in the workflow run", workflow_run_id=workflow_run_id)
+                break
 
         return result


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes infinite loop in `get_workflow_run_timeline()` by adding a counter and error logging for excessive block count.
> 
>   - **Behavior**:
>     - Fixes infinite loop in `get_workflow_run_timeline()` in `service.py` by adding a counter to track iterations.
>     - Breaks loop and logs an error if more than 1000 iterations occur, indicating too many blocks in the workflow run.
>   - **Logging**:
>     - Adds error logging for excessive block count in `get_workflow_run_timeline()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 703faaa3ee089d35274a59d9e421e6f1a1366198. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->