### PR TITLE
do not use status as a log key

### DIFF
--- a/skyvern/forge/sdk/services/observer_service.py
+++ b/skyvern/forge/sdk/services/observer_service.py
@@ -1203,11 +1203,11 @@ async def mark_observer_task_as_completed(
     # Track observer cruise duration when completed
     duration_seconds = (datetime.now(UTC) - observer_task.created_at.replace(tzinfo=UTC)).total_seconds()
     LOG.info(
-        "Observer cruise duration metrics",
+        "Observer task duration metrics",
         observer_cruise_id=observer_cruise_id,
         workflow_run_id=workflow_run_id,
         duration_seconds=duration_seconds,
-        status=ObserverTaskStatus.completed,
+        observer_task_status=ObserverTaskStatus.completed,
         organization_id=organization_id,
     )
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change log key from `status` to `observer_task_status` in `mark_observer_task_as_completed()` in `observer_service.py`.
> 
>   - **Logging**:
>     - In `observer_service.py`, change log key from `status` to `observer_task_status` in `mark_observer_task_as_completed()` to avoid using `status` as a log key.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 49e99c67dcaaa73bcb7becf7375313a1bbc13db6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->