### PR TITLE
task v2 refactor part 10: ObserverTask -> TaskV2 in backend code

### DIFF
--- a/evaluation/core/__init__.py
+++ b/evaluation/core/__init__.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from skyvern.forge import app
 from skyvern.forge.prompts import prompt_engine
 from skyvern.forge.sdk.api.files import create_folder_if_not_exist
-from skyvern.forge.sdk.schemas.task_v2 import ObserverTask, ObserverTaskRequest
+from skyvern.forge.sdk.schemas.task_v2 import TaskV2, TaskV2Request
 from skyvern.forge.sdk.schemas.tasks import ProxyLocation, TaskRequest, TaskResponse, TaskStatus
 from skyvern.forge.sdk.workflow.models.workflow import WorkflowRequestBody, WorkflowRunStatus, WorkflowRunStatusResponse
 
@@ -55,12 +55,12 @@ class SkyvernClient:
         assert "workflow_run_id" in response.json(), f"Failed to create workflow run: {response.text}"
         return response.json()["workflow_run_id"]
 
-    def create_task_v2(self, task_v2_request: ObserverTaskRequest, max_steps: int | None = None) -> ObserverTask:
+    def create_task_v2(self, task_v2_request: TaskV2Request, max_steps: int | None = None) -> TaskV2:
         url = f"{self.v2_base_url}/tasks"
         payload, headers = self.generate_curl_params(task_v2_request, max_steps=max_steps)
         response = requests.post(url, headers=headers, data=payload)
         assert "task_id" in response.json(), f"Failed to create task v2: {response.text}"
-        return ObserverTask.model_validate(response.json())
+        return TaskV2.model_validate(response.json())
 
     def get_task(self, task_id: str) -> TaskResponse:
         """Get a task by id."""
@@ -213,7 +213,7 @@ class Evaluator:
         assert workflow_run_id
         return workflow_run_id
 
-    def queue_skyvern_cruise(self, cruise_request: ObserverTaskRequest, max_step: int | None = None) -> ObserverTask:
+    def queue_skyvern_task_v2(self, cruise_request: TaskV2Request, max_step: int | None = None) -> TaskV2:
         cruise = self.client.create_task_v2(task_v2_request=cruise_request, max_steps=max_step)
         self._save_artifact("cruise.json", cruise.model_dump_json(indent=2).encode())
         return cruise

--- a/evaluation/script/create_webvoyager_task_v2.py
+++ b/evaluation/script/create_webvoyager_task_v2.py
@@ -10,7 +10,7 @@ from evaluation.core import Evaluator, SkyvernClient
 from evaluation.core.utils import load_webvoyager_case_from_json
 from skyvern.forge import app
 from skyvern.forge.prompts import prompt_engine
-from skyvern.forge.sdk.schemas.task_v2 import ObserverTaskRequest
+from skyvern.forge.sdk.schemas.task_v2 import TaskV2Request
 
 load_dotenv()
 
