### PR TITLE
Simplify create_session

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1327,7 +1327,7 @@ async def get_browser_sessions(
 async def create_browser_session(
     current_org: Organization = Depends(org_auth_service.get_current_org),
 ) -> BrowserSessionResponse:
-    browser_session, _ = await app.PERSISTENT_SESSIONS_MANAGER.create_session(current_org.organization_id)
+    browser_session = await app.PERSISTENT_SESSIONS_MANAGER.create_session(current_org.organization_id)
     return BrowserSessionResponse.from_browser_session(browser_session)
 
 


### PR DESCRIPTION
Remove context creation from `create_session` function
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplified `create_session` in `persistent_sessions_manager.py` by removing context creation logic, affecting `create_browser_session` in `agent_protocol.py`.
> 
>   - **Behavior**:
>     - `create_session` in `persistent_sessions_manager.py` now returns only `PersistentBrowserSession`, removing context creation logic.
>     - `create_browser_session` in `agent_protocol.py` updated to reflect `create_session` changes.
>   - **Removed Logic**:
>     - Removed context creation, socket binding, and browser context setup from `create_session` in `persistent_sessions_manager.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 8fcf8c96dafb134b83284990aa39e0332e4edb5b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->