### PR TITLE
Add FR Proxy + small script

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -35,6 +35,8 @@ export const ProxyLocation = {
   ResidentialES: "RESIDENTIAL_ES",
   ResidentialIN: "RESIDENTIAL_IN",
   ResidentialJP: "RESIDENTIAL_JP",
+  ResidentialGB: "RESIDENTIAL_GB",
+  ResidentialFR: "RESIDENTIAL_FR",
   None: "NONE",
 } as const;
 

--- a/skyvern-frontend/src/components/ProxySelector.tsx
+++ b/skyvern-frontend/src/components/ProxySelector.tsx
@@ -33,6 +33,12 @@ function ProxySelector({ value, onChange, className }: Props) {
         <SelectItem value={ProxyLocation.ResidentialJP}>
           Residential (Japan)
         </SelectItem>
+        <SelectItem value={ProxyLocation.ResidentialGB}>
+          Residential (United Kingdom)
+        </SelectItem>
+        <SelectItem value={ProxyLocation.ResidentialFR}>
+          Residential (France)
+        </SelectItem>
       </SelectContent>
     </Select>
   );

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -24,6 +24,7 @@ class ProxyLocation(StrEnum):
     RESIDENTIAL_GB = "RESIDENTIAL_GB"
     RESIDENTIAL_IN = "RESIDENTIAL_IN"
     RESIDENTIAL_JP = "RESIDENTIAL_JP"
+    RESIDENTIAL_FR = "RESIDENTIAL_FR"
     NONE = "NONE"
 
 
@@ -63,6 +64,9 @@ def get_tzinfo_from_proxy(proxy_location: ProxyLocation) -> ZoneInfo | None:
 
     if proxy_location == ProxyLocation.RESIDENTIAL_JP:
         return ZoneInfo("Asia/Kolkata")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_FR:
+        return ZoneInfo("Europe/Paris")
 
     return None
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for France as a proxy location in `types.ts`, `ProxySelector.tsx`, and `tasks.py`.
> 
>   - **Proxy Location**:
>     - Add `ResidentialFR` to `ProxyLocation` in `types.ts`, `ProxySelector.tsx`, and `tasks.py`.
>     - Update `get_tzinfo_from_proxy()` in `tasks.py` to return `ZoneInfo("Europe/Paris")` for `ResidentialFR`.
>   - **UI**:
>     - Add "Residential (France)" option to `ProxySelector` in `ProxySelector.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f3e0f912c08fe062f808b94e8a618738c4a974b6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->