### PR TITLE
task v2 refactor part 6 - observer_cruise_id -> task_v2_id

### DIFF
--- a/evaluation/script/create_webvoyager_evaluation_result.py
+++ b/evaluation/script/create_webvoyager_evaluation_result.py
@@ -48,8 +48,8 @@ def main(
                     {
                         "workflow_permanent_id": workflow_pid,
                         "status": str(workflow_run_response.status),
-                        "summary": workflow_run_response.observer_cruise.summary,
-                        "output": workflow_run_response.observer_cruise.output,
+                        "summary": workflow_run_response.observer_task.summary,
+                        "output": workflow_run_response.observer_task.output,
                         "assertion": workflow_run_response.status == WorkflowRunStatus.completed,
                         "failure_reason": workflow_run_response.failure_reason or "",
                     }

--- a/evaluation/script/create_webvoyager_task_v2.py
+++ b/evaluation/script/create_webvoyager_task_v2.py
@@ -12,7 +12,7 @@ from skyvern.forge.prompts import prompt_engine
 from skyvern.forge.sdk.schemas.task_v2 import ObserverTaskRequest
 
 
-async def create_observer_cruise(
+async def create_task_v2(
     base_url: str,
     cred: str,
 ) -> None:
@@ -42,7 +42,7 @@ async def create_observer_cruise(
             dumped_data = case_data.model_dump()
             dumped_data.update(
                 {
-                    "observer_cruise_id": cruise.observer_cruise_id,
+                    "task_v2_id": cruise.observer_cruise_id,
                     "workflow_run_id": cruise.workflow_run_id,
                     "workflow_permanent_id": cruise.workflow_permanent_id,
                     "cruise_url": str(cruise.url) if cruise.url else cruise.url,
@@ -59,7 +59,7 @@ def main(
     base_url: str = typer.Option(..., "--base-url", help="base url for Skyvern client"),
     cred: str = typer.Option(..., "--cred", help="credential for Skyvern organization"),
 ) -> None:
-    asyncio.run(create_observer_cruise(base_url=base_url, cred=cred))
+    asyncio.run(create_task_v2(base_url=base_url, cred=cred))
 
 
 if __name__ == "__main__":

--- a/evaluation/script/eval_webvoyager_cruise.py
+++ b/evaluation/script/eval_webvoyager_cruise.py
@@ -33,8 +33,8 @@ async def process_record(client: SkyvernClient, one_record: dict[str, Any]) -> d
     one_record.update(
         {
             "status": str(workflow_run_response.status),
-            "summary": workflow_run_response.observer_cruise.summary,
-            "output": workflow_run_response.observer_cruise.output,
+            "summary": workflow_run_response.observer_task.summary,
+            "output": workflow_run_response.observer_task.output,
         }
     )
     if workflow_run_response.status != WorkflowRunStatus.completed:

--- a/skyvern/agent/local.py
+++ b/skyvern/agent/local.py
@@ -66,23 +66,23 @@ class Agent:
             api_key=org_auth_token.token if org_auth_token else None,
         )
 
-    async def _run_observer_task(self, organization: Organization, observer_task: ObserverTask) -> None:
+    async def _run_task_v2(self, organization: Organization, task_v2: ObserverTask) -> None:
         # mark observer cruise as queued
-        await app.DATABASE.update_observer_cruise(
-            observer_cruise_id=observer_task.observer_cruise_id,
+        await app.DATABASE.update_task_v2(
+            task_v2_id=task_v2.observer_cruise_id,
             status=ObserverTaskStatus.queued,
             organization_id=organization.organization_id,
         )
 
-        assert observer_task.workflow_run_id
+        assert task_v2.workflow_run_id
         await app.DATABASE.update_workflow_run(
-            workflow_run_id=observer_task.workflow_run_id,
+            workflow_run_id=task_v2.workflow_run_id,
             status=WorkflowRunStatus.queued,
         )
 
         await task_v2_service.run_observer_task(
             organization=organization,
-            observer_cruise_id=observer_task.observer_cruise_id,
+            task_v2_id=task_v2.observer_cruise_id,
         )
 
     async def create_task(
@@ -170,12 +170,12 @@ class Agent:
         if not observer_task.workflow_run_id:
             raise Exception("Observer cruise missing workflow run id")
 
-        asyncio.create_task(self._run_observer_task(organization, observer_task))
+        asyncio.create_task(self._run_task_v2(organization, observer_task))
         return observer_task
 
     async def get_observer_task_v_2(self, task_id: str) -> ObserverTask | None:
         organization = await self._get_organization()
-        return await app.DATABASE.get_observer_cruise(task_id, organization.organization_id)
+        return await app.DATABASE.get_task_v2(task_id, organization.organization_id)
 
     async def run_observer_task_v_2(
         self, task_request: ObserverTaskRequest, timeout_seconds: int = 600

--- a/skyvern/client/agent/client.py
+++ b/skyvern/client/agent/client.py
@@ -3115,7 +3115,7 @@ class AgentClient:
             publish_workflow=publish_workflow,
             request_options=request_options,
         )
-        observer_cruise_id = observer_task.get("task_id")
+        task_id = observer_task.get("task_id")
 
         start_time = time.time()
         while True:
@@ -3123,7 +3123,7 @@ class AgentClient:
                 raise TimeoutError(f"Task timed out after {timeout_seconds} seconds")
 
             task = self.get_observer_task_v_2(
-                str(observer_cruise_id), api_key=api_key, authorization=authorization, request_options=request_options
+                str(task_id), api_key=api_key, authorization=authorization, request_options=request_options
             )
             if str(task.get("status")) in ["timed_out", "failed", "terminated", "completed", "canceled"]:
                 return task
@@ -7358,11 +7358,11 @@ class AsyncAgentClient:
             publish_workflow=publish_workflow,
             request_options=request_options,
         )
-        observer_cruise_id = observer_task.get("task_id")
+        task_id = observer_task.get("task_id")
         async with asyncio.timeout(timeout_seconds):
             while True:
                 task = await self.get_observer_task_v_2(
-                    str(observer_cruise_id),
+                    str(task_id),
                     api_key=api_key,
                     authorization=authorization,
                     request_options=request_options,

--- a/skyvern/exceptions.py
+++ b/skyvern/exceptions.py
@@ -31,13 +31,13 @@ class FailedToSendWebhook(SkyvernException):
         task_id: str | None = None,
         workflow_run_id: str | None = None,
         workflow_id: str | None = None,
-        observer_cruise_id: str | None = None,
+        task_v2_id: str | None = None,
     ):
         workflow_run_str = f"workflow_run_id={workflow_run_id}" if workflow_run_id else ""
         workflow_str = f"workflow_id={workflow_id}" if workflow_id else ""
         task_str = f"task_id={task_id}" if task_id else ""
-        observer_cruise_str = f"observer_cruise_id={observer_cruise_id}" if observer_cruise_id else ""
-        super().__init__(f"Failed to send webhook. {workflow_run_str} {workflow_str} {task_str} {observer_cruise_str}")
+        task_v2_str = f"task_v2_id={task_v2_id}" if task_v2_id else ""
+        super().__init__(f"Failed to send webhook. {workflow_run_str} {workflow_str} {task_str} {task_v2_str}")
 
 
 class ProxyLocationNotSupportedError(SkyvernException):
@@ -632,9 +632,9 @@ class UrlGenerationFailure(SkyvernHTTPException):
         super().__init__("Failed to generate the url for the prompt")
 
 
-class ObserverCruiseNotFound(SkyvernHTTPException):
-    def __init__(self, observer_cruise_id: str) -> None:
-        super().__init__(f"Observer task {observer_cruise_id} not found")
+class TaskV2NotFound(SkyvernHTTPException):
+    def __init__(self, task_v2_id: str) -> None:
+        super().__init__(f"Task v2 {task_v2_id} not found")
 
 
 class NoTOTPVerificationCodeFound(SkyvernHTTPException):

--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -63,7 +63,7 @@ class LLMAPIHandlerFactory:
             prompt: str,
             prompt_name: str,
             step: Step | None = None,
-            observer_cruise: ObserverTask | None = None,
+            task_v2: ObserverTask | None = None,
             observer_thought: ObserverThought | None = None,
             ai_suggestion: AISuggestion | None = None,
             screenshots: list[bytes] | None = None,
@@ -92,7 +92,7 @@ class LLMAPIHandlerFactory:
                     data=json.dumps(context.hashed_href_map, indent=2).encode("utf-8"),
                     artifact_type=ArtifactType.HASHED_HREF_MAP,
                     step=step,
-                    observer_cruise=observer_cruise,
+                    task_v2=task_v2,
                     observer_thought=observer_thought,
                     ai_suggestion=ai_suggestion,
                 )
@@ -102,7 +102,7 @@ class LLMAPIHandlerFactory:
                 artifact_type=ArtifactType.LLM_PROMPT,
                 screenshots=screenshots,
                 step=step,
-                observer_cruise=observer_cruise,
+                task_v2=task_v2,
                 observer_thought=observer_thought,
             )
             messages = await llm_messages_builder(prompt, screenshots, llm_config.add_assistant_prefix)
@@ -117,7 +117,7 @@ class LLMAPIHandlerFactory:
                 ).encode("utf-8"),
                 artifact_type=ArtifactType.LLM_REQUEST,
                 step=step,
-                observer_cruise=observer_cruise,
+                task_v2=task_v2,
                 observer_thought=observer_thought,
                 ai_suggestion=ai_suggestion,
             )
@@ -144,7 +144,7 @@ class LLMAPIHandlerFactory:
                 data=response.model_dump_json(indent=2).encode("utf-8"),
                 artifact_type=ArtifactType.LLM_RESPONSE,
                 step=step,
-                observer_cruise=observer_cruise,
+                task_v2=task_v2,
                 observer_thought=observer_thought,
                 ai_suggestion=ai_suggestion,
             )
