### PR TITLE
O3 Mini support

### DIFF
--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -80,7 +80,19 @@ if settings.ENABLE_OPENAI:
     LLMConfigRegistry.register_config(
         "OPENAI_GPT4O",
         LLMConfig(
-            "gpt-4o", ["OPENAI_API_KEY"], supports_vision=True, add_assistant_prefix=False, max_output_tokens=16384
+            "gpt-4o", ["OPENAI_API_KEY"], supports_vision=True, add_assistant_prefix=False, max_completion_tokens=16384
+        ),
+    )
+    LLMConfigRegistry.register_config(
+        "OPENAI_O3_MINI",
+        LLMConfig(
+            "o3-mini",
+            ["OPENAI_API_KEY"],
+            supports_vision=False,
+            add_assistant_prefix=False,
+            max_completion_tokens=16384,
+            temperature=None,  # Temperature isn't supported in the O-model series
+            reasoning_effort="high",
         ),
     )
     LLMConfigRegistry.register_config(
@@ -90,7 +102,7 @@ if settings.ENABLE_OPENAI:
             ["OPENAI_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=False,
-            max_output_tokens=16384,
+            max_completion_tokens=16384,
         ),
     )
     LLMConfigRegistry.register_config(
@@ -100,7 +112,7 @@ if settings.ENABLE_OPENAI:
             ["OPENAI_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=False,
-            max_output_tokens=16384,
+            max_completion_tokens=16384,
         ),
     )
 
@@ -149,7 +161,7 @@ if settings.ENABLE_ANTHROPIC:
             ["ANTHROPIC_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=True,
-            max_output_tokens=8192,
+            max_completion_tokens=8192,
         ),
     )
 
@@ -275,7 +287,7 @@ if settings.ENABLE_GEMINI:
             ["GEMINI_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=False,
-            max_output_tokens=8192,
+            max_completion_tokens=8192,
         ),
     )
     LLMConfigRegistry.register_config(
@@ -285,7 +297,7 @@ if settings.ENABLE_GEMINI:
             ["GEMINI_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=False,
-            max_output_tokens=8192,
+            max_completion_tokens=8192,
         ),
     )
 

--- a/skyvern/forge/sdk/api/llm/models.py
+++ b/skyvern/forge/sdk/api/llm/models.py
@@ -36,7 +36,9 @@ class LLMConfigBase:
 @dataclass(frozen=True)
 class LLMConfig(LLMConfigBase):
     litellm_params: Optional[LiteLLMParams] = field(default=None)
-    max_output_tokens: int = SettingsManager.get_settings().LLM_CONFIG_MAX_TOKENS
+    max_completion_tokens: int = SettingsManager.get_settings().LLM_CONFIG_MAX_TOKENS
+    temperature: float | None = SettingsManager.get_settings().LLM_CONFIG_TEMPERATURE
+    reasoning_effort: str | None = None
 
 
 @dataclass(frozen=True)
@@ -72,7 +74,9 @@ class LLMRouterConfig(LLMConfigBase):
     allowed_fails: int | None = None
     allowed_fails_policy: AllowedFailsPolicy | None = None
     cooldown_time: float | None = None
-    max_output_tokens: int = SettingsManager.get_settings().LLM_CONFIG_MAX_TOKENS
+    max_completion_tokens: int = SettingsManager.get_settings().LLM_CONFIG_MAX_TOKENS
+    reasoning_effort: str | None = None
+    temperature: float | None = SettingsManager.get_settings().LLM_CONFIG_TEMPERATURE
 
 
 class LLMAPIHandler(Protocol):


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for O3 Mini model with reasoning tokens handling and update configurations and models accordingly.
> 
>   - **Behavior**:
>     - Add support for `OPENAI_O3_MINI` in `config_registry.py` with `max_completion_tokens=16384`, `temperature=None`, and `reasoning_effort="high"`.
>     - Update `llm_api_handler_with_router_and_fallback()` in `api_handler_factory.py` to handle `reasoning_tokens` by adding them to `completion_tokens`.
>   - **Models**:
>     - Add `reasoning_effort` to `LLMConfig` and `LLMRouterConfig` in `models.py`.
>     - Rename `max_output_tokens` to `max_completion_tokens` in `LLMConfig` and `LLMRouterConfig` in `models.py`.
>   - **Misc**:
>     - Update `get_api_parameters()` in `api_handler_factory.py` to include `reasoning_effort` if present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 94bcff518e9d9dddb05c29f4270af8a2574a99e1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->