### PR TITLE
Revert "fix filter pick issue"

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -804,7 +804,12 @@ const isDropdownButton = (element) => {
   const haspopup = element.getAttribute("aria-haspopup")
     ? element.getAttribute("aria-haspopup").toLowerCase()
     : "";
-  return tagName === "button" && type === "button" && haspopup === "listbox";
+  const hasExpanded = element.hasAttribute("aria-expanded");
+  return (
+    tagName === "button" &&
+    type === "button" &&
+    (hasExpanded || haspopup === "listbox")
+  );
 };
 
 const isSelect2Dropdown = (element) => {


### PR DESCRIPTION
Reverts Skyvern-AI/skyvern#1577
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reverts `isDropdownButton` logic in `domUtils.js` to only check `aria-haspopup` for "listbox", removing `aria-expanded` check.
> 
>   - **Revert Changes**:
>     - Reverts logic in `isDropdownButton` function in `domUtils.js` to only check `aria-haspopup` attribute for "listbox" value, removing `aria-expanded` check.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 35e07dd2810e68d232588ec093f85304c706d596. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->