### PR TITLE
fix task v2 block goto url issue

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -68,6 +68,7 @@ from skyvern.forge.sdk.workflow.models.parameter import (
     WorkflowParameter,
 )
 from skyvern.webeye.browser_factory import BrowserState
+from skyvern.webeye.utils.page import SkyvernFrame
 
 LOG = structlog.get_logger()
 
@@ -2143,6 +2144,15 @@ class TaskV2Block(Block):
     ) -> BlockResult:
         from skyvern.forge.sdk.services import task_v2_service
         from skyvern.forge.sdk.workflow.models.workflow import WorkflowRunStatus
+
+        if not self.url:
+            browser_state = app.BROWSER_MANAGER.get_for_workflow_run(workflow_run_id)
+            if browser_state:
+                page = await browser_state.get_working_page()
+                if page:
+                    current_url = await SkyvernFrame.get_url(frame=page)
+                    if current_url != "about:blank":
+                        self.url = current_url
 
         if not organization_id:
             raise ValueError("Running TaskV2Block requires organization_id")

--- a/skyvern/webeye/browser_manager.py
+++ b/skyvern/webeye/browser_manager.py
@@ -132,13 +132,11 @@ class BrowserManager:
     ) -> BrowserState:
         parent_workflow_run_id = workflow_run.parent_workflow_run_id
         workflow_run_id = workflow_run.workflow_run_id
-        browser_state = self.get_for_workflow_run(workflow_run_id=workflow_run_id)
-        if parent_workflow_run_id:
-            browser_state = self.get_for_workflow_run(workflow_run_id=parent_workflow_run_id)
-            if browser_state:
-                self.pages[workflow_run_id] = browser_state
-
-        if browser_state is not None:
+        browser_state = self.get_for_workflow_run(
+            workflow_run_id=workflow_run_id, parent_workflow_run_id=parent_workflow_run_id
+        )
+        if browser_state:
+            self.pages[workflow_run_id] = browser_state
             return browser_state
 
         if browser_session_id:
@@ -193,9 +191,15 @@ class BrowserManager:
         )
         return browser_state
 
-    def get_for_workflow_run(self, workflow_run_id: str) -> BrowserState | None:
+    def get_for_workflow_run(
+        self, workflow_run_id: str, parent_workflow_run_id: str | None = None
+    ) -> BrowserState | None:
         if workflow_run_id in self.pages:
             return self.pages[workflow_run_id]
+
+        if parent_workflow_run_id and parent_workflow_run_id in self.pages:
+            return self.pages[parent_workflow_run_id]
+
         return None
 
     def set_video_artifact_for_task(self, task: Task, artifacts: list[VideoArtifact]) -> None:

--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -47,6 +47,10 @@ class SkyvernFrame:
             raise TimeoutError("timeout to evaluate expression")
 
     @staticmethod
+    async def get_url(frame: Page | Frame) -> str:
+        return await SkyvernFrame.evaluate(frame=frame, expression="() => document.location.href")
+
+    @staticmethod
     async def take_screenshot(
         page: Page,
         full_page: bool = False,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes task v2 block URL handling by ensuring correct URL usage in task execution and browser state management.
> 
>   - **Behavior**:
>     - Fixes URL handling in `run_task_v2_helper()` in `task_v2_service.py` by checking `current_url` against `url` before setting task type to `goto_url`.
>     - Updates `execute()` in `block.py` to set `self.url` if not already set, using `SkyvernFrame.get_url()`.
>     - Ensures `get_for_workflow_run()` in `browser_manager.py` checks both `workflow_run_id` and `parent_workflow_run_id` for existing browser states.
>   - **Utilities**:
>     - Adds `SkyvernFrame.get_url()` in `page.py` to retrieve the current URL from a `Page` or `Frame`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for eaf6f6fa9db33fa51a3e70990cd8161e732cdae7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->