### PR TITLE
Allow nested loop blocks

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -73,6 +73,7 @@ import {
   convertEchoParameters,
   createNode,
   defaultEdge,
+  descendants,
   generateNodeLabel,
   getAdditionalParametersForEmailBlock,
   getOutputParameterKey,
@@ -408,10 +409,20 @@ function FlowRenderer({
     if (!node || !isWorkflowBlockNode(node)) {
       return;
     }
+    const nodesToDelete = descendants(nodes, id);
     const deletedNodeLabel = node.data.label;
-    const newNodes = nodes.filter((node) => node.id !== id);
+    const newNodes = nodes.filter(
+      (node) => !nodesToDelete.includes(node) && node.id !== id,
+    );
     const newEdges = edges.flatMap((edge) => {
       if (edge.source === id) {
+        return [];
+      }
+      if (
+        nodesToDelete.some(
+          (node) => node.id === edge.source || node.id === edge.target,
+        )
+      ) {
         return [];
       }
       if (edge.target === id) {

--- a/skyvern-frontend/src/routes/workflows/editor/edges/EdgeWithAddButton.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/edges/EdgeWithAddButton.tsx
@@ -56,7 +56,6 @@ function EdgeWithAddButton({
             size="icon"
             className="h-4 w-4 rounded-full transition-all hover:scale-150"
             onClick={() => {
-              const disableLoop = Boolean(sourceNode?.parentId);
               setWorkflowPanelState({
                 active: true,
                 content: "nodeLibrary",
@@ -64,7 +63,6 @@ function EdgeWithAddButton({
                   previous: source,
                   next: target,
                   parent: sourceNode?.parentId,
-                  disableLoop,
                 },
               });
             }}

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/LoopNode/LoopNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/LoopNode/LoopNode.tsx
@@ -21,10 +21,15 @@ import type { LoopNode } from "./types";
 import { useState } from "react";
 import { useIsFirstBlockInWorkflow } from "../../hooks/useIsFirstNodeInWorkflow";
 import { Checkbox } from "@/components/ui/checkbox";
+import { getLoopNodeWidth } from "../../workflowEditorUtils";
 
 function LoopNode({ id, data }: NodeProps<LoopNode>) {
   const { updateNodeData } = useReactFlow();
   const nodes = useNodes<AppNode>();
+  const node = nodes.find((n) => n.id === id);
+  if (!node) {
+    throw new Error("Node not found"); // not possible
+  }
   const [label, setLabel] = useNodeLabelChangeHandler({
     id,
     initialValue: data.label,
@@ -55,6 +60,7 @@ function LoopNode({ id, data }: NodeProps<LoopNode>) {
     (furthestDownChild?.position.y ?? 0) +
     24;
 
+  const loopNodeWidth = getLoopNodeWidth(node, nodes);
   function handleChange(key: string, value: unknown) {
     if (!data.editable) {
       return;
@@ -78,8 +84,9 @@ function LoopNode({ id, data }: NodeProps<LoopNode>) {
         className="opacity-0"
       />
       <div
-        className="w-[600px] rounded-xl border-2 border-dashed border-slate-600 p-2"
+        className="rounded-xl border-2 border-dashed border-slate-600 p-2"
         style={{
+          width: loopNodeWidth,
           height: childrenHeightExtent,
         }}
       >

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/NodeAdderNode/NodeAdderNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/NodeAdderNode/NodeAdderNode.tsx
@@ -27,7 +27,6 @@ function NodeAdderNode({ id, parentId }: NodeProps<NodeAdderNode>) {
         className="rounded-full bg-slate-50 p-2"
         onClick={() => {
           const previous = edges.find((edge) => edge.target === id)?.source;
-          const disableLoop = Boolean(parentId);
           setWorkflowPanelState({
             active: true,
             content: "nodeLibrary",
@@ -36,7 +35,6 @@ function NodeAdderNode({ id, parentId }: NodeProps<NodeAdderNode>) {
               next: id,
               parent: parentId,
               connectingEdgeType: "default",
-              disableLoop,
             },
           });
         }}


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enable nested loop blocks in the workflow editor by updating node and edge management, layout logic, and introducing new utility functions.
> 
>   - **Behavior**:
>     - Allow nested loop blocks in `FlowRenderer.tsx` by updating `deleteNode()` to handle descendant nodes and edges.
>     - Adjust `addNode()` to initialize loop nodes with `startNode` and `nodeAdderNode`.
>     - Update `getOrderedChildrenBlocks()` in `workflowEditorUtils.ts` to handle nested loops.
>   - **Functions**:
>     - Add `descendants()` in `workflowEditorUtils.ts` to retrieve all descendant nodes.
>     - Add `getLoopNodeWidth()` in `workflowEditorUtils.ts` to calculate loop node width based on nesting level.
>   - **Misc**:
>     - Remove `disableLoop` logic from `EdgeWithAddButton.tsx` and `NodeAdderNode.tsx`.
>     - Update layout logic in `layout()` in `workflowEditorUtils.ts` to accommodate nested loops.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 165e423a08ee0071e968639fe97867a138ff1ff1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->