### PR TITLE
fix: row value overflow in history table for task run rows

### DIFF
--- a/skyvern-frontend/src/routes/history/RunHistory.tsx
+++ b/skyvern-frontend/src/routes/history/RunHistory.tsx
@@ -95,12 +95,19 @@ function RunHistory() {
                         handleNavigate(event, `/tasks/${run.task_id}/actions`);
                       }}
                     >
-                      <TableCell>{run.task_id}</TableCell>
-                      <TableCell>{run.url}</TableCell>
+                      <TableCell className="max-w-0 truncate">
+                        {run.task_id}
+                      </TableCell>
+                      <TableCell className="max-w-0 truncate">
+                        {run.url}
+                      </TableCell>
                       <TableCell>
                         <StatusBadge status={run.status} />
                       </TableCell>
-                      <TableCell title={basicTimeFormat(run.created_at)}>
+                      <TableCell
+                        title={basicTimeFormat(run.created_at)}
+                        className="max-w-0 truncate"
+                      >
                         {basicLocalTimeFormat(run.created_at)}
                       </TableCell>
                     </TableRow>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix text overflow in `RunHistory.tsx` by truncating long text in table cells.
> 
>   - **UI Fix**:
>     - In `RunHistory.tsx`, added `className="max-w-0 truncate"` to `TableCell` components for `task_id`, `url`, and `created_at` to prevent text overflow by truncating long text.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 694855287a5925e5a06c75941d265fbc6cbfb0b3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->