### PR TITLE
sync - deleteOrphaned: true

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,8 +1,7 @@
 Skyvern-AI/skyvern-cloud:
   - source: skyvern/
     dest: skyvern/
-  - source: streamlit_app/
-    dest: streamlit_app/
+    deleteOrphaned: true
   - source: pyproject.toml
     dest: pyproject.toml
   - source: poetry.lock
@@ -19,3 +18,4 @@ Skyvern-AI/skyvern-cloud:
     dest: run_alembic_check.sh
   - source: skyvern-frontend/src/
     dest: skyvern-frontend/src/
+    deleteOrphaned: true


### PR DESCRIPTION
according to https://github.com/marketplace/actions/repo-file-sync-action#delete-orphaned-files, we want to make sure we also delete files in the cloud repo if they're deleted in the open source side.


<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `deleteOrphaned: true` to sync operations for `skyvern/` and `skyvern-frontend/src/` in `.github/sync.yml`.
> 
>   - **Sync Configuration**:
>     - Adds `deleteOrphaned: true` to `skyvern/` sync operation in `.github/sync.yml`.
>     - Adds `deleteOrphaned: true` to `skyvern-frontend/src/` sync operation in `.github/sync.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 8efa0b4e07b815f3764591e91341a987dcb4d763. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->