### PR TITLE
fix workflow runs GET api

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -736,7 +736,7 @@ async def get_workflow_run(
     )
     if observer_cruise:
         return_dict["observer_task"] = observer_cruise.model_dump(by_alias=True)
-    return workflow_run_status_response
+    return return_dict
 
 
 @base_router.get(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix return value in `get_workflow_run()` to include `observer_task` data if available.
> 
>   - **Behavior**:
>     - Fix return value in `get_workflow_run()` in `agent_protocol.py` to return `return_dict` instead of `workflow_run_status_response`.
>     - Ensures `observer_task` data is included in the response if `observer_cruise` is present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c1ef43126b3174ffcff17e0626970a29c086087f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->