### PR TITLE
Add browser session id to global context

### DIFF
--- a/skyvern/forge/sdk/core/skyvern_context.py
+++ b/skyvern/forge/sdk/core/skyvern_context.py
@@ -14,6 +14,7 @@ class SkyvernContext:
     workflow_run_id: str | None = None
     task_v2_id: str | None = None
     max_steps_override: int | None = None
+    browser_session_id: str | None = None
     tz_info: ZoneInfo | None = None
     totp_codes: dict[str, str | None] = field(default_factory=dict)
     log: list[dict] = field(default_factory=list)

--- a/skyvern/forge/sdk/forge_log.py
+++ b/skyvern/forge/sdk/forge_log.py
@@ -34,6 +34,8 @@ def add_kv_pairs_to_msg(logger: logging.Logger, method_name: str, event_dict: Ev
             event_dict["workflow_run_id"] = context.workflow_run_id
         if context.task_v2_id:
             event_dict["task_v2_id"] = context.task_v2_id
+        if context.browser_session_id:
+            event_dict["browser_session_id"] = context.browser_session_id
 
     # Add env to the log
     event_dict["env"] = settings.ENV

--- a/skyvern/forge/sdk/services/task_v2_service.py
+++ b/skyvern/forge/sdk/services/task_v2_service.py
@@ -359,6 +359,7 @@ async def run_task_v2_helper(
             workflow_run_id=workflow_run_id,
             request_id=request_id,
             task_v2_id=task_v2_id,
+            browser_session_id=browser_session_id,
         )
     )
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `browser_session_id` to `SkyvernContext` and include it in logging and task execution contexts.
> 
>   - **SkyvernContext**:
>     - Add `browser_session_id` field to `SkyvernContext` in `skyvern_context.py`.
>   - **Logging**:
>     - Include `browser_session_id` in log context in `add_kv_pairs_to_msg()` in `forge_log.py`.
>   - **Task Execution**:
>     - Pass `browser_session_id` to `SkyvernContext` in `run_task_v2_helper()` in `task_v2_service.py`.
>     - Update `run_task_v2()` to accept `browser_session_id` parameter in `task_v2_service.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 26a2c22b80b57595f5a72f93ac481ec56dee6b62. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->