### PR TITLE
Remove credential helper text from login block, it no longer applies

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/LoginNode/LoginNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/LoginNode/LoginNode.tsx
@@ -165,16 +165,6 @@ function LoginNode({ id, data }: NodeProps<LoginNode>) {
               }}
             />
           </div>
-          <div className="rounded-md bg-slate-800 p-2">
-            <div className="space-y-1 text-xs text-slate-400">
-              <div>Credentials need to be added with the help of our team.</div>
-              <div>
-                Reach out to{" "}
-                <span className="text-slate-200">support@skyvern.com</span> for
-                assistance.
-              </div>
-            </div>
-          </div>
         </div>
         <Separator />
         <Accordion type="single" collapsible>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove outdated credential helper text from `LoginNode` in `LoginNode.tsx`.
> 
>   - **UI Update**:
>     - Removed outdated credential helper text from `LoginNode` in `LoginNode.tsx`. The text suggested contacting support for credential assistance, which is no longer applicable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for bb661979728a0f52edb27812a0d606f2352aaf33. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->