@@ -184,7 +184,7 @@ class LLMAPIHandlerFactory:
                 data=json.dumps(parsed_response, indent=2).encode("utf-8"),
                 artifact_type=ArtifactType.LLM_RESPONSE_PARSED,
                 step=step,
-                observer_cruise=observer_cruise,
+                task_v2=task_v2,
                 observer_thought=observer_thought,
                 ai_suggestion=ai_suggestion,
             )
@@ -197,7 +197,7 @@ class LLMAPIHandlerFactory:
                     data=json.dumps(parsed_response, indent=2).encode("utf-8"),
                     artifact_type=ArtifactType.LLM_RESPONSE_RENDERED,
                     step=step,
-                    observer_cruise=observer_cruise,
+                    task_v2=task_v2,
                     observer_thought=observer_thought,
                     ai_suggestion=ai_suggestion,
                 )
@@ -234,7 +234,7 @@ class LLMAPIHandlerFactory:
             prompt: str,
             prompt_name: str,
             step: Step | None = None,
-            observer_cruise: ObserverTask | None = None,
+            task_v2: ObserverTask | None = None,
             observer_thought: ObserverThought | None = None,
             ai_suggestion: AISuggestion | None = None,
             screenshots: list[bytes] | None = None,
@@ -255,7 +255,7 @@ class LLMAPIHandlerFactory:
                     data=json.dumps(context.hashed_href_map, indent=2).encode("utf-8"),
                     artifact_type=ArtifactType.HASHED_HREF_MAP,
                     step=step,
