### PR TITLE
Upload downloaded files to S3 after every block so they can be used for subsequent blocks (for real)

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -309,8 +309,6 @@ class ForgeAgent:
                 status=StepStatus.canceled,
                 is_last=True,
             )
-            # We don't send task response for now as the task is canceled
-            # TODO: shall we send task response here?
             await self.clean_up_task(
                 task=task,
                 last_step=step,
@@ -1687,7 +1685,7 @@ class ForgeAgent:
             try:
                 async with asyncio.timeout(SAVE_DOWNLOADED_FILES_TIMEOUT):
                     await app.STORAGE.save_downloaded_files(
-                        task.organization_id, task_id=task.task_id, workflow_run_id=None
+                        task.organization_id, task_id=task.task_id, workflow_run_id=task.workflow_run_id
                     )
             except asyncio.TimeoutError:
                 LOG.warning(

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -640,7 +640,7 @@ class BaseTaskBlock(Block):
                         downloaded_file_urls = await app.STORAGE.get_downloaded_files(
                             organization_id=workflow_run.organization_id,
                             task_id=updated_task.task_id,
-                            workflow_run_id=None,
+                            workflow_run_id=workflow_run_id,
                         )
                 except asyncio.TimeoutError:
                     LOG.warning("Timeout getting downloaded files", task_id=updated_task.task_id)
@@ -699,8 +699,9 @@ class BaseTaskBlock(Block):
                         downloaded_file_urls = await app.STORAGE.get_downloaded_files(
                             organization_id=workflow_run.organization_id,
                             task_id=updated_task.task_id,
-                            workflow_run_id=None,
+                            workflow_run_id=workflow_run_id,
                         )
+
                 except asyncio.TimeoutError:
                     LOG.warning("Timeout getting downloaded files", task_id=updated_task.task_id)
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Ensure downloaded files are uploaded to S3 after each block execution by updating `workflow_run_id` parameter in relevant function calls.
> 
>   - **Behavior**:
>     - Ensure downloaded files are uploaded to S3 after each block execution by updating `workflow_run_id` parameter in `save_downloaded_files()` in `agent.py` and `get_downloaded_files()` in `block.py`.
>   - **Functions**:
>     - Update `save_downloaded_files()` call in `clean_up_task()` in `agent.py` to use `workflow_run_id`.
>     - Update `get_downloaded_files()` calls in `execute()` in `block.py` to use `workflow_run_id`.
>   - **Misc**:
>     - Remove outdated comments in `execute_step()` in `agent.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ece52cc7ef25f4cc2da8653bc8c038c5103429e1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->