### PR TITLE
fix get_or_create_page by ensuring the page is returned

### DIFF
--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -536,7 +536,7 @@ class BrowserState:
                 workflow_run_id=workflow_run_id,
                 organization_id=organization_id,
             )
-        await self.__assert_page()
+        page = await self.__assert_page()
 
         if not await BrowserContextFactory.validate_browser_context(await self.get_working_page()):
             await self.close_current_open_page()
@@ -547,8 +547,7 @@ class BrowserState:
                 workflow_run_id=workflow_run_id,
                 organization_id=organization_id,
             )
-            await self.__assert_page()
-
+            page = await self.__assert_page()
         return page
 
     async def close_current_open_page(self) -> None:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `get_or_create_page` in `browser_factory.py` to ensure a `Page` is returned by assigning and returning the result of `__assert_page()`.
> 
>   - **Behavior**:
>     - Fixes `get_or_create_page` in `browser_factory.py` to ensure a `Page` is returned by assigning `page = await self.__assert_page()` and returning `page`.
>     - Handles cases where the browser context is invalid by closing the current page and re-creating the state.
>   - **Functions**:
>     - Modifies `get_or_create_page` to store the result of `__assert_page()` in a variable `page` and return it.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0a0aa53b4ba280b5b6dd468ee3e7d78f82809d4f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->