### PR TITLE
it's okay to have null password and we just show it as an empty string

### DIFF
--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -61,8 +61,8 @@ def get_list_response_item_from_bitwarden_item(item: dict) -> CredentialItem:
         return CredentialItem(
             item_id=item["id"],
             credential=PasswordCredential(
-                username=login["username"],
-                password=login["password"],
+                username=login["username"] or "",
+                password=login["password"] or "",
                 totp=login["totp"],
             ),
             name=item["name"],
@@ -742,8 +742,8 @@ class BitwardenService:
             raise BitwardenGetItemError(f"Item with ID: {item_id} is not a login item")
 
         return PasswordCredential(
-            username=login["username"],
-            password=login["password"],
+            username=login["username"] or "",
+            password=login["password"] or "",
             totp=login["totp"],
         )
 
@@ -981,8 +981,8 @@ class BitwardenService:
                 credential_type=CredentialType.PASSWORD,
                 name=name,
                 credential=PasswordCredential(
-                    username=login_item["username"],
-                    password=login_item["password"],
+                    username=login_item["username"] or "",
+                    password=login_item["password"] or "",
                     totp=login_item["totp"],
                 ),
             )


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Ensure null `username` and `password` are replaced with empty strings in `bitwarden.py`.
> 
>   - **Behavior**:
>     - In `get_list_response_item_from_bitwarden_item()`, `username` and `password` are set to empty strings if null.
>     - In `_get_login_item_by_id_using_server()`, `username` and `password` are set to empty strings if null.
>     - In `_get_credential_item_by_id_using_server()`, `username` and `password` are set to empty strings if null.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for f6375a677e7a99ee944079c055cdb8f0bc39e2fe. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->