### PR TITLE
hash long href link

### DIFF
--- a/skyvern/forge/prompts/skyvern/extract-information.j2
+++ b/skyvern/forge/prompts/skyvern/extract-information.j2
@@ -9,6 +9,8 @@ Do not ever include anything other than the JSON object in your output, and do n
 
 If you are unable to extract the requested information for a specific field in the json schema, please output a null value for that field.
 
+If you are trying to extract the href links which are using the jinja style like "{% raw %}{{}}{% endraw %}", please keep the orignal string.
+
 User Data Extraction Goal: {{ data_extraction_goal }}
 
 {% if error_code_mapping_str %}

--- a/skyvern/forge/sdk/artifact/models.py
+++ b/skyvern/forge/sdk/artifact/models.py
@@ -26,11 +26,14 @@ class ArtifactType(StrEnum):
     LLM_REQUEST = "llm_request"
     LLM_RESPONSE = "llm_response"
     LLM_RESPONSE_PARSED = "llm_response_parsed"
+    LLM_RESPONSE_RENDERED = "llm_response_rendered"
     VISIBLE_ELEMENTS_ID_CSS_MAP = "visible_elements_id_css_map"
     VISIBLE_ELEMENTS_ID_FRAME_MAP = "visible_elements_id_frame_map"
     VISIBLE_ELEMENTS_TREE = "visible_elements_tree"
     VISIBLE_ELEMENTS_TREE_TRIMMED = "visible_elements_tree_trimmed"
     VISIBLE_ELEMENTS_TREE_IN_PROMPT = "visible_elements_tree_in_prompt"
+
+    HASHED_HREF_MAP = "hashed_href_map"
 
     # DEPRECATED. pls use VISIBLE_ELEMENTS_ID_CSS_MAP
     VISIBLE_ELEMENTS_ID_XPATH_MAP = "visible_elements_id_xpath_map"

--- a/skyvern/forge/sdk/artifact/storage/base.py
+++ b/skyvern/forge/sdk/artifact/storage/base.py
@@ -18,6 +18,7 @@ FILE_EXTENTSION_MAP: dict[ArtifactType, str] = {
     ArtifactType.LLM_REQUEST: "json",
     ArtifactType.LLM_RESPONSE: "json",
     ArtifactType.LLM_RESPONSE_PARSED: "json",
+    ArtifactType.LLM_RESPONSE_RENDERED: "json",
     ArtifactType.VISIBLE_ELEMENTS_ID_CSS_MAP: "json",
     ArtifactType.VISIBLE_ELEMENTS_ID_FRAME_MAP: "json",
     ArtifactType.VISIBLE_ELEMENTS_TREE: "json",
@@ -27,6 +28,7 @@ FILE_EXTENTSION_MAP: dict[ArtifactType, str] = {
     ArtifactType.HTML_ACTION: "html",
     ArtifactType.TRACE: "zip",
     ArtifactType.HAR: "har",
+    ArtifactType.HASHED_HREF_MAP: "json",
     # DEPRECATED: we're using CSS selector map now
     ArtifactType.VISIBLE_ELEMENTS_ID_XPATH_MAP: "json",
 }

--- a/skyvern/forge/sdk/core/skyvern_context.py
+++ b/skyvern/forge/sdk/core/skyvern_context.py
@@ -15,6 +15,7 @@ class SkyvernContext:
     tz_info: ZoneInfo | None = None
     totp_codes: dict[str, str | None] = field(default_factory=dict)
     log: list[dict] = field(default_factory=list)
+    hashed_href_map: dict[str, str] = field(default_factory=dict)
 
     def __repr__(self) -> str:
         return f"SkyvernContext(request_id={self.request_id}, organization_id={self.organization_id}, task_id={self.task_id}, workflow_id={self.workflow_id}, workflow_run_id={self.workflow_run_id}, max_steps_override={self.max_steps_override})"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> This PR hashes long href links in HTML elements, storing them in a context map, and updates LLM handlers to render responses using these hashes.
> 
>   - **Behavior**:
>     - Hashes href links longer than 300 characters in `json_to_html()` in `scraper.py`, storing them in `SkyvernContext.hashed_href_map`.
>     - Renders LLM responses using hashed hrefs in `llm_api_handler_with_router_and_fallback()` and `llm_api_handler()` in `api_handler_factory.py`.
>   - **Models**:
>     - Adds `hashed_href_map` to `SkyvernContext` in `skyvern_context.py`.
>     - Adds `HASHED_HREF_MAP` and `LLM_RESPONSE_RENDERED` to `ArtifactType` in `models.py`.
>   - **Storage**:
>     - Maps `HASHED_HREF_MAP` and `LLM_RESPONSE_RENDERED` to `json` in `base.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e45ace0883edd489001f7de9d247914511dabc93. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->