### PR TITLE
shu/fix cdp connect with browser path

### DIFF
--- a/skyvern/agent/agent.py
+++ b/skyvern/agent/agent.py
@@ -44,10 +44,10 @@ class SkyvernAgent:
             # TODO validate browser_path
             # Supported Browsers: Google Chrome, Brave Browser, Microsoft Edge, Firefox
             if "Chrome" in browser_path or "Brave" in browser_path or "Edge" in browser_path:
-                result = subprocess.run(
-                    ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome", "--remote-debugging-port=9222"]
+                self.browser_process = subprocess.Popen(
+                    [browser_path, "--remote-debugging-port=9222"], stdout=subprocess.PIPE, stderr=subprocess.PIPE
                 )
-                if result.returncode != 0:
+                if self.browser_process.poll() is not None:
                     raise Exception(f"Failed to open browser. browser_path: {browser_path}")
 
                 self.cdp_url = "http://127.0.0.1:9222"

--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -417,7 +417,13 @@ class BrowserState:
         pages = self.browser_context.pages
         for page in pages:
             if page != cur_page:
-                await page.close()
+                try:
+                    async with asyncio.timeout(2):
+                        await page.close()
+                except asyncio.TimeoutError:
+                    LOG.warning("Timeout to close the page. Skip closing the page", url=page.url)
+                except Exception:
+                    LOG.exception("Error while closing the page", url=page.url)
 
     async def check_and_fix_state(
         self,


### PR DESCRIPTION
- fix cdp_connect with browser
- bump version 0.1.67

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix `cdp_connect` in `agent.py` and add error handling in `browser_factory.py`, bump version to 0.1.67.
> 
>   - **Behavior**:
>     - Fix `cdp_connect` in `agent.py` by using `subprocess.Popen` instead of `subprocess.run` and checking with `poll()`.
>     - Add error handling for page closing in `_close_all_other_pages()` in `browser_factory.py` using `asyncio.timeout` and logging exceptions.
>   - **Version**:
>     - Bump version to 0.1.67.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 09ebc1c24a15424dcfdcb004abaf617c941274f2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->