### PR TITLE
Rename observer to task 2.0

### DIFF
--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowPostRunParameters.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowPostRunParameters.tsx
@@ -143,12 +143,12 @@ function WorkflowPostRunParameters() {
       {workflowRun.observer_task ? (
         <div className="rounded bg-slate-elevation2 p-6">
           <div className="space-y-4">
-            <h1 className="text-lg font-bold">Observer Parameters</h1>
+            <h1 className="text-lg font-bold">Task 2.0 Parameters</h1>
             <div className="flex gap-16">
               <div className="w-80">
-                <h1 className="text-lg">Observer Prompt</h1>
+                <h1 className="text-lg">Task 2.0 Prompt</h1>
                 <h2 className="text-base text-slate-400">
-                  The original prompt for the observer
+                  The original prompt for the task
                 </h2>
               </div>
               <AutoResizingTextarea

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunOutput.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunOutput.tsx
@@ -137,7 +137,7 @@ function WorkflowRunOutput() {
       {observerOutput ? (
         <div className="rounded bg-slate-elevation2 p-6">
           <div className="space-y-4">
-            <h1 className="text-lg font-bold">Observer Output</h1>
+            <h1 className="text-lg font-bold">Task 2.0 Output</h1>
             <CodeEditor
               language="json"
               value={JSON.stringify(observerOutput, null, 2)}


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Renames 'observer' to 'task 2.0' in UI text within `WorkflowPostRunParameters.tsx` and `WorkflowRunOutput.tsx`.
> 
>   - **UI Text Changes**:
>     - Rename 'Observer Parameters' to 'Task 2.0 Parameters' in `WorkflowPostRunParameters.tsx`.
>     - Rename 'Observer Prompt' to 'Task 2.0 Prompt' in `WorkflowPostRunParameters.tsx`.
>     - Rename 'Observer Output' to 'Task 2.0 Output' in `WorkflowRunOutput.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a33057e247156243f6bae613475722dc31202f3d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->