### PR TITLE
add support back for old gpt versions by supporting `max_tokens`

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -389,7 +389,11 @@ class LLMAPIHandlerFactory:
 
     @staticmethod
     def get_api_parameters(llm_config: LLMConfig | LLMRouterConfig) -> dict[str, Any]:
-        params: dict[str, Any] = {"max_completion_tokens": llm_config.max_completion_tokens}
+        params: dict[str, Any] = {}
+        if llm_config.max_completion_tokens is not None:
+            params["max_completion_tokens"] = llm_config.max_completion_tokens
+        elif llm_config.max_tokens is not None:
+            params["max_tokens"] = llm_config.max_tokens
 
         if llm_config.temperature is not None:
             params["temperature"] = llm_config.temperature

--- a/skyvern/forge/sdk/api/llm/models.py
+++ b/skyvern/forge/sdk/api/llm/models.py
@@ -36,7 +36,8 @@ class LLMConfigBase:
 @dataclass(frozen=True)
 class LLMConfig(LLMConfigBase):
     litellm_params: Optional[LiteLLMParams] = field(default=None)
-    max_completion_tokens: int = SettingsManager.get_settings().LLM_CONFIG_MAX_TOKENS
+    max_tokens: int | None = SettingsManager.get_settings().LLM_CONFIG_MAX_TOKENS
+    max_completion_tokens: int | None = None
     temperature: float | None = SettingsManager.get_settings().LLM_CONFIG_TEMPERATURE
     reasoning_effort: str | None = None
 
@@ -74,7 +75,8 @@ class LLMRouterConfig(LLMConfigBase):
     allowed_fails: int | None = None
     allowed_fails_policy: AllowedFailsPolicy | None = None
     cooldown_time: float | None = None
-    max_completion_tokens: int = SettingsManager.get_settings().LLM_CONFIG_MAX_TOKENS
+    max_tokens: int | None = SettingsManager.get_settings().LLM_CONFIG_MAX_TOKENS
+    max_completion_tokens: int | None = None
     reasoning_effort: str | None = None
     temperature: float | None = SettingsManager.get_settings().LLM_CONFIG_TEMPERATURE
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds support for older GPT versions by introducing a fallback from `max_completion_tokens` to `max_tokens` in `LLMConfig` and `LLMRouterConfig`.
> 
>   - **Behavior**:
>     - `get_api_parameters` in `api_handler_factory.py` now checks `max_completion_tokens` first, then `max_tokens`.
>   - **Models**:
>     - `LLMConfig` and `LLMRouterConfig` in `models.py` now include `max_tokens` and `max_completion_tokens` with `max_completion_tokens` defaulting to `None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1c783d14827e1e4f1df1d4838d9946ab2ae91884. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->