### PR TITLE
remove redundant task_history_record in observer service

### DIFF
--- a/skyvern/forge/sdk/services/observer_service.py
+++ b/skyvern/forge/sdk/services/observer_service.py
@@ -369,7 +369,6 @@ async def run_observer_task_helper(
                 workflow_id=workflow_id,
                 url=url,
             )
-            task_history_record = {"type": task_type, "task": plan}
         else:
             try:
                 browser_state = await app.BROWSER_MANAGER.get_or_create_for_workflow_run(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove redundant assignment in `run_observer_task_helper()` in `observer_service.py`.
> 
>   - **Code Simplification**:
>     - Remove redundant assignment `task_history_record = {"type": task_type, "task": plan}` in `run_observer_task_helper()` function in `observer_service.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b0865bf3ce2dd28f1133cee1b6abebd701631979. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->