### PR TITLE
fix verification code hallucination

### DIFF
--- a/skyvern/forge/prompts/skyvern/extract-action.j2
+++ b/skyvern/forge/prompts/skyvern/extract-action.j2
@@ -38,7 +38,7 @@ Reply in JSON format with the following keys:
 {% endif %}
     }],{% if verification_code_check %}
     "verification_code_reasoning": str, // Let's think step by step. Describe what you see and think if a verification code is needed for login or any verification step. Explain why you believe a verification code is needed or not. Has the code been sent and is code available somewhere (email, phone or 2FA device)?
-    "need_verification_code": bool, // Whether a verification code is needed to proceed. True only if the code is available to user. If the code is not sent, return false {% endif %}
+    "need_verification_code": bool, // Whether a verification code must be entered on this page now. True only if the code is available to user. If the code is not sent, return false {% endif %}
 }
 {% if action_history %}
 Consider the action history from the last step and the screenshot together, if actions from the last step don't yield positive impact, try other actions or other action combinations.


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Clarifies `need_verification_code` comment in `extract-action.j2` to specify that the code must be entered on the current page.
> 
>   - **Behavior**:
>     - Clarifies `need_verification_code` comment in `extract-action.j2` to specify that the code must be entered on the current page.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 457897c40cfd97f9b18db384ad23319b1b75704d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->