### PR TITLE
fix unbounded variable bug in observer service

### DIFF
--- a/skyvern/forge/sdk/services/observer_service.py
+++ b/skyvern/forge/sdk/services/observer_service.py
@@ -165,7 +165,7 @@ async def initialize_observer_task(
         # fail the workflow run
         await mark_observer_task_as_failed(
             observer_cruise_id=observer_task.observer_cruise_id,
-            workflow_run_id=workflow_run.workflow_run_id,
+            workflow_run_id=observer_task.workflow_run_id,
             failure_reason="Skyvern failed to setup the workflow run",
             organization_id=organization.organization_id,
         )
@@ -186,7 +186,7 @@ async def initialize_observer_task(
 
     # update oserver cruise
     try:
-        observer_task = await app.DATABASE.update_observer_cruise(
+        observer_task = await app.database.update_observer_cruise(
             observer_cruise_id=observer_task.observer_cruise_id,
             workflow_run_id=workflow_run.workflow_run_id,
             workflow_id=new_workflow.workflow_id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix unbounded variable bug in `initialize_observer_task()` by correcting `workflow_run_id` and updating database reference.
> 
>   - **Bug Fixes**:
>     - Correct `workflow_run_id` parameter in `mark_observer_task_as_failed()` in `initialize_observer_task()`.
>     - Change `app.DATABASE` to `app.database` in `initialize_observer_task()` for `update_observer_cruise()` call.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 19c88d4da0589733577e673b8bfff0d1c2ad8c9b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->