### PR TITLE
rename js sleep to asyncSleepFor

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -2165,7 +2165,7 @@ function waitForNextFrame() {
   });
 }
 
-function sleep(ms) {
+function asyncSleepFor(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
@@ -2311,7 +2311,7 @@ async function stopGlobalIncrementalObserver() {
     (await window.globalParsedElementCounter.get()) <
     window.globalOneTimeIncrementElements.length
   ) {
-    await sleep(100);
+    await asyncSleepFor(100);
   }
   window.globalOneTimeIncrementElements = [];
   window.globalDomDepthMap = new Map();
@@ -2322,7 +2322,7 @@ async function getIncrementElements() {
     (await window.globalParsedElementCounter.get()) <
     window.globalOneTimeIncrementElements.length
   ) {
-    await sleep(100);
+    await asyncSleepFor(100);
   }
 
   // cleanup the chidren tree, remove the duplicated element


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renames `sleep` to `asyncSleepFor` in `domUtils.js` and updates its usage in two functions.
> 
>   - **Renames**:
>     - `sleep` to `asyncSleepFor` in `domUtils.js`.
>   - **Function Calls**:
>     - Updated calls to `sleep` to `asyncSleepFor` in `stopGlobalIncrementalObserver()` and `getIncrementElements()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 01131716f6313abd5c24ef3e3268f2395f5a3377. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->