### PR TITLE
add get page video timeout

### DIFF
--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -480,14 +480,22 @@ class BrowserState:
             return
         if len(self.browser_artifacts.video_artifacts) > index:
             if self.browser_artifacts.video_artifacts[index].video_path is None:
-                self.browser_artifacts.video_artifacts[index].video_path = await page.video.path()
+                try:
+                    async with asyncio.timeout(settings.BROWSER_ACTION_TIMEOUT_MS / 1000):
+                        self.browser_artifacts.video_artifacts[index].video_path = await page.video.path()
+                except asyncio.TimeoutError:
+                    LOG.info("Timeout to get the page video, skip the exception")
             return
 
         target_lenght = index + 1
         self.browser_artifacts.video_artifacts.extend(
             [VideoArtifact()] * (target_lenght - len(self.browser_artifacts.video_artifacts))
         )
-        self.browser_artifacts.video_artifacts[index].video_path = await page.video.path()
+        try:
+            async with asyncio.timeout(settings.BROWSER_ACTION_TIMEOUT_MS / 1000):
+                self.browser_artifacts.video_artifacts[index].video_path = await page.video.path()
+        except asyncio.TimeoutError:
+            LOG.info("Timeout to get the page video, skip the exception")
         return
 
     async def get_or_create_page(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add timeout for retrieving page video path in `set_working_page()` in `browser_factory.py`, logging on timeout and skipping exception.
> 
>   - **Behavior**:
>     - Add timeout for `page.video.path()` in `set_working_page()` in `browser_factory.py`.
>     - Logs info message on `asyncio.TimeoutError` and skips exception.
>   - **Settings**:
>     - Uses `settings.BROWSER_ACTION_TIMEOUT_MS` for timeout duration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c803c8c5162d4f6845188b57b5a296d0321eba2e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->