### PR TITLE
only show output or files when there is at least one thing to show

### DIFF
--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -51,8 +51,11 @@ function WorkflowRun() {
     workflowPermanentId,
   });
 
-  const { data: workflowRun, isLoading: workflowRunIsLoading } =
-    useWorkflowRunQuery();
+  const {
+    data: workflowRun,
+    isLoading: workflowRunIsLoading,
+    isFetched,
+  } = useWorkflowRunQuery();
 
   const { data: workflowRunTimeline } = useWorkflowRunTimelineQuery();
 
@@ -137,7 +140,23 @@ function WorkflowRun() {
     outputs ?? {},
   );
 
-  const fileUrls = workflowRun?.downloaded_file_urls ?? [];
+  const hasSomeExtractedInformation = Object.values(
+    aggregatedExtractedInformation,
+  ).some((value) => value !== null);
+
+  const hasFileUrls =
+    isFetched &&
+    workflowRun &&
+    workflowRun.downloaded_file_urls &&
+    workflowRun.downloaded_file_urls.length > 0;
+  const fileUrls = hasFileUrls
+    ? (workflowRun.downloaded_file_urls as string[])
+    : [];
+
+  const showOutputSection =
+    workflowRunIsFinalized &&
+    (hasSomeExtractedInformation || hasFileUrls) &&
+    workflowRun.status === Status.Completed;
 
   return (
     <div className="space-y-8">
@@ -240,7 +259,7 @@ function WorkflowRun() {
           )}
         </div>
       </header>
-      {workflowRunIsFinalized && workflowRun.status === Status.Completed && (
+      {showOutputSection && (
         <div className="grid grid-cols-2 gap-4 rounded-lg bg-slate-elevation1 p-4">
           <div className="space-y-4">
             <Label>Extracted Information</Label>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Conditionally display output section in `WorkflowRun.tsx` based on workflow completion and presence of extracted information or file URLs.
> 
>   - **Behavior**:
>     - In `WorkflowRun.tsx`, the output section is now shown only if `workflowRunIsFinalized`, `workflowRun.status` is `Status.Completed`, and there is either extracted information or file URLs.
>     - Introduces `hasSomeExtractedInformation` and `hasFileUrls` checks to determine the presence of extracted information and file URLs respectively.
>   - **Variables**:
>     - Adds `isFetched` to `useWorkflowRunQuery()` to check if data is fetched.
>     - Defines `hasSomeExtractedInformation` and `hasFileUrls` to check for extracted information and file URLs.
>     - Introduces `showOutputSection` to control the display of the output section.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 438b9f67a7955d91c416b19774dca3fe8c1869ee. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->