### PR TITLE
Link to task diagnostics in block card

### DIFF
--- a/skyvern-frontend/src/routes/workflows/workflowRun/BlockCard.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/BlockCard.tsx
@@ -1,8 +1,10 @@
-import { CubeIcon } from "@radix-ui/react-icons";
+import { ExternalLinkIcon } from "@radix-ui/react-icons";
 import { WorkflowRunBlock } from "../types/workflowRunTypes";
 import { cn } from "@/util/utils";
 import { WorkflowBlockIcon } from "../editor/nodes/WorkflowBlockIcon";
 import { workflowBlockTitle } from "../editor/nodes/types";
+import { Button } from "@/components/ui/button";
+import { Link } from "react-router-dom";
 
 type Props = {
   active: boolean;
@@ -21,7 +23,7 @@ function BlockCard({ block, onClick, active }: Props) {
       )}
       onClick={onClick}
     >
-      <div className="flex justify-between">
+      <div className="flex items-center justify-between">
         <div className="flex gap-3">
           <WorkflowBlockIcon
             workflowBlockType={block.block_type}
@@ -29,10 +31,18 @@ function BlockCard({ block, onClick, active }: Props) {
           />
           <span>{workflowBlockTitle[block.block_type]}</span>
         </div>
-        <div className="flex items-center gap-1 rounded bg-slate-elevation5 px-2 py-1">
-          <CubeIcon className="size-4" />
-          <span className="text-xs">Block</span>
-        </div>
+        {block.task_id && (
+          <Button
+            title="Go to task diagnostics"
+            asChild
+            size="icon"
+            className="size-8 bg-slate-800 text-primary hover:bg-slate-700"
+          >
+            <Link to={`/tasks/${block.task_id}/diagnostics`}>
+              <ExternalLinkIcon />
+            </Link>
+          </Button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a link to task diagnostics in `BlockCard` using `ExternalLinkIcon` and `Link` if `task_id` is present.
> 
>   - **Behavior**:
>     - Adds a link to task diagnostics in `BlockCard` if `block.task_id` is present.
>     - Uses `ExternalLinkIcon` and `Link` to navigate to `/tasks/{task_id}/diagnostics`.
>   - **UI Components**:
>     - Replaces `CubeIcon` with `ExternalLinkIcon` in `BlockCard`.
>     - Wraps `Link` in `Button` for improved styling and interaction.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6f53e0de55bd2423ee6ac026fce36c0fb3f25b33. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->