### PR TITLE
make observer prompt resize

### DIFF
--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowPostRunParameters.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowPostRunParameters.tsx
@@ -151,7 +151,7 @@ function WorkflowPostRunParameters() {
                   The original prompt for the observer
                 </h2>
               </div>
-              <Input
+              <AutoResizingTextarea
                 value={workflowRun.observer_cruise.prompt ?? ""}
                 readOnly
               />


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replace `Input` with `AutoResizingTextarea` in `WorkflowPostRunParameters.tsx` for multi-line observer prompt display.
> 
>   - **UI Update**:
>     - Replace `Input` with `AutoResizingTextarea` for `workflowRun.observer_cruise.prompt` in `WorkflowPostRunParameters.tsx` to support multi-line text display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0e7f8e86367864b6a28266def5c0476ea4eb42fb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->