### PR TITLE
Don't allow empty strings in credential creation api

### DIFF
--- a/skyvern/forge/sdk/schemas/credentials.py
+++ b/skyvern/forge/sdk/schemas/credentials.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class CredentialType(StrEnum):
@@ -24,6 +24,11 @@ class PasswordCredential(BaseModel):
     totp: str | None = None
 
 
+class NonEmptyPasswordCredential(PasswordCredential):
+    password: str = Field(..., min_length=1)
+    username: str = Field(..., min_length=1)
+
+
 class CreditCardCredential(BaseModel):
     card_number: str
     card_cvv: str
@@ -31,6 +36,15 @@ class CreditCardCredential(BaseModel):
     card_exp_year: str
     card_brand: str
     card_holder_name: str
+
+
+class NonEmptyCreditCardCredential(CreditCardCredential):
+    card_number: str = Field(..., min_length=1)
+    card_cvv: str = Field(..., min_length=1)
+    card_exp_month: str = Field(..., min_length=1)
+    card_exp_year: str = Field(..., min_length=1)
+    card_brand: str = Field(..., min_length=1)
+    card_holder_name: str = Field(..., min_length=1)
 
 
 class CredentialItem(BaseModel):
@@ -43,7 +57,7 @@ class CredentialItem(BaseModel):
 class CreateCredentialRequest(BaseModel):
     name: str
     credential_type: CredentialType
-    credential: PasswordCredential | CreditCardCredential
+    credential: NonEmptyPasswordCredential | NonEmptyCreditCardCredential
 
 
 class CredentialResponse(BaseModel):


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `CreateCredentialRequest` to prevent empty strings in credential fields using new non-empty credential classes.
> 
>   - **Behavior**:
>     - `CreateCredentialRequest` now uses `NonEmptyPasswordCredential` and `NonEmptyCreditCardCredential` to prevent empty strings in credential fields.
>   - **Models**:
>     - Adds `NonEmptyPasswordCredential` with non-empty `password` and `username` fields.
>     - Adds `NonEmptyCreditCardCredential` with non-empty fields for `card_number`, `card_cvv`, `card_exp_month`, `card_exp_year`, `card_brand`, and `card_holder_name`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d1f536c7ff22aa528a7de17488f4780510cee3fc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->