### PR TITLE
fix new tab link

### DIFF
--- a/skyvern-frontend/src/components/NavLinkGroup.tsx
+++ b/skyvern-frontend/src/components/NavLinkGroup.tsx
@@ -48,7 +48,7 @@ function NavLinkGroup({ title, links }: Props) {
               key={link.to}
               to={link.to}
               target={link.newTab ? "_blank" : undefined}
-              rel={link.newTab ? "noreferrer,noopener" : undefined}
+              rel={link.newTab ? "noopener noreferrer" : undefined}
               className={({ isActive }) => {
                 return cn(
                   "block rounded-lg py-2 pl-3 text-slate-400 hover:bg-muted hover:text-primary",


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes `rel` attribute order in `NavLinkGroup` component for new tab links.
> 
>   - **Behavior**:
>     - Fixes `rel` attribute order in `NavLinkGroup` component to `noopener noreferrer` for links opening in a new tab.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 3ecf7d4b1b6f78f3c0febb9cb34cce63fe11f908. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->