### PR TITLE
add dataSchema to task v2 UI

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
@@ -167,7 +167,15 @@ function PromptBox() {
           proxy_location: proxyLocation,
           totp_identifier: totpIdentifier,
           publish_workflow: publishWorkflow,
-          extracted_information_schema: dataSchema,
+          extracted_information_schema: dataSchema
+            ? (() => {
+                try {
+                  return JSON.parse(dataSchema);
+                } catch (e) {
+                  return dataSchema;
+                }
+              })()
+            : null,
         },
         {
           headers: {
@@ -425,8 +433,8 @@ function PromptBox() {
                         onChange={(value) => setDataSchema(value || null)}
                         language="json"
                         minHeight="100px"
-                        maxHeight="200px"
-                        fontSize={14}
+                        maxHeight="500px"
+                        fontSize={8}
                       />
                     </div>
                   </div>

--- a/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
@@ -25,6 +25,7 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { toast } from "@/components/ui/use-toast";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
+import { CodeEditor } from "@/routes/workflows/components/CodeEditor";
 import {
   FileTextIcon,
   GearIcon,
@@ -153,6 +154,7 @@ function PromptBox() {
   const [totpIdentifier, setTotpIdentifier] = useState("");
   const [maxStepsOverride, setMaxStepsOverride] = useState<string | null>(null);
   const [showAdvancedSettings, setShowAdvancedSettings] = useState(false);
+  const [dataSchema, setDataSchema] = useState<string | null>(null);
 
   const startObserverCruiseMutation = useMutation({
     mutationFn: async (prompt: string) => {
@@ -165,6 +167,7 @@ function PromptBox() {
           proxy_location: proxyLocation,
           totp_identifier: totpIdentifier,
           publish_workflow: publishWorkflow,
+          extracted_information_schema: dataSchema,
         },
         {
           headers: {
@@ -408,6 +411,24 @@ function PromptBox() {
                         setMaxStepsOverride(event.target.value);
                       }}
                     />
+                  </div>
+                  <div className="flex gap-16">
+                    <div className="w-48 shrink-0">
+                      <div className="text-sm">Data Schema</div>
+                      <div className="text-xs text-slate-400">
+                        Specify the output data schema in JSON format
+                      </div>
+                    </div>
+                    <div className="flex-1">
+                      <CodeEditor
+                        value={dataSchema ?? ""}
+                        onChange={(value) => setDataSchema(value || null)}
+                        language="json"
+                        minHeight="100px"
+                        maxHeight="200px"
+                        fontSize={14}
+                      />
+                    </div>
                   </div>
                 </div>
               </div>

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -839,7 +839,7 @@ async def delete_workflow(
 
 
 @base_router.get("/workflows", response_model=list[Workflow])
-@base_router.get("/workflows/", response_model=list[Workflow])
+@base_router.get("/workflows/", response_model=list[Workflow], include_in_schema=False)
 async def get_workflows(
     page: int = Query(1, ge=1),
     page_size: int = Query(10, ge=1),


### PR DESCRIPTION
preview of the UI:
<img width="679" alt="Screenshot 2025-03-18 at 2 39 23 PM" src="https://github.com/user-attachments/assets/ce800e11-0f4c-42c8-9683-5f4b61195db2" />



<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add JSON data schema input to task creation UI in `PromptBox.tsx`.
> 
>   - **Behavior**:
>     - Adds `dataSchema` state to `PromptBox` in `PromptBox.tsx` to store JSON data schema.
>     - Includes `dataSchema` in task creation request in `startObserverCruiseMutation`.
>   - **UI**:
>     - Adds `CodeEditor` for JSON input in `PromptBox.tsx` under advanced settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b291a3e472729823edd0010d3ea4dcf52fccfb7c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->