### PR TITLE
get RESIDENTIAL_DE back which was deleted unexpectedly

### DIFF
--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -25,6 +25,7 @@ class ProxyLocation(StrEnum):
     RESIDENTIAL_IN = "RESIDENTIAL_IN"
     RESIDENTIAL_JP = "RESIDENTIAL_JP"
     RESIDENTIAL_FR = "RESIDENTIAL_FR"
+    RESIDENTIAL_DE = "RESIDENTIAL_DE"
     NONE = "NONE"
 
 
@@ -63,10 +64,13 @@ def get_tzinfo_from_proxy(proxy_location: ProxyLocation) -> ZoneInfo | None:
         return ZoneInfo("Asia/Kolkata")
 
     if proxy_location == ProxyLocation.RESIDENTIAL_JP:
-        return ZoneInfo("Asia/Kolkata")
+        return ZoneInfo("Asia/Tokyo")
 
     if proxy_location == ProxyLocation.RESIDENTIAL_FR:
         return ZoneInfo("Europe/Paris")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_DE:
+        return ZoneInfo("Europe/Berlin")
 
     return None
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Re-add `RESIDENTIAL_DE` to `ProxyLocation` enum and update `get_tzinfo_from_proxy()` to handle it in `tasks.py`.
> 
>   - **Enums**:
>     - Re-add `RESIDENTIAL_DE` to `ProxyLocation` enum in `tasks.py`.
>   - **Functions**:
>     - Update `get_tzinfo_from_proxy()` in `tasks.py` to return `ZoneInfo("Europe/Berlin")` for `RESIDENTIAL_DE`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d8f9422ed89e785d1564e17f3f4f8e4ce7231105. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->