### PR TITLE
Make email block parameterized

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/SendEmailNode/SendEmailNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/SendEmailNode/SendEmailNode.tsx
@@ -1,5 +1,4 @@
 import { HelpTooltip } from "@/components/HelpTooltip";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { useDeleteNodeCallback } from "@/routes/workflows/hooks/useDeleteNodeCallback";
@@ -12,6 +11,8 @@ import { EditableNodeTitle } from "../components/EditableNodeTitle";
 import { NodeActionMenu } from "../NodeActionMenu";
 import { WorkflowBlockIcon } from "../WorkflowBlockIcon";
 import { type SendEmailNode } from "./types";
+import { WorkflowBlockInput } from "@/components/WorkflowBlockInput";
+import { WorkflowBlockInputTextarea } from "@/components/WorkflowBlockInputTextarea";
 
 function SendEmailNode({ id, data }: NodeProps<SendEmailNode>) {
   const { updateNodeData } = useReactFlow();
@@ -77,12 +78,10 @@ function SendEmailNode({ id, data }: NodeProps<SendEmailNode>) {
         </div>
         <div className="space-y-2">
           <Label className="text-xs text-slate-300">Recipients</Label>
-          <Input
-            onChange={(event) => {
-              if (!data.editable) {
-                return;
-              }
-              handleChange("recipients", event.target.value);
+          <WorkflowBlockInput
+            nodeId={id}
+            onChange={(value) => {
+              handleChange("recipients", value);
             }}
             value={inputs.recipients}
             placeholder="example@gmail.com, example2@gmail.com..."
@@ -92,12 +91,10 @@ function SendEmailNode({ id, data }: NodeProps<SendEmailNode>) {
         <Separator />
         <div className="space-y-2">
           <Label className="text-xs text-slate-300">Subject</Label>
-          <Input
-            onChange={(event) => {
-              if (!data.editable) {
-                return;
-              }
-              handleChange("subject", event.target.value);
+          <WorkflowBlockInput
+            nodeId={id}
+            onChange={(value) => {
+              handleChange("subject", value);
             }}
             value={inputs.subject}
             placeholder="What is the gist?"
@@ -106,12 +103,10 @@ function SendEmailNode({ id, data }: NodeProps<SendEmailNode>) {
         </div>
         <div className="space-y-2">
           <Label className="text-xs text-slate-300">Body</Label>
-          <Input
-            onChange={(event) => {
-              if (!data.editable) {
-                return;
-              }
-              handleChange("body", event.target.value);
+          <WorkflowBlockInputTextarea
+            nodeId={id}
+            onChange={(value) => {
+              handleChange("body", value);
             }}
             value={inputs.body}
             placeholder="What would you like to say?"
@@ -126,13 +121,11 @@ function SendEmailNode({ id, data }: NodeProps<SendEmailNode>) {
               content={helpTooltips["sendEmail"]["fileAttachments"]}
             />
           </div>
-          <Input
+          <WorkflowBlockInput
+            nodeId={id}
             value={inputs.fileAttachments}
-            onChange={(event) => {
-              if (!data.editable) {
-                return;
-              }
-              handleChange("fileAttachments", event.target.value);
+            onChange={(value) => {
+              handleChange("fileAttachments", value);
             }}
             disabled
             className="nopan text-xs"


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `SendEmailNode` to use `WorkflowBlockInput` and `WorkflowBlockInputTextarea` for parameterized email block inputs.
> 
>   - **Refactoring**:
>     - Replace `Input` with `WorkflowBlockInput` for `recipients`, `subject`, and `fileAttachments` fields in `SendEmailNode`.
>     - Replace `Input` with `WorkflowBlockInputTextarea` for `body` field in `SendEmailNode`.
>   - **Behavior**:
>     - Inputs are now parameterized using `nodeId` for better integration with workflow blocks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 17b807085c8bf4682042783283c560fef9b4fe64. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->