### PR TITLE
Workflow output hide whatever is not present

### DIFF
--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -38,6 +38,7 @@ import { findActiveItem } from "./workflowRun/workflowTimelineUtils";
 import { getAggregatedExtractedInformation } from "./workflowRun/workflowRunUtils";
 import { Label } from "@/components/ui/label";
 import { CodeEditor } from "./components/CodeEditor";
+import { cn } from "@/util/utils";
 
 function WorkflowRun() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -153,6 +154,8 @@ function WorkflowRun() {
     ? (workflowRun.downloaded_file_urls as string[])
     : [];
 
+  const showBoth = hasSomeExtractedInformation && hasFileUrls;
+
   const showOutputSection =
     workflowRunIsFinalized &&
     (hasSomeExtractedInformation || hasFileUrls) &&
@@ -260,35 +263,43 @@ function WorkflowRun() {
         </div>
       </header>
       {showOutputSection && (
-        <div className="grid grid-cols-2 gap-4 rounded-lg bg-slate-elevation1 p-4">
-          <div className="space-y-4">
-            <Label>Extracted Information</Label>
-            <CodeEditor
-              language="json"
-              value={JSON.stringify(aggregatedExtractedInformation, null, 2)}
-              readOnly
-              maxHeight="250px"
-            />
-          </div>
-          <div className="space-y-4">
-            <Label>Downloaded Files</Label>
-            <div className="space-y-2">
-              {fileUrls.length > 0 ? (
-                fileUrls.map((url, index) => {
-                  return (
-                    <div key={url} title={url} className="flex gap-2">
-                      <FileIcon className="size-6" />
-                      <a href={url} className="underline underline-offset-4">
-                        <span>{`File ${index + 1}`}</span>
-                      </a>
-                    </div>
-                  );
-                })
-              ) : (
-                <div className="text-sm">No files downloaded</div>
-              )}
+        <div
+          className={cn("grid gap-4 rounded-lg bg-slate-elevation1 p-4", {
+            "grid-cols-2": showBoth,
+          })}
+        >
+          {hasSomeExtractedInformation && (
+            <div className="space-y-4">
+              <Label>Extracted Information</Label>
+              <CodeEditor
+                language="json"
+                value={JSON.stringify(aggregatedExtractedInformation, null, 2)}
+                readOnly
+                maxHeight="250px"
+              />
             </div>
-          </div>
+          )}
+          {hasFileUrls && (
+            <div className="space-y-4">
+              <Label>Downloaded Files</Label>
+              <div className="space-y-2">
+                {fileUrls.length > 0 ? (
+                  fileUrls.map((url, index) => {
+                    return (
+                      <div key={url} title={url} className="flex gap-2">
+                        <FileIcon className="size-6" />
+                        <a href={url} className="underline underline-offset-4">
+                          <span>{`File ${index + 1}`}</span>
+                        </a>
+                      </div>
+                    );
+                  })
+                ) : (
+                  <div className="text-sm">No files downloaded</div>
+                )}
+              </div>
+            </div>
+          )}
         </div>
       )}
       {workflowFailureReason}


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Conditionally render output sections in `WorkflowRun.tsx` based on extracted information and file URLs presence.
> 
>   - **Behavior**:
>     - In `WorkflowRun.tsx`, output sections for "Extracted Information" and "Downloaded Files" are now conditionally rendered based on the presence of data.
>     - Introduces `showBoth` to determine if both sections should be displayed side by side.
>     - Updates `showOutputSection` logic to only display if `workflowRun` is finalized and has either extracted information or file URLs.
>   - **Utilities**:
>     - Imports `cn` from `@/util/utils` for conditional class names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a6ec4347531825c0aeb4a78cfa6540004cc7303b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->