### PR TITLE
Remove upload block from node library

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
@@ -166,17 +166,17 @@ const nodeLibraryItems: Array<{
   //   title: "Download Block",
   //   description: "Downloads a file from S3",
   // },
-  {
-    nodeType: "upload",
-    icon: (
-      <WorkflowBlockIcon
-        workflowBlockType={WorkflowBlockTypes.UploadToS3}
-        className="size-6"
-      />
-    ),
-    title: "Upload Block",
-    description: "Uploads a file to S3",
-  },
+  // {
+  //   nodeType: "upload",
+  //   icon: (
+  //     <WorkflowBlockIcon
+  //       workflowBlockType={WorkflowBlockTypes.UploadToS3}
+  //       className="size-6"
+  //     />
+  //   ),
+  //   title: "Upload Block",
+  //   description: "Uploads a file to S3",
+  // },
   {
     nodeType: "fileDownload",
     icon: (


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Commented out the 'Upload Block' in `WorkflowNodeLibraryPanel.tsx`, removing it from the node library.
> 
>   - **Behavior**:
>     - Commented out the 'Upload Block' in `nodeLibraryItems` in `WorkflowNodeLibraryPanel.tsx`, removing it from the node library display.
>     - The 'Upload Block' was responsible for uploading files to S3.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 43eec16cce9a16594f3e9430d00248d715f90e7e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->