### PR TITLE
add anthropic claude3.7 support

### DIFF
--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -164,6 +164,16 @@ if settings.ENABLE_ANTHROPIC:
             max_completion_tokens=8192,
         ),
     )
+    LLMConfigRegistry.register_config(
+        "ANTHROPIC_CLAUDE3.7_SONNET",
+        LLMConfig(
+            "anthropic/claude-3-7-sonnet-latest",
+            ["ANTHROPIC_API_KEY"],
+            supports_vision=True,
+            add_assistant_prefix=True,
+            max_completion_tokens=8192,
+        ),
+    )
 
 if settings.ENABLE_BEDROCK:
     # Supported through AWS IAM authentication


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for `ANTHROPIC_CLAUDE3.7_SONNET` in `config_registry.py` with specific configuration parameters.
> 
>   - **Behavior**:
>     - Adds support for `ANTHROPIC_CLAUDE3.7_SONNET` in `config_registry.py`.
>     - Registers `LLMConfig` with `supports_vision=True`, `add_assistant_prefix=True`, and `max_completion_tokens=8192`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6664f2da0097c672d5491c9f65cbf7c84e414733. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->