### PR TITLE
Fix overflow in workflow run timeline

### DIFF
--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunOverview.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunOverview.tsx
@@ -109,7 +109,7 @@ function WorkflowRunOverview() {
       </div>
       <div className="w-1/3 min-w-0 rounded bg-slate-elevation1 p-4">
         <ScrollArea>
-          <ScrollAreaViewport className="max-h-[42rem]">
+          <ScrollAreaViewport className="max-h-[40rem]">
             <div className="space-y-4">
               <div className="gap-2"></div>
               {workflowRunIsNotFinalized && (

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineBlockItem.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineBlockItem.tsx
@@ -45,6 +45,7 @@ function WorkflowRunTimelineBlockItem({
       {subBlocks.map((block) => {
         return (
           <WorkflowRunTimelineBlockItem
+            key={block.workflow_run_block_id}
             block={block}
             activeItem={activeItem}
             onActionClick={onActionClick}


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes UI overflow and adds unique keys to React components in workflow run timeline.
> 
>   - **UI Fixes**:
>     - Adjust `max-h` from `42rem` to `40rem` in `WorkflowRunOverview.tsx` to fix overflow issue.
>   - **React Key Fixes**:
>     - Add `key` prop to `WorkflowRunTimelineBlockItem` in `WorkflowRunTimelineBlockItem.tsx` for unique identification of mapped components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0893445c78ec38c97e77cbabd8e166a5e31744bf. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->