### PR TITLE
fix TOTP input issue

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -664,7 +664,13 @@ async def handle_input_text_action(
             return [ActionFailure(InvalidElementForTextInput(element_id=action.element_id, tag_name=tag_name))]
         except Exception:
             LOG.warning("Failed to clear the input field", action=action, exc_info=True)
-            return [ActionFailure(InvalidElementForTextInput(element_id=action.element_id, tag_name=tag_name))]
+
+            # some <span> is supported to use `locator.press_sequentially()` to fill in the data
+            if skyvern_element.get_tag_name() != "span":
+                return [ActionFailure(InvalidElementForTextInput(element_id=action.element_id, tag_name=tag_name))]
+
+            await skyvern_element.press_fill(text=text)
+            return [ActionSuccess()]
 
     try:
         # TODO: not sure if this case will trigger auto-completion

--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -619,6 +619,9 @@ function isInteractable(element) {
     if (hasAngularClickBinding(element)) {
       return true;
     }
+    if (element.className.toString().includes("blinking-cursor")) {
+      return true;
+    }
     // https://www.oxygenxml.com/dita/1.3/specs/langRef/technicalContent/svg-container.html
     // svg-container is usually used for clickable elements that wrap SVGs
     if (element.className.toString().includes("svg-container")) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes TOTP input issue by adding support for `<span>` elements in `handle_input_text_action` and recognizing `blinking-cursor` class in `isInteractable`.
> 
>   - **Behavior**:
>     - In `handle_input_text_action` in `handler.py`, added support for `<span>` elements using `press_fill()` if clearing the input field fails.
>     - Returns `ActionSuccess` for `<span>` elements after using `press_fill()`.
>   - **Error Handling**:
>     - Previously returned `ActionFailure` for all elements if clearing failed; now only for non-`<span>` elements.
>   - **DOM Utils**:
>     - In `domUtils.js`, updated `isInteractable` to return true for elements with class `blinking-cursor`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c92c8aacd347dc41d698aaa7b3f7bc63e69ec05b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->