### PR TITLE
Disable complete verification for returend complete_action when complete_verification flag is set to False

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -989,6 +989,10 @@ class ForgeAgent:
 
                 self.async_operation_pool.run_operation(task.task_id, AgentPhase.action)
                 current_page = await browser_state.must_get_working_page()
+                if isinstance(action, CompleteAction) and not complete_verification:
+                    # Do not verify the complete action when complete_verification is False
+                    # set verified to True will skip the completion verification
+                    action.verified = True
                 results = await ActionHandler.handle_action(scraped_page, task, step, current_page, action)
                 detailed_agent_step_output.actions_and_results[action_idx] = (
                     action,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Skip verification for `CompleteAction` in `agent_step()` when `complete_verification` is `False` by setting `action.verified = True`.
> 
>   - **Behavior**:
>     - In `agent_step()` in `agent.py`, skip verification for `CompleteAction` when `complete_verification` is `False` by setting `action.verified = True`.
>   - **Misc**:
>     - No other changes or refactoring were made.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9368fb26dd6e26cc3b4832cd225064cb26909d48. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->