### PR TITLE
fix restart workflow run

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -2132,6 +2132,17 @@ class AgentDB:
             task = await self.get_task(task_id, organization_id=organization_id)
         return convert_to_workflow_run_block(new_workflow_run_block, task=task)
 
+    async def delete_workflow_run_blocks(self, workflow_run_id: str, organization_id: str | None = None) -> None:
+        async with self.Session() as session:
+            stmt = delete(WorkflowRunBlockModel).where(
+                and_(
+                    WorkflowRunBlockModel.workflow_run_id == workflow_run_id,
+                    WorkflowRunBlockModel.organization_id == organization_id,
+                )
+            )
+            await session.execute(stmt)
+            await session.commit()
+
     async def update_workflow_run_block(
         self,
         workflow_run_block_id: str,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `delete_workflow_run_blocks` in `client.py` and updates `reset_workflow_run` in `workflows.py` to delete workflow run blocks during reset.
> 
>   - **Behavior**:
>     - In `reset_workflow_run` in `workflows.py`, added call to `delete_workflow_run_blocks` to remove workflow run blocks during reset.
>   - **Database**:
>     - Added `delete_workflow_run_blocks` function in `client.py` to delete `WorkflowRunBlockModel` entries by `workflow_run_id` and `organization_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for bc3fe61e20d5c80bc4774c075196018d73b39ba3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->