### PR TITLE
Put max height on file panel

### DIFF
--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -39,6 +39,7 @@ import { getAggregatedExtractedInformation } from "./workflowRun/workflowRunUtil
 import { Label } from "@/components/ui/label";
 import { CodeEditor } from "./components/CodeEditor";
 import { cn } from "@/util/utils";
+import { ScrollArea, ScrollAreaViewport } from "@/components/ui/scroll-area";
 
 function WorkflowRun() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -282,22 +283,27 @@ function WorkflowRun() {
           {hasFileUrls && (
             <div className="space-y-4">
               <Label>Downloaded Files</Label>
-              <div className="space-y-2">
-                {fileUrls.length > 0 ? (
-                  fileUrls.map((url, index) => {
-                    return (
-                      <div key={url} title={url} className="flex gap-2">
-                        <FileIcon className="size-6" />
-                        <a href={url} className="underline underline-offset-4">
-                          <span>{`File ${index + 1}`}</span>
-                        </a>
-                      </div>
-                    );
-                  })
-                ) : (
-                  <div className="text-sm">No files downloaded</div>
-                )}
-              </div>
+              <ScrollArea>
+                <ScrollAreaViewport className="max-h-[250px] space-y-2">
+                  {fileUrls.length > 0 ? (
+                    fileUrls.map((url, index) => {
+                      return (
+                        <div key={url} title={url} className="flex gap-2">
+                          <FileIcon className="size-6" />
+                          <a
+                            href={url}
+                            className="underline underline-offset-4"
+                          >
+                            <span>{`File ${index + 1}`}</span>
+                          </a>
+                        </div>
+                      );
+                    })
+                  ) : (
+                    <div className="text-sm">No files downloaded</div>
+                  )}
+                </ScrollAreaViewport>
+              </ScrollArea>
             </div>
           )}
         </div>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add scrollable area with max height to file panel in `WorkflowRun.tsx`.
> 
>   - **UI Enhancement**:
>     - Adds `ScrollArea` and `ScrollAreaViewport` to the file panel in `WorkflowRun.tsx`.
>     - Sets a maximum height of `250px` for the file panel to improve scrollability and UI layout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 1fb13da46a55dbc1ee4fa8d61d3b21b0d65b18cc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->