### PR TITLE
control workflow timeline order in backend - descending

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -379,7 +379,7 @@ class AgentDB:
                     select(ActionModel)
                     .filter(ActionModel.organization_id == organization_id)
                     .filter(ActionModel.task_id.in_(task_ids))
-                    .order_by(ActionModel.created_at)
+                    .order_by(ActionModel.created_at.desc())
                 )
                 actions = (await session.scalars(query)).all()
                 return [Action.model_validate(action) for action in actions]
@@ -2241,7 +2241,7 @@ class AgentDB:
                     select(WorkflowRunBlockModel)
                     .filter_by(workflow_run_id=workflow_run_id)
                     .filter_by(organization_id=organization_id)
-                    .order_by(WorkflowRunBlockModel.created_at)
+                    .order_by(WorkflowRunBlockModel.created_at.desc())
                 )
             ).all()
             tasks = await self.get_tasks_by_workflow_run_id(workflow_run_id)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change order of task actions and workflow run blocks retrieval to descending by creation time in `client.py`.
> 
>   - **Behavior**:
>     - Change order of `get_tasks_actions()` in `client.py` to descending by `ActionModel.created_at`.
>     - Change order of `get_workflow_run_blocks()` in `client.py` to descending by `WorkflowRunBlockModel.created_at`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 52d9df829695193162203d802beb70687584925d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->