### PR TITLE
Disable rerun when v2 task is used

### DIFF
--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -126,6 +126,8 @@ function WorkflowRun() {
     });
   }
 
+  const isTaskv2Run = workflowRun && workflowRun.observer_task !== null;
+
   return (
     <div className="space-y-8">
       <header className="flex justify-between">
@@ -211,7 +213,7 @@ function WorkflowRun() {
               </DialogContent>
             </Dialog>
           )}
-          {workflowRunIsFinalized && (
+          {workflowRunIsFinalized && !isTaskv2Run && (
             <Button asChild>
               <Link
                 to={`/workflows/${workflowPermanentId}/run`}


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Disable rerun button in `WorkflowRun` component for v2 tasks by checking `workflowRun.observer_task`.
> 
>   - **Behavior**:
>     - Disable rerun button in `WorkflowRun` component when `workflowRun.observer_task` is not null, indicating a v2 task.
>     - Rerun button remains enabled for finalized runs that are not v2 tasks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b4357f318136c6e74752274a967750abf00b243e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->