### PR TITLE
migrate ProxyLocation to skyvern.schemas.runs

### DIFF
--- a/evaluation/core/__init__.py
+++ b/evaluation/core/__init__.py
@@ -13,8 +13,9 @@ from skyvern.forge import app
 from skyvern.forge.prompts import prompt_engine
 from skyvern.forge.sdk.api.files import create_folder_if_not_exist
 from skyvern.forge.sdk.schemas.task_v2 import TaskV2, TaskV2Request
-from skyvern.forge.sdk.schemas.tasks import ProxyLocation, TaskRequest, TaskResponse, TaskStatus
+from skyvern.forge.sdk.schemas.tasks import TaskRequest, TaskResponse, TaskStatus
 from skyvern.forge.sdk.workflow.models.workflow import WorkflowRequestBody, WorkflowRunResponse, WorkflowRunStatus
+from skyvern.schemas.runs import ProxyLocation
 
 
 class TaskOutput(BaseModel):

--- a/evaluation/script/create_webvoyager_workflow.py
+++ b/evaluation/script/create_webvoyager_workflow.py
@@ -11,8 +11,8 @@ from evaluation.core import Evaluator, SkyvernClient
 from evaluation.core.utils import load_webvoyager_case_from_json
 from skyvern.forge import app
 from skyvern.forge.prompts import prompt_engine
-from skyvern.forge.sdk.schemas.tasks import ProxyLocation
 from skyvern.forge.sdk.workflow.models.workflow import WorkflowRequestBody
+from skyvern.schemas.runs import ProxyLocation
 
 load_dotenv()
 

--- a/skyvern/agent/client.py
+++ b/skyvern/agent/client.py
@@ -6,8 +6,8 @@ import httpx
 from skyvern.config import settings
 from skyvern.exceptions import SkyvernClientException
 from skyvern.forge.sdk.schemas.task_runs import TaskRunResponse
-from skyvern.forge.sdk.schemas.tasks import ProxyLocation
 from skyvern.forge.sdk.workflow.models.workflow import RunWorkflowResponse, WorkflowRunResponse
+from skyvern.schemas.runs import ProxyLocation
 
 
 class RunEngine(StrEnum):

--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -69,7 +69,7 @@ from skyvern.forge.sdk.schemas.persistent_browser_sessions import PersistentBrow
 from skyvern.forge.sdk.schemas.task_generations import TaskGeneration
 from skyvern.forge.sdk.schemas.task_runs import TaskRun, TaskRunType
 from skyvern.forge.sdk.schemas.task_v2 import TaskV2, TaskV2Status, Thought, ThoughtType
-from skyvern.forge.sdk.schemas.tasks import OrderBy, ProxyLocation, SortDirection, Task, TaskStatus
+from skyvern.forge.sdk.schemas.tasks import OrderBy, SortDirection, Task, TaskStatus
 from skyvern.forge.sdk.schemas.totp_codes import TOTPCode
 from skyvern.forge.sdk.schemas.workflow_runs import WorkflowRunBlock
 from skyvern.forge.sdk.workflow.models.block import BlockStatus, BlockType
@@ -91,6 +91,7 @@ from skyvern.forge.sdk.workflow.models.workflow import (
     WorkflowRunStatus,
     WorkflowStatus,
 )
+from skyvern.schemas.runs import ProxyLocation
 from skyvern.webeye.actions.actions import Action
 from skyvern.webeye.actions.models import AgentStepOutput
 

--- a/skyvern/forge/sdk/db/utils.py
+++ b/skyvern/forge/sdk/db/utils.py
@@ -25,7 +25,7 @@ from skyvern.forge.sdk.db.models import (
 )
 from skyvern.forge.sdk.models import Step, StepStatus
 from skyvern.forge.sdk.schemas.organizations import Organization, OrganizationAuthToken
