### PR TITLE
Prevent default on drag over for file upload

### DIFF
--- a/skyvern-frontend/src/components/FileUpload.tsx
+++ b/skyvern-frontend/src/components/FileUpload.tsx
@@ -126,6 +126,9 @@ function FileUpload({ value, onChange }: Props) {
             className={cn(
               "flex w-full cursor-pointer items-center justify-center border border-dashed py-8 hover:border-slate-500",
             )}
+            onDragOver={(event) => {
+              event.preventDefault();
+            }}
             onDrop={(event) => {
               event.preventDefault();
               event.stopPropagation();


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `preventDefault()` to `onDragOver` in `FileUpload.tsx` to prevent default browser behavior during file drag over.
> 
>   - **Behavior**:
>     - Add `event.preventDefault()` to `onDragOver` event in `FileUpload.tsx` to prevent default browser behavior during file drag over.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f339dfc9ef0a878435cf7704eba687a11ae9ba83. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->