### PR TITLE
⚡️ Speed up method `AsyncOperationPool._get_operation` by 10%

### DIFF
--- a/skyvern/forge/async_operations.py
+++ b/skyvern/forge/async_operations.py
@@ -83,7 +83,11 @@ class AsyncOperationPool:
             self._add_operation(task_id, operation)
 
     def _get_operation(self, task_id: str, agent_phase: AgentPhase) -> AsyncOperation | None:
-        return self._operations.get(task_id, {}).get(agent_phase, None)
+        # Direct dictionary access and exception handling to minimize overhead
+        try:
+            return self._operations[task_id][agent_phase]
+        except KeyError:
+            return None
 
     def _remove_operations(self, task_id: str) -> None:
         if task_id in self._operations:


### PR DESCRIPTION
### 📄 10% (0.10x) speedup for ***`AsyncOperationPool._get_operation` in `skyvern/forge/async_operations.py`***

⏱️ Runtime :   **`630 microseconds`**  **→** **`573 microseconds`** (best of `25` runs)
<details>
<summary> 📝 Explanation and details</summary>

To improve the runtime efficiency of the `_get_operation` method in the `AsyncOperationPool` class, we can reduce the number of dictionary accesses. By using exception handling, we can avoid redundant `dict.get` calls. Also, since dict operations are usually optimized in Python, we should avoid the method call when possible.

Here is an optimized version of this method.



</details>

✅ **Correctness verification report:**

| Test                        | Status            |
| --------------------------- | ----------------- |
| ⚙️ Existing Unit Tests | 🔘 **None Found** |
| 🌀 Generated Regression Tests | ✅ **12 Passed** |
| ⏪ Replay Tests | 🔘 **None Found** |
| 🔎 Concolic Coverage Tests | 🔘 **None Found** |
|📊 Tests Coverage       | 100.0% |
<details>
<summary>🌀 Generated Regression Tests Details</summary>

