### PR TITLE
fix get first step issue

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -400,6 +400,7 @@ class AgentDB:
                         .filter_by(task_id=task_id)
                         .filter_by(organization_id=organization_id)
                         .order_by(StepModel.order.asc())
+                        .order_by(StepModel.retry_index.asc())
                     )
                 ).first():
                     return convert_to_step(step, debug_enabled=self.debug_enabled)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes step retrieval order in `get_first_step()` in `client.py` by adding `retry_index` to the ordering criteria.
> 
>   - **Behavior**:
>     - Fixes ordering in `get_first_step()` in `client.py` to include `retry_index` in ascending order, ensuring correct step retrieval sequence.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e805d1897a4e69808d38edc4fe3a3641d29c6bb8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->