### PR TITLE
do not use status as a param in logs - use step_status and task_status

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1928,7 +1928,7 @@ class ForgeAgent:
                 task_id=step.task_id,
                 step_id=step.step_id,
                 duration_seconds=duration_seconds,
-                status=status,
+                step_status=status,
                 organization_id=step.organization_id,
             )
 
@@ -1975,7 +1975,7 @@ class ForgeAgent:
                 task_id=task.task_id,
                 workflow_run_id=task.workflow_run_id,
                 duration_seconds=duration_seconds,
-                status=status,
+                task_status=status,
                 organization_id=task.organization_id,
             )
 

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -685,7 +685,7 @@ class BaseTaskBlock(Block):
                 LOG.warning(
                     f"Task failed with status {updated_task.status}{retry_message}",
                     task_id=updated_task.task_id,
-                    status=updated_task.status,
+                    task_status=updated_task.status,
                     workflow_run_id=workflow_run_id,
                     workflow_id=workflow.workflow_id,
                     organization_id=workflow_run.organization_id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename `status` to `step_status` and `task_status` in `agent.py` and `block.py` for clearer logging.
> 
>   - **Behavior**:
>     - Rename `status` to `step_status` in `update_step()` in `agent.py`.
>     - Rename `status` to `task_status` in `update_task()` in `agent.py`.
>     - Rename `status` to `task_status` in a logging statement in `execute()` in `block.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0a3ca6f0122bfa346a3d0ccd1511c649e184be7a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->