```python
import asyncio
from enum import StrEnum
from unittest.mock import Mock

# imports
import pytest  # used for our unit tests
from playwright.async_api import Page
from skyvern.forge.async_operations import AsyncOperationPool


# function to test
class AgentPhase(StrEnum):
    """
    Phase of agent when async execution events are happening
    """

    action = "action"
    scrape = "scrape"
    llm = "llm"

class AsyncOperation:
    """
    AsyncOperation can take async actions on the page while agent is performing the task.

    Examples:
        - collect info based on the html/DOM and send data to your server
    """

    def __init__(self, task_id: str, operation_type: str, agent_phase: AgentPhase, page: Page) -> None:
        """
        :param task_id: task_id of the task
        :param operation_type: it's the custom type of the operation.
            there will only be up to one aio task running per operation_type
        :param agent_phase: AgentPhase type. phase of the agent when the operation is running
        :param page: playwright page for the task
        """
        self.task_id = task_id
        self.type = operation_type
        self.agent_phase = agent_phase
        self.aio_task: asyncio.Task | None = None

        # playwright page could be used by the operation to take actions
        self.page = page

    async def execute(self) -> None:
        return

    def run(self) -> asyncio.Task | None:
        if self.aio_task is not None and is_aio_task_running(self.aio_task):
            LOG.warning(
                "Task already running",
                task_id=self.task_id,
                operation_type=self.type,
                agent_phase=self.agent_phase,
            )
            return None
        self.aio_task = asyncio.create_task(self.execute())
        return self.aio_task
from skyvern.forge.async_operations import AsyncOperationPool


# unit tests
@pytest.fixture
def async_operation_pool():
    pool = AsyncOperationPool()
    page = Mock(spec=Page)
    pool._operations = {
        "task1": {
            AgentPhase.action: AsyncOperation("task1", "type1", AgentPhase.action, page),
            AgentPhase.scrape: AsyncOperation("task1", "type2", AgentPhase.scrape, page),
        },
        "task2": {
            AgentPhase.action: AsyncOperation("task2", "type3", AgentPhase.action, page),
        }
    }
    return pool


def test_get_operation_edge_cases(async_operation_pool):
    # Test empty string as task_id
    codeflash_output = async_operation_pool._get_operation("", AgentPhase.action)

    # Test None as task_id
    codeflash_output = async_operation_pool._get_operation(None, AgentPhase.action)

    # Test None as agent_phase
    codeflash_output = async_operation_pool._get_operation("task1", None)

    # Test both task_id and agent_phase as None
    codeflash_output = async_operation_pool._get_operation(None, None)

def test_get_operation_invalid_inputs(async_operation_pool):
    # Test invalid type for task_id (integer)
    codeflash_output = async_operation_pool._get_operation(123, AgentPhase.action)

    # Test invalid type for agent_phase (string not in AgentPhase)
    codeflash_output = async_operation_pool._get_operation("task1", "invalid_phase")




def test_get_operation_concurrent_modifications(async_operation_pool):
    # Test modifying _operations dictionary during retrieval
    async_operation_pool._operations.clear()
    codeflash_output = async_operation_pool._get_operation("task1", AgentPhase.action)



import asyncio
from enum import StrEnum

# imports
import pytest  # used for our unit tests
from playwright.async_api import Page
from skyvern.forge.async_operations import AsyncOperationPool


# function to test
class AgentPhase(StrEnum):
    """
    Phase of agent when async execution events are happening
    """

    action = "action"
    scrape = "scrape"
    llm = "llm"

class AsyncOperation:
    """
    AsyncOperation can take async actions on the page while agent is performing the task.

    Examples:
        - collect info based on the html/DOM and send data to your server
    """

    def __init__(self, task_id: str, operation_type: str, agent_phase: AgentPhase, page: Page) -> None:
        """
        :param task_id: task_id of the task
        :param operation_type: it's the custom type of the operation.
            there will only be up to one aio task running per operation_type
        :param agent_phase: AgentPhase type. phase of the agent when the operation is running
        :param page: playwright page for the task
        """
        self.task_id = task_id
        self.type = operation_type
        self.agent_phase = agent_phase
        self.aio_task: asyncio.Task | None = None

        # playwright page could be used by the operation to take actions
        self.page = page

    async def execute(self) -> None:
        return

    def run(self) -> asyncio.Task | None:
        if self.aio_task is not None and is_aio_task_running(self.aio_task):
            LOG.warning(
                "Task already running",
                task_id=self.task_id,
                operation_type=self.type,
                agent_phase=self.agent_phase,
            )
            return None
        self.aio_task = asyncio.create_task(self.execute())
        return self.aio_task
from skyvern.forge.async_operations import AsyncOperationPool


# unit tests
@pytest.fixture
def async_operation_pool():
    pool = AsyncOperationPool()
    page = Page()  # Mocked Page object
    # Adding some operations for testing
    pool._operations = {
        "task1": {
            AgentPhase.action: AsyncOperation("task1", "type1", AgentPhase.action, page),
            AgentPhase.scrape: AsyncOperation("task1", "type2", AgentPhase.scrape, page)
        },
        "task_with_empty_dict": {},
        "complex_task": {phase: AsyncOperation("complex_task", f"type_{phase}", phase, page) for phase in AgentPhase}
    }
    return pool

# Basic Functionality
def test_valid_task_id_and_agent_phase(async_operation_pool):
    codeflash_output = async_operation_pool._get_operation("task1", AgentPhase.action)

def test_valid_task_id_but_invalid_agent_phase(async_operation_pool):
    codeflash_output = async_operation_pool._get_operation("task1", AgentPhase.llm)

# Edge Cases
def test_non_existent_task_id(async_operation_pool):
    codeflash_output = async_operation_pool._get_operation("non_existent_task", AgentPhase.scrape)

def test_empty_operations_dict():
    pool = AsyncOperationPool()
    codeflash_output = pool._get_operation("task1", AgentPhase.action)

def test_task_id_with_empty_dict(async_operation_pool):
    codeflash_output = async_operation_pool._get_operation("task_with_empty_dict", AgentPhase.scrape)

# Data Types and Invalid Inputs
def test_invalid_task_id_type(async_operation_pool):
    with pytest.raises(AttributeError):
        async_operation_pool._get_operation(12345, AgentPhase.action)

def test_invalid_agent_phase_type(async_operation_pool):
    with pytest.raises(AttributeError):
        async_operation_pool._get_operation("task1", "invalid_phase")

# Large Scale Test Cases

def test_large_number_of_phases_within_task(async_operation_pool):
    codeflash_output = async_operation_pool._get_operation("complex_task", AgentPhase.action)

# Performance and Scalability
def test_high_frequency_of_access(async_operation_pool):
    for _ in range(1000):
        codeflash_output = async_operation_pool._get_operation("task1", AgentPhase.action)

def test_simultaneous_access(async_operation_pool):
    async def access_operation():
        codeflash_output = async_operation_pool._get_operation("task1", AgentPhase.action)

    asyncio.run(asyncio.gather(*[access_operation() for _ in range(100)]))

# Complex Nested Structures

def test_boundary_values_for_task_id_and_agent_phase(async_operation_pool):
    codeflash_output = async_operation_pool._get_operation("", AgentPhase.action)

    long_task_id = "a" * 1000
    async_operation_pool._operations[long_task_id] = {AgentPhase.action: AsyncOperation(long_task_id, "type", AgentPhase.action, Page())}
    codeflash_output = async_operation_pool._get_operation(long_task_id, AgentPhase.action)
# codeflash_output is used to check that the output of the original code is the same as that of the optimized code.
```

