### PR TITLE
do not show child task run in the /runs history page

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -1408,6 +1408,7 @@ class AgentDB:
                     select(WorkflowRunModel, WorkflowModel.title)
                     .join(WorkflowModel, WorkflowModel.workflow_id == WorkflowRunModel.workflow_id)
                     .filter(WorkflowRunModel.organization_id == organization_id)
+                    .filter(WorkflowRunModel.parent_workflow_run_id.is_(None))
                 )
                 if status:
                     workflow_run_query = workflow_run_query.filter(WorkflowRunModel.status.in_(status))


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Exclude child workflow runs from `get_all_runs` results in `client.py`.
> 
>   - **Behavior**:
>     - Update `get_all_runs` in `client.py` to exclude child workflow runs by adding a filter for `parent_workflow_run_id` being `None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 79d2e818652378e1dc5d481a4d20194266060bba. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->