### PR TITLE
Do not sync bitwarden before fetching from `bw serve`

### DIFF
--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -726,10 +726,6 @@ class BitwardenService:
             )
 
     @staticmethod
-    async def _sync_using_server() -> None:
-        await aiohttp_post(f"{BITWARDEN_SERVER_BASE_URL}/sync")
-
-    @staticmethod
     async def _unlock_using_server(master_password: str) -> None:
         status_response = await aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/status")
         status = status_response["data"]["template"]["status"]
@@ -823,7 +819,6 @@ class BitwardenService:
         try:
             master_password, bw_organization_id, _, _ = await BitwardenService._get_skyvern_auth_secrets()
 
-            await BitwardenService._sync_using_server()
             await BitwardenService._unlock_using_server(master_password)
             if isinstance(credential, PasswordCredential):
                 return await BitwardenService._create_login_item_using_server(
@@ -888,7 +883,6 @@ class BitwardenService:
         try:
             master_password, bw_organization_id, _, _ = await BitwardenService._get_skyvern_auth_secrets()
 
-            await BitwardenService._sync_using_server()
             await BitwardenService._unlock_using_server(master_password)
             return await BitwardenService._create_collection_using_server(bw_organization_id, name)
 
@@ -928,7 +922,6 @@ class BitwardenService:
     ) -> list[CredentialItem]:
         try:
             master_password, _, _, _ = await BitwardenService._get_skyvern_auth_secrets()
-            await BitwardenService._sync_using_server()
             await BitwardenService._unlock_using_server(master_password)
             return await BitwardenService._get_items_by_item_ids_using_server(item_ids)
         except Exception as e:
@@ -950,7 +943,6 @@ class BitwardenService:
     ) -> list[CredentialItem]:
         try:
             master_password, _, _, _ = await BitwardenService._get_skyvern_auth_secrets()
-            await BitwardenService._sync_using_server()
             await BitwardenService._unlock_using_server(master_password)
             return await BitwardenService._get_collection_items_using_server(collection_id)
         except Exception as e:
@@ -972,7 +964,6 @@ class BitwardenService:
     ) -> CredentialItem:
         try:
             master_password, _, _, _ = await BitwardenService._get_skyvern_auth_secrets()
-            await BitwardenService._sync_using_server()
             await BitwardenService._unlock_using_server(master_password)
             return await BitwardenService._get_credential_item_by_id_using_server(item_id)
         except Exception as e:
@@ -1022,7 +1013,6 @@ class BitwardenService:
     ) -> None:
         try:
             master_password, _, _, _ = await BitwardenService._get_skyvern_auth_secrets()
-            await BitwardenService._sync_using_server()
             await BitwardenService._unlock_using_server(master_password)
             await BitwardenService._delete_credential_item_using_server(item_id)
         except Exception as e:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add GitHub Actions workflow, Docker setup, and modify Bitwarden service for Bitwarden Serve deployment and operation.
> 
>   - **Deployment**:
>     - Adds `.github/workflows/aws_staging_bitwarden_serve.yml` for deploying Bitwarden Serve to staging using GitHub Actions.
>     - Includes steps for AWS credentials configuration, Docker image build, and Slack notifications.
>   - **Docker and Compose**:
>     - Adds `bitwarden_serve.Dockerfile` to build Bitwarden Serve image with Node.js and Bitwarden CLI.
>     - Adds `bitwarden-serve-compose.yml` to define Docker Compose service for Bitwarden Serve.
>   - **Scripts**:
>     - Adds `scripts/bitwarden_sync.sh` for periodic sync requests to Bitwarden server.
>     - Modifies `scripts/run_bitwarden_server.sh` to run sync script in the background.
>   - **Bitwarden Service**:
>     - Removes `_sync_using_server()` calls from `skyvern/forge/sdk/services/bitwarden.py` in several functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 23b8e37ee34856bc6929980f18c11f167658f2c0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->