### PR TITLE
fix forloop output parameter issue

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -458,9 +458,13 @@ class BaseTaskBlock(Block):
         try:
             self.format_potential_template_parameters(workflow_run_context=workflow_run_context)
         except Exception as e:
+            failure_reason = f"Failed to format jinja template: {str(e)}"
+            await self.record_output_parameter_value(
+                workflow_run_context, workflow_run_id, {"failure_reason": failure_reason}
+            )
             return await self.build_block_result(
                 success=False,
-                failure_reason=f"Failed to format jinja template: {str(e)}",
+                failure_reason=failure_reason,
                 output_parameter_value=None,
                 status=BlockStatus.failed,
                 workflow_run_block_id=workflow_run_block_id,
@@ -843,7 +847,9 @@ class ForLoopBlock(Block):
                     {
                         "loop_value": loop_over_value,
                         "output_parameter": block_output.output_parameter,
-                        "output_value": workflow_run_context.get_value(block_output.output_parameter.key),
+                        "output_value": workflow_run_context.get_value(block_output.output_parameter.key)
+                        if workflow_run_context.has_value(block_output.output_parameter.key)
+                        else None,
                     }
                 )
                 try:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes output parameter handling in `execute_loop_helper` in `block.py` by setting `output_value` to `None` if not present in `workflow_run_context`.
> 
>   - **Behavior**:
>     - Fixes issue in `execute_loop_helper` in `block.py` where `output_value` is now set to `None` if `workflow_run_context` does not have the `output_parameter.key`.
>   - **Error Handling**:
>     - Adds error handling for missing `output_parameter` values in loop execution, preventing potential errors when values are not set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 49e9ee02090226b19b7d3317d99e4b941903fef6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->