### PR TITLE
When observer run, use observer task to get callback url and proxy lo…

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -282,6 +282,10 @@ export type ObserverTask = {
   modified_at: string;
   output: Record<string, unknown> | null;
   summary: string | null;
+  webhook_callback_url: string | null;
+  totp_verification_url: string | null;
+  totp_identifier: string | null;
+  proxy_location: ProxyLocation | null;
 };
 
 export type Createv2TaskRequest = {

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowPostRunParameters.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowPostRunParameters.tsx
@@ -44,6 +44,15 @@ function WorkflowPostRunParameters() {
   }
 
   const activeBlock = getActiveBlock();
+  const isObserverTask = workflowRun.observer_task !== null;
+
+  const webhookCallbackUrl = isObserverTask
+    ? workflowRun.observer_task?.webhook_callback_url
+    : workflowRun.webhook_callback_url;
+
+  const proxyLocation = isObserverTask
+    ? workflowRun.observer_task?.proxy_location
+    : workflowRun.proxy_location;
 
   return (
     <div className="space-y-5">
@@ -125,14 +134,14 @@ function WorkflowPostRunParameters() {
             <div className="w-80">
               <h1 className="text-lg">Webhook Callback URL</h1>
             </div>
-            <Input value={workflowRun.webhook_callback_url ?? ""} readOnly />
+            <Input value={webhookCallbackUrl ?? ""} readOnly />
           </div>
           <div className="flex gap-16">
             <div className="w-80">
               <h1 className="text-lg">Proxy Location</h1>
             </div>
             <ProxySelector
-              value={workflowRun.proxy_location ?? ProxyLocation.Residential}
+              value={proxyLocation ?? ProxyLocation.Residential}
               onChange={() => {
                 // TODO
               }}


### PR DESCRIPTION
…cation
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `WorkflowPostRunParameters.tsx` to prioritize observer task URLs and proxy location, and extend `ObserverTask` type in `types.ts`.
> 
>   - **Behavior**:
>     - Update `WorkflowPostRunParameters.tsx` to use `observer_task`'s `webhook_callback_url` and `proxy_location` if present, otherwise use `workflowRun` values.
>   - **Types**:
>     - Add `webhook_callback_url`, `totp_verification_url`, `totp_identifier`, and `proxy_location` to `ObserverTask` in `types.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e7895cecb4d7cc85b904d3ff32d8f85e09ee90f9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->