### PR TITLE
Add credential input parameter options in login block dropdown

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/LoginNode/LoginBlockCredentialSelector.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/LoginNode/LoginBlockCredentialSelector.tsx
@@ -22,6 +22,11 @@ function LoginBlockCredentialSelector({ value, onChange }: Props) {
   const credentialParameters = workflowParameters.filter(
     (parameter) => parameter.parameterType === "credential",
   );
+  const credentialInputParameters = workflowParameters.filter(
+    (parameter) =>
+      parameter.parameterType === "workflow" &&
+      parameter.dataType === "credential_id",
+  );
   const isCloud = useContext(CloudContext);
   const { data: credentials = [], isLoading } = useCredentialsQuery({
     enabled: isCloud,
@@ -44,6 +49,14 @@ function LoginBlockCredentialSelector({ value, onChange }: Props) {
     type: "parameter",
   }));
 
+  const credentialInputParameterOptions = credentialInputParameters.map(
+    (parameter) => ({
+      label: parameter.key,
+      value: parameter.key,
+      type: "parameter",
+    }),
+  );
+
   const filteredCredentialParameterOptions = credentialParameterOptions.filter(
     (option) =>
       !credentialOptions.some(
@@ -51,7 +64,11 @@ function LoginBlockCredentialSelector({ value, onChange }: Props) {
       ),
   );
 
-  const options = [...credentialOptions, ...filteredCredentialParameterOptions];
+  const options = [
+    ...credentialOptions,
+    ...filteredCredentialParameterOptions,
+    ...credentialInputParameterOptions,
+  ];
 
   return (
     <Select


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add credential input parameters to `LoginBlockCredentialSelector` dropdown options by filtering workflow parameters for specific types.
> 
>   - **Behavior**:
>     - Adds credential input parameters to the dropdown options in `LoginBlockCredentialSelector.tsx`.
>     - Filters workflow parameters for `parameterType` as `workflow` and `dataType` as `credential_id`.
>     - Appends these filtered parameters to the existing options list.
>   - **Functionality**:
>     - Updates `options` array to include `credentialInputParameterOptions`.
>     - Ensures dropdown reflects new parameter types alongside existing credentials and filtered parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ad62e39a861217f9c65a7bbafce36e2cac99db6e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->