### PR TITLE
support frameset

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -594,6 +594,10 @@ function isInteractable(element, hoverStylesMap) {
     return false;
   }
 
+  if (tagName === "frameset") {
+    return false;
+  }
+
   if (tagName === "a" && element.href) {
     return true;
   }
@@ -1289,8 +1293,9 @@ function buildElementTree(starter = document.body, frame, full_tree = false) {
     }
 
     // Check if the element is interactable
-    if (isInteractable(element, hoverStylesMap)) {
-      var elementObj = buildElementObject(frame, element, true);
+    var interactable = isInteractable(element, hoverStylesMap);
+    if (interactable || element.tagName.toLowerCase() === "frameset") {
+      var elementObj = buildElementObject(frame, element, interactable);
       elements.push(elementObj);
       // If the element is interactable but has no interactable parent,
       // then it starts a new tree, so add it to the result array
@@ -1314,7 +1319,10 @@ function buildElementTree(starter = document.body, frame, full_tree = false) {
         processElement(childElement, elementObj.id);
       }
       return elementObj;
-    } else if (element.tagName.toLowerCase() === "iframe") {
+    } else if (
+      element.tagName.toLowerCase() === "iframe" ||
+      element.tagName.toLowerCase() === "frame"
+    ) {
       let iframeElementObject = buildElementObject(frame, element, false);
 
       elements.push(iframeElementObject);


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for `frameset` elements in DOM processing by updating `isInteractable` and `buildElementTree` functions in `domUtils.js`.
> 
>   - **Behavior**:
>     - `isInteractable` function updated to return `false` for `frameset` elements in `domUtils.js`.
>     - `buildElementTree` function modified to handle `frameset` elements similarly to `iframe` and `frame` elements in `domUtils.js`.
>   - **Misc**:
>     - Minor logic adjustments in `buildElementTree` to accommodate `frameset` elements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d0f5a47be7a1d17cae09b82073da7185075faed6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->