### PR TITLE
Show url for tasks in history table and change header to detail

### DIFF
--- a/skyvern-frontend/src/routes/history/RunHistory.tsx
+++ b/skyvern-frontend/src/routes/history/RunHistory.tsx
@@ -62,7 +62,7 @@ function RunHistory() {
               <TableHead className="w-1/4 rounded-tl-lg text-slate-400">
                 Run ID
               </TableHead>
-              <TableHead className="w-1/4 text-slate-400">Title</TableHead>
+              <TableHead className="w-1/4 text-slate-400">Detail</TableHead>
               <TableHead className="w-1/4 text-slate-400">Status</TableHead>
               <TableHead className="w-1/4 rounded-tr-lg text-slate-400">
                 Created At
@@ -97,7 +97,7 @@ function RunHistory() {
                     }}
                   >
                     <TableCell>{run.task_id}</TableCell>
-                    <TableCell>{run.title ?? "Untitled Task"}</TableCell>
+                    <TableCell>{run.url}</TableCell>
                     <TableCell>
                       <StatusBadge status={run.status} />
                     </TableCell>
@@ -118,12 +118,25 @@ function RunHistory() {
                     );
                   }}
                 >
-                  <TableCell>{run.workflow_run_id}</TableCell>
-                  <TableCell>{run.workflow_title ?? ""}</TableCell>
+                  <TableCell
+                    className="max-w-0 truncate"
+                    title={run.workflow_run_id}
+                  >
+                    {run.workflow_run_id}
+                  </TableCell>
+                  <TableCell
+                    className="max-w-0 truncate"
+                    title={run.workflow_title ?? undefined}
+                  >
+                    {run.workflow_title ?? ""}
+                  </TableCell>
                   <TableCell>
                     <StatusBadge status={run.status} />
                   </TableCell>
-                  <TableCell title={basicTimeFormat(run.created_at)}>
+                  <TableCell
+                    className="max-w-0 truncate"
+                    title={basicTimeFormat(run.created_at)}
+                  >
                     {basicLocalTimeFormat(run.created_at)}
                   </TableCell>
                 </TableRow>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change table header to 'Detail' and display task URL instead of title in `RunHistory.tsx`.
> 
>   - **UI Changes**:
>     - Change table header from `Title` to `Detail` in `RunHistory.tsx`.
>     - Display `run.url` instead of `run.title` for tasks in `RunHistory.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 74700edb0f1e7bc755bf1637dbb94aaf5476c2f5. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->