### PR TITLE
add reset observer cruise functions

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -1744,6 +1744,19 @@ class AgentDB:
             await session.execute(stmt)
             await session.commit()
 
+    async def delete_observer_cruise_artifacts(
+        self, observer_cruise_id: str, organization_id: str | None = None
+    ) -> None:
+        async with self.Session() as session:
+            stmt = delete(ArtifactModel).where(
+                and_(
+                    ArtifactModel.observer_cruise_id == observer_cruise_id,
+                    ArtifactModel.organization_id == organization_id,
+                )
+            )
+            await session.execute(stmt)
+            await session.commit()
+
     async def delete_task_steps(self, organization_id: str, task_id: str) -> None:
         async with self.Session() as session:
             # delete artifacts by filtering organization_id and task_id
@@ -1932,6 +1945,19 @@ class AgentDB:
             ).first():
                 return ObserverCruise.model_validate(observer_cruise)
             return None
+
+    async def delete_observer_thoughts_for_cruise(
+        self, observer_cruise_id: str, organization_id: str | None = None
+    ) -> None:
+        async with self.Session() as session:
+            stmt = delete(ObserverThoughtModel).where(
+                and_(
+                    ObserverThoughtModel.observer_cruise_id == observer_cruise_id,
+                    ObserverThoughtModel.organization_id == organization_id,
+                )
+            )
+            await session.execute(stmt)
+            await session.commit()
 
     async def get_observer_cruise_by_workflow_run_id(
         self,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add functions to delete observer cruise artifacts and thoughts in `AgentDB` in `client.py`.
> 
>   - **Functions**:
>     - Add `delete_observer_cruise_artifacts` to `AgentDB` in `client.py` to delete artifacts by `observer_cruise_id` and `organization_id`.
>     - Add `delete_observer_thoughts_for_cruise` to `AgentDB` in `client.py` to delete thoughts by `observer_cruise_id` and `organization_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0d1b3e554e99a0b802e0ccf7023391158fd00f0f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->