### PR TITLE
add azure o3 mini

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -103,6 +103,7 @@ class Settings(BaseSettings):
     ENABLE_ANTHROPIC: bool = False
     ENABLE_AZURE: bool = False
     ENABLE_AZURE_GPT4O_MINI: bool = False
+    ENABLE_AZURE_O3_MINI: bool = False
     ENABLE_BEDROCK: bool = False
     ENABLE_GEMINI: bool = False
     # OPENAI
@@ -120,6 +121,12 @@ class Settings(BaseSettings):
     AZURE_GPT4O_MINI_API_KEY: str | None = None
     AZURE_GPT4O_MINI_API_BASE: str | None = None
     AZURE_GPT4O_MINI_API_VERSION: str | None = None
+
+    # AZURE o3 mini
+    AZURE_O3_MINI_DEPLOYMENT: str | None = None
+    AZURE_O3_MINI_API_KEY: str | None = None
+    AZURE_O3_MINI_API_BASE: str | None = None
+    AZURE_O3_MINI_API_VERSION: str | None = None
 
     # GEMINI
     GEMINI_API_KEY: str | None = None

--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -279,6 +279,31 @@ if settings.ENABLE_AZURE_GPT4O_MINI:
         ),
     )
 
+if settings.ENABLE_AZURE_O3_MINI:
+    LLMConfigRegistry.register_config(
+        "AZURE_OPENAI_O3_MINI",
+        LLMConfig(
+            f"azure/{settings.AZURE_O3_MINI_DEPLOYMENT}",
+            [
+                "AZURE_O3_MINI_DEPLOYMENT",
+                "AZURE_O3_MINI_API_KEY",
+                "AZURE_O3_MINI_API_BASE",
+                "AZURE_O3_MINI_API_VERSION",
+            ],
+            litellm_params=LiteLLMParams(
+                api_base=settings.AZURE_O3_MINI_API_BASE,
+                api_key=settings.AZURE_O3_MINI_API_KEY,
+                api_version=settings.AZURE_O3_MINI_API_VERSION,
+                model_info={"model_name": "azure/o3-mini"},
+            ),
+            supports_vision=False,
+            add_assistant_prefix=False,
+            max_completion_tokens=16384,
+            temperature=None,  # Temperature isn't supported in the O-model series
+            reasoning_effort="low",
+        ),
+    )
+
 if settings.ENABLE_GEMINI:
     LLMConfigRegistry.register_config(
         "GEMINI_PRO",


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for Azure O3 Mini model configuration in `skyvern` with new settings and registration logic.
> 
>   - **Behavior**:
>     - Adds support for `AZURE_O3_MINI` model in `config_registry.py`.
>     - Registers `AZURE_O3_MINI` configuration with `LLMConfigRegistry` if `ENABLE_AZURE_O3_MINI` is true.
>   - **Configuration**:
>     - Adds `ENABLE_AZURE_O3_MINI`, `AZURE_O3_MINI_DEPLOYMENT`, `AZURE_O3_MINI_API_KEY`, `AZURE_O3_MINI_API_BASE`, `AZURE_O3_MINI_API_VERSION` to `Settings` in `config.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 197cc6069d4493199a3e5d0b66fa36582bf95606. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->