-from skyvern.forge.sdk.schemas.tasks import ProxyLocation, Task, TaskStatus
+from skyvern.forge.sdk.schemas.tasks import Task, TaskStatus
 from skyvern.forge.sdk.schemas.workflow_runs import WorkflowRunBlock
 from skyvern.forge.sdk.workflow.models.block import BlockStatus, BlockType
 from skyvern.forge.sdk.workflow.models.parameter import (
@@ -45,6 +45,7 @@ from skyvern.forge.sdk.workflow.models.workflow import (
     WorkflowRunStatus,
     WorkflowStatus,
 )
+from skyvern.schemas.runs import ProxyLocation
 
 LOG = structlog.get_logger()
 

--- a/skyvern/forge/sdk/schemas/task_runs.py
+++ b/skyvern/forge/sdk/schemas/task_runs.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 
 from pydantic import BaseModel, ConfigDict
 
-from skyvern.forge.sdk.schemas.tasks import ProxyLocation
+from skyvern.schemas.runs import ProxyLocation
 
 
 class TaskRunStatus(StrEnum):

--- a/skyvern/forge/sdk/schemas/task_v2.py
+++ b/skyvern/forge/sdk/schemas/task_v2.py
@@ -5,7 +5,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from skyvern.forge.sdk.core.validators import validate_url
-from skyvern.forge.sdk.schemas.tasks import ProxyLocation
+from skyvern.schemas.runs import ProxyLocation
 
 DEFAULT_WORKFLOW_TITLE = "New Workflow"
 

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from datetime import datetime
 from enum import StrEnum
 from typing import Any
-from zoneinfo import ZoneInfo
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -11,85 +10,7 @@ from skyvern.exceptions import InvalidTaskStatusTransition, TaskAlreadyCanceled,
 from skyvern.forge.sdk.core.validators import validate_url
 from skyvern.forge.sdk.db.enums import TaskType
 from skyvern.forge.sdk.schemas.files import FileInfo
-
-
-class ProxyLocation(StrEnum):
-    US_CA = "US-CA"
-    US_NY = "US-NY"
-    US_TX = "US-TX"
-    US_FL = "US-FL"
-    US_WA = "US-WA"
-    RESIDENTIAL = "RESIDENTIAL"
-    RESIDENTIAL_ES = "RESIDENTIAL_ES"
-    RESIDENTIAL_IE = "RESIDENTIAL_IE"
-    RESIDENTIAL_GB = "RESIDENTIAL_GB"
-    RESIDENTIAL_IN = "RESIDENTIAL_IN"
-    RESIDENTIAL_JP = "RESIDENTIAL_JP"
-    RESIDENTIAL_FR = "RESIDENTIAL_FR"
-    RESIDENTIAL_DE = "RESIDENTIAL_DE"
-    RESIDENTIAL_NZ = "RESIDENTIAL_NZ"
-    RESIDENTIAL_ZA = "RESIDENTIAL_ZA"
-    RESIDENTIAL_AR = "RESIDENTIAL_AR"
-    RESIDENTIAL_ISP = "RESIDENTIAL_ISP"
-    NONE = "NONE"
-
-
-def get_tzinfo_from_proxy(proxy_location: ProxyLocation) -> ZoneInfo | None:
-    if proxy_location == ProxyLocation.NONE:
-        return None
-
-    if proxy_location == ProxyLocation.US_CA:
-        return ZoneInfo("America/Los_Angeles")
-
-    if proxy_location == ProxyLocation.US_NY:
-        return ZoneInfo("America/New_York")
-
-    if proxy_location == ProxyLocation.US_TX:
-        return ZoneInfo("America/Chicago")
-
-    if proxy_location == ProxyLocation.US_FL:
-        return ZoneInfo("America/New_York")
-
-    if proxy_location == ProxyLocation.US_WA:
-        return ZoneInfo("America/New_York")
-
-    if proxy_location == ProxyLocation.RESIDENTIAL:
-        return ZoneInfo("America/New_York")
-
-    if proxy_location == ProxyLocation.RESIDENTIAL_ES:
-        return ZoneInfo("Europe/Madrid")
-
-    if proxy_location == ProxyLocation.RESIDENTIAL_IE:
-        return ZoneInfo("Europe/Dublin")
-
-    if proxy_location == ProxyLocation.RESIDENTIAL_GB:
-        return ZoneInfo("Europe/London")
-
-    if proxy_location == ProxyLocation.RESIDENTIAL_IN:
-        return ZoneInfo("Asia/Kolkata")
-
-    if proxy_location == ProxyLocation.RESIDENTIAL_JP:
-        return ZoneInfo("Asia/Tokyo")
-
-    if proxy_location == ProxyLocation.RESIDENTIAL_FR:
-        return ZoneInfo("Europe/Paris")
-
-    if proxy_location == ProxyLocation.RESIDENTIAL_DE:
-        return ZoneInfo("Europe/Berlin")
-
-    if proxy_location == ProxyLocation.RESIDENTIAL_NZ:
-        return ZoneInfo("Pacific/Auckland")
-
-    if proxy_location == ProxyLocation.RESIDENTIAL_ZA:
-        return ZoneInfo("Africa/Johannesburg")
-
-    if proxy_location == ProxyLocation.RESIDENTIAL_AR:
-        return ZoneInfo("America/Argentina/Buenos_Aires")
-
-    if proxy_location == ProxyLocation.RESIDENTIAL_ISP:
-        return ZoneInfo("America/New_York")
-
-    return None
+from skyvern.schemas.runs import ProxyLocation
 
 
 class TaskBase(BaseModel):

--- a/skyvern/forge/sdk/services/task_v2_service.py
+++ b/skyvern/forge/sdk/services/task_v2_service.py
@@ -22,7 +22,6 @@ from skyvern.forge.sdk.db.enums import OrganizationAuthTokenType
 from skyvern.forge.sdk.schemas.organizations import Organization
 from skyvern.forge.sdk.schemas.task_runs import TaskRunType
 from skyvern.forge.sdk.schemas.task_v2 import TaskV2, TaskV2Metadata, TaskV2Status, ThoughtScenario, ThoughtType
-from skyvern.forge.sdk.schemas.tasks import ProxyLocation
 from skyvern.forge.sdk.schemas.workflow_runs import WorkflowRunTimeline, WorkflowRunTimelineType
 from skyvern.forge.sdk.workflow.models.block import (
     BlockResult,
@@ -54,6 +53,7 @@ from skyvern.forge.sdk.workflow.models.yaml import (
     WorkflowCreateYAMLRequest,
     WorkflowDefinitionYAML,
 )
+from skyvern.schemas.runs import ProxyLocation
 from skyvern.webeye.browser_factory import BrowserState
 from skyvern.webeye.scraper.scraper import ElementTreeFormat, ScrapedPage, scrape_website
 from skyvern.webeye.utils.page import SkyvernFrame

--- a/skyvern/forge/sdk/workflow/models/workflow.py
+++ b/skyvern/forge/sdk/workflow/models/workflow.py
@@ -7,10 +7,10 @@ from pydantic import BaseModel, field_validator
 from skyvern.forge.sdk.core.validators import validate_url
 from skyvern.forge.sdk.schemas.files import FileInfo
 from skyvern.forge.sdk.schemas.task_v2 import TaskV2
-from skyvern.forge.sdk.schemas.tasks import ProxyLocation
 from skyvern.forge.sdk.workflow.exceptions import WorkflowDefinitionHasDuplicateBlockLabels
 from skyvern.forge.sdk.workflow.models.block import BlockTypeVar
 from skyvern.forge.sdk.workflow.models.parameter import PARAMETER_TYPE
+from skyvern.schemas.runs import ProxyLocation
 
 
 class WorkflowRequestBody(BaseModel):

--- a/skyvern/forge/sdk/workflow/models/yaml.py
+++ b/skyvern/forge/sdk/workflow/models/yaml.py
@@ -4,11 +4,11 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, Field
 
 from skyvern.config import settings
-from skyvern.forge.sdk.schemas.tasks import ProxyLocation
 from skyvern.forge.sdk.workflow.models.block import BlockType, FileType
 from skyvern.forge.sdk.workflow.models.constants import FileStorageType
 from skyvern.forge.sdk.workflow.models.parameter import ParameterType, WorkflowParameterType
 from skyvern.forge.sdk.workflow.models.workflow import WorkflowStatus
+from skyvern.schemas.runs import ProxyLocation
 
 
 class ParameterYAML(BaseModel, abc.ABC):

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -25,7 +25,7 @@ from skyvern.forge.sdk.db.enums import TaskType
 from skyvern.forge.sdk.models import Step, StepStatus
 from skyvern.forge.sdk.schemas.files import FileInfo
 from skyvern.forge.sdk.schemas.organizations import Organization
-from skyvern.forge.sdk.schemas.tasks import ProxyLocation, Task
+from skyvern.forge.sdk.schemas.tasks import Task
 from skyvern.forge.sdk.schemas.workflow_runs import WorkflowRunBlock, WorkflowRunTimeline, WorkflowRunTimelineType
 from skyvern.forge.sdk.workflow.exceptions import (
     ContextParameterSourceNotDefined,
@@ -90,6 +90,7 @@ from skyvern.forge.sdk.workflow.models.yaml import (
     WorkflowCreateYAMLRequest,
     WorkflowDefinitionYAML,
 )
+from skyvern.schemas.runs import ProxyLocation
 from skyvern.webeye.browser_factory import BrowserState
 
 LOG = structlog.get_logger()

--- a/skyvern/schemas/runs.py
+++ b/skyvern/schemas/runs.py
@@ -1,0 +1,81 @@
+from enum import StrEnum
+from zoneinfo import ZoneInfo
+
+
+class ProxyLocation(StrEnum):
+    US_CA = "US-CA"
+    US_NY = "US-NY"
+    US_TX = "US-TX"
+    US_FL = "US-FL"
+    US_WA = "US-WA"
+    RESIDENTIAL = "RESIDENTIAL"
+    RESIDENTIAL_ES = "RESIDENTIAL_ES"
+    RESIDENTIAL_IE = "RESIDENTIAL_IE"
+    RESIDENTIAL_GB = "RESIDENTIAL_GB"
+    RESIDENTIAL_IN = "RESIDENTIAL_IN"
+    RESIDENTIAL_JP = "RESIDENTIAL_JP"
+    RESIDENTIAL_FR = "RESIDENTIAL_FR"
+    RESIDENTIAL_DE = "RESIDENTIAL_DE"
+    RESIDENTIAL_NZ = "RESIDENTIAL_NZ"
+    RESIDENTIAL_ZA = "RESIDENTIAL_ZA"
+    RESIDENTIAL_AR = "RESIDENTIAL_AR"
+    RESIDENTIAL_ISP = "RESIDENTIAL_ISP"
+    NONE = "NONE"
+
+
+def get_tzinfo_from_proxy(proxy_location: ProxyLocation) -> ZoneInfo | None:
+    if proxy_location == ProxyLocation.NONE:
+        return None
+
+    if proxy_location == ProxyLocation.US_CA:
+        return ZoneInfo("America/Los_Angeles")
+
+    if proxy_location == ProxyLocation.US_NY:
+        return ZoneInfo("America/New_York")
+
+    if proxy_location == ProxyLocation.US_TX:
+        return ZoneInfo("America/Chicago")
+
+    if proxy_location == ProxyLocation.US_FL:
+        return ZoneInfo("America/New_York")
+
+    if proxy_location == ProxyLocation.US_WA:
+        return ZoneInfo("America/New_York")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL:
+        return ZoneInfo("America/New_York")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_ES:
+        return ZoneInfo("Europe/Madrid")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_IE:
+        return ZoneInfo("Europe/Dublin")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_GB:
+        return ZoneInfo("Europe/London")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_IN:
+        return ZoneInfo("Asia/Kolkata")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_JP:
+        return ZoneInfo("Asia/Tokyo")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_FR:
+        return ZoneInfo("Europe/Paris")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_DE:
+        return ZoneInfo("Europe/Berlin")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_NZ:
+        return ZoneInfo("Pacific/Auckland")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_ZA:
+        return ZoneInfo("Africa/Johannesburg")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_AR:
+        return ZoneInfo("America/Argentina/Buenos_Aires")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_ISP:
+        return ZoneInfo("America/New_York")
+
+    return None

--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -26,7 +26,7 @@ from skyvern.exceptions import (
 )
 from skyvern.forge.sdk.api.files import get_download_dir, make_temp_directory
 from skyvern.forge.sdk.core.skyvern_context import current, ensure_context
-from skyvern.forge.sdk.schemas.tasks import ProxyLocation, get_tzinfo_from_proxy
+from skyvern.schemas.runs import ProxyLocation, get_tzinfo_from_proxy
 from skyvern.webeye.utils.page import SkyvernFrame
 
 LOG = structlog.get_logger()

--- a/skyvern/webeye/browser_manager.py
+++ b/skyvern/webeye/browser_manager.py
@@ -7,8 +7,9 @@ from playwright.async_api import async_playwright
 
 from skyvern.exceptions import MissingBrowserState
 from skyvern.forge import app
-from skyvern.forge.sdk.schemas.tasks import ProxyLocation, Task
+from skyvern.forge.sdk.schemas.tasks import Task
 from skyvern.forge.sdk.workflow.models.workflow import WorkflowRun
+from skyvern.schemas.runs import ProxyLocation
 from skyvern.webeye.browser_factory import BrowserContextFactory, BrowserState, VideoArtifact
 
 LOG = structlog.get_logger()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Migrate `ProxyLocation` and `get_tzinfo_from_proxy` to `skyvern.schemas.runs` and update imports across the codebase.
> 
>   - **Migration**:
>     - Move `ProxyLocation` and `get_tzinfo_from_proxy` from `skyvern.forge.sdk.schemas.tasks` to `skyvern.schemas.runs`.
>   - **Imports Update**:
>     - Update imports in `__init__.py`, `create_webvoyager_workflow.py`, and `client.py` to use `skyvern.schemas.runs` for `ProxyLocation`.
>     - Similar updates in `client.py`, `utils.py`, and `task_runs.py`.
>     - Update `task_v2.py`, `tasks.py`, and `task_v2_service.py`.
>     - Update `workflow.py`, `yaml.py`, and `service.py`.
>     - Update `browser_factory.py` and `browser_manager.py`.
>   - **Code Removal**:
>     - Remove `ProxyLocation` and `get_tzinfo_from_proxy` from `tasks.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6aa69c3274ca45c1c4c2ac1ce570e38d222ab952. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->