### PR TITLE
revert checkbox detect enhance

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -811,21 +811,6 @@ function isDatePickerSelector(element) {
   return false;
 }
 
-function isCheckableDiv(element) {
-  const tagName = element.tagName.toLowerCase();
-  if (tagName !== "div") {
-    return false;
-  }
-  if (
-    element.className &&
-    element.className.toString().includes("checkbox") &&
-    element.childElementCount === 0
-  ) {
-    return true;
-  }
-  return false;
-}
-
 const isComboboxDropdown = (element) => {
   if (element.tagName.toLowerCase() !== "input") {
     return false;
@@ -1345,7 +1330,6 @@ async function buildElementObject(
       isAngularMaterialDatePicker(element) ||
       isSelect2Dropdown(element) ||
       isSelect2MultiChoice(element),
-    isCheckable: isCheckableDiv(element),
   };
 
   let isInShadowRoot = element.getRootNode() instanceof ShadowRoot;

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -105,10 +105,6 @@ def json_to_html(element: dict, need_skyvern_attrs: bool = True) -> str:
             LOG.info("Element is interactable. Trimmed all attributes instead of dropping it", element=element)
             attributes = {}
 
-    if element.get("isCheckable", False) and tag != "input":
-        tag = "input"
-        attributes["type"] = "checkbox"
-
     context = skyvern_context.ensure_context()
 
     # FIXME: Theoretically, all href links with over 69(64+1+4) length could be hashed


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reverts checkbox detection enhancement by removing `isCheckableDiv` function and related logic in `domUtils.js` and `scraper.py`.
> 
>   - **Behavior**:
>     - Remove `isCheckableDiv` function from `domUtils.js`.
>     - Remove `isCheckable` property assignment in `buildElementObject()` in `domUtils.js`.
>     - Remove logic in `json_to_html()` in `scraper.py` that converted non-input checkable elements to input type checkbox.
>   - **Misc**:
>     - Simplifies element processing by removing checkable div detection logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c358dc0aa4d50649bf9c801ad19e64a7f7ea8386. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->