### PR TITLE
When replaying cached actions, ignore input_text action with empty text

### DIFF
--- a/skyvern/webeye/actions/caching.py
+++ b/skyvern/webeye/actions/caching.py
@@ -213,6 +213,8 @@ async def personalize_action(
 
     if action.action_type == ActionType.INPUT_TEXT:
         action.text = answer
+        if not answer:
+            return []
     elif action.action_type == ActionType.UPLOAD_FILE:
         action.file_url = answer
     elif action.action_type == ActionType.CLICK:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ignore `INPUT_TEXT` actions with empty text during replay in `personalize_action()` in `caching.py`.
> 
>   - **Behavior**:
>     - In `personalize_action()` in `caching.py`, `INPUT_TEXT` actions with empty `answer` now return an empty list, effectively ignoring them during replay.
>   - **Misc**:
>     - No changes to other action types or functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5f14409103924436ec341ee8356eea333bb50f57. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->