### PR TITLE
Include downloaded files in the task block outputs within workflows so subsequent blocks can use them

### DIFF
--- a/skyvern/forge/sdk/api/files.py
+++ b/skyvern/forge/sdk/api/files.py
@@ -7,7 +7,7 @@ import shutil
 import tempfile
 import zipfile
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import aiohttp
 import structlog
@@ -71,6 +71,15 @@ async def download_file(url: str, max_size_mb: int | None = None) -> str:
             LOG.info("Downloading Skyvern file from S3", url=url)
             client = AsyncAWSClient()
             return await download_from_s3(client, url)
+
+        # Check if URL is a file:// URI
+        # we only support to download local files when the environment is local
+        # and the file is in the skyvern downloads directory
+        if url.startswith("file://") and settings.ENV == "local":
+            file_path = parse_uri_to_path(url)
+            if file_path.startswith(f"{REPO_ROOT_DIR}/downloads"):
+                LOG.info("Downloading file from local file system", url=url)
+                return file_path
 
         async with aiohttp.ClientSession(raise_for_status=True) as session:
             LOG.info("Starting to download file", url=url)
@@ -273,3 +282,11 @@ def clean_up_dir(dir: str) -> None:
 
 def clean_up_skyvern_temp_dir() -> None:
     return clean_up_dir(get_skyvern_temp_dir())
+
+
+def parse_uri_to_path(uri: str) -> str:
+    parsed_uri = urlparse(uri)
+    if parsed_uri.scheme != "file":
+        raise ValueError(f"Invalid URI scheme: {parsed_uri.scheme} expected: file")
+    path = parsed_uri.netloc + parsed_uri.path
+    return unquote(path)

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -352,15 +352,17 @@ class TaskOutput(BaseModel):
     extracted_information: list | dict[str, Any] | str | None = None
     failure_reason: str | None = None
     errors: list[dict[str, Any]] = []
+    downloaded_file_urls: list[str] | None = None
 
     @staticmethod
-    def from_task(task: Task) -> TaskOutput:
+    def from_task(task: Task, downloaded_file_urls: list[str] | None = None) -> TaskOutput:
         return TaskOutput(
             task_id=task.task_id,
             status=task.status,
             extracted_information=task.extracted_information,
             failure_reason=task.failure_reason,
             errors=task.errors,
+            downloaded_file_urls=downloaded_file_urls,
         )
 
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> This PR adds support for including downloaded files in task block outputs, enabling subsequent blocks to access them, with changes in `files.py`, `tasks.py`, and `block.py`.
> 
>   - **Behavior**:
>     - `download_file()` in `files.py` now supports `file://` URIs for local files in local environments.
>     - `TaskOutput` in `tasks.py` now includes `downloaded_file_urls`.
>     - `execute()` in `block.py` retrieves downloaded files and includes them in task outputs.
>   - **Functions**:
>     - New `parse_uri_to_path()` function in `files.py` to convert `file://` URIs to file paths.
>   - **Refactoring**:
>     - Replaces `_parse_uri_to_path()` with `parse_uri_to_path()` in `local.py` for consistency.
>   - **Constants**:
>     - Adds `GET_DOWNLOADED_FILES_TIMEOUT` to `constants.py` for timeout handling in file retrieval.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 0cf754b1977d6fd02fd40de3c507ef9a4aa7e38a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->