### PR TITLE
Fix workflow webhooks for Tasks V2

### DIFF
--- a/skyvern/forge/sdk/executor/async_executor.py
+++ b/skyvern/forge/sdk/executor/async_executor.py
@@ -54,6 +54,7 @@ class AsyncExecutor(abc.ABC):
         observer_cruise_id: str,
         max_iterations_override: int | str | None,
         browser_session_id: str | None,
+        api_key: str | None,
         **kwargs: dict,
     ) -> None:
         pass
@@ -146,6 +147,7 @@ class BackgroundTaskExecutor(AsyncExecutor):
         observer_cruise_id: str,
         max_iterations_override: int | str | None,
         browser_session_id: str | None,
+        api_key: str | None,
         **kwargs: dict,
     ) -> None:
         LOG.info(
@@ -154,6 +156,7 @@ class BackgroundTaskExecutor(AsyncExecutor):
         )
 
         organization = await app.DATABASE.get_organization(organization_id)
+        
         if organization is None:
             raise OrganizationNotFound(organization_id)
 
@@ -181,4 +184,5 @@ class BackgroundTaskExecutor(AsyncExecutor):
                 observer_cruise_id=observer_cruise_id,
                 max_iterations_override=max_iterations_override,
                 browser_session_id=browser_session_id,
+                api_key=api_key
             )

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1193,7 +1193,8 @@ async def observer_task(
     background_tasks: BackgroundTasks,
     data: ObserverTaskRequest,
     organization: Organization = Depends(org_auth_service.get_current_org),
-    x_max_iterations_override: Annotated[int | str | None, Header()] = None,
+    x_max_iterations_override: Annotated[int | None, Header()] = None,
+    x_api_key: Annotated[str | None, Header()] = None,
 ) -> dict[str, Any]:
     if x_max_iterations_override:
         LOG.info("Overriding max iterations for observer", max_iterations_override=x_max_iterations_override)
@@ -1222,6 +1223,7 @@ async def observer_task(
         observer_cruise_id=observer_task.observer_cruise_id,
         max_iterations_override=x_max_iterations_override,
         browser_session_id=data.browser_session_id,
+        api_key=x_api_key
     )
     return observer_task.model_dump(by_alias=True)
 

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -2112,6 +2112,7 @@ class TaskV2Block(Block):
         workflow_run_block_id: str,
         organization_id: str | None = None,
         browser_session_id: str | None = None,
+        api_key: str | None = None,
         **kwargs: dict,
     ) -> BlockResult:
         from skyvern.forge.sdk.services import observer_service
@@ -2153,6 +2154,7 @@ class TaskV2Block(Block):
             request_id=None,
             max_iterations_override=self.max_iterations,
             browser_session_id=browser_session_id,
+            api_key=api_key
         )
         result_dict = None
         if observer_task:

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -1155,7 +1155,7 @@ class WorkflowService:
             headers=headers,
         )
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(follow_redirects=True) as client:
                 resp = await client.post(
                     url=workflow_run.webhook_callback_url, data=payload, headers=headers, timeout=httpx.Timeout(30.0)
                 )


### PR DESCRIPTION
This PR ensures that a webhook:
1)  is sent on the entire workflow completion (not just individual observer tasks) when using the Tasks V2 API
2) will automatically follow if the webhook endpoint is a redirect (hosting providers like AWS Amplify/Cloudflare/etc implement custom domains with a redirect, so it's useful to specify the webhook URL as the "user-facing" domain (e.g. `my.domain.com` rather than the actual domain (e.g. `e62cad.aws.com`)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes webhook behavior for Tasks V2 by sending on workflow completion and handling redirects.
> 
>   - **Behavior**:
>     - Webhook is now sent upon entire workflow completion, not just individual tasks, in `async_executor.py` and `service.py`.
>     - Webhook requests now follow redirects by setting `follow_redirects=True` in `service.py`.
>   - **API Changes**:
>     - Added `api_key` parameter to `execute_cruise()` in `async_executor.py` and `run_observer_task()` in `observer_service.py`.
>     - Updated `observer_task()` in `agent_protocol.py` to accept `x_api_key` header.
>   - **Misc**:
>     - Minor refactoring and parameter additions across several functions to support new webhook behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 775c67dca9b18eb7deaf7484d7490ed220901fab. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->