### PR TITLE
task v2 refactor part 8: observer_task -> task_v2 in backend code

### DIFF
--- a/evaluation/core/__init__.py
+++ b/evaluation/core/__init__.py
@@ -260,7 +260,7 @@ class Evaluator:
         )
 
         extracted_information: list | dict[str, Any] | str | None = None
-        if workflow_run_response.observer_task is None:
+        if workflow_run_response.task_v2 is None:
             assert workflow_run_response.outputs and len(workflow_run_response.outputs) > 0, (
                 f"Expected {workflow_pid + '/' + workflow_run_id} with output, but got empty output"
             )
@@ -272,10 +272,10 @@ class Evaluator:
                 # FIXME: improve this when the last block is loop block
                 extracted_information = result
         else:
-            workflow_run_response.observer_task.summary
-            workflow_run_response.observer_task.output
-            summary = f"{('summary:' + workflow_run_response.observer_task.summary) if workflow_run_response.observer_task.summary else ''}"
-            output = f"{('output: ' + json.dumps(workflow_run_response.observer_task.output)) if workflow_run_response.observer_task.output else ''}"
+            workflow_run_response.task_v2.summary
+            workflow_run_response.task_v2.output
+            summary = f"{('summary:' + workflow_run_response.task_v2.summary) if workflow_run_response.task_v2.summary else ''}"
+            output = f"{('output: ' + json.dumps(workflow_run_response.task_v2.output)) if workflow_run_response.task_v2.output else ''}"
             extracted_information = ""
             if summary:
                 extracted_information = summary

--- a/evaluation/script/create_webvoyager_evaluation_result.py
+++ b/evaluation/script/create_webvoyager_evaluation_result.py
@@ -51,8 +51,8 @@ def main(
                     {
                         "workflow_permanent_id": workflow_pid,
                         "status": str(workflow_run_response.status),
-                        "summary": workflow_run_response.observer_task.summary,
-                        "output": workflow_run_response.observer_task.output,
+                        "summary": workflow_run_response.task_v2.summary,
+                        "output": workflow_run_response.task_v2.output,
                         "assertion": workflow_run_response.status == WorkflowRunStatus.completed,
                         "failure_reason": workflow_run_response.failure_reason or "",
                     }

--- a/evaluation/script/eval_webvoyager_task_v2.py
+++ b/evaluation/script/eval_webvoyager_task_v2.py
@@ -36,8 +36,8 @@ async def process_record(client: SkyvernClient, one_record: dict[str, Any]) -> d
     one_record.update(
         {
             "status": str(workflow_run_response.status),
-            "summary": workflow_run_response.observer_task.summary,
-            "output": workflow_run_response.observer_task.output,
+            "summary": workflow_run_response.task_v2.summary,
+            "output": workflow_run_response.task_v2.output,
         }
     )
     if workflow_run_response.status != WorkflowRunStatus.completed:

--- a/skyvern/forge/sdk/executor/async_executor.py
+++ b/skyvern/forge/sdk/executor/async_executor.py
@@ -174,7 +174,7 @@ class BackgroundTaskExecutor(AsyncExecutor):
 
         if background_tasks:
             background_tasks.add_task(
-                task_v2_service.run_observer_task,
+                task_v2_service.run_task_v2,
                 organization=organization,
                 task_v2_id=task_v2_id,
                 max_iterations_override=max_iterations_override,

--- a/skyvern/forge/sdk/workflow/models/workflow.py
+++ b/skyvern/forge/sdk/workflow/models/workflow.py
@@ -147,5 +147,5 @@ class WorkflowRunStatusResponse(BaseModel):
     outputs: dict[str, Any] | None = None
     total_steps: int | None = None
     total_cost: float | None = None
-    observer_task: ObserverTask | None = None
+    task_v2: ObserverTask | None = None
     workflow_title: str | None = None


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor codebase to rename `observer_task` to `task_v2`, updating related functions, logic, and API routes.
> 
>   - **Renaming**:
>     - Rename `observer_task` to `task_v2` in `evaluation/core/__init__.py`, `create_webvoyager_evaluation_result.py`, and `eval_webvoyager_task_v2.py`.
>     - Rename `initialize_observer_task` to `initialize_task_v2` and `run_observer_task` to `run_task_v2` in `task_v2_service.py`.
>     - Rename `observer_task_v_2` to `task_v2` in `local.py`.
>     - Rename `observer_task` to `task_v2` in `agent_protocol.py`.
>   - **Functionality**:
>     - Update logic to handle `task_v2` in `eval_skyvern_workflow_run()` in `evaluation/core/__init__.py`.
>     - Update CSV output fields to use `task_v2` in `create_webvoyager_evaluation_result.py` and `eval_webvoyager_task_v2.py`.
>     - Update task execution logic to use `task_v2` in `local.py` and `async_executor.py`.
>     - Update API routes to handle `task_v2` in `agent_protocol.py`.
>   - **Models**:
>     - Update `WorkflowRunStatusResponse` to use `task_v2` in `workflow.py`.
>     - Update `TaskV2Block` execution logic in `block.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2a8839d4d36ee7b2540f361f1161a9c705c0df6f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->