### PR TITLE
task v2 support jinja style

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -2229,6 +2229,22 @@ class TaskV2Block(Block):
     ) -> list[PARAMETER_TYPE]:
         return []
 
+    def format_potential_template_parameters(self, workflow_run_context: WorkflowRunContext) -> None:
+        self.prompt = self.format_block_parameter_template_from_workflow_run_context(self.prompt, workflow_run_context)
+        if self.url:
+            self.url = self.format_block_parameter_template_from_workflow_run_context(self.url, workflow_run_context)
+
+        if self.totp_identifier:
+            self.totp_identifier = self.format_block_parameter_template_from_workflow_run_context(
+                self.totp_identifier, workflow_run_context
+            )
+
+        if self.totp_verification_url:
+            self.totp_verification_url = self.format_block_parameter_template_from_workflow_run_context(
+                self.totp_verification_url, workflow_run_context
+            )
+            self.totp_verification_url = prepend_scheme_and_validate_url(self.totp_verification_url)
+
     async def execute(
         self,
         workflow_run_id: str,
@@ -2239,6 +2255,19 @@ class TaskV2Block(Block):
     ) -> BlockResult:
         from skyvern.forge.sdk.services import task_v2_service
         from skyvern.forge.sdk.workflow.models.workflow import WorkflowRunStatus
+
+        workflow_run_context = self.get_workflow_run_context(workflow_run_id)
+        try:
+            self.format_potential_template_parameters(workflow_run_context)
+        except Exception as e:
+            return await self.build_block_result(
+                success=False,
+                failure_reason=f"Failed to format jinja template: {str(e)}",
+                output_parameter_value=None,
+                status=BlockStatus.failed,
+                workflow_run_block_id=workflow_run_block_id,
+                organization_id=organization_id,
+            )
 
         if not self.url:
             browser_state = app.BROWSER_MANAGER.get_for_workflow_run(workflow_run_id)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add Jinja-style template support to `TaskV2Block` with error handling for template formatting failures.
> 
>   - **Behavior**:
>     - Adds `format_potential_template_parameters()` to `TaskV2Block` to support Jinja-style template formatting for `prompt`, `url`, `totp_identifier`, and `totp_verification_url`.
>     - Updates `execute()` in `TaskV2Block` to call `format_potential_template_parameters()` and handle exceptions by logging and returning a failure result.
>   - **Misc**:
>     - Adds error handling in `execute()` to log and return a failure result if template formatting fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d919524352b9f18542e9ea567caeecb0f97b0c6d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->