### PR TITLE
fix skyvern init cli

### DIFF
--- a/skyvern/cli/commands.py
+++ b/skyvern/cli/commands.py
@@ -24,14 +24,15 @@ def run_command(command: str, check: bool = True) -> tuple[Optional[str], Option
 
 def is_postgres_running() -> bool:
     if command_exists("pg_isready"):
-        result = run_command("pg_isready")
+        result, _ = run_command("pg_isready")
         return result is not None and "accepting connections" in result
     return False
 
 
 def database_exists(dbname: str, user: str) -> bool:
     check_db_command = f'psql {dbname} -U {user} -c "\\q"'
-    return run_command(check_db_command, check=False) is not None
+    output, _ = run_command(check_db_command, check=False)
+    return output is not None
 
 
 def create_database_and_user() -> None:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes output handling in `run_command` for `database_exists()` and `is_postgres_running()` in `commands.py`.
> 
>   - **Behavior**:
>     - Fixes handling of `run_command` output in `database_exists()` and `is_postgres_running()` in `commands.py` to correctly check for database existence and PostgreSQL status.
>   - **Functions**:
>     - Updates `run_command` usage to unpack output and return code in `database_exists()` and `is_postgres_running()`.
>   - **Misc**:
>     - No changes to the overall logic or additional features added.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 01e5614a199e590735b4ba17d7e264fae4838cbc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->