### PR TITLE
thought card uses answers or thoughts

### DIFF
--- a/skyvern-frontend/src/routes/workflows/workflowRun/ThoughtCard.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/ThoughtCard.tsx
@@ -28,7 +28,9 @@ function ThoughtCard({ thought, onClick, active }: Props) {
           <span className="text-xs">Decision</span>
         </div>
       </div>
-      <div className="text-xs text-slate-400">{thought.answer}</div>
+      <div className="text-xs text-slate-400">
+        {thought.answer || thought.thought}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `ThoughtCard` to display `thought.answer` or fallback to `thought.thought`.
> 
>   - **Behavior**:
>     - In `ThoughtCard.tsx`, modify display logic to show `thought.answer` or fallback to `thought.thought` if `answer` is not available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 05b4b37093d6a1c8d2b4e406a174bd4df0ed0583. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->