### PR TITLE
don't add helper attr as hack for checkbox and radio

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1311,16 +1311,6 @@ async function buildElementObject(
     attrs["required"] = true;
   }
 
-  if (
-    elementTagNameLower === "input" &&
-    (element.type === "radio" || element.type === "checkbox")
-  ) {
-    // if checkbox and radio don't have "checked" and "aria-checked", add a checked="false" to help LLM understand
-    if (!("checked" in attrs) && !("aria-checked" in attrs)) {
-      attrs["checked"] = false;
-    }
-  }
-
   if (elementTagNameLower === "input" || elementTagNameLower === "textarea") {
     if (element.type === "password") {
       attrs["value"] = element.value ? "*".repeat(element.value.length) : "";


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes code in `domUtils.js` that added `checked: false` to `radio` and `checkbox` inputs without `checked` or `aria-checked` attributes.
> 
>   - **Behavior**:
>     - Removes code in `buildElementObject` in `domUtils.js` that added `checked: false` to `input` elements of type `radio` or `checkbox` without `checked` or `aria-checked` attributes.
>   - **Misc**:
>     - Simplifies handling of `input` elements by relying on existing attributes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 7df11c389a202f268b59d7c2f8a2bf9a612f822e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->