### PR TITLE
Fix react query cache key problem for saved tasks

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskFormPage.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskFormPage.tsx
@@ -16,7 +16,7 @@ function CreateNewTaskFormPage() {
   const location = useLocation();
 
   const { data, isFetching } = useQuery({
-    queryKey: ["savedTask", template],
+    queryKey: ["savedTasks", template],
     queryFn: async () => {
       const client = await getClient(credentialGetter);
       return client

--- a/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
@@ -245,7 +245,7 @@ function SavedTaskForm({ initialValues }: Props) {
         description: "Changes saved successfully",
       });
       queryClient.invalidateQueries({
-        queryKey: ["savedTasks", template],
+        queryKey: ["savedTasks"],
       });
     },
   });


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes cache key issue by updating `queryKey` to `"savedTasks"` in `CreateNewTaskFormPage.tsx` and `SavedTaskForm.tsx` for proper cache invalidation.
> 
>   - **Behavior**:
>     - Fixes cache key issue by changing `queryKey` from `"savedTask"` to `"savedTasks"` in `CreateNewTaskFormPage.tsx` and `SavedTaskForm.tsx`.
>     - Ensures cache invalidation for `savedTasks` when tasks are saved.
>   - **Misc**:
>     - Minor refactor in `SavedTaskForm.tsx` to remove template from `queryKey` for cache invalidation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5c888f8e10017317bcecf2e56e6c18acd1297d1e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->