### PR TITLE
Handle createPolicy gracefully

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1882,12 +1882,17 @@ function createHintMarkersForGroups(groups) {
     } catch (e) {
       // Ensure trustedTypes is available
       if (typeof trustedTypes !== "undefined") {
-        const escapeHTMLPolicy = trustedTypes.createPolicy("default", {
-          createHTML: (string) => string,
-        });
-        hintMarker.element.innerHTML = escapeHTMLPolicy.createHTML(
-          hintMarker.hintString.toUpperCase(),
-        );
+        try {
+          const escapeHTMLPolicy = trustedTypes.createPolicy("hint-policy", {
+            createHTML: (string) => string,
+          });
+          hintMarker.element.innerHTML = escapeHTMLPolicy.createHTML(
+            hintMarker.hintString.toUpperCase(),
+          );
+        } catch (policyError) {
+          console.warn("Could not create trusted types policy:", policyError);
+          // Skip updating the hint marker if policy creation fails
+        }
       } else {
         console.error("trustedTypes is not supported in this environment.");
       }


### PR DESCRIPTION
- safeScrollToTop
- handle createPolicy failure gracefully

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces `safeScrollToTop` for safe scrolling and improves error handling for `createPolicy` in `domUtils.js`.
> 
>   - **Behavior**:
>     - Introduces `safeScrollToTop` in `domUtils.js`, replacing `scrollToTop` to ensure safe scrolling to the top of the page.
>     - Handles `createPolicy` failure gracefully in `createHintMarkersForGroups()` in `domUtils.js` by logging a warning and skipping hint marker update.
>   - **Integration**:
>     - Updates `scroll_to_top()` in `page.py` to use `safeScrollToTop` for scrolling operations.
>   - **Misc**:
>     - Renames `scrollToTop` to `safeScrollToTop` in `domUtils.js` and `page.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for fde14e63bfccdb72c336a68545333db27e7661d3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->