### PR TITLE
fix datetime diff with timezone issue for workflow metrics log

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -515,7 +515,7 @@ class WorkflowService:
         )
 
         # Track workflow run duration when completed
-        duration_seconds = (datetime.now(UTC) - workflow_run.created_at).total_seconds()
+        duration_seconds = (datetime.now(UTC) - workflow_run.created_at.replace(tzinfo=UTC)).total_seconds()
         LOG.info(
             "Workflow run duration metrics",
             workflow_run_id=workflow_run_id,


### PR DESCRIPTION
getting `TypeError: can't subtract offset-naive and offset-aware datetimes`
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `TypeError` in `execute_workflow` by making `workflow_run.created_at` timezone-aware before subtraction.
> 
>   - **Behavior**:
>     - Fixes `TypeError` in `execute_workflow` in `service.py` by ensuring `workflow_run.created_at` is timezone-aware before subtraction.
>   - **Misc**:
>     - Adjusts `workflow_run.created_at` to be timezone-aware using `replace(tzinfo=UTC)` in `service.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 712344dd4f154070fced112224c8e33e0e5e3e8a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->