### PR TITLE
reduce hover style map

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -2016,7 +2016,13 @@ function getHoverStylesMap() {
                   });
                 }
 
-                hoverMap.set(baseSelector, styles);
+                // only need the style which includes the cursor attribute.
+                for (const prop in styles) {
+                  if (prop.includes("cursor")) {
+                    hoverMap.set(baseSelector, styles);
+                    break;
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimizes `getHoverStylesMap()` in `domUtils.js` to store only hover styles with the `cursor` attribute.
> 
>   - **Behavior**:
>     - `getHoverStylesMap()` in `domUtils.js` now only stores styles with the `cursor` attribute in the `hoverMap`.
>     - This change optimizes memory usage by excluding unnecessary styles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 57011c5cbe441ab60af37e91e1a143128487172a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->