### PR TITLE
Make get_browser_state async

### DIFF
--- a/skyvern/webeye/browser_manager.py
+++ b/skyvern/webeye/browser_manager.py
@@ -81,7 +81,7 @@ class BrowserManager:
                 "Getting browser state for task from persistent sessions manager",
                 browser_session_id=browser_session_id,
             )
-            browser_state = app.PERSISTENT_SESSIONS_MANAGER.get_browser_state(browser_session_id)
+            browser_state = await app.PERSISTENT_SESSIONS_MANAGER.get_browser_state(browser_session_id)
             if browser_state is None:
                 LOG.warning(
                     "Browser state not found in persistent sessions manager",
@@ -139,7 +139,7 @@ class BrowserManager:
                 "Getting browser state for workflow run from persistent sessions manager",
                 browser_session_id=browser_session_id,
             )
-            browser_state = app.PERSISTENT_SESSIONS_MANAGER.get_browser_state(browser_session_id)
+            browser_state = await app.PERSISTENT_SESSIONS_MANAGER.get_browser_state(browser_session_id)
             if browser_state is None:
                 LOG.warning(
                     "Browser state not found in persistent sessions manager", browser_session_id=browser_session_id

--- a/skyvern/webeye/persistent_sessions_manager.py
+++ b/skyvern/webeye/persistent_sessions_manager.py
@@ -39,7 +39,7 @@ class PersistentSessionsManager:
         """Get all active sessions for an organization."""
         return await self.database.get_active_persistent_browser_sessions(organization_id)
 
-    def get_browser_state(self, session_id: str) -> BrowserState | None:
+    async def get_browser_state(self, session_id: str) -> BrowserState | None:
         """Get a specific browser session's state by session ID."""
         browser_session = self._browser_sessions.get(session_id)
         return browser_session.browser_state if browser_session else None


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make `get_browser_state` asynchronous and update its usage in `browser_manager.py`.
> 
>   - **Behavior**:
>     - `get_browser_state` in `persistent_sessions_manager.py` is now asynchronous.
>     - Updated calls to `get_browser_state` in `get_or_create_for_task` and `get_or_create_for_workflow_run` in `browser_manager.py` to use `await`.
>   - **Functions**:
>     - `get_browser_state` in `persistent_sessions_manager.py` changed to `async def`.
>     - Calls to `get_browser_state` in `browser_manager.py` updated to `await` the result.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 175723c8adfc41c51bde92103034071b1a7496fa. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->