### PR TITLE
add failure_reason to the TaskRunRepsonse for task v2

### DIFF
--- a/skyvern/services/run_service.py
+++ b/skyvern/services/run_service.py
@@ -37,13 +37,15 @@ async def get_run_response(run_id: str, organization_id: str | None = None) -> R
         task_v2 = await app.DATABASE.get_task_v2(run.run_id, organization_id=organization_id)
         if not task_v2:
             return None
+        workflow_run = None
+        if task_v2.workflow_run_id:
+            workflow_run = await app.DATABASE.get_workflow_run(task_v2.workflow_run_id, organization_id=organization_id)
         return TaskRunResponse(
             run_id=run.run_id,
             run_type=run.task_run_type,
             status=task_v2.status,
             output=task_v2.output,
-            # TODO: add failure reason
-            # failure_reason=task_v2.failure_reason,
+            failure_reason=workflow_run.failure_reason if workflow_run else None,
             created_at=task_v2.created_at,
             modified_at=task_v2.modified_at,
             run_request=TaskRunRequest(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `failure_reason` to `TaskRunResponse` for `task_v2` in `get_run_response()` by using `workflow_run.failure_reason`.
> 
>   - **Behavior**:
>     - Adds `failure_reason` to `TaskRunResponse` for `task_v2` in `get_run_response()` in `run_service.py`.
>     - Fetches `workflow_run` using `task_v2.workflow_run_id` and assigns `workflow_run.failure_reason` if available, otherwise `None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 239e23d63470fe4cb6d21a4faa77f7d6c293a716. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->