### PR TITLE
use the main prompt to generate the observer task url and title

### DIFF
--- a/skyvern/forge/prompts/skyvern/observer_generate_metadata.j2
+++ b/skyvern/forge/prompts/skyvern/observer_generate_metadata.j2
@@ -4,8 +4,8 @@ MAKE SURE YOU OUTPUT VALID JSON. No text before or after JSON, no trailing comma
 
 Reply in JSON format with the following keys:
 {
-  "thoughts": str, // Think step by step. If the user specifically mentioned which website it is to use, let's use that url. If the user doesn't specifify a specific website, to achieve what the user wants to do, what is most likely website url for achieving the goal? 
-  "url": str, // The url to type into the browser. DO NOT change the url if user specified one.
+  "thoughts": str, // Think step by step. Has the user specify a url to go? If yes, what is the complete url user specified? If not, to achieve what the user wants to do, what is most likely website url for achieving the goal?
+  "url": str, // The initial url to type into the browser. If the user specified one, use exactly that url.
   "title": str, // A descriptive and informative title for the goal. Use no more than 5 words
 }
 

--- a/skyvern/forge/sdk/services/observer_service.py
+++ b/skyvern/forge/sdk/services/observer_service.py
@@ -99,7 +99,7 @@ async def initialize_observer_cruise(
     )
 
     metadata_prompt = prompt_engine.load_prompt("observer_generate_metadata", user_goal=user_prompt, user_url=user_url)
-    metadata_response = await app.SECONDARY_LLM_API_HANDLER(prompt=metadata_prompt, observer_thought=observer_thought)
+    metadata_response = await app.LLM_API_HANDLER(prompt=metadata_prompt, observer_thought=observer_thought)
     # validate
     LOG.info(f"Initialized observer initial response: {metadata_response}")
     url: str = user_url or metadata_response.get("url", "")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update observer task metadata generation to use user-specified URLs and concise titles, and change API handler in `observer_service.py`.
> 
>   - **Behavior**:
>     - Update `observer_generate_metadata.j2` to ensure user-specified URLs are used exactly as provided and generate concise titles.
>     - Change API handler in `initialize_observer_cruise()` in `observer_service.py` from `SECONDARY_LLM_API_HANDLER` to `LLM_API_HANDLER` for metadata generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d2fff82678a4e5fe8dc750fc3a62595b78472f57. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->