### PR TITLE
fix a bug with file upload node

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/FileUploadNode/FileUploadNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/FileUploadNode/FileUploadNode.tsx
@@ -123,8 +123,8 @@ function FileUploadNode({ id, data }: NodeProps<FileUploadNode>) {
               type="password"
               value={inputs.awsSecretAccessKey}
               className="nopan text-xs"
-              onChange={(value) => {
-                handleChange("awsSecretAccessKey", value);
+              onChange={(event) => {
+                handleChange("awsSecretAccessKey", event.target.value);
               }}
             />
           </div>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes `onChange` handler for AWS Secret Access Key input in `FileUploadNode.tsx` to use `event.target.value`.
> 
>   - **Bug Fix**:
>     - Corrects `onChange` handler for AWS Secret Access Key input in `FileUploadNode.tsx` to use `event.target.value` instead of `value`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 33e146ab0c1900022f16c2d73fb219cb611dd9b0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->