### PR TITLE
fix prepend scheme for workflow url

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -48,7 +48,6 @@ from skyvern.forge.sdk.api.files import get_path_for_workflow_download_directory
 from skyvern.forge.sdk.artifact.models import ArtifactType
 from skyvern.forge.sdk.core import skyvern_context
 from skyvern.forge.sdk.core.security import generate_skyvern_signature
-from skyvern.forge.sdk.core.validators import prepend_scheme_and_validate_url
 from skyvern.forge.sdk.db.enums import TaskType
 from skyvern.forge.sdk.log_artifacts import save_step_logs, save_task_logs
 from skyvern.forge.sdk.models import Step, StepStatus
@@ -141,11 +140,6 @@ class ForgeAgent:
 
             task_url = working_page.url
 
-        task_url = prepend_scheme_and_validate_url(task_url)
-        totp_verification_url = task_block.totp_verification_url
-        if totp_verification_url:
-            totp_verification_url = prepend_scheme_and_validate_url(totp_verification_url)
-
         task = await app.DATABASE.create_task(
             url=task_url,
             task_type=task_block.task_type,
@@ -153,7 +147,7 @@ class ForgeAgent:
             terminate_criterion=task_block.terminate_criterion,
             title=task_block.title or task_block.label,
             webhook_callback_url=None,
-            totp_verification_url=totp_verification_url,
+            totp_verification_url=task_block.totp_verification_url,
             totp_identifier=task_block.totp_identifier,
             navigation_goal=task_block.navigation_goal,
             data_extraction_goal=task_block.data_extraction_goal,

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -44,6 +44,7 @@ from skyvern.forge.sdk.api.files import (
 )
 from skyvern.forge.sdk.api.llm.api_handler_factory import LLMAPIHandlerFactory
 from skyvern.forge.sdk.artifact.models import ArtifactType
+from skyvern.forge.sdk.core.validators import prepend_scheme_and_validate_url
 from skyvern.forge.sdk.db.enums import TaskType
 from skyvern.forge.sdk.schemas.tasks import Task, TaskOutput, TaskStatus
 from skyvern.forge.sdk.workflow.context_manager import BlockMetadata, WorkflowRunContext
@@ -290,6 +291,7 @@ class BaseTaskBlock(Block):
 
         if self.url:
             self.url = self.format_block_parameter_template_from_workflow_run_context(self.url, workflow_run_context)
+            self.url = prepend_scheme_and_validate_url(self.url)
 
         if self.totp_identifier:
             self.totp_identifier = self.format_block_parameter_template_from_workflow_run_context(
@@ -300,6 +302,7 @@ class BaseTaskBlock(Block):
             self.totp_verification_url = self.format_block_parameter_template_from_workflow_run_context(
                 self.totp_verification_url, workflow_run_context
             )
+            self.totp_verification_url = prepend_scheme_and_validate_url(self.totp_verification_url)
 
         if self.download_suffix:
             self.download_suffix = self.format_block_parameter_template_from_workflow_run_context(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Moved URL scheme validation from `agent.py` to `block.py` to ensure earlier validation in the workflow process.
> 
>   - **Behavior**:
>     - Moved `prepend_scheme_and_validate_url` call from `create_task_and_step_from_block` in `agent.py` to `format_potential_template_parameters` in `block.py`.
>     - Ensures URLs in `BaseTaskBlock` are validated and have a scheme prepended during parameter formatting.
>   - **Code Removal**:
>     - Removed `prepend_scheme_and_validate_url` call from `create_task_and_step_from_block` in `agent.py`.
>   - **Code Addition**:
>     - Added `prepend_scheme_and_validate_url` call in `format_potential_template_parameters` in `block.py` for `url` and `totp_verification_url`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1d901fc43d7122deb6f6799ba8c549afdac27270. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->