### PR TITLE
PROMPT_BLOCK_LLM_KEY renaming

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -99,7 +99,7 @@ class Settings(BaseSettings):
     SECONDARY_LLM_KEY: str | None = None
     SELECT_AGENT_LLM_KEY: str | None = None
     SINGLE_CLICK_AGENT_LLM_KEY: str | None = None
-    TEXT_ONLY_AGENT_LLM_KEY: str | None = None
+    PROMPT_BLOCK_LLM_KEY: str | None = None
     # COMMON
     LLM_CONFIG_TIMEOUT: int = 300
     LLM_CONFIG_MAX_TOKENS: int = 4096

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -1280,7 +1280,7 @@ async def wrapper():
         )
 
 
-DEFAULT_TEXT_PROMPT_LLM_KEY = settings.TEXT_ONLY_AGENT_LLM_KEY or settings.LLM_KEY
+DEFAULT_TEXT_PROMPT_LLM_KEY = settings.PROMPT_BLOCK_LLM_KEY or settings.LLM_KEY
 
 
 class TextPromptBlock(Block):


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renamed `TEXT_ONLY_AGENT_LLM_KEY` to `PROMPT_BLOCK_LLM_KEY` in `config.py` and updated its usage in `block.py`.
> 
>   - **Renaming**:
>     - Rename `TEXT_ONLY_AGENT_LLM_KEY` to `PROMPT_BLOCK_LLM_KEY` in `config.py`.
>     - Update reference from `TEXT_ONLY_AGENT_LLM_KEY` to `PROMPT_BLOCK_LLM_KEY` in `block.py`.
>   - **Behavior**:
>     - `DEFAULT_TEXT_PROMPT_LLM_KEY` in `block.py` now uses `PROMPT_BLOCK_LLM_KEY` or falls back to `LLM_KEY`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 858eee383c7bb10f9087f484544963eb4f6ff4d0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->