### PR TITLE
add screenshot for the first task block

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -438,7 +438,7 @@ class BaseTaskBlock(Block):
                 task_order=task_order,
                 task_retry=task_retry,
             )
-            await app.DATABASE.update_workflow_run_block(
+            workflow_run_block = await app.DATABASE.update_workflow_run_block(
                 workflow_run_block_id=workflow_run_block_id,
                 task_id=task.task_id,
                 organization_id=workflow.organization_id,
@@ -455,6 +455,14 @@ class BaseTaskBlock(Block):
                     browser_state = await app.BROWSER_MANAGER.get_or_create_for_workflow_run(
                         workflow_run=workflow_run, url=self.url
                     )
+                    # add screenshot artifact for the first task
+                    screenshot = await browser_state.take_screenshot(full_page=True)
+                    if screenshot:
+                        await app.ARTIFACT_MANAGER.create_workflow_run_block_artifact(
+                            workflow_run_block=workflow_run_block,
+                            artifact_type=ArtifactType.SCREENSHOT_LLM,
+                            data=screenshot,
+                        )
                 except Exception as e:
                     LOG.exception(
                         "Failed to get browser state for first task",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds screenshot capture for the first task block in `execute()` in `block.py`.
> 
>   - **Behavior**:
>     - Adds screenshot capture for the first task block in `execute()` in `block.py`.
>     - Screenshot is taken using `browser_state.take_screenshot(full_page=True)` and stored as an artifact with type `ArtifactType.SCREENSHOT_LLM`.
>   - **Error Handling**:
>     - Logs exception if browser state retrieval fails for the first task.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1d8be913021b16318be500800aa7ef18d8ffd9c8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->