### PR TITLE
trigger TerminateAction when totp code is not found

### DIFF
--- a/skyvern/exceptions.py
+++ b/skyvern/exceptions.py
@@ -594,3 +594,23 @@ class UrlGenerationFailure(SkyvernHTTPException):
 class ObserverCruiseNotFound(SkyvernHTTPException):
     def __init__(self, observer_cruise_id: str) -> None:
         super().__init__(f"Observer task {observer_cruise_id} not found")
+
+
+class NoTOTPVerificationCodeFound(SkyvernHTTPException):
+    def __init__(
+        self,
+        task_id: str | None = None,
+        workflow_run_id: str | None = None,
+        totp_verification_url: str | None = None,
+        totp_identifier: str | None = None,
+    ) -> None:
+        msg = "No TOTP verification code found."
+        if task_id:
+            msg += f" task_id={task_id}"
+        if workflow_run_id:
+            msg += f" workflow_run_id={workflow_run_id}"
+        if totp_verification_url:
+            msg += f" totp_verification_url={totp_verification_url}"
+        if totp_identifier:
+            msg += f" totp_identifier={totp_identifier}"
+        super().__init__(msg)

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -47,6 +47,7 @@ from skyvern.exceptions import (
     NoIncrementalElementFoundForAutoCompletion,
     NoIncrementalElementFoundForCustomSelection,
     NoSuitableAutoCompleteOption,
+    NoTOTPVerificationCodeFound,
     OptionIndexOutOfBound,
     WrongElementToUploadFile,
 )
@@ -2847,7 +2848,12 @@ async def poll_verification_code(
         # check timeout
         if datetime.utcnow() > timeout_datetime:
             LOG.warning("Polling verification code timed out", workflow_id=workflow_id)
-            return None
+            raise NoTOTPVerificationCodeFound(
+                task_id=task_id,
+                workflow_run_id=workflow_run_id,
+                totp_verification_url=totp_verification_url,
+                totp_identifier=totp_identifier,
+            )
         verification_code = None
         if totp_verification_url:
             verification_code = await _get_verification_code_from_url(task_id, totp_verification_url, org_token.token)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Trigger `TerminateAction` in `agent_step` when `NoTOTPVerificationCodeFound` is raised due to TOTP code polling timeout.
> 
>   - **Behavior**:
>     - Trigger `TerminateAction` in `agent_step` in `agent.py` when `NoTOTPVerificationCodeFound` is raised.
>     - Update `poll_verification_code` in `handler.py` to raise `NoTOTPVerificationCodeFound` on timeout.
>   - **Exceptions**:
>     - Add `NoTOTPVerificationCodeFound` exception in `exceptions.py` with details like `task_id`, `workflow_run_id`, `totp_verification_url`, and `totp_identifier`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 4c13233e301eaf683904ad9d74ba8c3c78b1930a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->