### PR TITLE
Fix broken link in task table to retry task

### DIFF
--- a/skyvern-frontend/src/routes/tasks/list/TaskActions.tsx
+++ b/skyvern-frontend/src/routes/tasks/list/TaskActions.tsx
@@ -160,7 +160,7 @@ function TaskActions({ task }: Props) {
             </DialogTrigger>
             <DropdownMenuItem
               onSelect={() => {
-                navigate(`/create/retry/${task.task_id}`);
+                navigate(`/tasks/create/retry/${task.task_id}`);
               }}
             >
               Rerun Task


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes broken link in `TaskActions` component by updating the path in `navigate()` function.
> 
>   - **Behavior**:
>     - Fixes broken link in `TaskActions` component by updating the path in `navigate()` from `/create/retry/${task.task_id}` to `/tasks/create/retry/${task.task_id}`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 92e6e75c1491ea6942269236c0417b4f3b769030. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->