### PR TITLE
use workflow_run_status in log instead of status

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -523,7 +523,7 @@ class WorkflowService:
             workflow_run_id=workflow_run_id,
             workflow_id=workflow_run.workflow_id,
             duration_seconds=duration_seconds,
-            status=WorkflowRunStatus.completed,
+            workflow_run_status=WorkflowRunStatus.completed,
             organization_id=organization_id,
         )
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `status` with `workflow_run_status` in `execute_workflow` function log entry in `service.py`.
> 
>   - **Behavior**:
>     - In `execute_workflow` function of `service.py`, replace `status` with `workflow_run_status` when logging workflow run duration metrics.
>   - **Logging**:
>     - Ensures correct parameter `workflow_run_status` is used in log entry for workflow run duration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2215f252a0c7ec4d6b708e58aff32a1eeba26ae1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->