### PR TITLE
fix output parameter bug

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -1718,6 +1718,21 @@ class AgentDB:
             LOG.error("SQLAlchemyError", exc_info=True)
             raise
 
+    async def get_workflow_output_parameters_by_ids(self, output_parameter_ids: list[str]) -> list[OutputParameter]:
+        try:
+            async with self.Session() as session:
+                output_parameters = (
+                    await session.scalars(
+                        select(OutputParameterModel).filter(
+                            OutputParameterModel.output_parameter_id.in_(output_parameter_ids)
+                        )
+                    )
+                ).all()
+                return [convert_to_output_parameter(parameter) for parameter in output_parameters]
+        except SQLAlchemyError:
+            LOG.error("SQLAlchemyError", exc_info=True)
+            raise
+
     async def create_credential_parameter(
         self, workflow_id: str, key: str, credential_id: str, description: str | None = None
     ) -> CredentialParameter:

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -929,7 +929,12 @@ class WorkflowService:
         workflow_run_output_parameters = await app.DATABASE.get_workflow_run_output_parameters(
             workflow_run_id=workflow_run_id
         )
-        output_parameters = await app.DATABASE.get_workflow_output_parameters(workflow_id=workflow_id)
+        output_parameters = await app.DATABASE.get_workflow_output_parameters_by_ids(
+            output_parameter_ids=[
+                workflow_run_output_parameter.output_parameter_id
+                for workflow_run_output_parameter in workflow_run_output_parameters
+            ]
+        )
 
         return [
             (output_parameter, workflow_run_output_parameter)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `get_workflow_output_parameters_by_ids()` in `client.py` and updates `service.py` to use it for fetching specific output parameters by IDs.
> 
>   - **Behavior**:
>     - Adds `get_workflow_output_parameters_by_ids()` in `client.py` to fetch output parameters by IDs.
>     - Updates `get_output_parameter_workflow_run_output_parameter_tuples()` in `service.py` to use `get_workflow_output_parameters_by_ids()` instead of fetching all parameters.
>   - **Error Handling**:
>     - Logs `SQLAlchemyError` in `get_workflow_output_parameters_by_ids()` in `client.py` and raises the exception.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 54c0b7327baeb5fc2a589c218738ed0877f7ce78. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->