### PR TITLE
shu/get rid off observer cruise part3

### DIFF
--- a/skyvern/forge/sdk/executor/async_executor.py
+++ b/skyvern/forge/sdk/executor/async_executor.py
@@ -176,7 +176,7 @@ class BackgroundTaskExecutor(AsyncExecutor):
 
         if background_tasks:
             background_tasks.add_task(
-                observer_service.run_observer_cruise,
+                observer_service.run_observer_task,
                 organization=organization,
                 observer_cruise_id=observer_cruise_id,
                 max_iterations_override=max_iterations_override,

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1152,7 +1152,7 @@ async def observer_task(
         LOG.info("Overriding max iterations for observer", max_iterations_override=x_max_iterations_override)
 
     try:
-        observer_task = await observer_service.initialize_observer_cruise(
+        observer_task = await observer_service.initialize_observer_task(
             organization=organization,
             user_prompt=data.user_prompt,
             user_url=str(data.url) if data.url else None,


### PR DESCRIPTION
- get rid of observer_cruise in observer_service code
- keep renaming

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor to rename 'observer_cruise' to 'observer_task' across multiple files for consistency.
> 
>   - **Renaming**:
>     - Rename `run_observer_cruise` to `run_observer_task` in `async_executor.py` and `observer_service.py`.
>     - Rename `initialize_observer_cruise` to `initialize_observer_task` in `agent_protocol.py` and `observer_service.py`.
>     - Rename `mark_observer_cruise_as_failed` to `mark_observer_task_as_failed` and `mark_observer_cruise_as_completed` to `mark_observer_task_as_completed` in `observer_service.py`.
>     - Rename `send_observer_cruise_webhook` to `send_observer_task_webhook` in `observer_service.py`.
>   - **Variables**:
>     - Rename `observer_cruise_id` to `observer_task_id` in `observer_service.py` and `async_executor.py`.
>     - Update context and logging references from `observer_cruise` to `observer_task` in `observer_service.py`.
>   - **Misc**:
>     - Update logging messages to reflect new naming conventions in `observer_service.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 7e474951f9061aea14aa1257dd5b827d8819b63f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->