### PR TITLE
Add page assignment before return from get_or_create_page

### DIFF
--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -549,6 +549,8 @@ class BrowserState:
             )
             await self.__assert_page()
 
+        page = await self.get_working_page()
+
         return page
 
     async def close_current_open_page(self) -> None:


### PR DESCRIPTION
Add page assignment before returning page
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Assigns `page` before returning in `get_or_create_page()` in `browser_factory.py` to ensure initialization.
> 
>   - **Behavior**:
>     - Assigns `page` variable before returning in `get_or_create_page()` in `browser_factory.py` to ensure it is initialized.
>   - **Functions**:
>     - Modifies `get_or_create_page()` to include `page = await self.get_working_page()` before returning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5a1c7e3fcddc4fb7506e41efa1e5bd8dd80040d7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->