### PR TITLE
cancel run API

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -1547,8 +1547,8 @@ class AgentDB:
 
     async def get_workflow_runs_by_parent_workflow_run_id(
         self,
-        organization_id: str,
         parent_workflow_run_id: str,
+        organization_id: str | None = None,
     ) -> list[WorkflowRun]:
         try:
             async with self.Session() as session:

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1468,15 +1468,15 @@ async def run_task(
         url = run_request.url
         data_extraction_goal = None
         data_extraction_schema = run_request.data_extraction_schema
-        navigation_goal = run_request.goal
+        navigation_goal = run_request.prompt
         navigation_payload = None
         if not url:
             task_generation = await task_v1_service.generate_task(
-                user_prompt=run_request.goal,
+                user_prompt=run_request.prompt,
                 organization=current_org,
             )
             url = task_generation.url
-            navigation_goal = task_generation.navigation_goal or run_request.goal
+            navigation_goal = task_generation.navigation_goal or run_request.prompt
             navigation_payload = task_generation.navigation_payload
             data_extraction_goal = task_generation.data_extraction_goal
             data_extraction_schema = data_extraction_schema or task_generation.extracted_information_schema


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `cancel_run` API endpoint to cancel task or workflow runs, with supporting changes in `run_service.py` and `agent_protocol.py`.
> 
>   - **API Changes**:
>     - Add `cancel_run` endpoint in `agent_protocol.py` to cancel task or workflow runs.
>     - Modify `cancel_workflow_run` in `agent_protocol.py` to adjust parameter order.
>   - **Service Changes**:
>     - Add `cancel_run` function in `run_service.py` to handle cancellation logic for `task_v1`, `task_v2`, and `workflow_run`.
>     - Implement `cancel_task_v1`, `cancel_task_v2`, and `cancel_workflow_run` functions in `run_service.py`.
>   - **Misc**:
>     - Adjust parameter order in `get_workflow_runs_by_parent_workflow_run_id` in `client.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9855572873dffbd3312a9435659553605f56ae72. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->