### PR TITLE
use user_url if specified by user when running cruise

### DIFF
--- a/skyvern/forge/sdk/services/observer_service.py
+++ b/skyvern/forge/sdk/services/observer_service.py
@@ -95,7 +95,7 @@ async def initialize_observer_cruise(
     metadata_response = await app.SECONDARY_LLM_API_HANDLER(prompt=metadata_prompt, observer_thought=observer_thought)
     # validate
     LOG.info(f"Initialized observer initial response: {metadata_response}")
-    url: str = metadata_response.get("url", "")
+    url: str = user_url or metadata_response.get("url", "")
     if not url:
         raise UrlGenerationFailure()
     title: str = metadata_response.get("title", DEFAULT_WORKFLOW_TITLE)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Prioritize `user_url` over generated URL in `initialize_observer_cruise` in `observer_service.py`.
> 
>   - **Behavior**:
>     - In `initialize_observer_cruise` in `observer_service.py`, prioritize `user_url` over `metadata_response` URL when setting `url`.
>     - Raises `UrlGenerationFailure` if neither `user_url` nor `metadata_response` URL is available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e2353ae6be9cb6b3094975058bd32d81fbc991b8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->