### PR TITLE
Make timeline background full height even when empty

### DIFF
--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimeline.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimeline.tsx
@@ -79,7 +79,7 @@ function WorkflowRunTimeline({
         </div>
       </div>
       <ScrollArea>
-        <ScrollAreaViewport className="max-h-[37rem]">
+        <ScrollAreaViewport className="h-[37rem] max-h-[37rem]">
           <div className="space-y-4">
             {workflowRunIsNotFinalized && (
               <div


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modify `ScrollAreaViewport` class in `WorkflowRunTimeline.tsx` for full height background when empty.
> 
>   - **UI Change**:
>     - Modify `ScrollAreaViewport` class in `WorkflowRunTimeline.tsx` to `h-[37rem] max-h-[37rem]` to ensure full height background even when empty.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0441eed5f6643815f04d7e9b2d8e54b40287a141. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->