### PR TITLE
get rid of observer_cruise in observer_service code

### DIFF
--- a/skyvern/exceptions.py
+++ b/skyvern/exceptions.py
@@ -571,3 +571,8 @@ class InteractWithDropdownContainer(SkyvernException):
 class UrlGenerationFailure(SkyvernHTTPException):
     def __init__(self) -> None:
         super().__init__("Failed to generate the url for the prompt")
+
+
+class ObserverCruiseNotFound(SkyvernHTTPException):
+    def __init__(self, observer_cruise_id: str) -> None:
+        super().__init__(f"Observer task {observer_cruise_id} not found")


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Renames `observer_cruise` to `observer_task` in `observer_service.py` and adds `ObserverCruiseNotFound` exception for missing tasks.
> 
>   - **Behavior**:
>     - Renames `observer_cruise` to `observer_task` in `run_observer_cruise`, `run_observer_cruise_helper`, and related functions in `observer_service.py`.
>     - Introduces `ObserverCruiseNotFound` exception in `exceptions.py` to handle missing observer tasks.
>   - **Functions**:
>     - Updates return type of `run_observer_cruise` and `mark_observer_cruise_as_failed` to `ObserverTask`.
>     - Modifies `_summarize_observer_cruise` to return `ObserverTask`.
>   - **Misc**:
>     - Adjusts logging and error handling to reflect the renaming changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0dfd4fedee4b054f93d6090c2901944bb06301b3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->