### PR TITLE
do not raise error when agent hallucinate the download

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -43,7 +43,6 @@ from skyvern.exceptions import (
     NoAutoCompleteOptionMeetCondition,
     NoAvailableOptionFoundForCustomSelection,
     NoElementMatchedForTargetOption,
-    NoFileDownloadTriggered,
     NoIncrementalElementFoundForAutoCompletion,
     NoIncrementalElementFoundForCustomSelection,
     NoSuitableAutoCompleteOption,
@@ -510,7 +509,7 @@ async def handle_click_to_download_file_action(
             step_id=step.step_id,
             workflow_run_id=task.workflow_run_id,
         )
-        return [ActionFailure(exception=NoFileDownloadTriggered(action.element_id))]
+        return [ActionSuccess(download_triggered=False)]
 
     # check if there's any file is still downloading
     downloading_files = list_downloading_files_in_directory(download_dir)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modify `handle_click_to_download_file_action` in `handler.py` to return `ActionSuccess` instead of raising an error when no file download is triggered.
> 
>   - **Behavior**:
>     - In `handle_click_to_download_file_action`, change return value to `ActionSuccess(download_triggered=False)` when no file download is triggered, instead of raising `NoFileDownloadTriggered`.
>   - **Exceptions**:
>     - Remove `NoFileDownloadTriggered` from imports in `handler.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2553da29f6727b0c6419ac7a3819abe0c8ff152a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->