### PR TITLE
use output for default json schema instead of extracted_information i…

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/types.ts
@@ -20,7 +20,7 @@ export const dataSchemaExampleValue = {
 export const dataSchemaExampleForFileExtraction = {
   type: "object",
   properties: {
-    extracted_information: {
+    output: {
       type: "object",
       description: "All of the information extracted from the file",
     },


### PR DESCRIPTION
…n frontend
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Renames `extracted_information` to `output` in JSON schema for file extraction in `types.ts`.
> 
>   - **Behavior**:
>     - Renames `extracted_information` to `output` in `dataSchemaExampleForFileExtraction` in `types.ts`.
>     - Affects JSON schema for file extraction in the frontend.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 09899e7607b235b7e9671322616e5690b8724625. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->