### PR TITLE
Update checks on save for new loop block field

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -1691,11 +1691,11 @@ function getWorkflowErrors(nodes: Array<AppNode>): Array<string> {
   // check loop node parameters
   const loopNodes: Array<LoopNode> = nodes.filter(isLoopNode);
   const emptyLoopNodes = loopNodes.filter(
-    (node: LoopNode) => node.data.loopValue === "",
+    (node: LoopNode) => node.data.loopVariableReference === "",
   );
   if (emptyLoopNodes.length > 0) {
     emptyLoopNodes.forEach((node) => {
-      errors.push(`${node.data.label}: Loop value parameter is required.`);
+      errors.push(`${node.data.label}: Loop value is required.`);
     });
   }
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `getWorkflowErrors()` in `workflowEditorUtils.ts` to check `loopVariableReference` instead of `loopValue` for empty loop nodes, with updated error message.
> 
>   - **Behavior**:
>     - Update `getWorkflowErrors()` in `workflowEditorUtils.ts` to check `loopVariableReference` instead of `loopValue` for empty loop nodes.
>     - Error message updated to "Loop value is required." for empty `loopVariableReference` cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 20aa2cc95fdcdc9860ca5dad0f575716b61ddf7c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->