### PR TITLE
remove dist before poetry build

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -70,6 +70,9 @@ jobs:
       # they'll be installed and working.
       - run: poetry install --no-interaction
 
+      - name: Clean dist directory
+        run: rm -rf dist
+    
       - name: Build Package
         run: poetry build
 
@@ -78,6 +81,3 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: poetry run twine upload --repository pypi dist/*
-
-
-


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add step to clean `dist` directory before building package in `sdk-release.yml`.
> 
>   - **Workflow Changes**:
>     - Adds a step to clean the `dist` directory in `.github/workflows/sdk-release.yml` before building the package with `poetry build`.
>     - Ensures no old build artifacts are present before the build process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b7a28937c45067f07a1b0bd9413a0e9ff1370153. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->