### PR TITLE
fix recording_url

### DIFF
--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunRecording.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunRecording.tsx
@@ -1,8 +1,12 @@
 import { useWorkflowRunQuery } from "../hooks/useWorkflowRunQuery";
+import { artifactApiBaseUrl } from "@/util/env";
 
 function WorkflowRunRecording() {
   const { data: workflowRun } = useWorkflowRunQuery();
-  const recordingURL = workflowRun?.recording_url;
+  let recordingURL = workflowRun?.recording_url;
+  if (recordingURL?.startsWith("file://")) {
+    recordingURL = `${artifactApiBaseUrl}/artifact/recording?path=${recordingURL.slice(7)}`;
+  }
   return recordingURL ? (
     <video src={recordingURL} controls className="w-full rounded-md" />
   ) : (


### PR DESCRIPTION
fixes https://github.com/Skyvern-AI/skyvern/issues/1653
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `recording_url` handling in `WorkflowRunRecording.tsx` by converting `file://` URLs to API-accessible URLs.
> 
>   - **Behavior**:
>     - Fixes `recording_url` handling in `WorkflowRunRecording.tsx`.
>     - Converts `file://` URLs to API-accessible URLs using `artifactApiBaseUrl`.
>   - **Imports**:
>     - Adds import for `artifactApiBaseUrl` from `@/util/env`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 4ecd480b53c64639de30c967b83ed3c0a9b6cb09. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->