### PR TITLE
Render nested blocks correctly in workflow run timeline

### DIFF
--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimeline.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimeline.tsx
@@ -98,13 +98,12 @@ function WorkflowRunTimeline({
                 return (
                   <WorkflowRunTimelineBlockItem
                     key={timelineItem.block.workflow_run_block_id}
-                    subBlocks={timelineItem.children
-                      .filter((item) => item.type === "block")
-                      .map((item) => item.block)}
+                    subItems={timelineItem.children}
                     activeItem={activeItem}
                     block={timelineItem.block}
                     onActionClick={onActionItemSelected}
                     onBlockItemClick={onBlockItemSelected}
+                    onThoughtCardClick={onObserverThoughtCardSelected}
                   />
                 );
               }

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineBlockItem.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineBlockItem.tsx
@@ -8,8 +8,12 @@ import { workflowBlockTitle } from "../editor/nodes/types";
 import { WorkflowBlockIcon } from "../editor/nodes/WorkflowBlockIcon";
 import {
   isAction,
+  isBlockItem,
+  isObserverThought,
+  isThoughtItem,
   isWorkflowRunBlock,
   WorkflowRunBlock,
+  WorkflowRunTimelineItem,
 } from "../types/workflowRunTypes";
 import { ActionCard } from "./ActionCard";
 import {
@@ -21,21 +25,24 @@ import { isTaskVariantBlock } from "../types/workflowTypes";
 import { Link } from "react-router-dom";
 import { useCallback } from "react";
 import { Status } from "@/api/types";
-
+import { ThoughtCard } from "./ThoughtCard";
+import { ObserverThought } from "../types/workflowRunTypes";
 type Props = {
   activeItem: WorkflowRunOverviewActiveElement;
   block: WorkflowRunBlock;
-  subBlocks: Array<WorkflowRunBlock>;
+  subItems: Array<WorkflowRunTimelineItem>;
   onBlockItemClick: (block: WorkflowRunBlock) => void;
   onActionClick: (action: ActionItem) => void;
+  onThoughtCardClick: (thought: ObserverThought) => void;
 };
 
 function WorkflowRunTimelineBlockItem({
   activeItem,
   block,
-  subBlocks,
+  subItems,
   onBlockItemClick,
   onActionClick,
+  onThoughtCardClick,
 }: Props) {
   const actions = block.actions ?? [];
 
@@ -164,17 +171,33 @@ function WorkflowRunTimelineBlockItem({
           />
         );
       })}
-      {subBlocks.map((block) => {
-        return (
-          <WorkflowRunTimelineBlockItem
-            key={block.workflow_run_block_id}
-            block={block}
-            activeItem={activeItem}
-            onActionClick={onActionClick}
-            onBlockItemClick={onBlockItemClick}
-            subBlocks={[]}
-          />
-        );
+      {subItems.map((item) => {
+        if (isBlockItem(item)) {
+          return (
+            <WorkflowRunTimelineBlockItem
+              key={item.block.workflow_run_block_id}
+              subItems={item.children}
+              activeItem={activeItem}
+              block={item.block}
+              onActionClick={onActionClick}
+              onBlockItemClick={onBlockItemClick}
+              onThoughtCardClick={onThoughtCardClick}
+            />
+          );
+        }
+        if (isThoughtItem(item)) {
+          return (
+            <ThoughtCard
+              key={item.thought.thought_id}
+              active={
+                isObserverThought(activeItem) &&
+                activeItem.thought_id === item.thought.thought_id
+              }
+              onClick={onThoughtCardClick}
+              thought={item.thought}
+            />
+          );
+        }
       })}
     </div>
   );


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `WorkflowRunTimeline` and `WorkflowRunTimelineBlockItem` to correctly render nested blocks and thought items using `subItems`.
> 
>   - **Behavior**:
>     - `WorkflowRunTimeline.tsx`: Replaces `subBlocks` with `subItems` to handle both block and thought items.
>     - `WorkflowRunTimelineBlockItem.tsx`: Updates rendering logic to correctly display nested blocks and thought items.
>   - **Functions**:
>     - `WorkflowRunTimelineBlockItem`: Now accepts `subItems` and handles both block and thought items.
>     - Adds `onThoughtCardClick` prop to handle thought item clicks.
>   - **Misc**:
>     - Adds `ThoughtCard` rendering for thought items in both `WorkflowRunTimeline.tsx` and `WorkflowRunTimelineBlockItem.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 823c4bf2c8d71c2aa1f9b417b1745c3e5f76c327. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->