### PR TITLE
workflow timeline in reversed order

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -763,7 +763,7 @@ async def get_workflow_run_timeline(
             organization_id=current_org.organization_id,
         )
         workflow_run_block_timeline.extend(observer_thought_timeline)
-    workflow_run_block_timeline.sort(key=lambda x: x.created_at)
+    workflow_run_block_timeline.sort(key=lambda x: x.created_at, reverse=True)
     return workflow_run_block_timeline
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reverse order of workflow timeline events in `get_workflow_run_timeline()` by sorting in descending order of `created_at`.
> 
>   - **Behavior**:
>     - Reverse order of workflow timeline events in `get_workflow_run_timeline()` in `agent_protocol.py` by sorting `workflow_run_block_timeline` in descending order of `created_at`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1b0c1990d15c8c0fb9f3855c8f496fee7e05c9a7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->