@@ -37,21 +37,21 @@ async def create_task_v2(
             case_data.question = tweaked_user_goal
 
             evaluator = Evaluator(client=client, artifact_folder=f"test/artifacts/{case_data.group_id}/{case_data.id}")
-            request_body = ObserverTaskRequest(
+            request_body = TaskV2Request(
                 url=case_data.url,
                 user_prompt=case_data.question,
             )
-            cruise = evaluator.queue_skyvern_cruise(cruise_request=request_body, max_step=case_data.max_steps)
+            task_v2 = evaluator.queue_skyvern_task_v2(cruise_request=request_body, max_step=case_data.max_steps)
             dumped_data = case_data.model_dump()
             dumped_data.update(
                 {
-                    "task_v2_id": cruise.observer_cruise_id,
-                    "workflow_run_id": cruise.workflow_run_id,
-                    "workflow_permanent_id": cruise.workflow_permanent_id,
-                    "cruise_url": str(cruise.url) if cruise.url else cruise.url,
+                    "task_v2_id": task_v2.observer_cruise_id,
+                    "workflow_run_id": task_v2.workflow_run_id,
+                    "workflow_permanent_id": task_v2.workflow_permanent_id,
+                    "cruise_url": str(task_v2.url) if task_v2.url else task_v2.url,
                 }
             )
-            print(f"Queued {cruise.observer_cruise_id} for {case_data.model_dump_json()}")
+            print(f"Queued {task_v2.observer_cruise_id} for {case_data.model_dump_json()}")
             f.write(json.dumps(dumped_data) + "\n")
             cnt += 1
 

--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -141,7 +141,7 @@ class Settings(BaseSettings):
     # TOTP Settings
     TOTP_LIFESPAN_MINUTES: int = 10
     VERIFICATION_CODE_INITIAL_WAIT_TIME_SECS: int = 40
-    VERIFICATION_CODE_POLLING_TIMEOUT_MINS: int = 5
+    VERIFICATION_CODE_POLLING_TIMEOUT_MINS: int = 15
 
     # Bitwarden Settings
     BITWARDEN_CLIENT_ID: str | None = None

--- a/skyvern/forge/sdk/api/llm/models.py
+++ b/skyvern/forge/sdk/api/llm/models.py
@@ -5,7 +5,7 @@ from litellm import AllowedFailsPolicy
 
 from skyvern.forge.sdk.models import Step
 from skyvern.forge.sdk.schemas.ai_suggestions import AISuggestion
-from skyvern.forge.sdk.schemas.task_v2 import ObserverTask, ObserverThought
+from skyvern.forge.sdk.schemas.task_v2 import TaskV2, Thought
 from skyvern.forge.sdk.settings_manager import SettingsManager
 
 
@@ -85,8 +85,8 @@ class LLMAPIHandler(Protocol):
         prompt: str,
         prompt_name: str,
         step: Step | None = None,
-        task_v2: ObserverTask | None = None,
-        observer_thought: ObserverThought | None = None,
+        task_v2: TaskV2 | None = None,
+        thought: Thought | None = None,
         ai_suggestion: AISuggestion | None = None,
         screenshots: list[bytes] | None = None,
         parameters: dict[str, Any] | None = None,

--- a/skyvern/forge/sdk/artifact/manager.py
+++ b/skyvern/forge/sdk/artifact/manager.py
@@ -9,7 +9,7 @@ from skyvern.forge.sdk.artifact.models import Artifact, ArtifactType, LogEntityT
 from skyvern.forge.sdk.db.id import generate_artifact_id
 from skyvern.forge.sdk.models import Step
 from skyvern.forge.sdk.schemas.ai_suggestions import AISuggestion
-from skyvern.forge.sdk.schemas.task_v2 import ObserverTask, ObserverThought
+from skyvern.forge.sdk.schemas.task_v2 import TaskV2, Thought
 from skyvern.forge.sdk.schemas.workflow_runs import WorkflowRunBlock
 
 LOG = structlog.get_logger(__name__)
@@ -29,7 +29,7 @@ class ArtifactManager:
         task_id: str | None = None,
         workflow_run_id: str | None = None,
         workflow_run_block_id: str | None = None,
-        observer_thought_id: str | None = None,
+        thought_id: str | None = None,
         task_v2_id: str | None = None,
         ai_suggestion_id: str | None = None,
         organization_id: str | None = None,
@@ -48,7 +48,7 @@ class ArtifactManager:
             task_id=task_id,
             workflow_run_id=workflow_run_id,
             workflow_run_block_id=workflow_run_block_id,
-            observer_thought_id=observer_thought_id,
+            thought_id=thought_id,
             task_v2_id=task_v2_id,
             organization_id=organization_id,
             ai_suggestion_id=ai_suggestion_id,
@@ -114,30 +114,30 @@ class ArtifactManager:
             path=path,
         )
 
-    async def create_observer_thought_artifact(
+    async def create_thought_artifact(
         self,
-        observer_thought: ObserverThought,
+        thought: Thought,
         artifact_type: ArtifactType,
         data: bytes | None = None,
         path: str | None = None,
     ) -> str:
         artifact_id = generate_artifact_id()
-        uri = app.STORAGE.build_observer_thought_uri(artifact_id, observer_thought, artifact_type)
+        uri = app.STORAGE.build_thought_uri(artifact_id, thought, artifact_type)
         return await self._create_artifact(
-            aio_task_primary_key=observer_thought.observer_cruise_id,
+            aio_task_primary_key=thought.observer_cruise_id,
             artifact_id=artifact_id,
             artifact_type=artifact_type,
             uri=uri,
-            observer_thought_id=observer_thought.observer_thought_id,
-            task_v2_id=observer_thought.observer_cruise_id,
-            organization_id=observer_thought.organization_id,
+            thought_id=thought.observer_thought_id,
+            task_v2_id=thought.observer_cruise_id,
+            organization_id=thought.organization_id,
             data=data,
             path=path,
         )
 
     async def create_task_v2_artifact(
         self,
-        task_v2: ObserverTask,
+        task_v2: TaskV2,
         artifact_type: ArtifactType,
         data: bytes | None = None,
         path: str | None = None,
@@ -202,8 +202,8 @@ class ArtifactManager:
         artifact_type: ArtifactType,
         screenshots: list[bytes] | None = None,
         step: Step | None = None,
-        observer_thought: ObserverThought | None = None,
-        task_v2: ObserverTask | None = None,
+        thought: Thought | None = None,
+        task_v2: TaskV2 | None = None,
         ai_suggestion: AISuggestion | None = None,
     ) -> None:
         if step:
@@ -230,15 +230,15 @@ class ArtifactManager:
                     artifact_type=ArtifactType.SCREENSHOT_LLM,
                     data=screenshot,
                 )
-        elif observer_thought:
-            await self.create_observer_thought_artifact(
-                observer_thought=observer_thought,
+        elif thought:
+            await self.create_thought_artifact(
+                thought=thought,
                 artifact_type=artifact_type,
                 data=data,
             )
             for screenshot in screenshots or []:
-                await self.create_observer_thought_artifact(
-                    observer_thought=observer_thought,
+                await self.create_thought_artifact(
+                    thought=thought,
                     artifact_type=ArtifactType.SCREENSHOT_LLM,
                     data=screenshot,
                 )

--- a/skyvern/forge/sdk/artifact/models.py
+++ b/skyvern/forge/sdk/artifact/models.py
@@ -88,4 +88,4 @@ class LogEntityType(StrEnum):
     TASK = "task"
     WORKFLOW_RUN = "workflow_run"
     WORKFLOW_RUN_BLOCK = "workflow_run_block"
-    OBSERVER = "observer"
+    TASK_V2 = "task_v2"

--- a/skyvern/forge/sdk/artifact/storage/base.py
+++ b/skyvern/forge/sdk/artifact/storage/base.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from skyvern.forge.sdk.artifact.models import Artifact, ArtifactType, LogEntityType
 from skyvern.forge.sdk.models import Step
 from skyvern.forge.sdk.schemas.ai_suggestions import AISuggestion
-from skyvern.forge.sdk.schemas.task_v2 import ObserverTask, ObserverThought
+from skyvern.forge.sdk.schemas.task_v2 import TaskV2, Thought
 from skyvern.forge.sdk.schemas.workflow_runs import WorkflowRunBlock
 
 # TODO: This should be a part of the ArtifactType model
@@ -49,13 +49,11 @@ class BaseStorage(ABC):
         pass
 
     @abstractmethod
-    def build_observer_thought_uri(
-        self, artifact_id: str, observer_thought: ObserverThought, artifact_type: ArtifactType
-    ) -> str:
+    def build_thought_uri(self, artifact_id: str, thought: Thought, artifact_type: ArtifactType) -> str:
         pass
 
     @abstractmethod
-    def build_task_v2_uri(self, artifact_id: str, task_v2: ObserverTask, artifact_type: ArtifactType) -> str:
+    def build_task_v2_uri(self, artifact_id: str, task_v2: TaskV2, artifact_type: ArtifactType) -> str:
         pass
 
     @abstractmethod

--- a/skyvern/forge/sdk/artifact/storage/local.py
+++ b/skyvern/forge/sdk/artifact/storage/local.py
@@ -11,7 +11,7 @@ from skyvern.forge.sdk.artifact.models import Artifact, ArtifactType, LogEntityT
 from skyvern.forge.sdk.artifact.storage.base import FILE_EXTENTSION_MAP, BaseStorage
 from skyvern.forge.sdk.models import Step
 from skyvern.forge.sdk.schemas.ai_suggestions import AISuggestion
-from skyvern.forge.sdk.schemas.task_v2 import ObserverTask, ObserverThought
+from skyvern.forge.sdk.schemas.task_v2 import TaskV2, Thought
 from skyvern.forge.sdk.schemas.workflow_runs import WorkflowRunBlock
 
 LOG = structlog.get_logger()
@@ -40,13 +40,11 @@ class LocalStorage(BaseStorage):
         file_ext = FILE_EXTENTSION_MAP[artifact_type]
         return f"file://{self.artifact_path}/logs/{log_entity_type}/{log_entity_id}/{datetime.utcnow().isoformat()}_{artifact_type}.{file_ext}"
 
-    def build_observer_thought_uri(
-        self, artifact_id: str, observer_thought: ObserverThought, artifact_type: ArtifactType
-    ) -> str:
+    def build_thought_uri(self, artifact_id: str, thought: Thought, artifact_type: ArtifactType) -> str:
         file_ext = FILE_EXTENTSION_MAP[artifact_type]
-        return f"file://{self.artifact_path}/{settings.ENV}/observers/{observer_thought.observer_cruise_id}/{observer_thought.observer_thought_id}/{datetime.utcnow().isoformat()}_{artifact_id}_{artifact_type}.{file_ext}"
+        return f"file://{self.artifact_path}/{settings.ENV}/tasks/{thought.observer_cruise_id}/{thought.observer_thought_id}/{datetime.utcnow().isoformat()}_{artifact_id}_{artifact_type}.{file_ext}"
 
-    def build_task_v2_uri(self, artifact_id: str, task_v2: ObserverTask, artifact_type: ArtifactType) -> str:
+    def build_task_v2_uri(self, artifact_id: str, task_v2: TaskV2, artifact_type: ArtifactType) -> str:
         file_ext = FILE_EXTENTSION_MAP[artifact_type]
         return f"file://{self.artifact_path}/{settings.ENV}/observers/{task_v2.observer_cruise_id}/{datetime.utcnow().isoformat()}_{artifact_id}_{artifact_type}.{file_ext}"
 

--- a/skyvern/forge/sdk/artifact/storage/s3.py
+++ b/skyvern/forge/sdk/artifact/storage/s3.py
@@ -16,7 +16,7 @@ from skyvern.forge.sdk.artifact.models import Artifact, ArtifactType, LogEntityT
 from skyvern.forge.sdk.artifact.storage.base import FILE_EXTENTSION_MAP, BaseStorage
 from skyvern.forge.sdk.models import Step
 from skyvern.forge.sdk.schemas.ai_suggestions import AISuggestion
-from skyvern.forge.sdk.schemas.task_v2 import ObserverTask, ObserverThought
+from skyvern.forge.sdk.schemas.task_v2 import TaskV2, Thought
 from skyvern.forge.sdk.schemas.workflow_runs import WorkflowRunBlock
 
 
@@ -40,13 +40,11 @@ class S3Storage(BaseStorage):
         file_ext = FILE_EXTENTSION_MAP[artifact_type]
         return f"s3://{self.bucket}/{settings.ENV}/logs/{log_entity_type}/{log_entity_id}/{datetime.utcnow().isoformat()}_{artifact_type}.{file_ext}"
 
-    def build_observer_thought_uri(
-        self, artifact_id: str, observer_thought: ObserverThought, artifact_type: ArtifactType
-    ) -> str:
+    def build_thought_uri(self, artifact_id: str, thought: Thought, artifact_type: ArtifactType) -> str:
         file_ext = FILE_EXTENTSION_MAP[artifact_type]
-        return f"s3://{self.bucket}/{settings.ENV}/observers/{observer_thought.observer_cruise_id}/{observer_thought.observer_thought_id}/{datetime.utcnow().isoformat()}_{artifact_id}_{artifact_type}.{file_ext}"
+        return f"s3://{self.bucket}/{settings.ENV}/observers/{thought.observer_cruise_id}/{thought.observer_thought_id}/{datetime.utcnow().isoformat()}_{artifact_id}_{artifact_type}.{file_ext}"
 
-    def build_task_v2_uri(self, artifact_id: str, task_v2: ObserverTask, artifact_type: ArtifactType) -> str:
+    def build_task_v2_uri(self, artifact_id: str, task_v2: TaskV2, artifact_type: ArtifactType) -> str:
         file_ext = FILE_EXTENTSION_MAP[artifact_type]
         return f"s3://{self.bucket}/{settings.ENV}/observers/{task_v2.observer_cruise_id}/{datetime.utcnow().isoformat()}_{artifact_id}_{artifact_type}.{file_ext}"
 

--- a/skyvern/forge/sdk/db/id.py
+++ b/skyvern/forge/sdk/db/id.py
@@ -38,7 +38,7 @@ CREDENTIAL_PARAMETER_PREFIX = "cp"
 CREDENTIAL_PREFIX = "cred"
 ORGANIZATION_BITWARDEN_COLLECTION_PREFIX = "obc"
 TASK_V2_ID = "oc"
-OBSERVER_THOUGHT_ID = "ot"
+THOUGHT_ID = "ot"
 ORGANIZATION_AUTH_TOKEN_PREFIX = "oat"
 ORG_PREFIX = "o"
 OUTPUT_PARAMETER_PREFIX = "op"
@@ -161,9 +161,9 @@ def generate_task_v2_id() -> str:
     return f"{TASK_V2_ID}_{int_id}"
 
 
-def generate_observer_thought_id() -> str:
+def generate_thought_id() -> str:
     int_id = generate_id()
-    return f"{OBSERVER_THOUGHT_ID}_{int_id}"
+    return f"{THOUGHT_ID}_{int_id}"
 
 
 def generate_persistent_browser_session_id() -> str:

--- a/skyvern/forge/sdk/db/models.py
+++ b/skyvern/forge/sdk/db/models.py
@@ -29,7 +29,6 @@ from skyvern.forge.sdk.db.id import (
     generate_bitwarden_sensitive_information_parameter_id,
     generate_credential_id,
     generate_credential_parameter_id,
-    generate_observer_thought_id,
     generate_org_id,
     generate_organization_auth_token_id,
     generate_organization_bitwarden_collection_id,
@@ -40,6 +39,7 @@ from skyvern.forge.sdk.db.id import (
     generate_task_id,
     generate_task_run_id,
     generate_task_v2_id,
+    generate_thought_id,
     generate_totp_code_id,
     generate_workflow_id,
     generate_workflow_parameter_id,
@@ -47,7 +47,7 @@ from skyvern.forge.sdk.db.id import (
     generate_workflow_run_block_id,
     generate_workflow_run_id,
 )
-from skyvern.forge.sdk.schemas.task_v2 import ObserverThoughtType
+from skyvern.forge.sdk.schemas.task_v2 import ThoughtType
 
 
 class Base(AsyncAttrs, DeclarativeBase):
@@ -565,7 +565,7 @@ class WorkflowRunBlockModel(Base):
     modified_at = Column(DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow, nullable=False)
 
 
-class ObserverCruiseModel(Base):
+class TaskV2Model(Base):
     __tablename__ = "observer_cruises"
     __table_args__ = (Index("oc_org_wfr_index", "organization_id", "workflow_run_id"),)
 
@@ -589,11 +589,11 @@ class ObserverCruiseModel(Base):
     modified_at = Column(DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow, nullable=False)
 
 
-class ObserverThoughtModel(Base):
+class ThoughtModel(Base):
     __tablename__ = "observer_thoughts"
     __table_args__ = (Index("observer_cruise_index", "organization_id", "observer_cruise_id"),)
 
-    observer_thought_id = Column(String, primary_key=True, default=generate_observer_thought_id)
+    observer_thought_id = Column(String, primary_key=True, default=generate_thought_id)
     organization_id = Column(String, ForeignKey("organizations.organization_id"), nullable=True)
     observer_cruise_id = Column(String, ForeignKey("observer_cruises.observer_cruise_id"), nullable=False)
     workflow_run_id = Column(String, ForeignKey("workflow_runs.workflow_run_id"), nullable=True)
@@ -608,7 +608,7 @@ class ObserverThoughtModel(Base):
     output_token_count = Column(Integer, nullable=True)
     thought_cost = Column(Numeric, nullable=True)
 
-    observer_thought_type = Column(String, nullable=True, default=ObserverThoughtType.plan)
+    observer_thought_type = Column(String, nullable=True, default=ThoughtType.plan)
     observer_thought_scenario = Column(String, nullable=True)
     output = Column(JSON, nullable=True)
 

--- a/skyvern/forge/sdk/executor/async_executor.py
+++ b/skyvern/forge/sdk/executor/async_executor.py
@@ -7,7 +7,7 @@ from skyvern.exceptions import OrganizationNotFound
 from skyvern.forge import app
 from skyvern.forge.sdk.core import skyvern_context
 from skyvern.forge.sdk.core.skyvern_context import SkyvernContext
-from skyvern.forge.sdk.schemas.task_v2 import ObserverTaskStatus
+from skyvern.forge.sdk.schemas.task_v2 import TaskV2Status
 from skyvern.forge.sdk.schemas.tasks import TaskStatus
 from skyvern.forge.sdk.services import task_v2_service
 from skyvern.forge.sdk.workflow.models.workflow import WorkflowRunStatus
@@ -159,12 +159,12 @@ class BackgroundTaskExecutor(AsyncExecutor):
 
         task_v2 = await app.DATABASE.get_task_v2(task_v2_id=task_v2_id, organization_id=organization_id)
         if not task_v2 or not task_v2.workflow_run_id:
-            raise ValueError("No observer cruise or no workflow run associated with observer cruise")
+            raise ValueError("No task v2 or no workflow run associated with task v2")
 
-        # mark observer cruise as queued
+        # mark task v2 as queued
         await app.DATABASE.update_task_v2(
             task_v2_id=task_v2_id,
-            status=ObserverTaskStatus.queued,
+            status=TaskV2Status.queued,
             organization_id=organization_id,
         )
         await app.DATABASE.update_workflow_run(

--- a/skyvern/forge/sdk/log_artifacts.py
+++ b/skyvern/forge/sdk/log_artifacts.py
@@ -21,6 +21,8 @@ def primary_key_from_log_entity_type(log_entity_type: LogEntityType) -> str:
         return "workflow_run_id"
     elif log_entity_type == LogEntityType.WORKFLOW_RUN_BLOCK:
         return "workflow_run_block_id"
+    elif log_entity_type == LogEntityType.TASK_V2:
+        return "task_v2_id"
     else:
         raise ValueError(f"Invalid log entity type: {log_entity_type}")
 

--- a/skyvern/forge/sdk/schemas/task_v2.py
+++ b/skyvern/forge/sdk/schemas/task_v2.py
@@ -10,7 +10,7 @@ from skyvern.forge.sdk.schemas.tasks import ProxyLocation
 DEFAULT_WORKFLOW_TITLE = "New Workflow"
 
 
-class ObserverTaskStatus(StrEnum):
+class TaskV2Status(StrEnum):
     created = "created"
     queued = "queued"
     running = "running"
@@ -24,11 +24,11 @@ class ObserverTaskStatus(StrEnum):
         return self in [self.failed, self.terminated, self.canceled, self.timed_out, self.completed]
 
 
-class ObserverTask(BaseModel):
+class TaskV2(BaseModel):
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
     observer_cruise_id: str = Field(alias="task_id")
-    status: ObserverTaskStatus
+    status: TaskV2Status
     organization_id: str | None = None
     workflow_run_id: str | None = None
     workflow_id: str | None = None
@@ -54,14 +54,14 @@ class ObserverTask(BaseModel):
         return validate_url(url)
 
 
-class ObserverThoughtType(StrEnum):
+class ThoughtType(StrEnum):
     plan = "plan"
     metadata = "metadata"
     user_goal_check = "user_goal_check"
     internal_plan = "internal_plan"
 
 
-class ObserverThoughtScenario(StrEnum):
+class ThoughtScenario(StrEnum):
     generate_plan = "generate_plan"
     user_goal_check = "user_goal_check"
     summarization = "summarization"
@@ -71,7 +71,7 @@ class ObserverThoughtScenario(StrEnum):
     generate_task = "generate_general_task"
 
 
-class ObserverThought(BaseModel):
+class Thought(BaseModel):
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
     observer_thought_id: str = Field(alias="thought_id")
@@ -85,8 +85,8 @@ class ObserverThought(BaseModel):
     observation: str | None = None
     thought: str | None = None
     answer: str | None = None
-    observer_thought_type: ObserverThoughtType | None = Field(alias="thought_type", default=ObserverThoughtType.plan)
-    observer_thought_scenario: ObserverThoughtScenario | None = Field(alias="thought_scenario", default=None)
+    observer_thought_type: ThoughtType | None = Field(alias="thought_type", default=ThoughtType.plan)
+    observer_thought_scenario: ThoughtScenario | None = Field(alias="thought_scenario", default=None)
     output: dict[str, Any] | None = None
     input_token_count: int | None = None
     output_token_count: int | None = None
@@ -96,7 +96,7 @@ class ObserverThought(BaseModel):
     modified_at: datetime
 
 
-class ObserverMetadata(BaseModel):
+class TaskV2Metadata(BaseModel):
     url: str
     workflow_title: str = DEFAULT_WORKFLOW_TITLE
 
@@ -108,7 +108,7 @@ class ObserverMetadata(BaseModel):
         return validate_url(v)
 
 
-class ObserverTaskRequest(BaseModel):
+class TaskV2Request(BaseModel):
     user_prompt: str
     url: str | None = None
     browser_session_id: str | None = None

--- a/skyvern/forge/sdk/schemas/workflow_runs.py
+++ b/skyvern/forge/sdk/schemas/workflow_runs.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from skyvern.forge.sdk.schemas.task_v2 import ObserverThought
+from skyvern.forge.sdk.schemas.task_v2 import Thought
 from skyvern.forge.sdk.workflow.models.block import BlockType
 from skyvern.webeye.actions.actions import Action
 
@@ -58,7 +58,7 @@ class WorkflowRunTimelineType(StrEnum):
 class WorkflowRunTimeline(BaseModel):
     type: WorkflowRunTimelineType
     block: WorkflowRunBlock | None = None
-    thought: ObserverThought | None = None
+    thought: Thought | None = None
     children: list[WorkflowRunTimeline] = []
     created_at: datetime
     modified_at: datetime

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -49,7 +49,7 @@ from skyvern.forge.sdk.api.llm.api_handler_factory import LLMAPIHandlerFactory
 from skyvern.forge.sdk.artifact.models import ArtifactType
 from skyvern.forge.sdk.core.validators import prepend_scheme_and_validate_url
 from skyvern.forge.sdk.db.enums import TaskType
-from skyvern.forge.sdk.schemas.task_v2 import ObserverTaskStatus
+from skyvern.forge.sdk.schemas.task_v2 import TaskV2Status
 from skyvern.forge.sdk.schemas.tasks import Task, TaskOutput, TaskStatus
 from skyvern.forge.sdk.workflow.context_manager import BlockMetadata, WorkflowRunContext
 from skyvern.forge.sdk.workflow.exceptions import (
@@ -2115,7 +2115,6 @@ class UrlBlock(BaseTaskBlock):
     url: str
 
 
-# observer block
 class TaskV2Block(Block):
     block_type: Literal[BlockType.TaskV2] = BlockType.TaskV2
     prompt: str
@@ -2158,7 +2157,7 @@ class TaskV2Block(Block):
             proxy_location=workflow_run.proxy_location,
         )
         await app.DATABASE.update_task_v2(
-            task_v2.observer_cruise_id, status=ObserverTaskStatus.queued, organization_id=organization_id
+            task_v2.observer_cruise_id, status=TaskV2Status.queued, organization_id=organization_id
         )
         if task_v2.workflow_run_id:
             await app.DATABASE.update_workflow_run(

--- a/skyvern/forge/sdk/workflow/models/workflow.py
+++ b/skyvern/forge/sdk/workflow/models/workflow.py
@@ -5,7 +5,7 @@ from typing import Any, List
 from pydantic import BaseModel, field_validator
 
 from skyvern.forge.sdk.core.validators import validate_url
-from skyvern.forge.sdk.schemas.task_v2 import ObserverTask
+from skyvern.forge.sdk.schemas.task_v2 import TaskV2
 from skyvern.forge.sdk.schemas.tasks import ProxyLocation
 from skyvern.forge.sdk.workflow.exceptions import WorkflowDefinitionHasDuplicateBlockLabels
 from skyvern.forge.sdk.workflow.models.block import BlockTypeVar
@@ -147,5 +147,5 @@ class WorkflowRunStatusResponse(BaseModel):
     outputs: dict[str, Any] | None = None
     total_steps: int | None = None
     total_cost: float | None = None
-    task_v2: ObserverTask | None = None
+    task_v2: TaskV2 | None = None
     workflow_title: str | None = None


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor codebase to replace `ObserverTask` and `ObserverThought` with `TaskV2` and `Thought`, updating models, schemas, and logic accordingly.
> 
>   - **Behavior**:
>     - Refactor `ObserverTask` to `TaskV2` and `ObserverThought` to `Thought` across the codebase.
>     - Update function signatures and logic to use `TaskV2` and `Thought` in `task_v2_service.py`, `async_executor.py`, and `agent_protocol.py`.
>     - Modify `TaskV2` and `Thought` related logic in `block.py` and `workflow.py`.
>   - **Models**:
>     - Rename `ObserverCruiseModel` to `TaskV2Model` and `ObserverThoughtModel` to `ThoughtModel` in `models.py`.
>     - Update database interaction functions to use new model names in `client.py`.
>   - **Schemas**:
>     - Change `ObserverTask` to `TaskV2` and `ObserverThought` to `Thought` in `task_v2.py` and `workflow_runs.py`.
>   - **Misc**:
>     - Adjust logging and error messages to reflect new naming in `log_artifacts.py` and `api_handler_factory.py`.
>     - Update constants and ID generation functions in `id.py` to use `TaskV2` and `Thought` prefixes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 265a72af2141a944d47faa2dd52233cf6c9cbb8a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->