### PR TITLE
fix postgres env name issue in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - PGDATA=/var/lib/postgresql/data/pgdata
       - POSTGRES_USER=skyvern
       - POSTGRES_PASSWORD=skyvern
-      - POSTGRES_POSTGRES_DB=skyvern
+      - POSTGRES_DB=skyvern
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U skyvern"]
       interval: 5s


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes environment variable name from `POSTGRES_POSTGRES_DB` to `POSTGRES_DB` in `docker-compose.yml`.
> 
>   - **Environment Variable Fix**:
>     - Corrects `POSTGRES_POSTGRES_DB` to `POSTGRES_DB` in `docker-compose.yml` for PostgreSQL service.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 17c11d07fd93867a21e4ea029dfead83e1160dd0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->