### PR TITLE
Fix data schema issue with pdf parser

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/helpContent.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/helpContent.ts
@@ -91,6 +91,11 @@ export const helpTooltips = {
     waitInSeconds:
       "Specify a number for how many seconds to wait. Value must be between 0 and 300 seconds.",
   },
+  pdfParser: {
+    ...baseHelpTooltipContent,
+    fileUrl: "The URL from which the file will be downloaded",
+    jsonSchema: "Specify a format for the extracted information from the file",
+  },
 };
 
 export const placeholders = {
@@ -125,4 +130,5 @@ export const placeholders = {
   codeBlock: basePlaceholderContent,
   fileUrl: basePlaceholderContent,
   wait: basePlaceholderContent,
+  pdfParser: basePlaceholderContent,
 };

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/PDFParserNode/PDFParserNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/PDFParserNode/PDFParserNode.tsx
@@ -20,7 +20,7 @@ function PDFParserNode({ id, data }: NodeProps<PDFParserNode>) {
   const deleteNodeCallback = useDeleteNodeCallback();
   const [inputs, setInputs] = useState({
     fileUrl: data.fileUrl,
-    dataSchema: data.jsonSchema,
+    jsonSchema: data.jsonSchema,
   });
   const [label, setLabel] = useNodeLabelChangeHandler({
     id,
@@ -79,7 +79,7 @@ function PDFParserNode({ id, data }: NodeProps<PDFParserNode>) {
           <div className="space-y-2">
             <div className="flex gap-2">
               <Label className="text-xs text-slate-300">File URL</Label>
-              <HelpTooltip content={helpTooltips["fileParser"]["fileUrl"]} />
+              <HelpTooltip content={helpTooltips["pdfParser"]["fileUrl"]} />
             </div>
             <Input
               value={inputs.fileUrl}
@@ -97,13 +97,15 @@ function PDFParserNode({ id, data }: NodeProps<PDFParserNode>) {
             <div className="flex gap-4">
               <div className="flex gap-2">
                 <Label className="text-xs text-slate-300">Data Schema</Label>
-                <HelpTooltip content={helpTooltips["task"]["dataSchema"]} />
+                <HelpTooltip
+                  content={helpTooltips["pdfParser"]["jsonSchema"]}
+                />
               </div>
               <Checkbox
-                checked={inputs.dataSchema !== "null"}
+                checked={inputs.jsonSchema !== "null"}
                 onCheckedChange={(checked) => {
                   handleChange(
-                    "dataSchema",
+                    "jsonSchema",
                     checked
                       ? JSON.stringify(
                           dataSchemaExampleForFileExtraction,
@@ -115,13 +117,13 @@ function PDFParserNode({ id, data }: NodeProps<PDFParserNode>) {
                 }}
               />
             </div>
-            {inputs.dataSchema !== "null" && (
+            {inputs.jsonSchema !== "null" && (
               <div>
                 <CodeEditor
                   language="json"
-                  value={inputs.dataSchema}
+                  value={inputs.jsonSchema}
                   onChange={(value) => {
-                    handleChange("dataSchema", value);
+                    handleChange("jsonSchema", value);
                   }}
                   className="nowheel nopan"
                   fontSize={8}


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes schema issue in `PDFParserNode` by renaming `dataSchema` to `jsonSchema` and updating tooltips and placeholders.
> 
>   - **Behavior**:
>     - Fixes schema issue in `PDFParserNode.tsx` by renaming `dataSchema` to `jsonSchema`.
>     - Updates `HelpTooltip` references in `PDFParserNode.tsx` to use `pdfParser` tooltips.
>   - **Help Content**:
>     - Adds `pdfParser` tooltips for `fileUrl` and `jsonSchema` in `helpContent.ts`.
>     - Adds `pdfParser` to placeholders in `helpContent.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a401c2440435ecadd48bb005fb661e7507469165. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->