### PR TITLE
Add support for more proxies

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -38,6 +38,9 @@ export const ProxyLocation = {
   ResidentialGB: "RESIDENTIAL_GB",
   ResidentialFR: "RESIDENTIAL_FR",
   ResidentialDE: "RESIDENTIAL_DE",
+  ResidentialNZ: "RESIDENTIAL_NZ",
+  ResidentialZA: "RESIDENTIAL_ZA",
+  ResidentialAR: "RESIDENTIAL_AR",
   ResidentialISP: "RESIDENTIAL_ISP",
   None: "NONE",
 } as const;

--- a/skyvern-frontend/src/components/ProxySelector.tsx
+++ b/skyvern-frontend/src/components/ProxySelector.tsx
@@ -45,6 +45,15 @@ function ProxySelector({ value, onChange, className }: Props) {
         <SelectItem value={ProxyLocation.ResidentialDE}>
           Residential (Germany)
         </SelectItem>
+        <SelectItem value={ProxyLocation.ResidentialNZ}>
+          Residential (New Zealand)
+        </SelectItem>
+        <SelectItem value={ProxyLocation.ResidentialZA}>
+          Residential (South Africa)
+        </SelectItem>
+        <SelectItem value={ProxyLocation.ResidentialAR}>
+          Residential (Argentina)
+        </SelectItem>
       </SelectContent>
     </Select>
   );

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -27,6 +27,9 @@ class ProxyLocation(StrEnum):
     RESIDENTIAL_JP = "RESIDENTIAL_JP"
     RESIDENTIAL_FR = "RESIDENTIAL_FR"
     RESIDENTIAL_DE = "RESIDENTIAL_DE"
+    RESIDENTIAL_NZ = "RESIDENTIAL_NZ"
+    RESIDENTIAL_ZA = "RESIDENTIAL_ZA"
+    RESIDENTIAL_AR = "RESIDENTIAL_AR"
     RESIDENTIAL_ISP = "RESIDENTIAL_ISP"
     NONE = "NONE"
 
@@ -73,6 +76,15 @@ def get_tzinfo_from_proxy(proxy_location: ProxyLocation) -> ZoneInfo | None:
 
     if proxy_location == ProxyLocation.RESIDENTIAL_DE:
         return ZoneInfo("Europe/Berlin")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_NZ:
+        return ZoneInfo("Pacific/Auckland")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_ZA:
+        return ZoneInfo("Africa/Johannesburg")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_AR:
+        return ZoneInfo("America/Argentina/Buenos_Aires")
 
     if proxy_location == ProxyLocation.RESIDENTIAL_ISP:
         return ZoneInfo("America/New_York")


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for New Zealand, South Africa, and Argentina proxy locations with corresponding time zones.
> 
>   - **Proxy Locations**:
>     - Add `ResidentialNZ`, `ResidentialZA`, and `ResidentialAR` to `ProxyLocation` in `types.ts`, `ProxySelector.tsx`, and `tasks.py`.
>   - **Time Zone Handling**:
>     - Update `get_tzinfo_from_proxy()` in `tasks.py` to return `Pacific/Auckland` for `ResidentialNZ`, `Africa/Johannesburg` for `ResidentialZA`, and `America/Argentina/Buenos_Aires` for `ResidentialAR`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 99aea447b0e982b8d416794d5bab535a841e130b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->