### PR TITLE
Add totp field in bitwarden password credential

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/ExampleCasePill.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/ExampleCasePill.tsx
@@ -23,9 +23,10 @@ function ExampleCasePill({ exampleId, version, icon, label, prompt }: Props) {
   const startObserverCruiseMutation = useMutation({
     mutationFn: async (prompt: string) => {
       const client = await getClient(credentialGetter, "v2");
-      return client.post<{ user_prompt: string }, { data: TaskV2 }>("/tasks", {
-        user_prompt: prompt,
-      });
+      return client.post<{ user_prompt: string }, { data: TaskV2 }>(
+        "/tasks",
+        { user_prompt: prompt },
+      );
     },
     onSuccess: (response) => {
       toast({

--- a/skyvern-frontend/src/routes/tasks/create/ExampleCasePill.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/ExampleCasePill.tsx
@@ -23,10 +23,9 @@ function ExampleCasePill({ exampleId, version, icon, label, prompt }: Props) {
   const startObserverCruiseMutation = useMutation({
     mutationFn: async (prompt: string) => {
       const client = await getClient(credentialGetter, "v2");
-      return client.post<{ user_prompt: string }, { data: TaskV2 }>(
-        "/tasks",
-        { user_prompt: prompt },
-      );
+      return client.post<{ user_prompt: string }, { data: TaskV2 }>("/tasks", {
+        user_prompt: prompt,
+      });
     },
     onSuccess: (response) => {
       toast({

--- a/skyvern/forge/sdk/schemas/credentials.py
+++ b/skyvern/forge/sdk/schemas/credentials.py
@@ -21,6 +21,7 @@ class CreditCardCredentialResponse(BaseModel):
 class PasswordCredential(BaseModel):
     password: str
     username: str
+    totp: str | None = None
 
 
 class CreditCardCredential(BaseModel):

--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -60,6 +60,7 @@ def get_list_response_item_from_bitwarden_item(item: dict) -> CredentialItem:
             credential=PasswordCredential(
                 username=login["username"],
                 password=login["password"],
+                totp=login["totp"],
             ),
             name=item["name"],
             credential_type=CredentialType.PASSWORD,
@@ -726,6 +727,7 @@ class BitwardenService:
         return PasswordCredential(
             username=login["username"],
             password=login["password"],
+            totp=login["totp"],
         )
 
     @staticmethod
@@ -743,6 +745,7 @@ class BitwardenService:
 
         login_template["username"] = credential.username
         login_template["password"] = credential.password
+        login_template["totp"] = credential.totp
 
         item_template["type"] = get_bitwarden_item_type_code(BitwardenItemType.LOGIN)
         item_template["name"] = name
@@ -968,6 +971,7 @@ class BitwardenService:
                 credential=PasswordCredential(
                     username=login_item["username"],
                     password=login_item["password"],
+                    totp=login_item["totp"],
                 ),
             )
         elif response["data"]["type"] == BitwardenItemType.CREDIT_CARD:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `totp` field to `PasswordCredential` and update related functions to handle it in `credentials.py`, `bitwarden.py`, and `context_manager.py`.
> 
>   - **Behavior**:
>     - Add `totp` field to `PasswordCredential` in `credentials.py`, defaulting to `None`.
>     - Update `get_list_response_item_from_bitwarden_item()` and `_get_login_item_by_id_using_server()` in `bitwarden.py` to handle `totp`.
>     - Modify `register_credential_parameter_value()` in `context_manager.py` to register `totp` if present.
>   - **Misc**:
>     - Update `BitwardenService` methods to include `totp` when creating and retrieving login items.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 99bf66829ee6d23b4e0a9ea640baa8e914c74747. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->