### PR TITLE
update action history prompt

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1542,29 +1542,28 @@ class ForgeAgent:
                 actions_and_results.extend(window_step.output.actions_and_results)
 
         # exclude successful action from history
-        return json.dumps(
-            [
-                {
-                    "action": action.model_dump(
+        action_history = [
+            {
+                "action": action.model_dump(
+                    exclude_none=True,
+                    include={"action_type", "element_id", "status", "reasoning", "option", "download"},
+                ),
+                "results": [
+                    result.model_dump(
                         exclude_none=True,
-                        include={"action_type", "element_id", "status", "reasoning", "option", "download"},
-                    ),
-                    "results": [
-                        result.model_dump(
-                            exclude_none=True,
-                            include={
-                                "success",
-                                "exception_type",
-                                "exception_message",
-                            },
-                        )
-                        for result in results
-                    ],
-                }
-                for action, results in actions_and_results
-                if len(results) > 0
-            ]
-        )
+                        include={
+                            "success",
+                            "exception_type",
+                            "exception_message",
+                        },
+                    )
+                    for result in results
+                ],
+            }
+            for action, results in actions_and_results
+            if len(results) > 0
+        ]
+        return json.dumps(action_history) if action_history else ""
 
     async def get_extracted_information_for_task(self, task: Task) -> dict[str, Any] | list | str | None:
         """

--- a/skyvern/forge/prompts/skyvern/check-user-goal.j2
+++ b/skyvern/forge/prompts/skyvern/check-user-goal.j2
@@ -9,11 +9,6 @@ Make sure to ONLY return the JSON object in this format with no additional text 
 }
 ```
 
-Elements on the page:
-```
-{{ elements }}
-```
-
 User Goal:
 ```
 {{ navigation_goal }}
@@ -28,3 +23,8 @@ Complete Criterion:
 ```
 {{ complete_criterion }}
 ```{% endif %}
+
+Elements on the page:
+```
+{{ elements }}
+```

--- a/skyvern/forge/prompts/skyvern/extract-action.j2
+++ b/skyvern/forge/prompts/skyvern/extract-action.j2
@@ -42,13 +42,12 @@ Reply in JSON format with the following keys:
 }
 {% if action_history %}
 Consider the action history from the last step and the screenshot together, if actions from the last step don't yield positive impact, try other actions or other action combinations.
-{% endif %}
-Clickable elements from `{{ current_url }}`:
-```
-{{ elements }}
-```
 
-The URL of the page you're on right now is `{{ current_url }}`.
+Action history from previous steps: (note: even if the action history suggests goal is achieved, check the screenshot and the DOM elements to make sure the goal is achieved)
+```
+{{ action_history }}
+```
+{% endif %}
 {% if complete_criterion %}
 Complete criterion:
 ```
@@ -74,10 +73,14 @@ User details:
 ```
 {{ navigation_payload_str }}
 ```
-{% if action_history %}
-Action results from previous steps: (note: even if the action history suggests goal is achieved, check the screenshot and the DOM elements to make sure the goal is achieved)
-{{ action_history }}
-{% endif %}
+
+Clickable elements from `{{ current_url }}`:
+```
+{{ elements }}
+```
+
+The URL of the page you're on right now is `{{ current_url }}`.
+
 Current datetime, ISO format:
 ```
 {{ local_datetime }}

--- a/skyvern/forge/prompts/skyvern/single-click-action.j2
+++ b/skyvern/forge/prompts/skyvern/single-click-action.j2
@@ -19,13 +19,6 @@ Reply in JSON format with the following keys:
     }]
 }
 
-The URL of the page you're on right now is `{{ current_url }}`.
-
-HTML elements from `{{ current_url }}`:
-```
-{{ elements }}
-```
-
 User instruction (user's intention or self questioning to help figure out what to click):
 ```
 {{ navigation_goal }}
@@ -40,6 +33,13 @@ Context of the big goal user wants to achieve:
 ```
 {{ user_context }}
 ```{% endif %}
+
+The URL of the page you're on right now is `{{ current_url }}`.
+
+HTML elements from `{{ current_url }}`:
+```
+{{ elements }}
+```
 
 Current datetime, ISO format:
 ```

--- a/skyvern/forge/prompts/skyvern/single-input-action.j2
+++ b/skyvern/forge/prompts/skyvern/single-input-action.j2
@@ -20,13 +20,6 @@ Reply in JSON format with the following keys:
     "need_verification_code": bool, // Whether a verification code is needed to proceed. True only if the code is available to user. If the code is not sent, return false {% endif %}
 }
 
-The URL of the page you're on right now is `{{ current_url }}`.
-
-HTML elements from `{{ current_url }}`:
-```
-{{ elements }}
-```
-
 User instruction:
 ```
 {{ navigation_goal }}
@@ -35,6 +28,13 @@ User instruction:
 User details:
 ```
 {{ navigation_payload_str }}
+```
+
+The URL of the page you're on right now is `{{ current_url }}`.
+
+HTML elements from `{{ current_url }}`:
+```
+{{ elements }}
 ```
 
 Current datetime, ISO format:

--- a/skyvern/forge/prompts/skyvern/single-select-action.j2
+++ b/skyvern/forge/prompts/skyvern/single-select-action.j2
@@ -22,13 +22,6 @@ Reply in JSON format with the following keys:
     }]
 }
 
-The URL of the page you're on right now is `{{ current_url }}`.
-
-HTML elements from `{{ current_url }}`:
-```
-{{ elements }}
-```
-
 User instruction:
 ```
 {{ navigation_goal }}
@@ -37,6 +30,13 @@ User instruction:
 User details:
 ```
 {{ navigation_payload_str }}
+```
+
+The URL of the page you're on right now is `{{ current_url }}`.
+
+HTML elements from `{{ current_url }}`:
+```
+{{ elements }}
 ```
 
 Current datetime, ISO format:

--- a/skyvern/forge/prompts/skyvern/single-upload-action.j2
+++ b/skyvern/forge/prompts/skyvern/single-upload-action.j2
@@ -18,13 +18,6 @@ Reply in JSON format with the following keys:
     }]
 }
 
-The URL of the page you're on right now is `{{ current_url }}`.
-
-HTML elements from `{{ current_url }}`:
-```
-{{ elements }}
-```
-
 User instruction:
 ```
 {{ navigation_goal }}
@@ -33,6 +26,13 @@ User instruction:
 User details:
 ```
 {{ navigation_payload_str }}
+```
+
+The URL of the page you're on right now is `{{ current_url }}`.
+
+HTML elements from `{{ current_url }}`:
+```
+{{ elements }}
 ```
 
 Current datetime, ISO format:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update action history prompt in `agent.py` and reorder sections in several prompt templates for clarity.
> 
>   - **Behavior**:
>     - In `agent.py`, `_get_action_results()` now returns an empty string if `action_history` is empty.
>   - **Prompts**:
>     - In `check-user-goal.j2`, moved "Elements on the page" section to the end.
>     - In `extract-action.j2`, moved "Clickable elements" and "URL" sections to the end.
>     - In `single-click-action.j2`, `single-input-action.j2`, `single-select-action.j2`, and `single-upload-action.j2`, moved "URL" and "HTML elements" sections to the end.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 408b7f4dee854d7c883d063dba70882aa0b3d52c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->