### PR TITLE
Upload downloaded files to S3 after every block so they can be used for subsequent blocks

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1683,16 +1683,6 @@ class ForgeAgent:
                         step_id=last_step.step_id,
                     )
 
-        # if it's a task block from workflow run,
-        # we don't need to close the browser, save browser artifacts, or call webhook
-        if task.workflow_run_id:
-            LOG.info(
-                "Task is part of a workflow run, not sending a webhook response",
-                task_id=task.task_id,
-                workflow_run_id=task.workflow_run_id,
-            )
-            return
-
         if task.organization_id:
             try:
                 async with asyncio.timeout(SAVE_DOWNLOADED_FILES_TIMEOUT):
@@ -1712,6 +1702,16 @@ class ForgeAgent:
                     task_id=task.task_id,
                     workflow_run_id=task.workflow_run_id,
                 )
+
+        # if it's a task block from workflow run,
+        # we don't need to close the browser, save browser artifacts, or call webhook
+        if task.workflow_run_id:
+            LOG.info(
+                "Task is part of a workflow run, not sending a webhook response",
+                task_id=task.task_id,
+                workflow_run_id=task.workflow_run_id,
+            )
+            return
 
         await self.async_operation_pool.remove_task(task.task_id)
         await self.cleanup_browser_and_create_artifacts(

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -640,7 +640,7 @@ class BaseTaskBlock(Block):
                         downloaded_file_urls = await app.STORAGE.get_downloaded_files(
                             organization_id=workflow_run.organization_id,
                             task_id=updated_task.task_id,
-                            workflow_run_id=workflow_run_id,
+                            workflow_run_id=None,
                         )
                 except asyncio.TimeoutError:
                     LOG.warning("Timeout getting downloaded files", task_id=updated_task.task_id)
@@ -699,7 +699,7 @@ class BaseTaskBlock(Block):
                         downloaded_file_urls = await app.STORAGE.get_downloaded_files(
                             organization_id=workflow_run.organization_id,
                             task_id=updated_task.task_id,
-                            workflow_run_id=workflow_run_id,
+                            workflow_run_id=None,
                         )
                 except asyncio.TimeoutError:
                     LOG.warning("Timeout getting downloaded files", task_id=updated_task.task_id)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reorder file upload logic in `agent.py` and adjust `get_downloaded_files` calls in `block.py` to ensure S3 uploads after every block execution.
> 
>   - **Behavior**:
>     - Reorder conditional block in `clean_up_task` in `agent.py` to upload files to S3 before checking if task is part of a workflow run.
>     - Set `workflow_run_id` to `None` in `get_downloaded_files` calls in `block.py` to ensure files are uploaded to S3 after every block execution.
>   - **Misc**:
>     - Minor reordering of code in `agent.py` for logical consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for fce6a353e5a947efc6a74f83f102e5c53924c015. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->