### PR TITLE
task v2 max steps doc

### DIFF
--- a/docs/running-tasks/api-v2-spec.mdx
+++ b/docs/running-tasks/api-v2-spec.mdx
@@ -14,6 +14,7 @@ Production:`https://api.skyvern.com/api/v2/tasks/`
 | --- | --- | --- | --- | --- |
 | x-api-key | String | yes | [your-api-key-here] | Bearer token that gives your backend access to the Skyvern API. This will be manually provided by us |
 | x-max-iterations-override | Integer | no | 10 | The max number of iterations skyvern attempts to divide and conquer a complicated task. In each iteration, Skyvern does a "mini task" planning, mini task execution and validation. The default is 10. |
+| x-max-steps-override | Integer | no | 25 | The max number of steps skyvern can take. The default is 25. |
 
 ### Body
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `x-max-steps-override` header parameter to API v2 spec, allowing control over max steps with default 25.
> 
>   - **Documentation Update**:
>     - Adds `x-max-steps-override` header parameter to `api-v2-spec.mdx`.
>     - Specifies it as an optional integer with a default value of 25, controlling max steps Skyvern can take.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5c6864b1d74b5aa590faf7e66b1be94505abb584. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->