### PR TITLE
task v2 refactor part 9: ObserverTask -> TaskV2 in frontend code

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -247,7 +247,7 @@ export type WorkflowRunStatusApiResponse = {
   downloaded_file_urls: Array<string> | null;
   total_steps: number | null;
   total_cost: number | null;
-  task_v2: ObserverTask | null;
+  task_v2: TaskV2 | null;
   workflow_title: string | null;
 };
 
@@ -275,7 +275,7 @@ export type ActionsApiResponse = {
   response: string | null;
 };
 
-export type ObserverTask = {
+export type TaskV2 = {
   task_id: string;
   status: Status;
   workflow_run_id: string | null;

--- a/skyvern-frontend/src/routes/tasks/create/ExampleCasePill.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/ExampleCasePill.tsx
@@ -24,8 +24,9 @@ function ExampleCasePill({ exampleId, version, icon, label, prompt }: Props) {
     mutationFn: async (prompt: string) => {
       const client = await getClient(credentialGetter, "v2");
       return client.post<{ user_prompt: string }, { data: TaskV2 }>(
-        "/tasks",
-        { user_prompt: prompt },
+        "/tasks", {
+          user_prompt: prompt
+        },
       );
     },
     onSuccess: (response) => {

--- a/skyvern-frontend/src/routes/tasks/create/ExampleCasePill.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/ExampleCasePill.tsx
@@ -23,11 +23,9 @@ function ExampleCasePill({ exampleId, version, icon, label, prompt }: Props) {
   const startObserverCruiseMutation = useMutation({
     mutationFn: async (prompt: string) => {
       const client = await getClient(credentialGetter, "v2");
-      return client.post<{ user_prompt: string }, { data: TaskV2 }>(
-        "/tasks", {
-          user_prompt: prompt
-        },
-      );
+      return client.post<{ user_prompt: string }, { data: TaskV2 }>("/tasks", {
+        user_prompt: prompt,
+      });
     },
     onSuccess: (response) => {
       toast({

--- a/skyvern-frontend/src/routes/tasks/create/ExampleCasePill.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/ExampleCasePill.tsx
@@ -1,5 +1,5 @@
 import { getClient } from "@/api/AxiosClient";
-import { ObserverTask } from "@/api/types";
+import { TaskV2 } from "@/api/types";
 import { toast } from "@/components/ui/use-toast";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
 import { ReloadIcon } from "@radix-ui/react-icons";
@@ -23,7 +23,7 @@ function ExampleCasePill({ exampleId, version, icon, label, prompt }: Props) {
   const startObserverCruiseMutation = useMutation({
     mutationFn: async (prompt: string) => {
       const client = await getClient(credentialGetter, "v2");
-      return client.post<{ user_prompt: string }, { data: ObserverTask }>(
+      return client.post<{ user_prompt: string }, { data: TaskV2 }>(
         "/tasks",
         { user_prompt: prompt },
       );

--- a/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
@@ -1,7 +1,7 @@
 import { getClient } from "@/api/AxiosClient";
 import {
   Createv2TaskRequest,
-  ObserverTask,
+  TaskV2,
   ProxyLocation,
   TaskGenerationApiResponse,
 } from "@/api/types";
@@ -156,7 +156,7 @@ function PromptBox() {
   const startObserverCruiseMutation = useMutation({
     mutationFn: async (prompt: string) => {
       const client = await getClient(credentialGetter, "v2");
-      return client.post<Createv2TaskRequest, { data: ObserverTask }>(
+      return client.post<Createv2TaskRequest, { data: TaskV2 }>(
         "/tasks",
         {
           user_prompt: prompt,

--- a/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
@@ -157,8 +157,7 @@ function PromptBox() {
     mutationFn: async (prompt: string) => {
       const client = await getClient(credentialGetter, "v2");
       return client.post<Createv2TaskRequest, { data: TaskV2 }>(
-        "/tasks",
-        {
+        "/tasks", {
           user_prompt: prompt,
           webhook_callback_url: webhookCallbackUrl,
           proxy_location: proxyLocation,

--- a/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
@@ -157,7 +157,8 @@ function PromptBox() {
     mutationFn: async (prompt: string) => {
       const client = await getClient(credentialGetter, "v2");
       return client.post<Createv2TaskRequest, { data: TaskV2 }>(
-        "/tasks", {
+        "/tasks",
+        {
           user_prompt: prompt,
           webhook_callback_url: webhookCallbackUrl,
           proxy_location: proxyLocation,

--- a/skyvern-frontend/src/routes/workflows/workflowRun/ObserverThoughtScreenshot.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/ObserverThoughtScreenshot.tsx
@@ -21,7 +21,7 @@ function ObserverThoughtScreenshot({ observerThoughtId, taskStatus }: Props) {
     queryFn: async () => {
       const client = await getClient(credentialGetter);
       return client
-        .get(`${apiPathPrefix}/task_thought/${observerThoughtId}/artifacts`)
+        .get(`${apiPathPrefix}/thought/${observerThoughtId}/artifacts`)
         .then((response) => response.data);
     },
     refetchInterval: (query) => {

--- a/skyvern-frontend/src/routes/workflows/workflowRun/ObserverThoughtScreenshot.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/ObserverThoughtScreenshot.tsx
@@ -21,7 +21,7 @@ function ObserverThoughtScreenshot({ observerThoughtId, taskStatus }: Props) {
     queryFn: async () => {
       const client = await getClient(credentialGetter);
       return client
-        .get(`${apiPathPrefix}/observer_thought/${observerThoughtId}/artifacts`)
+        .get(`${apiPathPrefix}/task_thought/${observerThoughtId}/artifacts`)
         .then((response) => response.data);
     },
     refetchInterval: (query) => {

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowPostRunParameters.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowPostRunParameters.tsx
@@ -44,13 +44,13 @@ function WorkflowPostRunParameters() {
   }
 
   const activeBlock = getActiveBlock();
-  const isObserverTask = workflowRun.task_v2 !== null;
+  const isTaskV2 = workflowRun.task_v2 !== null;
 
-  const webhookCallbackUrl = isObserverTask
+  const webhookCallbackUrl = isTaskV2
     ? workflowRun.task_v2?.webhook_callback_url
     : workflowRun.webhook_callback_url;
 
-  const proxyLocation = isObserverTask
+  const proxyLocation = isTaskV2
     ? workflowRun.task_v2?.proxy_location
     : workflowRun.proxy_location;
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor frontend code by renaming `ObserverTask` to `TaskV2` and updating API paths and variable names accordingly.
> 
>   - **Renames**:
>     - `ObserverTask` to `TaskV2` in `types.ts`, `ExampleCasePill.tsx`, and `PromptBox.tsx`.
>   - **API Path Change**:
>     - In `ObserverThoughtScreenshot.tsx`, changes API path from `/observer_thought/` to `/thought/`.
>   - **Variable Renames**:
>     - `isObserverTask` to `isTaskV2` in `WorkflowPostRunParameters.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e83154887e74c2d8c8ab4a8e19ca2805a01211db. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->