### PR TITLE
shu/fix cache task run

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -2675,8 +2675,10 @@ class AgentDB:
 
     async def cache_task_run(self, run_id: str, organization_id: str | None = None) -> TaskRun:
         async with self.Session() as session:
-            task_run = await session.scalars(
-                select(TaskRunModel).filter_by(organization_id=organization_id).filter_by(run_id=run_id)
+            task_run = (
+                await session.scalars(
+                    select(TaskRunModel).filter_by(organization_id=organization_id).filter_by(run_id=run_id)
+                )
             ).first()
             if task_run:
                 task_run.cached = True
@@ -2697,5 +2699,5 @@ class AgentDB:
             if organization_id:
                 query = query.filter_by(organization_id=organization_id)
             query = query.filter_by(cached=True).order_by(TaskRunModel.created_at.desc())
-            task_run = await session.scalars(query).first()
+            task_run = (await session.scalars(query)).first()
             return TaskRun.model_validate(task_run) if task_run else None

--- a/skyvern/forge/sdk/services/observer_service.py
+++ b/skyvern/forge/sdk/services/observer_service.py
@@ -1203,11 +1203,11 @@ async def mark_observer_task_as_completed(
     # Track observer cruise duration when completed
     duration_seconds = (datetime.now(UTC) - observer_task.created_at.replace(tzinfo=UTC)).total_seconds()
     LOG.info(
-        "Observer cruise duration metrics",
+        "Observer task duration metrics",
         observer_cruise_id=observer_cruise_id,
         workflow_run_id=workflow_run_id,
         duration_seconds=duration_seconds,
-        status=ObserverTaskStatus.completed,
+        observer_task_status=ObserverTaskStatus.completed,
         organization_id=organization_id,
     )
 


### PR DESCRIPTION
- fix cache task run in db client
- do not use status as a log key

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix cache task run in `client.py` and update logging key in `observer_service.py`.
> 
>   - **Database Client**:
>     - Fix `cache_task_run()` in `client.py` by ensuring the `session.scalars()` call is properly awaited and the result is correctly accessed.
>     - Fix `get_cached_task_run()` in `client.py` by ensuring the `session.scalars()` call is properly awaited and the result is correctly accessed.
>   - **Logging**:
>     - Change log key from `status` to `observer_task_status` in `mark_observer_task_as_completed()` in `observer_service.py` to improve clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 349c5ebfcfd085c47c5123a06efb5d2608f08495. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->