### PR TITLE
Return only standalone tasks, no workflow tasks in /runs

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -1409,7 +1409,11 @@ class AgentDB:
                     convert_to_workflow_run(run, debug_enabled=self.debug_enabled) for run in workflow_run_query_result
                 ]
 
-                task_query = select(TaskModel).filter(TaskModel.organization_id == organization_id)
+                task_query = (
+                    select(TaskModel)
+                    .filter(TaskModel.organization_id == organization_id)
+                    .filter(TaskModel.workflow_run_id.is_(None))
+                )
                 if status:
                     task_query = task_query.filter(TaskModel.status.in_(status))
                 task_query = task_query.order_by(TaskModel.created_at.desc()).limit(limit)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modify `get_all_runs()` in `client.py` to return only standalone tasks by filtering out tasks with `workflow_run_id`.
> 
>   - **Behavior**:
>     - Modify `get_all_runs()` in `client.py` to return only standalone tasks by adding a filter for `TaskModel.workflow_run_id.is_(None)`.
>   - **Misc**:
>     - No changes to workflow run retrieval logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6223d297daaa4d42812e9a41b4f508f7f11ac91d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->