### PR TITLE
add svg into interactable detecting

### DIFF
--- a/skyvern/forge/agent_functions.py
+++ b/skyvern/forge/agent_functions.py
@@ -136,7 +136,7 @@ async def _convert_svg_to_string(
         skyvern_element = SkyvernElement(locator=locater, frame=skyvern_frame.get_frame(), static_element=element)
 
         _, blocked = await skyvern_frame.get_blocking_element_id(await skyvern_element.get_element_handler())
-        if blocked:
+        if not skyvern_element.is_interactable() and blocked:
             del element["children"]
             element["isDropped"] = True
             return

--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -733,7 +733,8 @@ function isInteractable(element, hoverStylesMap) {
     tagName === "i" ||
     tagName === "li" ||
     tagName === "p" ||
-    tagName === "td"
+    tagName === "td" ||
+    tagName === "svg"
   ) {
     const elementCursor = getElementComputedStyle(element)?.cursor;
     if (elementCursor === "pointer") {

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -94,11 +94,16 @@ def json_to_html(element: dict, need_skyvern_attrs: bool = True) -> str:
     """
     if element is flagged as dropped, the html format is empty
     """
-    if element.get("isDropped", False):
-        return ""
-
     tag = element["tagName"]
     attributes: dict[str, Any] = copy.deepcopy(element.get("attributes", {}))
+
+    interactable = element.get("interactable", False)
+    if element.get("isDropped", False):
+        if not interactable:
+            return ""
+        else:
+            LOG.info("Element is interactable. Trimmed all attributes instead of dropping it", element=element)
+            attributes = {}
 
     if element.get("isCheckable", False) and tag != "input":
         tag = "input"


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add SVG elements to interactable detection in `domUtils.js` and update handling in `agent_functions.py` and `scraper.py`.
> 
>   - **Behavior**:
>     - Modify `_convert_svg_to_string` in `agent_functions.py` to check `is_interactable` before marking SVG elements as dropped.
>     - Update `json_to_html` in `scraper.py` to retain interactable elements even if marked as dropped.
>   - **Interactable Detection**:
>     - Add `svg` to interactable tags in `isInteractable` function in `domUtils.js`.
>   - **Misc**:
>     - Minor logging changes in `scraper.py` for interactable elements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 868338a00ee54ddafd6e73e536dd8626ed3b6339. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->