### PR TITLE
Fix loop block label update bug

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -1194,10 +1194,11 @@ function getUpdatedNodesAfterLabelUpdateForParameterKeys(
         ...node,
         data: {
           ...node.data,
-          loopValue:
-            node.data.loopValue === getOutputParameterKey(oldLabel)
+          label: node.id === id ? newLabel : node.data.label,
+          loopVariableReference:
+            node.data.loopVariableReference === getOutputParameterKey(oldLabel)
               ? getOutputParameterKey(newLabel)
-              : node.data.loopValue,
+              : node.data.loopVariableReference,
         },
       };
     }


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes label update bug in `getUpdatedNodesAfterLabelUpdateForParameterKeys` by correcting `loopVariableReference` update logic in `workflowEditorUtils.ts`.
> 
>   - **Bug Fix**:
>     - Fixes label update bug in `getUpdatedNodesAfterLabelUpdateForParameterKeys` in `workflowEditorUtils.ts`.
>     - Corrects `loopVariableReference` update logic to match new label if it matches old label's output parameter key.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for af92eabae81d8c0dd9a70b5e8931336a75ac5f9c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->