### PR TITLE
Add `persist_browser_session` value in convert() function

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -1653,6 +1653,7 @@ function convert(workflow: WorkflowApiResponse): WorkflowCreateYAMLRequest {
     proxy_location: workflow.proxy_location,
     webhook_callback_url: workflow.webhook_callback_url,
     totp_verification_url: workflow.totp_verification_url,
+    persist_browser_session: workflow.persist_browser_session,
     workflow_definition: {
       parameters: convertParametersToParameterYAML(userParameters),
       blocks: convertBlocksToBlockYAML(workflow.workflow_definition.blocks),


### PR DESCRIPTION
This parameter was missing while exporting a workflow to yaml file.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `persist_browser_session` to `convert()` in `workflowEditorUtils.ts` for complete YAML export.
> 
>   - **Behavior**:
>     - Add `persist_browser_session` to `convert()` in `workflowEditorUtils.ts` to include this value when exporting workflows to YAML.
>   - **Misc**:
>     - This parameter was previously missing, causing incomplete exports.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2994e913a1d6080918607f153b0510a0b4533f57. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->