### PR TITLE
Fix wrongly ordered action screenshots

### DIFF
--- a/skyvern-frontend/src/routes/tasks/detail/ActionScreenshot.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/ActionScreenshot.tsx
@@ -44,7 +44,8 @@ function ActionScreenshot({ stepId, index, taskStatus }: Props) {
     (artifact) => artifact.artifact_type === ArtifactType.ActionScreenshot,
   );
 
-  const screenshot = actionScreenshots?.[index];
+  // action screenshots are reverse ordered w.r.t action order
+  const screenshot = actionScreenshots?.[actionScreenshots.length - index - 1];
 
   if (isLoading) {
     return (

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineItemInfoSection.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineItemInfoSection.tsx
@@ -72,7 +72,7 @@ function WorkflowRunTimelineItemInfoSection({ activeItem }: Props) {
     ) {
       return (
         <div className="rounded bg-slate-elevation1 p-4">
-          <Tabs key={item.block_type} defaultValue={defaultTab}>
+          <Tabs key={item.task_id ?? item.block_type} defaultValue={defaultTab}>
             <TabsList>
               {item.status === Status.Completed && (
                 <TabsTrigger value="extracted_information">


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes action screenshot order and ensures unique `Tabs` keys in `WorkflowRunTimelineItemInfoSection.tsx`.
> 
>   - **Behavior**:
>     - Fixes ordering of action screenshots in `ActionScreenshot.tsx` by reversing the index calculation.
>     - Changes `Tabs` key in `WorkflowRunTimelineItemInfoSection.tsx` to use `item.task_id` if available, ensuring unique keys.
>   - **Misc**:
>     - Adds a comment in `ActionScreenshot.tsx` explaining the reverse order of screenshots.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 02c14b364ee9220280a0f07f676f90f7062c086a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->