### PR TITLE
Use larger page size in credential query temporarily

### DIFF
--- a/skyvern-frontend/src/routes/workflows/components/CredentialSelector.tsx
+++ b/skyvern-frontend/src/routes/workflows/components/CredentialSelector.tsx
@@ -1,5 +1,3 @@
-import { getClient } from "@/api/AxiosClient";
-import { CredentialApiResponse } from "@/api/types";
 import {
   Select,
   SelectContent,
@@ -8,8 +6,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
-import { useCredentialGetter } from "@/hooks/useCredentialGetter";
-import { useQuery } from "@tanstack/react-query";
+import { useCredentialsQuery } from "../hooks/useCredentialsQuery";
 
 type Props = {
   value: string;
@@ -17,17 +14,7 @@ type Props = {
 };
 
 function CredentialSelector({ value, onChange }: Props) {
-  const credentialGetter = useCredentialGetter();
-
-  const { data: credentials, isFetching } = useQuery<
-    Array<CredentialApiResponse>
-  >({
-    queryKey: ["credentials"],
-    queryFn: async () => {
-      const client = await getClient(credentialGetter);
-      return await client.get("/credentials").then((res) => res.data);
-    },
-  });
+  const { data: credentials, isFetching } = useCredentialsQuery();
 
   if (isFetching) {
     return <Skeleton className="h-10 w-full" />;

--- a/skyvern-frontend/src/routes/workflows/hooks/useCredentialsQuery.ts
+++ b/skyvern-frontend/src/routes/workflows/hooks/useCredentialsQuery.ts
@@ -1,0 +1,20 @@
+import { getClient } from "@/api/AxiosClient";
+import { CredentialApiResponse } from "@/api/types";
+import { useCredentialGetter } from "@/hooks/useCredentialGetter";
+import { useQuery } from "@tanstack/react-query";
+
+function useCredentialsQuery() {
+  const credentialGetter = useCredentialGetter();
+
+  return useQuery<Array<CredentialApiResponse>>({
+    queryKey: ["credentials"],
+    queryFn: async () => {
+      const client = await getClient(credentialGetter);
+      const params = new URLSearchParams();
+      params.set("page_size", "25");
+      return client.get("/credentials", { params }).then((res) => res.data);
+    },
+  });
+}
+
+export { useCredentialsQuery };


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor credential fetching logic by introducing `useCredentialsQuery` with a larger page size and updating related components.
> 
>   - **Behavior**:
>     - Introduces `useCredentialsQuery` in `useCredentialsQuery.ts` to fetch credentials with a page size of 25.
>     - Replaces individual credential fetching logic in `CredentialsList.tsx` and `CredentialSelector.tsx` with `useCredentialsQuery`.
>   - **Refactor**:
>     - Removes redundant imports and query logic from `CredentialsList.tsx` and `CredentialSelector.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for dddbb386013f53a1fb16c4b000493a45b8ecf9c5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->