### PR TITLE
fix StepModel.reasoning_token_count and cached_token_count

### DIFF
--- a/skyvern/forge/sdk/models.py
+++ b/skyvern/forge/sdk/models.py
@@ -52,8 +52,8 @@ class Step(BaseModel):
     organization_id: str | None = None
     input_token_count: int = 0
     output_token_count: int = 0
-    reasoning_token_count: int = 0
-    cached_token_count: int = 0
+    reasoning_token_count: int | None = None
+    cached_token_count: int | None = None
     step_cost: float = 0
 
     def validate_update(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change `reasoning_token_count` and `cached_token_count` in `Step` class to allow `None` values.
> 
>   - **Models**:
>     - Change `reasoning_token_count` and `cached_token_count` in `Step` class in `models.py` from `int` to `int | None` to allow `None` values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c6fb2389eb2e6019dde8479041d8ff442b8c9f43. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->