### PR TITLE
pass css svg in iframe

### DIFF
--- a/skyvern/forge/prompts/skyvern/single-click-action.j2
+++ b/skyvern/forge/prompts/skyvern/single-click-action.j2
@@ -15,6 +15,7 @@ Reply in JSON format with the following keys:
         "action_type": str, // It's a string enum: "CLICK". "CLICK" type means there's an element you'd like to click.
         "id": str, // The id of the element to take action on. The id has to be one from the elements list.
         "download": bool, // If true, the browser will trigger a download by clicking the element. If false, the browser will click the element without triggering a download.
+        "file_url": str, // The url of the file to upload if applicable. This field can be present for CLICK only if the click is to upload the file. It should be null otherwise.
     }]
 }
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds support for 'button' elements in CSS shape conversion and updates click action JSON schema to include 'file_url' for uploads.
> 
>   - **Behavior**:
>     - `_should_css_shape_convert()` in `agent_functions.py` now includes 'button' elements for CSS shape conversion.
>     - `cleanup_element_tree_func()` in `agent_functions.py` updated to handle frame index changes during element processing.
>   - **Prompts**:
>     - `single-click-action.j2` updated to include `file_url` field in JSON schema for click actions, applicable for file uploads.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2faf3914854f2c4177b5e626bc1ed0e10a35241c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->