### PR TITLE
Show task v2 output instead of extracted information

### DIFF
--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -146,6 +146,8 @@ function WorkflowRun() {
     aggregatedExtractedInformation,
   ).some((value) => value !== null);
 
+  const hasTaskv2Output = Boolean(isTaskv2Run && workflowRun.task_v2?.output);
+
   const hasFileUrls =
     isFetched &&
     workflowRun &&
@@ -155,11 +157,12 @@ function WorkflowRun() {
     ? (workflowRun.downloaded_file_urls as string[])
     : [];
 
-  const showBoth = hasSomeExtractedInformation && hasFileUrls;
+  const showBoth =
+    (hasSomeExtractedInformation || hasTaskv2Output) && hasFileUrls;
 
   const showOutputSection =
     workflowRunIsFinalized &&
-    (hasSomeExtractedInformation || hasFileUrls) &&
+    (hasSomeExtractedInformation || hasFileUrls || hasTaskv2Output) &&
     workflowRun.status === Status.Completed;
 
   return (
@@ -269,12 +272,18 @@ function WorkflowRun() {
             "grid-cols-2": showBoth,
           })}
         >
-          {hasSomeExtractedInformation && (
+          {(hasSomeExtractedInformation || hasTaskv2Output) && (
             <div className="space-y-4">
-              <Label>Extracted Information</Label>
+              <Label>
+                {hasTaskv2Output ? "Output" : "Extracted Information"}
+              </Label>
               <CodeEditor
                 language="json"
-                value={JSON.stringify(aggregatedExtractedInformation, null, 2)}
+                value={
+                  hasTaskv2Output
+                    ? JSON.stringify(workflowRun.task_v2?.output, null, 2)
+                    : JSON.stringify(aggregatedExtractedInformation, null, 2)
+                }
                 readOnly
                 maxHeight="250px"
               />


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Display task v2 output in `WorkflowRun.tsx` when available, updating UI and logic accordingly.
> 
>   - **Behavior**:
>     - Display task v2 output in `WorkflowRun.tsx` if available, otherwise show extracted information.
>     - Update `showBoth` and `showOutputSection` logic to include task v2 output.
>   - **UI**:
>     - Change label to "Output" if task v2 output is present, otherwise "Extracted Information".
>     - Use `workflowRun.task_v2?.output` for JSON display if task v2 output is available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0ddfc96e1e6f460146fa52ed87a1f10ce6958f82. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->