### PR TITLE
add all types of credential keys to login block

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/LoginNode/CredentialParameterSelector.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/LoginNode/CredentialParameterSelector.tsx
@@ -16,7 +16,9 @@ type Props = {
 function CredentialParameterSelector({ value, onChange }: Props) {
   const [workflowParameters] = useWorkflowParametersState();
   const credentialParameters = workflowParameters.filter(
-    (parameter) => parameter.parameterType === "credential",
+    (parameter) =>
+      parameter.parameterType === "credential" ||
+      parameter.parameterType === "bitwardenLoginCredential",
   );
   const noneItemValue = useId();
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `CredentialParameterSelector` now supports `bitwardenLoginCredential` type parameters in addition to `credential`.
> 
>   - **Behavior**:
>     - `CredentialParameterSelector` in `CredentialParameterSelector.tsx` now includes `bitwardenLoginCredential` in addition to `credential` in its filtering logic.
>   - **Functionality**:
>     - Allows selection of `bitwardenLoginCredential` type parameters in the login block.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ba9b9cfcadbe66a0a6882f29cc81ea9f93afb008. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->