### PR TITLE
task v2 refactor part 7: observer_task -> task_v2 frontend code

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -244,7 +244,7 @@ export type WorkflowRunStatusApiResponse = {
   downloaded_file_urls: Array<string> | null;
   total_steps: number | null;
   total_cost: number | null;
-  observer_task: ObserverTask | null;
+  task_v2: ObserverTask | null;
   workflow_title: string | null;
 };
 

--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -126,7 +126,7 @@ function WorkflowRun() {
     });
   }
 
-  const isTaskv2Run = workflowRun && workflowRun.observer_task !== null;
+  const isTaskv2Run = workflowRun && workflowRun.task_v2 !== null;
 
   return (
     <div className="space-y-8">

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowPostRunParameters.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowPostRunParameters.tsx
@@ -44,14 +44,14 @@ function WorkflowPostRunParameters() {
   }
 
   const activeBlock = getActiveBlock();
-  const isObserverTask = workflowRun.observer_task !== null;
+  const isObserverTask = workflowRun.task_v2 !== null;
 
   const webhookCallbackUrl = isObserverTask
-    ? workflowRun.observer_task?.webhook_callback_url
+    ? workflowRun.task_v2?.webhook_callback_url
     : workflowRun.webhook_callback_url;
 
   const proxyLocation = isObserverTask
-    ? workflowRun.observer_task?.proxy_location
+    ? workflowRun.task_v2?.proxy_location
     : workflowRun.proxy_location;
 
   return (
@@ -149,7 +149,7 @@ function WorkflowPostRunParameters() {
           </div>
         </div>
       </div>
-      {workflowRun.observer_task ? (
+      {workflowRun.task_v2 ? (
         <div className="rounded bg-slate-elevation2 p-6">
           <div className="space-y-4">
             <h1 className="text-lg font-bold">Task 2.0 Parameters</h1>
@@ -161,7 +161,7 @@ function WorkflowPostRunParameters() {
                 </h2>
               </div>
               <AutoResizingTextarea
-                value={workflowRun.observer_task.prompt ?? ""}
+                value={workflowRun.task_v2.prompt ?? ""}
                 readOnly
               />
             </div>

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunOutput.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunOutput.tsx
@@ -77,7 +77,7 @@ function WorkflowRunOutput() {
     ? formatExtractedInformation(outputs)
     : outputs;
   const fileUrls = workflowRun?.downloaded_file_urls ?? [];
-  const observerOutput = workflowRun?.observer_task?.output;
+  const observerOutput = workflowRun?.task_v2?.output;
 
   return (
     <div className="space-y-5">


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Rename `observer_task` to `task_v2` in frontend components to update task-related data handling and display.
> 
>   - **Renaming**:
>     - Rename `observer_task` to `task_v2` in `WorkflowRunStatusApiResponse` in `types.ts`.
>     - Update `isTaskv2Run` and `isObserverTask` checks in `WorkflowRun.tsx` and `WorkflowPostRunParameters.tsx`.
>     - Change `observerOutput` to use `task_v2.output` in `WorkflowRunOutput.tsx`.
>   - **Behavior**:
>     - Update logic to check for `task_v2` presence instead of `observer_task` in `WorkflowRun.tsx`, `WorkflowPostRunParameters.tsx`, and `WorkflowRunOutput.tsx`.
>     - Adjust UI elements to display `task_v2` related data, such as `webhook_callback_url`, `proxy_location`, and `prompt`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a5c75eb1cffedfa366efdde84cdf738cd22e6856. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->