### PR TITLE
make text promtp llm pickable in settings

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -98,6 +98,7 @@ class Settings(BaseSettings):
     SECONDARY_LLM_KEY: str | None = None
     SELECT_AGENT_LLM_KEY: str | None = None
     SINGLE_CLICK_AGENT_LLM_KEY: str | None = None
+    TEXT_ONLY_AGENT_LLM_KEY: str | None = None
     # COMMON
     LLM_CONFIG_TIMEOUT: int = 300
     LLM_CONFIG_MAX_TOKENS: int = 4096

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -1186,7 +1186,7 @@ async def user_code():
         )
 
 
-DEFAULT_TEXT_PROMPT_LLM_KEY = settings.SECONDARY_LLM_KEY or settings.LLM_KEY
+DEFAULT_TEXT_PROMPT_LLM_KEY = settings.TEXT_ONLY_AGENT_LLM_KEY or settings.LLM_KEY
 
 
 class TextPromptBlock(Block):


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `TEXT_ONLY_AGENT_LLM_KEY` to settings and update `TextPromptBlock` to use it as the default LLM key if available.
> 
>   - **Settings**:
>     - Add `TEXT_ONLY_AGENT_LLM_KEY` to `Settings` in `config.py`.
>   - **Behavior**:
>     - Change `DEFAULT_TEXT_PROMPT_LLM_KEY` in `block.py` to use `TEXT_ONLY_AGENT_LLM_KEY` if available, otherwise fallback to `LLM_KEY`.
>     - Update `TextPromptBlock` in `block.py` to use `DEFAULT_TEXT_PROMPT_LLM_KEY` for `llm_key`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b1b6e25070577c54cd06eb5af70084f11f9c797d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->