### PR TITLE
add observer cruise to get workflow_run api response

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -720,12 +720,19 @@ async def get_workflow_run(
     current_org: Organization = Depends(org_auth_service.get_current_org),
 ) -> WorkflowRunStatusResponse:
     analytics.capture("skyvern-oss-agent-workflow-run-get")
-    return await app.WORKFLOW_SERVICE.build_workflow_run_status_response(
+    workflow_run_status_response = await app.WORKFLOW_SERVICE.build_workflow_run_status_response(
         workflow_permanent_id=workflow_id,
         workflow_run_id=workflow_run_id,
         organization_id=current_org.organization_id,
         include_cost=True,
     )
+    observer_cruise = await app.DATABASE.get_observer_cruise_by_workflow_run_id(
+        workflow_run_id=workflow_run_id,
+        organization_id=current_org.organization_id,
+    )
+    if observer_cruise:
+        workflow_run_status_response.observer_cruise = observer_cruise
+    return workflow_run_status_response
 
 
 @base_router.get(

--- a/skyvern/forge/sdk/workflow/models/workflow.py
+++ b/skyvern/forge/sdk/workflow/models/workflow.py
@@ -5,6 +5,7 @@ from typing import Any, List
 from pydantic import BaseModel, field_validator
 
 from skyvern.forge.sdk.core.validators import validate_url
+from skyvern.forge.sdk.schemas.observers import ObserverCruise
 from skyvern.forge.sdk.schemas.tasks import ProxyLocation
 from skyvern.forge.sdk.workflow.exceptions import WorkflowDefinitionHasDuplicateBlockLabels
 from skyvern.forge.sdk.workflow.models.block import BlockTypeVar
@@ -136,3 +137,4 @@ class WorkflowRunStatusResponse(BaseModel):
     outputs: dict[str, Any] | None = None
     total_steps: int | None = None
     total_cost: float | None = None
+    observer_cruise: ObserverCruise | None = None


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add observer cruise data to workflow run status response in `get_workflow_run` function.
> 
>   - **Behavior**:
>     - `get_workflow_run` in `agent_protocol.py` now includes `observer_cruise` data in the response if available.
>     - Fetches `observer_cruise` using `get_observer_cruise_by_workflow_run_id` from the database.
>   - **Models**:
>     - Adds `observer_cruise` field to `WorkflowRunStatusResponse` in `workflow.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e0962011369f97abbf8f52618c0e3d03eb0416e5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->