### PR TITLE
fix workflow run browser context missing problem

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -138,7 +138,9 @@ class ForgeAgent:
 
         task_url = task_block.url
         if task_url is None:
-            browser_state = app.BROWSER_MANAGER.get_for_workflow_run(workflow_run_id=workflow_run.workflow_run_id)
+            browser_state = app.BROWSER_MANAGER.get_for_workflow_run(
+                workflow_run_id=workflow_run.workflow_run_id, parent_workflow_run_id=workflow_run.parent_workflow_run_id
+            )
             if browser_state is None:
                 raise MissingBrowserState(workflow_run_id=workflow_run.workflow_run_id)
 

--- a/skyvern/webeye/browser_manager.py
+++ b/skyvern/webeye/browser_manager.py
@@ -136,7 +136,10 @@ class BrowserManager:
             workflow_run_id=workflow_run_id, parent_workflow_run_id=parent_workflow_run_id
         )
         if browser_state:
+            # always keep the browser state for the workflow run and the parent workflow run synced
             self.pages[workflow_run_id] = browser_state
+            if parent_workflow_run_id:
+                self.pages[parent_workflow_run_id] = browser_state
             return browser_state
 
         if browser_session_id:
@@ -194,11 +197,11 @@ class BrowserManager:
     def get_for_workflow_run(
         self, workflow_run_id: str, parent_workflow_run_id: str | None = None
     ) -> BrowserState | None:
-        if workflow_run_id in self.pages:
-            return self.pages[workflow_run_id]
-
         if parent_workflow_run_id and parent_workflow_run_id in self.pages:
             return self.pages[parent_workflow_run_id]
+
+        if workflow_run_id in self.pages:
+            return self.pages[workflow_run_id]
 
         return None
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes missing browser context issue by synchronizing browser states for workflow runs and their parents in `browser_manager.py` and updating `agent.py` to handle both `workflow_run_id` and `parent_workflow_run_id`.
> 
>   - **Behavior**:
>     - Fixes missing browser context issue by synchronizing browser states for workflow runs and their parents in `get_for_workflow_run()` and `get_or_create_for_workflow_run()` in `browser_manager.py`.
>     - Updates `create_task_and_step_from_block()` in `agent.py` to retrieve browser state using both `workflow_run_id` and `parent_workflow_run_id`.
>   - **Error Handling**:
>     - Ensures `MissingBrowserState` is raised if browser state is not found for both workflow run and parent in `agent.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for cd462480e81cd11cd5cb0b6b8fb876f3a435c02e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->