### PR TITLE
Add better cache invalidation for history

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -173,6 +173,9 @@ function CreateNewTaskForm({ initialValues }: Props) {
       queryClient.invalidateQueries({
         queryKey: ["tasks"],
       });
+      queryClient.invalidateQueries({
+        queryKey: ["runs"],
+      });
     },
   });
 

--- a/skyvern-frontend/src/routes/tasks/create/ExampleCasePill.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/ExampleCasePill.tsx
@@ -40,6 +40,9 @@ function ExampleCasePill({ exampleId, version, icon, label, prompt }: Props) {
       queryClient.invalidateQueries({
         queryKey: ["workflows"],
       });
+      queryClient.invalidateQueries({
+        queryKey: ["runs"],
+      });
       navigate(
         `/workflows/${response.data.workflow_permanent_id}/${response.data.workflow_run_id}`,
       );

--- a/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
@@ -184,6 +184,9 @@ function PromptBox() {
       queryClient.invalidateQueries({
         queryKey: ["workflows"],
       });
+      queryClient.invalidateQueries({
+        queryKey: ["runs"],
+      });
       navigate(
         `/workflows/${response.data.workflow_permanent_id}/${response.data.workflow_run_id}`,
       );

--- a/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
+++ b/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
@@ -136,6 +136,9 @@ function RunWorkflowForm({
       queryClient.invalidateQueries({
         queryKey: ["workflowRuns"],
       });
+      queryClient.invalidateQueries({
+        queryKey: ["runs"],
+      });
       navigate(
         `/workflows/${workflowPermanentId}/${response.data.workflow_run_id}/overview`,
       );

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunStream.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunStream.tsx
@@ -69,6 +69,9 @@ function WorkflowRunStream() {
             queryClient.invalidateQueries({
               queryKey: ["workflowTasks", workflowRunId],
             });
+            queryClient.invalidateQueries({
+              queryKey: ["runs"],
+            });
             if (
               message.status === "failed" ||
               message.status === "terminated"

--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -141,7 +141,7 @@ class Settings(BaseSettings):
     # TOTP Settings
     TOTP_LIFESPAN_MINUTES: int = 10
     VERIFICATION_CODE_INITIAL_WAIT_TIME_SECS: int = 40
-    VERIFICATION_CODE_POLLING_TIMEOUT_MINS: int = 5
+    VERIFICATION_CODE_POLLING_TIMEOUT_MINS: int = 15
 
     # Bitwarden Settings
     BITWARDEN_CLIENT_ID: str | None = None

--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -141,7 +141,7 @@ class Settings(BaseSettings):
     # TOTP Settings
     TOTP_LIFESPAN_MINUTES: int = 10
     VERIFICATION_CODE_INITIAL_WAIT_TIME_SECS: int = 40
-    VERIFICATION_CODE_POLLING_TIMEOUT_MINS: int = 15
+    VERIFICATION_CODE_POLLING_TIMEOUT_MINS: int = 5
 
     # Bitwarden Settings
     BITWARDEN_CLIENT_ID: str | None = None


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add cache invalidation for 'runs' query key in multiple components to ensure data consistency after task and workflow operations.
> 
>   - **Cache Invalidation**:
>     - Add `queryClient.invalidateQueries` for `queryKey: ["runs"]` in `CreateNewTaskForm`, `ExampleCasePill`, `PromptBox`, `RunWorkflowForm`, and `WorkflowRunStream` to ensure cache consistency after task and workflow operations.
>   - **Files Affected**:
>     - `CreateNewTaskForm.tsx`: Invalidate `runs` cache on task creation success.
>     - `ExampleCasePill.tsx`: Invalidate `runs` cache on workflow run creation success.
>     - `PromptBox.tsx`: Invalidate `runs` cache on workflow run creation success.
>     - `RunWorkflowForm.tsx`: Invalidate `runs` cache on workflow run start success.
>     - `WorkflowRunStream.tsx`: Invalidate `runs` cache when workflow run status changes to completed, failed, or terminated.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 600fe55187d07884dc1bd75bc7cb0aa55d521240. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->