### PR TITLE
remove pypi output in fern generators.yml

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -12,9 +12,6 @@ groups:
       - name: fernapi/fern-python-sdk
         smart-casing: true
         version: 4.3.17
-        output:
-          location: pypi
-          package-name: skyvern
         github:
           repository: Skyvern-AI/skyvern-python
         config:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove PyPI output configuration from `fern/generators.yml` for `fernapi/fern-python-sdk`.
> 
>   - **Configuration Changes**:
>     - Remove PyPI output configuration from `fern/generators.yml` for `fernapi/fern-python-sdk`.
>     - `package-name: skyvern` and `location: pypi` removed.
>     - GitHub repository `Skyvern-AI/skyvern-python` configuration remains unchanged.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 68c84da77c46250d0976025f3cb72a487f3fad04. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->