### PR TITLE
Add workflow templates endpoint

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -943,6 +943,22 @@ async def get_workflows(
     )
 
 
+@base_router.get("/workflows/templates", response_model=list[Workflow])
+@base_router.get("/workflows/templates/", response_model=list[Workflow], include_in_schema=False)
+async def get_workflow_templates() -> list[Workflow]:
+    global_workflows_permanent_ids = await app.STORAGE.retrieve_global_workflows()
+
+    if not global_workflows_permanent_ids:
+        return []
+
+    workflows = await app.WORKFLOW_SERVICE.get_workflows_by_permanent_ids(
+        workflow_permanent_ids=global_workflows_permanent_ids,
+        statuses=[WorkflowStatus.published, WorkflowStatus.draft],
+    )
+
+    return workflows
+
+
 @base_router.get("/workflows/{workflow_permanent_id}", response_model=Workflow)
 @base_router.get("/workflows/{workflow_permanent_id}/", response_model=Workflow)
 async def get_workflow(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `/workflows/templates` endpoint in `agent_protocol.py` to retrieve workflow templates with `published` and `draft` statuses.
> 
>   - **New Endpoint**:
>     - Adds `get_workflow_templates()` function in `agent_protocol.py` to retrieve workflow templates.
>     - Endpoint: `/workflows/templates` returns a list of `Workflow` objects.
>   - **Functionality**:
>     - Fetches global workflow permanent IDs using `app.STORAGE.retrieve_global_workflows()`.
>     - Retrieves workflows with statuses `published` and `draft` using `app.WORKFLOW_SERVICE.get_workflows_by_permanent_ids()`.
>     - Returns an empty list if no global workflow permanent IDs are found.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 3f748207f8d383614b1ed6b08f05240efdba3701. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->