### PR TITLE
Fix redirect bug when new template created

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/SavedTasks.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTasks.tsx
@@ -102,7 +102,7 @@ function SavedTasks() {
       queryClient.invalidateQueries({
         queryKey: ["savedTasks"],
       });
-      navigate(`/create/${response.workflow_permanent_id}`);
+      navigate(`/tasks/create/${response.workflow_permanent_id}`);
     },
   });
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix redirect URL in `SavedTasks.tsx` to ensure correct navigation after template creation.
> 
>   - **Behavior**:
>     - Fix redirect URL in `onSuccess` callback of mutation in `SavedTasks.tsx` from `/create/` to `/tasks/create/`.
>   - **Misc**:
>     - No other changes or refactors were made.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9a533f0f76c11608f190ebf0be7fb33ea2b69718. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->