### PR TITLE
fix a bug where too many adder nodes are added

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -583,16 +583,14 @@ function getElements(
       ),
     );
     const children = data.filter((b) => b.parentId === block.id);
+    const adderNodeId = nanoid();
     if (children.length === 0) {
-      const adderNodeId = nanoid();
-      nodes.push(nodeAdderNode(adderNodeId, block.id));
       edges.push(defaultEdge(startNodeId, adderNodeId));
     } else {
       const firstChild = children.find((c) => c.previous === null)!;
       edges.push(edgeWithAddButton(startNodeId, firstChild.id));
     }
     const lastChild = children.find((c) => c.next === null);
-    const adderNodeId = nanoid();
     nodes.push(nodeAdderNode(adderNodeId, block.id));
     if (lastChild) {
       edges.push(defaultEdge(lastChild.id, adderNodeId));


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes bug in `getElements` function in `workflowEditorUtils.ts` to prevent adding multiple adder nodes by reusing `adderNodeId`.
> 
>   - **Bug Fix**:
>     - Fixes bug in `getElements` function in `workflowEditorUtils.ts` where multiple adder nodes were added unnecessarily.
>     - Reuses `adderNodeId` variable instead of redeclaring it, ensuring only one adder node is added per block.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for dfd401f5bfc04861f6c7084236449eef0bc15239. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->