### PR TITLE
fix boolean workflow param convertion bug

### DIFF
--- a/skyvern/forge/sdk/workflow/models/parameter.py
+++ b/skyvern/forge/sdk/workflow/models/parameter.py
@@ -145,7 +145,7 @@ class WorkflowParameterType(StrEnum):
                 if isinstance(value, bool):
                     return value
                 lower_case = str(value).lower()
-                if lower_case in ["true", "false", "1", "0"]:
+                if lower_case not in ["true", "false", "1", "0"]:
                     raise InvalidWorkflowParameter(expected_parameter_type=self, value=str(value))
                 return lower_case in ["true", "1"]
             elif self == WorkflowParameterType.JSON:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes logical error in `convert_value` method for `WorkflowParameterType.BOOLEAN` to correctly handle invalid boolean strings.
> 
>   - **Bug Fix**:
>     - Fixes logical error in `convert_value` method of `WorkflowParameterType.BOOLEAN` in `parameter.py`.
>     - Corrects condition to raise `InvalidWorkflowParameter` for invalid boolean strings not in ['true', 'false', '1', '0'].
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0d2cec940a5f2caa191b8189ed8343c22da3d920. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->