### PR TITLE
Support ISP Proxies in Skyvern

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -38,6 +38,7 @@ export const ProxyLocation = {
   ResidentialGB: "RESIDENTIAL_GB",
   ResidentialFR: "RESIDENTIAL_FR",
   ResidentialDE: "RESIDENTIAL_DE",
+  ResidentialISP: "RESIDENTIAL_ISP",
   None: "NONE",
 } as const;
 

--- a/skyvern-frontend/src/components/ProxySelector.tsx
+++ b/skyvern-frontend/src/components/ProxySelector.tsx
@@ -21,6 +21,9 @@ function ProxySelector({ value, onChange, className }: Props) {
       </SelectTrigger>
       <SelectContent>
         <SelectItem value={ProxyLocation.Residential}>Residential</SelectItem>
+        <SelectItem value={ProxyLocation.ResidentialISP}>
+          Residential ISP (US)
+        </SelectItem>
         <SelectItem value={ProxyLocation.ResidentialES}>
           Residential (Spain)
         </SelectItem>

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -26,6 +26,7 @@ class ProxyLocation(StrEnum):
     RESIDENTIAL_JP = "RESIDENTIAL_JP"
     RESIDENTIAL_FR = "RESIDENTIAL_FR"
     RESIDENTIAL_DE = "RESIDENTIAL_DE"
+    RESIDENTIAL_ISP = "RESIDENTIAL_ISP"
     NONE = "NONE"
 
 
@@ -71,6 +72,9 @@ def get_tzinfo_from_proxy(proxy_location: ProxyLocation) -> ZoneInfo | None:
 
     if proxy_location == ProxyLocation.RESIDENTIAL_DE:
         return ZoneInfo("Europe/Berlin")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_ISP:
+        return ZoneInfo("America/New_York")
 
     return None
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for ISP proxies in Skyvern by updating proxy configurations and UI components to include `RESIDENTIAL_ISP`.
> 
>   - **Backend**:
>     - Add `RESIDENTIAL_ISP` to `ProxyLocation` in `tasks.py`.
>     - Update `build_proxy_config_smartproxy_isp()` in `proxy.py` to handle `RESIDENTIAL_ISP`.
>     - Modify `build_proxy_config()` in `proxy.py` to include `RESIDENTIAL_ISP` logic.
>   - **Frontend**:
>     - Add `ResidentialISP` to `ProxyLocation` in `types.ts`.
>     - Update `ProxySelector.tsx` to include "Residential ISP (US)" option.
>   - **Misc**:
>     - Update `get_tzinfo_from_proxy()` in `tasks.py` to return `ZoneInfo("America/New_York")` for `RESIDENTIAL_ISP`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for af0efa4dfa277dffbcfdfc995b3578be6c258cd4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->