### PR TITLE
Redirect directly to workflow run when observer task created

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/ExampleCasePill.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/ExampleCasePill.tsx
@@ -1,13 +1,11 @@
 import { getClient } from "@/api/AxiosClient";
 import { ObserverTask } from "@/api/types";
-import { Button } from "@/components/ui/button";
 import { toast } from "@/components/ui/use-toast";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
 import { ReloadIcon } from "@radix-ui/react-icons";
-import { ToastAction } from "@radix-ui/react-toast";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 type Props = {
   exampleId: string;
@@ -35,17 +33,6 @@ function ExampleCasePill({ exampleId, version, icon, label, prompt }: Props) {
         variant: "success",
         title: "Workflow Run Created",
         description: `Workflow run created successfully.`,
-        action: (
-          <ToastAction altText="View">
-            <Button asChild>
-              <Link
-                to={`/workflows/${response.data.workflow_permanent_id}/${response.data.workflow_run_id}`}
-              >
-                View
-              </Link>
-            </Button>
-          </ToastAction>
-        ),
       });
       queryClient.invalidateQueries({
         queryKey: ["workflowRuns"],
@@ -53,6 +40,9 @@ function ExampleCasePill({ exampleId, version, icon, label, prompt }: Props) {
       queryClient.invalidateQueries({
         queryKey: ["workflows"],
       });
+      navigate(
+        `/workflows/${response.data.workflow_permanent_id}/${response.data.workflow_run_id}`,
+      );
     },
     onError: (error: AxiosError) => {
       toast({

--- a/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
@@ -12,7 +12,8 @@ import { GraphIcon } from "@/components/icons/GraphIcon";
 import { InboxIcon } from "@/components/icons/InboxIcon";
 import { MessageIcon } from "@/components/icons/MessageIcon";
 import { TrophyIcon } from "@/components/icons/TrophyIcon";
-import { Button } from "@/components/ui/button";
+import { ProxySelector } from "@/components/ProxySelector";
+import { Input } from "@/components/ui/input";
 import {
   CustomSelectItem,
   Select,
@@ -21,6 +22,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { toast } from "@/components/ui/use-toast";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
 import {
@@ -31,20 +33,16 @@ import {
   PlusIcon,
   ReloadIcon,
 } from "@radix-ui/react-icons";
-import { ToastAction } from "@radix-ui/react-toast";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { stringify as convertToYAML } from "yaml";
 import {
   generatePhoneNumber,
   generateUniqueEmail,
 } from "../data/sampleTaskData";
 import { ExampleCasePill } from "./ExampleCasePill";
-import { Input } from "@/components/ui/input";
-import { ProxySelector } from "@/components/ProxySelector";
-import { Switch } from "@/components/ui/switch";
 
 function createTemplateTaskFromTaskGenerationParameters(
   values: TaskGenerationApiResponse,
@@ -174,17 +172,6 @@ function PromptBox() {
         variant: "success",
         title: "Workflow Run Created",
         description: `Workflow run created successfully.`,
-        action: (
-          <ToastAction altText="View">
-            <Button asChild>
-              <Link
-                to={`/workflows/${response.data.workflow_permanent_id}/${response.data.workflow_run_id}`}
-              >
-                View
-              </Link>
-            </Button>
-          </ToastAction>
-        ),
       });
       queryClient.invalidateQueries({
         queryKey: ["workflowRuns"],
@@ -192,6 +179,9 @@ function PromptBox() {
       queryClient.invalidateQueries({
         queryKey: ["workflows"],
       });
+      navigate(
+        `/workflows/${response.data.workflow_permanent_id}/${response.data.workflow_run_id}`,
+      );
     },
     onError: (error: AxiosError) => {
       toast({


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Redirects directly to workflow run page upon task creation in `ExampleCasePill` and `PromptBox`, removing toast link.
> 
>   - **Behavior**:
>     - Directly navigates to the workflow run page upon successful task creation in `ExampleCasePill` and `PromptBox`.
>     - Removes toast action with link to workflow run in both components.
>   - **Components**:
>     - `ExampleCasePill`: Removes `ToastAction` and `Link` components, adds `navigate` call.
>     - `PromptBox`: Similar changes as `ExampleCasePill`, ensuring direct navigation to workflow run.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for fe949cc56ada5d3cb3c2f54a5bd6c62466b68e5a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->