### PR TITLE
make aws keys work with credentials

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -1698,9 +1698,17 @@ class FileUploadBlock(Block):
 
         s3_uris = []
         try:
+            workflow_run_context = self.get_workflow_run_context(workflow_run_id)
+            actual_aws_access_key_id = (
+                workflow_run_context.get_original_secret_value_or_none(self.aws_access_key_id) or self.aws_access_key_id
+            )
+            actual_aws_secret_access_key = (
+                workflow_run_context.get_original_secret_value_or_none(self.aws_secret_access_key)
+                or self.aws_secret_access_key
+            )
             client = AsyncAWSClient(
-                aws_access_key_id=self.aws_access_key_id,
-                aws_secret_access_key=self.aws_secret_access_key,
+                aws_access_key_id=actual_aws_access_key_id,
+                aws_secret_access_key=actual_aws_secret_access_key,
                 region_name=self.region_name,
             )
             # is the file path a file or a directory?


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance AWS credential handling in `block.py` by retrieving original secret values from workflow context if available.
> 
>   - **Behavior**:
>     - In `block.py`, `execute()` method now retrieves AWS credentials using `get_original_secret_value_or_none()` from `workflow_run_context`.
>     - If original secret values are not available, it defaults to existing `aws_access_key_id` and `aws_secret_access_key`.
>   - **Misc**:
>     - No changes to function signatures or additional functionality added.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e78e07fb7a96dbd2a6a55034e3dbc043085910b4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->