### PR TITLE
let observer continue exploring when task failed/terminated

### DIFF
--- a/skyvern/forge/prompts/skyvern/observer.j2
+++ b/skyvern/forge/prompts/skyvern/observer.j2
@@ -12,10 +12,10 @@ MAKE SURE YOU OUTPUT VALID JSON. No text before or after JSON, no trailing comma
 Reply in JSON format with the following keys:
 {
   "page_info": str, // Think step by step. Describe all the useful information in the page related to the user goal.
-  "thoughts": str, // Think step by step. What has been done so far and what is the next reasonable mini goal a human can do foreseeably move towards the overall goal.
   "extraction_thought": str, // Think step by step. Should any information be extracted given the user goal? If yes, has all the information been extracted? If the user is searching for something, looking for information or specifically trying to extract information along side the goal, consider it an intention to extract information. Phrases like "find something", "show me something", "search something" and so on indicate the intention to extract information.
   "require_extraction": bool, // True if the user goal requires information extraction. False otherwise.
-  "information_extracted": optional[bool], // True if the needed information has been extracted. False if the needed information has not been extracted. Null if the user goal does not require information extraction.
+  "information_extracted": optional[bool], // True if the needed information has been extracted. False if the needed information has not been extracted. If task history has no "extract" type, that means no data extraction has happened, return false. Null if the user goal does not require information extraction.
+  "thoughts": str, // Think step by step. What has been done so far and what is the next reasonable mini goal a human can do foreseeably move towards the overall goal.
   "user_goal_achieved": bool, // True if the user goal has been completed, false otherwise. If the user wants to extract information and it has not been done, the user goal is not achieved.
   "plan": str, // The mini goal to achieve to move towards the user goal. DO NOT come up or hallucinate any data that's not provided in the user goal. Be accurate and precise. Return null if the user goal has been achieved.
   "task_type": str, // One of the available task types: navigate, extract, loop
@@ -39,6 +39,10 @@ Task history (the earliest task is the first in the list and the latest is the l
 ```
 {{ task_history }}
 ```
+
+Task history explanation:
+- completed status means the mini goal has been completed
+- terminated and failed mean the mini goal was not fully achieved or couldn't be achieved so you might want to try something else. The reason is given to explain why.
 
 Current datetime, ISO format:
 ```

--- a/skyvern/forge/prompts/skyvern/observer_check_completion.j2
+++ b/skyvern/forge/prompts/skyvern/observer_check_completion.j2
@@ -2,8 +2,12 @@ You're to assist the user to achieve the user goal in the web, given the user go
 
 Reply in JSON format with the following keys:
 {
+  "page_info": str, // Think step by step. Describe all the useful information in the page related to the user goal.
+  "extraction_thought": str, // Think step by step. Should any information be extracted given the user goal? If yes, has all the information been extracted? If the user is searching for something, looking for information or specifically trying to extract information along side the goal, consider it an intention to extract information. Phrases like "find something", "show me something", "search something" and so on indicate the intention to extract information.
+  "require_extraction": bool, // True if the user goal requires information extraction. False otherwise.
+  "information_extracted": optional[bool], // True if the needed information has been extracted. False if the needed information has not been extracted. Null if the user goal does not require information extraction.
   "thoughts": str, // Think step by step. Would completing the tasks in the task history be good enough to achieve the user goal? If more tasks need to be completed to achieve the goal, what would be the next task?
-  "user_goal_achieved": bool, // True if the user goal has been completed, false otherwise. If the user wants to extract information along side the goal, make sure the extract task has happened before claiming that the goal is achieved.
+  "user_goal_achieved": bool, // True if the user goal has been completed, false otherwise. If the user wants to extract information and it has not been done, the user goal is not achieved.
 }
 
 User goal:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Observer now continues exploring when tasks fail or terminate, with updated task history explanations and JSON key order in prompts.
> 
>   - **Behavior**:
>     - Observer continues exploring when tasks fail or terminate in `observer_service.py`.
>     - Task history explanation updated in `observer.j2` to clarify statuses.
>   - **Prompts**:
>     - Reorder JSON keys in `observer.j2` and `observer_check_completion.j2` for clarity.
>   - **Functions**:
>     - Modify `handle_block_result()` in `observer_service.py` to not mark workflow as failed or terminated on task failure or termination.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 853c0afc9bd788dc9154116affec4dfe45acbb9e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->