### PR TITLE
Fix timeline building infinite loop

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -1960,6 +1960,7 @@ class WorkflowService:
             if block.parent_workflow_run_block_id:
                 if block.parent_workflow_run_block_id in block_map:
                     block_map[block.parent_workflow_run_block_id].children.append(workflow_run_timeline)
+                    block_map[block.workflow_run_block_id] = workflow_run_timeline
                 else:
                     # put the block back to the queue
                     workflow_run_blocks.append(block)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes infinite loop in `get_workflow_run_timeline` by updating `block_map` with processed blocks in `service.py`.
> 
>   - **Bug Fix**:
>     - Fix infinite loop in `get_workflow_run_timeline` in `service.py` by ensuring `block_map` is updated with `workflow_run_timeline` for each processed block.
>     - Handles cases where `block.parent_workflow_run_block_id` is present but not in `block_map` by re-queuing the block.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for c93279afd94a983d1e60b0ba6cbe5661a09ef52d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->