### PR TITLE
fix workflow run / observer schema

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -744,6 +744,7 @@ async def get_workflow_run(
 )
 @base_router.get(
     "/workflows/{workflow_id}/runs/{workflow_run_id}/timeline/",
+    include_in_schema=False,
 )
 async def get_workflow_run_timeline(
     workflow_run_id: str,

--- a/skyvern/forge/sdk/workflow/models/workflow.py
+++ b/skyvern/forge/sdk/workflow/models/workflow.py
@@ -138,4 +138,4 @@ class WorkflowRunStatusResponse(BaseModel):
     outputs: dict[str, Any] | None = None
     total_steps: int | None = None
     total_cost: float | None = None
-    observer_cruise: ObserverTask | None = None
+    observer_task: ObserverTask | None = None


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Rename `observer_cruise` to `observer_task` in `WorkflowRunStatusResponse` and exclude a route from schema in `agent_protocol.py`.
> 
>   - **Models**:
>     - Rename `observer_cruise` to `observer_task` in `WorkflowRunStatusResponse` class in `workflow.py`.
>   - **Routes**:
>     - Mark `/workflows/{workflow_id}/runs/{workflow_run_id}/timeline/` route in `agent_protocol.py` to be excluded from the schema.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 7d47e899d0992b0babdca0ad93993d8004564cac. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->