### PR TITLE
use the first screenshot for llm thought

### DIFF
--- a/skyvern-frontend/src/routes/workflows/workflowRun/ObserverThoughtScreenshot.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/ObserverThoughtScreenshot.tsx
@@ -39,7 +39,8 @@ function ObserverThoughtScreenshot({ observerThoughtId, taskStatus }: Props) {
     (artifact) => artifact.artifact_type === ArtifactType.LLMScreenshot,
   );
 
-  const screenshot = llmScreenshots?.[0];
+  // use the last screenshot as the llmScreenshots are in reverse order
+  const screenshot = llmScreenshots?.[llmScreenshots.length - 1];
 
   if (isLoading) {
     return (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change screenshot selection to use the last screenshot from `llmScreenshots` in `ObserverThoughtScreenshot.tsx`.
> 
>   - **Behavior**:
>     - In `ObserverThoughtScreenshot.tsx`, change screenshot selection to use the last screenshot from `llmScreenshots` array instead of the first.
>     - This change is due to `llmScreenshots` being in reverse order.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6587d6a4cc9ba4f14bc77f0854e01a1d186e1f6f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->