-                    observer_cruise=observer_cruise,
+                    task_v2=task_v2,
                     observer_thought=observer_thought,
                     ai_suggestion=ai_suggestion,
                 )
@@ -265,7 +265,7 @@ class LLMAPIHandlerFactory:
                 artifact_type=ArtifactType.LLM_PROMPT,
                 screenshots=screenshots,
                 step=step,
-                observer_cruise=observer_cruise,
+                task_v2=task_v2,
                 observer_thought=observer_thought,
                 ai_suggestion=ai_suggestion,
             )
@@ -285,7 +285,7 @@ class LLMAPIHandlerFactory:
                 ).encode("utf-8"),
                 artifact_type=ArtifactType.LLM_REQUEST,
                 step=step,
-                observer_cruise=observer_cruise,
+                task_v2=task_v2,
                 observer_thought=observer_thought,
                 ai_suggestion=ai_suggestion,
             )
@@ -319,7 +319,7 @@ class LLMAPIHandlerFactory:
                 data=response.model_dump_json(indent=2).encode("utf-8"),
                 artifact_type=ArtifactType.LLM_RESPONSE,
                 step=step,
-                observer_cruise=observer_cruise,
+                task_v2=task_v2,
                 observer_thought=observer_thought,
                 ai_suggestion=ai_suggestion,
             )
