### PR TITLE
add safeWindowScroll function in js

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1952,13 +1952,23 @@ function removeBoundingBoxes() {
   }
 }
 
+function safeWindowScroll(x, y) {
+  if (typeof window.scroll === "function") {
+    window.scroll(x, y, { behavior: "instant" });
+  } else if (typeof window.scrollTo === "function") {
+    window.scrollTo(x, y, { behavior: "instant" });
+  } else {
+    console.error("window.scroll and window.scrollTo are both not supported");
+  }
+}
+
 async function scrollToTop(
   draw_boxes,
   frame = "main.frame",
   frame_index = undefined,
 ) {
   removeBoundingBoxes();
-  window.scroll({ left: 0, top: 0, behavior: "instant" });
+  safeWindowScroll(0, 0);
   if (draw_boxes) {
     await buildElementsAndDrawBoundingBoxes(frame, frame_index);
   }
@@ -1970,7 +1980,7 @@ function getScrollXY() {
 }
 
 function scrollToXY(x, y) {
-  window.scroll({ left: x, top: y, behavior: "instant" });
+  safeWindowScroll(x, y);
 }
 
 async function scrollToNextPage(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `safeWindowScroll` function to safely handle window scrolling in `domUtils.js`, replacing direct `window.scroll` calls in `scrollToTop` and `scrollToXY`.
> 
>   - **Behavior**:
>     - Adds `safeWindowScroll(x, y)` to `domUtils.js` to safely scroll the window by checking for `window.scroll` and `window.scrollTo`.
>     - Replaces `window.scroll` with `safeWindowScroll` in `scrollToTop()` and `scrollToXY()` to ensure compatibility.
>   - **Error Handling**:
>     - Logs an error if neither `window.scroll` nor `window.scrollTo` are supported.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for cf902484ca2a529df665a7221c90f5848a35d30b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->