### PR TITLE
Define get_persistent_browser_session_by_id

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -2323,7 +2323,7 @@ class AgentDB:
             LOG.error("UnexpectedError", exc_info=True)
             raise
 
-    async def get_persistent_browser_session_by_id(self, session_id: str) -> Optional[PersistentBrowserSessionModel]:
+    async def get_persistent_browser_session_by_id(self, session_id: str) -> Optional[PersistentBrowserSession]:
         """Get a specific persistent browser session."""
         try:
             async with self.Session() as session:

--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -2323,6 +2323,30 @@ class AgentDB:
             LOG.error("UnexpectedError", exc_info=True)
             raise
 
+    async def get_persistent_browser_session_by_id(self, session_id: str) -> Optional[PersistentBrowserSessionModel]:
+        """Get a specific persistent browser session."""
+        try:
+            async with self.Session() as session:
+                persistent_browser_session = (
+                    await session.scalars(
+                        select(PersistentBrowserSessionModel)
+                        .filter_by(persistent_browser_session_id=session_id)
+                        .filter_by(deleted_at=None)
+                    )
+                ).first()
+                if persistent_browser_session:
+                    return PersistentBrowserSession.model_validate(persistent_browser_session)
+                raise NotFoundError(f"PersistentBrowserSession {session_id} not found")
+        except NotFoundError:
+            LOG.error("NotFoundError", exc_info=True)
+            raise
+        except SQLAlchemyError:
+            LOG.error("SQLAlchemyError", exc_info=True)
+            raise
+        except Exception:
+            LOG.error("UnexpectedError", exc_info=True)
+            raise
+
     async def get_persistent_browser_session(
         self, session_id: str, organization_id: str
     ) -> Optional[PersistentBrowserSessionModel]:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `get_persistent_browser_session_by_id()` to retrieve a persistent browser session by ID in `client.py`.
> 
>   - **Functionality**:
>     - Adds `get_persistent_browser_session_by_id()` to `client.py` to retrieve a persistent browser session by `session_id`.
>     - Raises `NotFoundError` if session not found, logs error.
>     - Handles `SQLAlchemyError` and generic exceptions, logging errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b7a199c4d9b38dcaca66b03d1c083cac4e323df6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->