@@ -354,7 +354,7 @@ class LLMAPIHandlerFactory:
                 data=json.dumps(parsed_response, indent=2).encode("utf-8"),
                 artifact_type=ArtifactType.LLM_RESPONSE_PARSED,
                 step=step,
-                observer_cruise=observer_cruise,
+                task_v2=task_v2,
                 observer_thought=observer_thought,
                 ai_suggestion=ai_suggestion,
             )
@@ -367,7 +367,7 @@ class LLMAPIHandlerFactory:
                     data=json.dumps(parsed_response, indent=2).encode("utf-8"),
                     artifact_type=ArtifactType.LLM_RESPONSE_RENDERED,
                     step=step,
-                    observer_cruise=observer_cruise,
+                    task_v2=task_v2,
                     observer_thought=observer_thought,
                     ai_suggestion=ai_suggestion,
                 )

--- a/skyvern/forge/sdk/api/llm/models.py
+++ b/skyvern/forge/sdk/api/llm/models.py
@@ -85,7 +85,7 @@ class LLMAPIHandler(Protocol):
         prompt: str,
         prompt_name: str,
         step: Step | None = None,
-        observer_cruise: ObserverTask | None = None,
+        task_v2: ObserverTask | None = None,
         observer_thought: ObserverThought | None = None,
         ai_suggestion: AISuggestion | None = None,
         screenshots: list[bytes] | None = None,

--- a/skyvern/forge/sdk/artifact/manager.py
+++ b/skyvern/forge/sdk/artifact/manager.py
@@ -30,7 +30,7 @@ class ArtifactManager:
         workflow_run_id: str | None = None,
         workflow_run_block_id: str | None = None,
         observer_thought_id: str | None = None,
-        observer_cruise_id: str | None = None,
+        task_v2_id: str | None = None,
         ai_suggestion_id: str | None = None,
         organization_id: str | None = None,
         data: bytes | None = None,
@@ -49,7 +49,7 @@ class ArtifactManager:
             workflow_run_id=workflow_run_id,
             workflow_run_block_id=workflow_run_block_id,
             observer_thought_id=observer_thought_id,
-            observer_cruise_id=observer_cruise_id,
+            task_v2_id=task_v2_id,
             organization_id=organization_id,
             ai_suggestion_id=ai_suggestion_id,
         )
@@ -129,28 +129,28 @@ class ArtifactManager:
             artifact_type=artifact_type,
             uri=uri,
             observer_thought_id=observer_thought.observer_thought_id,
-            observer_cruise_id=observer_thought.observer_cruise_id,
+            task_v2_id=observer_thought.observer_cruise_id,
             organization_id=observer_thought.organization_id,
             data=data,
             path=path,
         )
 
