### PR TITLE
Use output in the schema instead of extracted_information

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -1918,7 +1918,7 @@ class PDFParserBlock(Block):
             self.json_schema = {
                 "type": "object",
                 "properties": {
-                    "extracted_information": {
+                    "output": {
                         "type": "object",
                         "description": "Information extracted from the text",
                     }


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Rename `extracted_information` to `output` in `PDFParserBlock` JSON schema.
> 
>   - **Behavior**:
>     - In `PDFParserBlock`, rename `extracted_information` to `output` in the JSON schema within the `execute` function.
>   - **Schema**:
>     - Updates the `json_schema` property to use `output` instead of `extracted_information` for extracted text information.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0d6e8ece0109e38b5f33c712a6dbb65db5bbac1c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->