### PR TITLE
Fern Github action update

### DIFF
--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/heads/main') && github.run_number > 1 }}
+    if: ${{ github.event_name == 'push' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Simplifies GitHub Action trigger condition to run on any push event in `publish-fern-docs.yml`.
> 
>   - **Behavior**:
>     - Simplifies the trigger condition in `.github/workflows/publish-fern-docs.yml` to run on any `push` event.
>     - Removes the condition `github.run_number > 1` and branch-specific trigger for `main`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for aba018433fffacd1e0564ded6ee1797ef25670e4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->