-    async def create_observer_cruise_artifact(
+    async def create_task_v2_artifact(
         self,
-        observer_cruise: ObserverTask,
+        task_v2: ObserverTask,
         artifact_type: ArtifactType,
         data: bytes | None = None,
         path: str | None = None,
     ) -> str:
         artifact_id = generate_artifact_id()
-        uri = app.STORAGE.build_observer_cruise_uri(artifact_id, observer_cruise, artifact_type)
+        uri = app.STORAGE.build_task_v2_uri(artifact_id, task_v2, artifact_type)
         return await self._create_artifact(
-            aio_task_primary_key=observer_cruise.observer_cruise_id,
+            aio_task_primary_key=task_v2.observer_cruise_id,
             artifact_id=artifact_id,
             artifact_type=artifact_type,
             uri=uri,
-            observer_cruise_id=observer_cruise.observer_cruise_id,
-            organization_id=observer_cruise.organization_id,
+            task_v2_id=task_v2.observer_cruise_id,
+            organization_id=task_v2.organization_id,
             data=data,
             path=path,
         )
@@ -203,7 +203,7 @@ class ArtifactManager:
         screenshots: list[bytes] | None = None,
         step: Step | None = None,
         observer_thought: ObserverThought | None = None,
-        observer_cruise: ObserverTask | None = None,
+        task_v2: ObserverTask | None = None,
         ai_suggestion: AISuggestion | None = None,
     ) -> None:
         if step:
@@ -218,15 +218,15 @@ class ArtifactManager:
                     artifact_type=ArtifactType.SCREENSHOT_LLM,
                     data=screenshot,
                 )
