### PR TITLE
show error for invalid schema in extraction, text prompt, pdf parser

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/PDFParserNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/PDFParserNode/types.ts
@@ -1,5 +1,6 @@
 import type { Node } from "@xyflow/react";
 import { NodeBaseData } from "../types";
+import { AppNode } from "..";
 
 export type PDFParserNodeData = NodeBaseData & {
   fileUrl: string;
@@ -15,3 +16,7 @@ export const pdfParserNodeDefaultData: PDFParserNodeData = {
   continueOnFailure: false,
   jsonSchema: "null",
 } as const;
+
+export function isPdfParserNode(node: AppNode): node is PDFParserNode {
+  return node.type === "pdfParser";
+}

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TextPromptNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TextPromptNode/types.ts
@@ -1,5 +1,6 @@
 import type { Node } from "@xyflow/react";
 import { NodeBaseData } from "../types";
+import { AppNode } from "..";
 
 export type TextPromptNodeData = NodeBaseData & {
   prompt: string;
@@ -17,3 +18,7 @@ export const textPromptNodeDefaultData: TextPromptNodeData = {
   continueOnFailure: false,
   parameterKeys: [],
 } as const;
+
+export function isTextPromptNode(node: AppNode): node is TextPromptNode {
+  return node.type === "textPrompt";
+}

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -67,7 +67,10 @@ import {
   StartNodeData,
 } from "./nodes/StartNode/types";
 import { isTaskNode, taskNodeDefaultData } from "./nodes/TaskNode/types";
-import { textPromptNodeDefaultData } from "./nodes/TextPromptNode/types";
+import {
+  isTextPromptNode,
+  textPromptNodeDefaultData,
+} from "./nodes/TextPromptNode/types";
 import { NodeBaseData } from "./nodes/types";
 import { uploadNodeDefaultData } from "./nodes/UploadNode/types";
 import {
@@ -87,7 +90,10 @@ import { loginNodeDefaultData } from "./nodes/LoginNode/types";
 import { isWaitNode, waitNodeDefaultData } from "./nodes/WaitNode/types";
 import { fileDownloadNodeDefaultData } from "./nodes/FileDownloadNode/types";
 import { ProxyLocation } from "@/api/types";
-import { pdfParserNodeDefaultData } from "./nodes/PDFParserNode/types";
+import {
+  isPdfParserNode,
+  pdfParserNodeDefaultData,
+} from "./nodes/PDFParserNode/types";
 import { taskv2NodeDefaultData } from "./nodes/Taskv2Node/types";
 import { urlNodeDefaultData } from "./nodes/URLNode/types";
 
@@ -1897,6 +1903,29 @@ function getWorkflowErrors(nodes: Array<AppNode>): Array<string> {
   extractionNodes.forEach((node) => {
     if (node.data.dataExtractionGoal.length === 0) {
       errors.push(`${node.data.label}: Data extraction goal is required.`);
+    }
+    try {
+      JSON.parse(node.data.dataSchema);
+    } catch {
+      errors.push(`${node.data.label}: Data schema is not valid JSON.`);
+    }
+  });
+
+  const textPromptNodes = nodes.filter(isTextPromptNode);
+  textPromptNodes.forEach((node) => {
+    try {
+      JSON.parse(node.data.jsonSchema);
+    } catch {
+      errors.push(`${node.data.label}: Data schema is not valid JSON.`);
+    }
+  });
+
+  const pdfParserNodes = nodes.filter(isPdfParserNode);
+  pdfParserNodes.forEach((node) => {
+    try {
+      JSON.parse(node.data.jsonSchema);
+    } catch {
+      errors.push(`${node.data.label}: Data schema is not valid JSON.`);
     }
   });
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds JSON schema validation for `extraction`, `text prompt`, and `pdf parser` nodes, with type guards for `PDFParserNode` and `TextPromptNode`.
> 
>   - **Error Handling**:
>     - Adds JSON schema validation for `extraction`, `text prompt`, and `pdf parser` nodes in `getWorkflowErrors()` in `workflowEditorUtils.ts`.
>   - **Type Guards**:
>     - Adds `isPdfParserNode()` in `PDFParserNode/types.ts`.
>     - Adds `isTextPromptNode()` in `TextPromptNode/types.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 79a7f49ef93e98b287f113bdccbca22fe2d5249b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->