### PR TITLE
fix max_iterations_override

### DIFF
--- a/skyvern/forge/sdk/executor/async_executor.py
+++ b/skyvern/forge/sdk/executor/async_executor.py
@@ -52,7 +52,7 @@ class AsyncExecutor(abc.ABC):
         background_tasks: BackgroundTasks | None,
         organization_id: str,
         observer_cruise_id: str,
-        max_iterations_override: int | None,
+        max_iterations_override: int | str | None,
         browser_session_id: str | None,
         **kwargs: dict,
     ) -> None:
@@ -144,7 +144,7 @@ class BackgroundTaskExecutor(AsyncExecutor):
         background_tasks: BackgroundTasks | None,
         organization_id: str,
         observer_cruise_id: str,
-        max_iterations_override: int | None,
+        max_iterations_override: int | str | None,
         browser_session_id: str | None,
         **kwargs: dict,
     ) -> None:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `max_iterations_override` type to `int | str | None` in `execute_cruise()` functions in `async_executor.py`.
> 
>   - **Type Change**:
>     - Modify `max_iterations_override` parameter type from `int | None` to `int | str | None` in `execute_cruise()` in `async_executor.py`.
>     - Apply the same type change to `execute_cruise()` in `BackgroundTaskExecutor` class.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 58db89d0c7b3dfbdbc7d9d38e308c86ca7db0080. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->