-        elif observer_cruise:
-            await self.create_observer_cruise_artifact(
-                observer_cruise=observer_cruise,
+        elif task_v2:
+            await self.create_task_v2_artifact(
+                task_v2=task_v2,
                 artifact_type=artifact_type,
                 data=data,
             )
             for screenshot in screenshots or []:
-                await self.create_observer_cruise_artifact(
-                    observer_cruise=observer_cruise,
+                await self.create_task_v2_artifact(
+                    task_v2=task_v2,
                     artifact_type=ArtifactType.SCREENSHOT_LLM,
                     data=screenshot,
                 )

--- a/skyvern/forge/sdk/artifact/storage/base.py
+++ b/skyvern/forge/sdk/artifact/storage/base.py
@@ -55,9 +55,7 @@ class BaseStorage(ABC):
         pass
 
     @abstractmethod
-    def build_observer_cruise_uri(
-        self, artifact_id: str, observer_cruise: ObserverTask, artifact_type: ArtifactType
-    ) -> str:
+    def build_task_v2_uri(self, artifact_id: str, task_v2: ObserverTask, artifact_type: ArtifactType) -> str:
         pass
 
     @abstractmethod

--- a/skyvern/forge/sdk/artifact/storage/local.py
+++ b/skyvern/forge/sdk/artifact/storage/local.py
@@ -46,11 +46,9 @@ class LocalStorage(BaseStorage):
         file_ext = FILE_EXTENTSION_MAP[artifact_type]
         return f"file://{self.artifact_path}/{settings.ENV}/observers/{observer_thought.observer_cruise_id}/{observer_thought.observer_thought_id}/{datetime.utcnow().isoformat()}_{artifact_id}_{artifact_type}.{file_ext}"
 
-    def build_observer_cruise_uri(
-        self, artifact_id: str, observer_cruise: ObserverTask, artifact_type: ArtifactType
-    ) -> str:
+    def build_task_v2_uri(self, artifact_id: str, task_v2: ObserverTask, artifact_type: ArtifactType) -> str:
         file_ext = FILE_EXTENTSION_MAP[artifact_type]
-        return f"file://{self.artifact_path}/{settings.ENV}/observers/{observer_cruise.observer_cruise_id}/{datetime.utcnow().isoformat()}_{artifact_id}_{artifact_type}.{file_ext}"
+        return f"file://{self.artifact_path}/{settings.ENV}/observers/{task_v2.observer_cruise_id}/{datetime.utcnow().isoformat()}_{artifact_id}_{artifact_type}.{file_ext}"
 
     def build_workflow_run_block_uri(
         self, artifact_id: str, workflow_run_block: WorkflowRunBlock, artifact_type: ArtifactType

--- a/skyvern/forge/sdk/artifact/storage/s3.py
+++ b/skyvern/forge/sdk/artifact/storage/s3.py
@@ -46,11 +46,9 @@ class S3Storage(BaseStorage):
         file_ext = FILE_EXTENTSION_MAP[artifact_type]
         return f"s3://{self.bucket}/{settings.ENV}/observers/{observer_thought.observer_cruise_id}/{observer_thought.observer_thought_id}/{datetime.utcnow().isoformat()}_{artifact_id}_{artifact_type}.{file_ext}"
 
-    def build_observer_cruise_uri(
-        self, artifact_id: str, observer_cruise: ObserverTask, artifact_type: ArtifactType
-    ) -> str:
+    def build_task_v2_uri(self, artifact_id: str, task_v2: ObserverTask, artifact_type: ArtifactType) -> str:
         file_ext = FILE_EXTENTSION_MAP[artifact_type]
-        return f"s3://{self.bucket}/{settings.ENV}/observers/{observer_cruise.observer_cruise_id}/{datetime.utcnow().isoformat()}_{artifact_id}_{artifact_type}.{file_ext}"
+        return f"s3://{self.bucket}/{settings.ENV}/observers/{task_v2.observer_cruise_id}/{datetime.utcnow().isoformat()}_{artifact_id}_{artifact_type}.{file_ext}"
 
     def build_workflow_run_block_uri(
         self, artifact_id: str, workflow_run_block: WorkflowRunBlock, artifact_type: ArtifactType

--- a/skyvern/forge/sdk/core/skyvern_context.py
+++ b/skyvern/forge/sdk/core/skyvern_context.py
@@ -12,7 +12,7 @@ class SkyvernContext:
     task_id: str | None = None
     workflow_id: str | None = None
     workflow_run_id: str | None = None
-    observer_cruise_id: str | None = None
+    task_v2_id: str | None = None
     max_steps_override: int | None = None
     tz_info: ZoneInfo | None = None
     totp_codes: dict[str, str | None] = field(default_factory=dict)
@@ -22,7 +22,7 @@ class SkyvernContext:
     frame_index_map: dict[Frame, int] = field(default_factory=dict)
 
     def __repr__(self) -> str:
-        return f"SkyvernContext(request_id={self.request_id}, organization_id={self.organization_id}, task_id={self.task_id}, workflow_id={self.workflow_id}, workflow_run_id={self.workflow_run_id}, max_steps_override={self.max_steps_override})"
+        return f"SkyvernContext(request_id={self.request_id}, organization_id={self.organization_id}, task_id={self.task_id}, workflow_id={self.workflow_id}, workflow_run_id={self.workflow_run_id}, task_v2_id={self.task_v2_id}, max_steps_override={self.max_steps_override})"
 
     def __str__(self) -> str:
         return self.__repr__()

--- a/skyvern/forge/sdk/db/id.py
+++ b/skyvern/forge/sdk/db/id.py
@@ -37,7 +37,7 @@ BITWARDEN_SENSITIVE_INFORMATION_PARAMETER_PREFIX = "bsi"
 CREDENTIAL_PARAMETER_PREFIX = "cp"
 CREDENTIAL_PREFIX = "cred"
 ORGANIZATION_BITWARDEN_COLLECTION_PREFIX = "obc"
-OBSERVER_CRUISE_ID = "oc"
+TASK_V2_ID = "oc"
 OBSERVER_THOUGHT_ID = "ot"
 ORGANIZATION_AUTH_TOKEN_PREFIX = "oat"
 ORG_PREFIX = "o"
@@ -156,9 +156,9 @@ def generate_action_id() -> str:
     return f"{ACTION_PREFIX}_{int_id}"
 
 
-def generate_observer_cruise_id() -> str:
+def generate_task_v2_id() -> str:
     int_id = generate_id()
-    return f"{OBSERVER_CRUISE_ID}_{int_id}"
+    return f"{TASK_V2_ID}_{int_id}"
 
 
 def generate_observer_thought_id() -> str:

--- a/skyvern/forge/sdk/db/models.py
+++ b/skyvern/forge/sdk/db/models.py
@@ -29,7 +29,6 @@ from skyvern.forge.sdk.db.id import (
     generate_bitwarden_sensitive_information_parameter_id,
     generate_credential_id,
     generate_credential_parameter_id,
-    generate_observer_cruise_id,
     generate_observer_thought_id,
     generate_org_id,
     generate_organization_auth_token_id,
@@ -40,6 +39,7 @@ from skyvern.forge.sdk.db.id import (
     generate_task_generation_id,
     generate_task_id,
     generate_task_run_id,
+    generate_task_v2_id,
     generate_totp_code_id,
     generate_workflow_id,
     generate_workflow_parameter_id,
@@ -569,7 +569,8 @@ class ObserverCruiseModel(Base):
     __tablename__ = "observer_cruises"
     __table_args__ = (Index("oc_org_wfr_index", "organization_id", "workflow_run_id"),)
 
-    observer_cruise_id = Column(String, primary_key=True, default=generate_observer_cruise_id)
+    # observer_cruise_id is the task_id for task v2
+    observer_cruise_id = Column(String, primary_key=True, default=generate_task_v2_id)
     status = Column(String, nullable=False, default="created")
     organization_id = Column(String, ForeignKey("organizations.organization_id"), nullable=True)
     workflow_run_id = Column(String, ForeignKey("workflow_runs.workflow_run_id"), nullable=True)

--- a/skyvern/forge/sdk/forge_log.py
+++ b/skyvern/forge/sdk/forge_log.py
@@ -32,8 +32,8 @@ def add_kv_pairs_to_msg(logger: logging.Logger, method_name: str, event_dict: Ev
             event_dict["workflow_id"] = context.workflow_id
         if context.workflow_run_id:
             event_dict["workflow_run_id"] = context.workflow_run_id
-        if context.observer_cruise_id:
-            event_dict["observer_cruise_id"] = context.observer_cruise_id
+        if context.task_v2_id:
+            event_dict["task_v2_id"] = context.task_v2_id
 
     # Add env to the log
     event_dict["env"] = settings.ENV

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -2157,7 +2157,7 @@ class TaskV2Block(Block):
             parent_workflow_run_id=workflow_run_id,
             proxy_location=workflow_run.proxy_location,
         )
-        await app.DATABASE.update_observer_cruise(
+        await app.DATABASE.update_task_v2(
             observer_task.observer_cruise_id, status=ObserverTaskStatus.queued, organization_id=organization_id
         )
         if observer_task.workflow_run_id:
@@ -2173,7 +2173,7 @@ class TaskV2Block(Block):
 
         observer_task = await task_v2_service.run_observer_task(
             organization=organization,
-            observer_cruise_id=observer_task.observer_cruise_id,
+            task_v2_id=observer_task.observer_cruise_id,
             request_id=None,
             max_iterations_override=self.max_iterations,
             browser_session_id=browser_session_id,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor codebase to replace `observer_cruise_id` with `task_v2_id`, updating functions, logs, and database interactions to support `task_v2`.
> 
>   - **Refactor**:
>     - Rename `observer_cruise_id` to `task_v2_id` across multiple files and functions, including `task_v2_service.py`, `async_executor.py`, and `agent_protocol.py`.
>     - Update function names from `create_cruise` to `create_task_v2` and `run_observer_task` to `run_task_v2` in `task_v2_service.py` and `async_executor.py`.
>     - Change log messages and error handling to reflect the new `task_v2` terminology.
>   - **Functionality**:
>     - Modify `initialize_observer_task` and `run_observer_task` in `task_v2_service.py` to handle `task_v2` logic.
>     - Update database interactions to use `task_v2_id` in `models.py` and `db/client.py`.
>   - **Miscellaneous**:
>     - Adjust logging in `forge_log.py` to include `task_v2_id` in context.
>     - Rename `create_webvoyager_observer.py` to `create_webvoyager_task_v2.py` and update its content accordingly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for cb1f754e5d42f2f5bfa247cc93c4801e2c6cbb2d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->