### PR TITLE
Add Bitwarden to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,25 @@ RUN playwright install-deps
 RUN playwright install
 RUN apt-get install -y xauth x11-apps netpbm && apt-get clean
 
+# nvm env vars
+RUN mkdir -p /usr/local/nvm
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_VERSION v20.12.2
+# install nvm
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+# install node and npm
+RUN /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use --delete-prefix $NODE_VERSION"
+# add node and npm to the PATH
+ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/bin
+ENV PATH $NODE_PATH:$PATH
+# confirm installation
+RUN npm -v
+RUN node -v
+# install bitwarden cli
+RUN npm install -g @bitwarden/cli@2024.9.0
+# checking bw version also initializes the bw config
+RUN bw --version
+
 COPY . /app
 
 ENV PYTHONPATH="/app:$PYTHONPATH"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY --from=requirements-stage /tmp/requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r requirements.txt
 RUN playwright install-deps
 RUN playwright install
-RUN apt-get install -y xauth x11-apps netpbm && apt-get clean
+RUN apt-get install -y xauth x11-apps netpbm curl && apt-get clean
 
 # nvm env vars
 RUN mkdir -p /usr/local/nvm


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add Bitwarden CLI installation to Dockerfile with Node.js setup using nvm.
> 
>   - **Dockerfile Changes**:
>     - Add `curl` to `apt-get install` command.
>     - Set up `nvm` environment variables and install `nvm`.
>     - Install Node.js version `v20.12.2` and npm using `nvm`.
>     - Add Node.js and npm to `PATH`.
>     - Install Bitwarden CLI version `2024.9.0` using npm.
>     - Confirm installations by checking versions of npm, node, and Bitwarden CLI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 61246c79a6b30d47d75e5f3afa3fb35df097b53b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->