### PR TITLE
WorkflowRunNotFound should be a SkyvernHTTPException error

### DIFF
--- a/skyvern/exceptions.py
+++ b/skyvern/exceptions.py
@@ -140,9 +140,9 @@ class WorkflowNotFound(SkyvernHTTPException):
         )
 
 
-class WorkflowRunNotFound(SkyvernException):
+class WorkflowRunNotFound(SkyvernHTTPException):
     def __init__(self, workflow_run_id: str) -> None:
-        super().__init__(f"WorkflowRun {workflow_run_id} not found")
+        super().__init__(f"WorkflowRun {workflow_run_id} not found", status_code=status.HTTP_404_NOT_FOUND)
 
 
 class MissingValueForParameter(SkyvernHTTPException):


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `WorkflowRunNotFound` to inherit from `SkyvernHTTPException` with a 404 status code in `exceptions.py`.
> 
>   - **Exception Handling**:
>     - Change `WorkflowRunNotFound` to inherit from `SkyvernHTTPException` instead of `SkyvernException` in `exceptions.py`.
>     - Set `status_code` to `status.HTTP_404_NOT_FOUND` for `WorkflowRunNotFound` to indicate a 404 error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f31db2eeda25457bc965cfdd6600b22ea26c3aa1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->