### PR TITLE
check null for document.body and document.documentElement inside function isWindowScrollable

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1993,11 +1993,15 @@ async function scrollToNextPage(
 }
 
 function isWindowScrollable() {
+  const documentBody = document.body;
+  const documentElement = document.documentElement;
+  if (!documentBody || !documentElement) {
+    return false;
+  }
+
   // Check if the body's overflow style is set to hidden
-  const bodyOverflow = getElementComputedStyle(document.body)?.overflow;
-  const htmlOverflow = getElementComputedStyle(
-    document.documentElement,
-  )?.overflow;
+  const bodyOverflow = getElementComputedStyle(documentBody)?.overflow;
+  const htmlOverflow = getElementComputedStyle(documentElement)?.overflow;
 
   // Check if the document height is greater than the window height
   const isScrollable =


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add null checks for `document.body` and `document.documentElement` in `isWindowScrollable()` to prevent errors when they are null.
> 
>   - **Functionality**:
>     - Add null checks for `document.body` and `document.documentElement` in `isWindowScrollable()` to prevent errors when these are null.
>     - Modify `bodyOverflow` and `htmlOverflow` to use checked variables in `isWindowScrollable()`.
>   - **Behavior**:
>     - `isWindowScrollable()` now returns `false` if `document.body` or `document.documentElement` is null.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f6c73bd04124e21252f0689d129c7f353dd3a18b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->