### PR TITLE
update too many parameters created when using login block

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/LoginNode/LoginNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/LoginNode/LoginNode.tsx
@@ -152,6 +152,7 @@ function LoginNode({ id, data }: NodeProps<LoginNode>) {
           <div className="space-y-2">
             <Label className="text-xs text-slate-300">Credential</Label>
             <LoginBlockCredentialSelector
+              nodeId={id}
               value={
                 data.parameterKeys.length > 0
                   ? data.parameterKeys[0]


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refines parameter management in `LoginBlockCredentialSelector` by using `nodeId` to prevent unnecessary parameter creation and deletion.
> 
>   - **Behavior**:
>     - `LoginBlockCredentialSelector` now accepts `nodeId` as a prop to manage node-specific parameters.
>     - Refines parameter update logic to prevent unnecessary parameter creation and deletion.
>     - Ensures parameters are only added if not existing and removed if not used by other nodes.
>   - **Files**:
>     - Updates in `LoginBlockCredentialSelector.tsx` to handle `nodeId` and refine parameter logic.
>     - Modifications in `LoginNode.tsx` to pass `nodeId` to `LoginBlockCredentialSelector`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 809537fce5eef9ba9d0a8180c800a85be4f0eb95. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->