### PR TITLE
Change order of information in timeline info section

### DIFF
--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineItemInfoSection.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineItemInfoSection.tsx
@@ -53,6 +53,14 @@ function WorkflowRunTimelineItemInfoSection({ activeItem }: Props) {
     );
   }
   if (isWorkflowRunBlock(item)) {
+    const showExtractedInformationTab = item.status === Status.Completed;
+    const showFailureReasonTab =
+      item.status && statusIsAFailureType({ status: item.status });
+    const defaultTab = showExtractedInformationTab
+      ? "extracted_information"
+      : showFailureReasonTab
+        ? "failure_reason"
+        : "navigation_goal";
     if (
       item.block_type === WorkflowBlockTypes.Task ||
       item.block_type === WorkflowBlockTypes.Navigation ||
@@ -64,9 +72,8 @@ function WorkflowRunTimelineItemInfoSection({ activeItem }: Props) {
     ) {
       return (
         <div className="rounded bg-slate-elevation1 p-4">
-          <Tabs key={item.block_type} defaultValue="navigation_goal">
+          <Tabs key={item.block_type} defaultValue={defaultTab}>
             <TabsList>
-              <TabsTrigger value="navigation_goal">Navigation Goal</TabsTrigger>
               {item.status === Status.Completed && (
                 <TabsTrigger value="extracted_information">
                   Extracted Information
@@ -75,14 +82,9 @@ function WorkflowRunTimelineItemInfoSection({ activeItem }: Props) {
               {item.status && statusIsAFailureType({ status: item.status }) && (
                 <TabsTrigger value="failure_reason">Failure Reason</TabsTrigger>
               )}
+              <TabsTrigger value="navigation_goal">Navigation Goal</TabsTrigger>
               <TabsTrigger value="parameters">Parameters</TabsTrigger>
             </TabsList>
-            <TabsContent value="navigation_goal">
-              <AutoResizingTextarea
-                value={item.navigation_goal ?? ""}
-                readOnly
-              />
-            </TabsContent>
             {item.status === Status.Completed && (
               <TabsContent value="extracted_information">
                 <CodeEditor
@@ -112,6 +114,12 @@ function WorkflowRunTimelineItemInfoSection({ activeItem }: Props) {
                 />
               </TabsContent>
             )}
+            <TabsContent value="navigation_goal">
+              <AutoResizingTextarea
+                value={item.navigation_goal ?? ""}
+                readOnly
+              />
+            </TabsContent>
             <TabsContent value="parameters">
               <CodeEditor
                 value={JSON.stringify(item.navigation_payload, null, 2)}


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reorders tabs and changes default tab logic in `WorkflowRunTimelineItemInfoSection` based on item status.
> 
>   - **Behavior**:
>     - Changes default tab logic in `WorkflowRunTimelineItemInfoSection` to prioritize `extracted_information` if status is `Completed`, otherwise `failure_reason` if status is a failure type, else `navigation_goal`.
>     - Reorders `TabsTrigger` for `navigation_goal` to appear after `failure_reason` and `extracted_information`.
>   - **UI**:
>     - Adjusts `Tabs` component in `WorkflowRunTimelineItemInfoSection` to reflect new tab order and default selection logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 8c993fd0527209ada4116b3b39e61dc3618a977b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->