### PR TITLE
decrease the hash trigger to 150

### DIFF
--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -103,8 +103,8 @@ def json_to_html(element: dict, need_skyvern_attrs: bool = True) -> str:
     context = skyvern_context.ensure_context()
 
     # FIXME: Theoretically, all href links with over 69(64+1+4) length could be hashed
-    # but currently, just hash length>300 links to confirm the solution goes well
-    if "href" in attributes and len(attributes.get("href", "")) > 300:
+    # but currently, just hash length>150 links to confirm the solution goes well
+    if "href" in attributes and len(attributes.get("href", "")) > 150:
         href = attributes.get("href", "")
         # jinja style can't accept the variable name starts with number
         # adding "_" to make sure the variable name is valid.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Decrease hash trigger length for href attributes from 300 to 150 in `json_to_html()` in `scraper.py`.
> 
>   - **Behavior**:
>     - Decrease hash trigger length for `href` attributes from 300 to 150 in `json_to_html()` in `scraper.py`. This affects when hrefs are hashed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9353750e869f370c51fad00466f8896575f39e2a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->