### PR TITLE
Handle exception if missing video

### DIFF
--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -485,6 +485,8 @@ class BrowserState:
                         self.browser_artifacts.video_artifacts[index].video_path = await page.video.path()
                 except asyncio.TimeoutError:
                     LOG.info("Timeout to get the page video, skip the exception")
+                except Exception:
+                    LOG.exception("Error while getting the page video", exc_info=True)
             return
 
         target_lenght = index + 1
@@ -496,6 +498,8 @@ class BrowserState:
                 self.browser_artifacts.video_artifacts[index].video_path = await page.video.path()
         except asyncio.TimeoutError:
             LOG.info("Timeout to get the page video, skip the exception")
+        except Exception:
+            LOG.exception("Error while getting the page video", exc_info=True)
         return
 
     async def get_or_create_page(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add exception handling in `set_working_page()` in `browser_factory.py` to log errors when retrieving video paths.
> 
>   - **Exception Handling**:
>     - Add generic `Exception` handler in `set_working_page()` in `browser_factory.py` to log errors when retrieving video paths.
>     - Logs exceptions with `LOG.exception()` including `exc_info=True` for detailed traceback.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 4d85416f3a2068e67f8b255d5978b42d85c255da. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->