### PR TITLE
dont generate loop-over value when saving the workflow anymore

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -1110,7 +1110,6 @@ function getWorkflowBlocksUtil(
           block_type: "for_loop",
           label: node.data.label,
           continue_on_failure: node.data.continueOnFailure,
-          loop_over_parameter_key: node.data.loopValue,
           loop_blocks: getOrderedChildrenBlocks(nodes, edges, node.id),
           loop_variable_reference: node.data.loopVariableReference,
         },

--- a/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
@@ -262,7 +262,7 @@ export type FileUrlParserBlockYAML = BlockYAMLBase & {
 
 export type ForLoopBlockYAML = BlockYAMLBase & {
   block_type: "for_loop";
-  loop_over_parameter_key: string;
+  loop_over_parameter_key?: string;
   loop_blocks: Array<BlockYAML>;
   loop_variable_reference: string | null;
 };


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Removes `loop_over_parameter_key` from `for_loop` blocks and makes it optional in YAML representation.
> 
>   - **Behavior**:
>     - Removes `loop_over_parameter_key` from `for_loop` block in `getWorkflowBlocksUtil()` in `workflowEditorUtils.ts`.
>     - Makes `loop_over_parameter_key` optional in `ForLoopBlockYAML` in `workflowYamlTypes.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6ebe05e09f715b58892bce55616f46acc9c6fc63. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->