</details>


To edit these changes `git checkout codeflash/optimize-AsyncOperationPool._get_operation-m7ubaym2` and push.

[![Codeflash](https://img.shields.io/badge/Optimized%20with-Codeflash-yellow?style=flat&color=%23ffc428&logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDgwIiBoZWlnaHQ9ImF1dG8iIHZpZXdCb3g9IjAgMCA0ODAgMjgwIiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8cGF0aCBmaWxsLXJ1bGU9ImV2ZW5vZGQiIGNsaXAtcnVsZT0iZXZlbm9kZCIgZD0iTTI4Ni43IDAuMzc4NDE4SDIwMS43NTFMNTAuOTAxIDE0OC45MTFIMTM1Ljg1MUwwLjk2MDkzOCAyODEuOTk5SDk1LjQzNTJMMjgyLjMyNCA4OS45NjE2SDE5Ni4zNDVMMjg2LjcgMC4zNzg0MThaIiBmaWxsPSIjRkZDMDQzIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzExLjYwNyAwLjM3ODkwNkwyNTguNTc4IDU0Ljk1MjZIMzc5LjU2N0w0MzIuMzM5IDAuMzc4OTA2SDMxMS42MDdaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMzA5LjU0NyA4OS45NjAxTDI1Ni41MTggMTQ0LjI3NkgzNzcuNTA2TDQzMC4wMjEgODkuNzAyNkgzMDkuNTQ3Vjg5Ljk2MDFaIiBmaWxsPSIjMEIwQTBBIi8+CjxwYXRoIGZpbGwtcnVsZT0iZXZlbm9kZCIgY2xpcC1ydWxlPSJldmVub2RkIiBkPSJNMjQyLjg3MyAxNjQuNjZMMTg5Ljg0NCAyMTkuMjM0SDMxMC44MzNMMzYzLjM0NyAxNjQuNjZIMjQyLjg3M1oiIGZpbGw9IiMwQjBBMEEiLz4KPC9zdmc+Cg==)](https://codeflash.ai)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimizes `AsyncOperationPool._get_operation` in `async_operations.py` for a 10% speed improvement by using direct dictionary access and exception handling.
> 
>   - **Optimization**:
>     - Optimizes `AsyncOperationPool._get_operation` in `async_operations.py` by replacing `dict.get` with direct access and exception handling.
>     - Achieves a 10% speed improvement (630µs to 573µs).
>   - **Testing**:
>     - Adds 12 regression tests covering edge cases, invalid inputs, concurrent modifications, and performance scenarios.
>     - Ensures 100% test coverage for the optimized method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9b4f1c7cf0ad979d351307dfd144f84c8bd5f556. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->