### PR TITLE
add observer_cruise_id to SkyvernContext and logs

### DIFF
--- a/skyvern/forge/sdk/core/skyvern_context.py
+++ b/skyvern/forge/sdk/core/skyvern_context.py
@@ -10,6 +10,7 @@ class SkyvernContext:
     task_id: str | None = None
     workflow_id: str | None = None
     workflow_run_id: str | None = None
+    observer_cruise_id: str | None = None
     max_steps_override: int | None = None
     tz_info: ZoneInfo | None = None
     totp_codes: dict[str, str | None] = field(default_factory=dict)

--- a/skyvern/forge/sdk/forge_log.py
+++ b/skyvern/forge/sdk/forge_log.py
@@ -32,6 +32,8 @@ def add_kv_pairs_to_msg(logger: logging.Logger, method_name: str, event_dict: Ev
             event_dict["workflow_id"] = context.workflow_id
         if context.workflow_run_id:
             event_dict["workflow_run_id"] = context.workflow_run_id
+        if context.observer_cruise_id:
+            event_dict["observer_cruise_id"] = context.observer_cruise_id
 
     # Add env to the log
     event_dict["env"] = settings.ENV

--- a/skyvern/forge/sdk/services/observer_service.py
+++ b/skyvern/forge/sdk/services/observer_service.py
@@ -84,6 +84,10 @@ async def initialize_observer_cruise(
         prompt=user_prompt,
         organization_id=organization.organization_id,
     )
+    # set observer cruise id in context
+    context = skyvern_context.current()
+    if context:
+        context.observer_cruise_id = observer_cruise.observer_cruise_id
 
     observer_thought = await app.DATABASE.create_observer_thought(
         observer_cruise_id=observer_cruise.observer_cruise_id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `observer_cruise_id` to `SkyvernContext` and log it in `forge_log.py`, setting it in `initialize_observer_cruise()` in `observer_service.py`.
> 
>   - **SkyvernContext**:
>     - Add `observer_cruise_id` attribute to `SkyvernContext` class in `skyvern_context.py`.
>   - **Logging**:
>     - Log `observer_cruise_id` in `add_kv_pairs_to_msg()` in `forge_log.py` if present in context.
>   - **Observer Service**:
>     - Set `observer_cruise_id` in `SkyvernContext` within `initialize_observer_cruise()` in `observer_service.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 796405aa747395dea0ed032d9b77c59118e2ad90. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->