### PR TITLE
Check if video exists before assignment

### DIFF
--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -482,7 +482,8 @@ class BrowserState:
             if self.browser_artifacts.video_artifacts[index].video_path is None:
                 try:
                     async with asyncio.timeout(settings.BROWSER_ACTION_TIMEOUT_MS / 1000):
-                        self.browser_artifacts.video_artifacts[index].video_path = await page.video.path()
+                        if page.video:
+                            self.browser_artifacts.video_artifacts[index].video_path = await page.video.path()
                 except asyncio.TimeoutError:
                     LOG.info("Timeout to get the page video, skip the exception")
             return
@@ -493,7 +494,8 @@ class BrowserState:
         )
         try:
             async with asyncio.timeout(settings.BROWSER_ACTION_TIMEOUT_MS / 1000):
-                self.browser_artifacts.video_artifacts[index].video_path = await page.video.path()
+                if page.video:
+                    self.browser_artifacts.video_artifacts[index].video_path = await page.video.path()
         except asyncio.TimeoutError:
             LOG.info("Timeout to get the page video, skip the exception")
         return


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Check for existence of `page.video` before accessing its path in `set_working_page()` to prevent errors.
> 
>   - **Behavior**:
>     - In `set_working_page()` in `browser_factory.py`, check if `page.video` exists before accessing `video.path()` to prevent errors when `page.video` is `None`.
>     - Applied in two locations within the function to ensure robustness against missing video objects.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 3e21f9f272959145210c9835e744552a8d3637f7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->