### PR TITLE
fix param typing in retry decor

### DIFF
--- a/skyvern/forge/sdk/core/retry.py
+++ b/skyvern/forge/sdk/core/retry.py
@@ -14,8 +14,8 @@ F = TypeVar("F", bound=Callable[..., Any])
 def retry(
     exceptions: Type[Exception] | tuple[Type[Exception], ...] | None = None,
     tries: int = 3,
-    delay: int = 3,
-    backoff: int = 2,
+    delay: float = 3.0,
+    backoff: float = 2.0,
 ) -> Callable[[F], F]:
     """
     Decorator to retry a function a specified number of times with a delay between attempts.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `delay` and `backoff` parameters in `retry()` to `float` for fractional second support.
> 
>   - **Function Signature**:
>     - Change `delay` and `backoff` parameters in `retry()` from `int` to `float` in `retry.py`.
>     - Allows for fractional seconds in delay and backoff calculations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9f57280a5a9234c5078167bbb79ba67152190ab5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->