### PR TITLE
fix build boundingbox timeout

### DIFF
--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -218,11 +218,11 @@ class SkyvernFrame:
         :param page: Page instance to remove the bounding boxes from.
         """
         js_script = "() => removeBoundingBoxes()"
-        await self.evaluate(frame=self.frame, expression=js_script)
+        await self.evaluate(frame=self.frame, expression=js_script, timeout_ms=BUILDING_ELEMENT_TREE_TIMEOUT_MS)
 
     async def build_elements_and_draw_bounding_boxes(self) -> None:
         js_script = "() => buildElementsAndDrawBoundingBoxes()"
-        await self.evaluate(frame=self.frame, expression=js_script)
+        await self.evaluate(frame=self.frame, expression=js_script, timeout_ms=BUILDING_ELEMENT_TREE_TIMEOUT_MS)
 
     async def is_window_scrollable(self) -> bool:
         js_script = "() => isWindowScrollable()"


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add timeout to `remove_bounding_boxes()` and `build_elements_and_draw_bounding_boxes()` in `page.py` using `BUILDING_ELEMENT_TREE_TIMEOUT_MS`.
> 
>   - **Behavior**:
>     - Add `timeout_ms=BUILDING_ELEMENT_TREE_TIMEOUT_MS` to `evaluate()` calls in `remove_bounding_boxes()` and `build_elements_and_draw_bounding_boxes()` in `page.py`.
>   - **Constants**:
>     - Use `BUILDING_ELEMENT_TREE_TIMEOUT_MS` for timeout settings in the above functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d98e777f02bee0f594b5e7928b85aa5f30ac85c7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->