### PR TITLE
Start workflow runs instantly instead of showing a notification which…

### DIFF
--- a/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
+++ b/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
@@ -17,11 +17,10 @@ import { useCredentialGetter } from "@/hooks/useCredentialGetter";
 import { copyText } from "@/util/copyText";
 import { apiBaseUrl } from "@/util/env";
 import { CopyIcon, PlayIcon, ReloadIcon } from "@radix-ui/react-icons";
-import { ToastAction } from "@radix-ui/react-toast";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import fetchToCurl from "fetch-to-curl";
 import { useForm } from "react-hook-form";
-import { Link, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { z } from "zod";
 import { WorkflowParameter } from "./types/workflowTypes";
 import { WorkflowParameterInput } from "./WorkflowParameterInput";
@@ -107,6 +106,7 @@ function RunWorkflowForm({
 }: Props) {
   const { workflowPermanentId } = useParams();
   const credentialGetter = useCredentialGetter();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const form = useForm<RunWorkflowFormType>({
     defaultValues: {
@@ -131,21 +131,13 @@ function RunWorkflowForm({
         variant: "success",
         title: "Workflow run started",
         description: "The workflow run has been started successfully",
-        action: (
-          <ToastAction altText="View">
-            <Button asChild>
-              <Link
-                to={`/workflows/${workflowPermanentId}/${response.data.workflow_run_id}/overview`}
-              >
-                View
-              </Link>
-            </Button>
-          </ToastAction>
-        ),
       });
       queryClient.invalidateQueries({
         queryKey: ["workflowRuns"],
       });
+      navigate(
+        `/workflows/${workflowPermanentId}/${response.data.workflow_run_id}/overview`,
+      );
     },
     onError: (error) => {
       toast({


### PR DESCRIPTION
… can redirect
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Directly navigates to workflow overview page after starting a workflow run, removing the notification action.
> 
>   - **Behavior**:
>     - Directly navigates to workflow overview page after starting a workflow run in `RunWorkflowForm`.
>     - Removes `ToastAction` notification that previously redirected to the overview page.
>   - **Navigation**:
>     - Uses `useNavigate` from `react-router-dom` to handle redirection in `RunWorkflowForm`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for a8e98fcd5a8d6a140043607b6bf91b17fa769e34. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->