### PR TITLE
add helper to generate webhook headers

### DIFF
--- a/skyvern/forge/sdk/core/security.py
+++ b/skyvern/forge/sdk/core/security.py
@@ -41,3 +41,13 @@ def generate_skyvern_signature(
     """
     hash_obj = hmac.new(api_key.encode("utf-8"), msg=payload.encode("utf-8"), digestmod=hashlib.sha256)
     return hash_obj.hexdigest()
+
+
+def generate_skyvern_webhook_headers(payload: str, api_key: str) -> dict[str, str]:
+    signature = generate_skyvern_signature(payload=payload, api_key=api_key)
+    timestamp = str(int(datetime.utcnow().timestamp()))
+    return {
+        "x-skyvern-timestamp": timestamp,
+        "x-skyvern-signature": signature,
+        "Content-Type": "application/json",
+    }

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-from datetime import datetime
 from typing import Any
 
 import httpx
@@ -19,7 +18,7 @@ from skyvern.exceptions import (
 from skyvern.forge import app
 from skyvern.forge.sdk.artifact.models import ArtifactType
 from skyvern.forge.sdk.core import skyvern_context
-from skyvern.forge.sdk.core.security import generate_skyvern_signature
+from skyvern.forge.sdk.core.security import generate_skyvern_webhook_headers
 from skyvern.forge.sdk.core.skyvern_context import SkyvernContext
 from skyvern.forge.sdk.db.enums import TaskType
 from skyvern.forge.sdk.models import Step, StepStatus
@@ -974,17 +973,11 @@ class WorkflowService:
             return
 
         # send webhook to the webhook callback url
-        timestamp = str(int(datetime.utcnow().timestamp()))
         payload = workflow_run_status_response.model_dump_json()
-        signature = generate_skyvern_signature(
+        headers = generate_skyvern_webhook_headers(
             payload=payload,
             api_key=api_key,
         )
-        headers = {
-            "x-skyvern-timestamp": timestamp,
-            "x-skyvern-signature": signature,
-            "Content-Type": "application/json",
-        }
         LOG.info(
             "Sending webhook run status to webhook callback url",
             workflow_id=workflow_id,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `generate_skyvern_webhook_headers()` to simplify webhook header generation in `agent.py` and `service.py`.
> 
>   - **Functionality**:
>     - Adds `generate_skyvern_webhook_headers()` in `security.py` to generate webhook headers with signature and timestamp.
>   - **Refactoring**:
>     - Replaces manual header creation with `generate_skyvern_webhook_headers()` in `execute_task_webhook()` in `agent.py`.
>     - Replaces manual header creation with `generate_skyvern_webhook_headers()` in `execute_workflow_webhook()` in `service.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c8df0e3ff480dd9ca4aa9be9944db136d9e8915b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->