### PR TITLE
get the no observer plan warning back

### DIFF
--- a/skyvern/forge/sdk/services/observer_service.py
+++ b/skyvern/forge/sdk/services/observer_service.py
@@ -391,6 +391,10 @@ async def run_observer_cruise_helper(
             output={"task_type": task_type, "user_goal_achieved": user_goal_achieved},
         )
 
+        if not plan:
+            LOG.warning("No plan found in observer response", observer_response=observer_response)
+            continue
+
         if user_goal_achieved is True:
             LOG.info(
                 "User goal achieved. Workflow run will complete. Observer is stopping",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add warning log in `run_observer_cruise_helper()` when no plan is found in observer response.
> 
>   - **Logging**:
>     - Add warning log in `run_observer_cruise_helper()` in `observer_service.py` when no plan is found in observer response.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 800a60d144d716588734164f7a2c1d7113e2875f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->