### PR TITLE
get observer cruise API

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1097,3 +1097,15 @@ async def observer_cruise(
         max_iterations_override=x_max_iterations_override,
     )
     return observer_cruise
+
+
+@base_router.get("/cruise/{observer_cruise_id}")
+@base_router.get("/cruise/{observer_cruise_id}/", include_in_schema=False)
+async def get_observer_cruise(
+    observer_cruise_id: str,
+    organization: Organization = Depends(org_auth_service.get_current_org),
+) -> ObserverCruise:
+    observer_cruise = await observer_service.get_observer_cruise(observer_cruise_id, organization.organization_id)
+    if not observer_cruise:
+        raise HTTPException(status_code=404, detail=f"Observer cruise {observer_cruise_id} not found")
+    return observer_cruise

--- a/skyvern/forge/sdk/services/observer_service.py
+++ b/skyvern/forge/sdk/services/observer_service.py
@@ -919,3 +919,7 @@ async def _record_thought_screenshot(observer_thought: ObserverThought, workflow
         artifact_type=ArtifactType.SCREENSHOT_LLM,
         data=screenshot,
     )
+
+
+async def get_observer_cruise(observer_cruise_id: str, organization_id: str | None = None) -> ObserverCruise | None:
+    return await app.DATABASE.get_observer_cruise(observer_cruise_id, organization_id=organization_id)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add new API endpoint in `agent_protocol.py` to retrieve observer cruise details, with service function in `observer_service.py`.
> 
>   - **New API Endpoint**:
>     - Adds `get_observer_cruise` route in `agent_protocol.py` to retrieve observer cruise details by `observer_cruise_id`.
>     - Route requires `organization` dependency for authorization.
>   - **Service Function**:
>     - Implements `get_observer_cruise` in `observer_service.py` to fetch cruise details from the database using `observer_cruise_id` and `organization_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 17131f6937c36957e2a76bbda8f47ba63b7ef87b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->