### PR TITLE
Use API order instead of reordering timeline

### DIFF
--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimeline.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimeline.tsx
@@ -56,8 +56,6 @@ function WorkflowRunTimeline({
 
   const workflowRunIsNotFinalized = statusIsNotFinalized(workflowRun);
 
-  const timeline = workflowRunTimeline.slice().reverse();
-
   const numberOfActions = workflowRunTimeline.reduce((total, current) => {
     if (isTaskVariantBlockItem(current)) {
       return total + current.block!.actions!.length;
@@ -98,8 +96,10 @@ function WorkflowRunTimeline({
                 </div>
               </div>
             )}
-            {timeline.length === 0 && <div>Workflow timeline is empty</div>}
-            {timeline?.map((timelineItem) => {
+            {workflowRunTimeline.length === 0 && (
+              <div>Workflow timeline is empty</div>
+            )}
+            {workflowRunTimeline?.map((timelineItem) => {
               if (isBlockItem(timelineItem)) {
                 return (
                   <WorkflowRunTimelineBlockItem

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineBlockItem.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineBlockItem.tsx
@@ -31,7 +31,7 @@ function WorkflowRunTimelineBlockItem({
   onBlockItemClick,
   onActionClick,
 }: Props) {
-  const actions = block.actions ? [...block.actions].reverse() : [];
+  const actions = block.actions ?? [];
 
   const hasActiveAction =
     isAction(activeItem) &&

--- a/skyvern-frontend/src/routes/workflows/workflowRun/workflowTimelineUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/workflowTimelineUtils.ts
@@ -37,15 +37,13 @@ function findActiveItem(
       return "stream";
     }
     if (timeline?.length > 0) {
-      const last = timeline.length - 1;
-      const timelineItem = timeline![last];
+      const timelineItem = timeline![0];
       if (isBlockItem(timelineItem)) {
         if (
           timelineItem.block.actions &&
           timelineItem.block.actions.length > 0
         ) {
-          const last = timelineItem.block.actions.length - 1;
-          return timelineItem.block.actions[last]!;
+          return timelineItem.block.actions[0]!;
         }
         return timelineItem.block;
       }


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Use API order for timeline and actions in `WorkflowRunTimeline` and `WorkflowRunTimelineBlockItem`, removing unnecessary reversals.
> 
>   - **Behavior**:
>     - Use API order for `workflowRunTimeline` in `WorkflowRunTimeline.tsx` instead of reversing it.
>     - Use API order for `actions` in `WorkflowRunTimelineBlockItem.tsx` instead of reversing them.
>     - Update `findActiveItem` in `workflowTimelineUtils.ts` to use the first item instead of the last for determining active items.
>   - **Misc**:
>     - Remove unnecessary reversal of `timeline` and `actions` in `WorkflowRunTimeline.tsx` and `WorkflowRunTimelineBlockItem.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 31a13196daefd3121e802a8f3f38ca654c5ca7de. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->