### PR TITLE
add retry decorator

### DIFF
--- a/skyvern/forge/sdk/core/retry.py
+++ b/skyvern/forge/sdk/core/retry.py
@@ -1,0 +1,65 @@
+import asyncio
+import time
+from functools import wraps
+from typing import Any, Callable, Type, TypeVar, cast
+
+import structlog
+
+LOG = structlog.get_logger()
+
+# Type for any callable (sync or async)
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def retry(
+    exceptions: Type[Exception] | tuple[Type[Exception], ...] | None = None,
+    tries: int = 3,
+    delay: int = 3,
+    backoff: int = 2,
+) -> Callable[[F], F]:
+    """
+    Decorator to retry a function a specified number of times with a delay between attempts.
+    Works with both async and sync functions.
+
+    Args:
+        exceptions: A tuple of exceptions to catch and retry on.
+        tries: The total number attempts to make.
+        delay: The initial delay between attempts.
+        backoff: The factor by which the delay increases after each attempt.
+    """
+    if exceptions is None:
+        exceptions = Exception
+
+    def retry_decorator(func: F) -> F:
+        @wraps(func)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            remaining_tries, current_delay = tries, delay
+            while remaining_tries > 1:
+                try:
+                    return await func(*args, **kwargs)
+                except exceptions as e:
+                    LOG.warning(f"Retrying {func.__name__} in {current_delay} seconds... {e}")
+                    await asyncio.sleep(current_delay)
+                    remaining_tries -= 1
+                    current_delay *= backoff
+            return await func(*args, **kwargs)
+
+        @wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            remaining_tries, current_delay = tries, delay
+            while remaining_tries > 1:
+                try:
+                    return func(*args, **kwargs)
+                except exceptions as e:
+                    LOG.warning(f"Retrying {func.__name__} in {current_delay} seconds... {e}")
+                    time.sleep(current_delay)
+                    remaining_tries -= 1
+                    current_delay *= backoff
+            return func(*args, **kwargs)
+
+        # Return async wrapper if function is async, otherwise sync wrapper
+        if asyncio.iscoroutinefunction(func):
+            return cast(F, async_wrapper)
+        return cast(F, sync_wrapper)
+
+    return retry_decorator


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `retry` decorator in `retry.py` to handle function failures with retries, supporting both async and sync functions.
> 
>   - **Retry Decorator**:
>     - Adds `retry` decorator in `retry.py` to handle function failures with retries.
>     - Supports both async and sync functions with separate wrappers.
>     - Parameters: `exceptions`, `tries`, `delay`, `backoff`.
>     - Logs retry attempts using `structlog`.
>   - **Functionality**:
>     - Retries function execution on specified exceptions.
>     - Implements exponential backoff for retry delays.
>     - Default behavior: 3 tries, 3-second delay, 2x backoff.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e77d8eb5e426ae240b53c4f7317e467822076bb4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->