### PR TITLE
truncate parameter names when they exceed the given width

### DIFF
--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowPostRunParameters.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowPostRunParameters.tsx
@@ -106,9 +106,9 @@ function WorkflowPostRunParameters() {
           {Object.entries(parameters).map(([key, value]) => {
             return (
               <div key={key} className="flex gap-16">
-                <div className="w-80">
-                  <h1 className="text-lg">{key}</h1>
-                </div>
+                <span className="w-80 truncate text-lg" title={key}>
+                  {key}
+                </span>
                 {typeof value === "string" ||
                 typeof value === "number" ||
                 typeof value === "boolean" ? (


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Truncate long parameter names in `WorkflowPostRunParameters` to improve UI readability.
> 
>   - **UI Enhancement**:
>     - Truncate long parameter names in `WorkflowPostRunParameters` to fit within a specified width.
>     - Add `title` attribute to display full parameter name on hover.
>     - Implemented using `span` with `truncate` class in `WorkflowPostRunParameters.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9c3a2937719ecaf6d4b928a7bf28ce1069a19d0a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->