### PR TITLE
Add max iterations override header

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
@@ -150,6 +150,7 @@ function PromptBox() {
   );
   const [publishWorkflow, setPublishWorkflow] = useState(false);
   const [totpIdentifier, setTotpIdentifier] = useState("");
+  const [maxStepsOverride, setMaxStepsOverride] = useState<string | null>(null);
   const [showAdvancedSettings, setShowAdvancedSettings] = useState(false);
 
   const startObserverCruiseMutation = useMutation({
@@ -163,6 +164,11 @@ function PromptBox() {
           proxy_location: proxyLocation,
           totp_identifier: totpIdentifier,
           publish_workflow: publishWorkflow,
+        },
+        {
+          headers: {
+            "x-max-iterations-override": maxStepsOverride,
+          },
         },
       );
     },
@@ -381,6 +387,20 @@ function PromptBox() {
                       checked={publishWorkflow}
                       onCheckedChange={(checked) => {
                         setPublishWorkflow(Boolean(checked));
+                      }}
+                    />
+                  </div>
+                  <div className="flex gap-16">
+                    <div className="w-48 shrink-0">
+                      <div className="text-sm">Max Steps Override</div>
+                      <div className="text-xs text-slate-400">
+                        The maximum number of steps to take for this task.
+                      </div>
+                    </div>
+                    <Input
+                      value={maxStepsOverride ?? ""}
+                      onChange={(event) => {
+                        setMaxStepsOverride(event.target.value);
                       }}
                     />
                   </div>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `maxStepsOverride` state and input in `PromptBox` to override max iterations for tasks via request header.
> 
>   - **Behavior**:
>     - Adds `maxStepsOverride` state in `PromptBox` to allow overriding max iterations for tasks.
>     - Includes `x-max-iterations-override` header in `startObserverCruiseMutation` request.
>   - **UI**:
>     - Adds input field for `Max Steps Override` in advanced settings of `PromptBox`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 7ad67ea8d6bbd7f47772269c6cad8254bed8853a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->