### PR TITLE
truncate parameter names that are too long

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParametersPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParametersPanel.tsx
@@ -129,10 +129,12 @@ function WorkflowParametersPanel() {
                 return (
                   <div
                     key={parameter.key}
-                    className="flex items-center justify-between rounded-md bg-slate-elevation1 px-3 py-2"
+                    className="flex items-center justify-between gap-2 rounded-md bg-slate-elevation1 px-3 py-2"
                   >
-                    <div className="flex items-center gap-4">
-                      <span className="text-sm">{parameter.key}</span>
+                    <div className="flex min-w-0 items-center gap-4">
+                      <span className="truncate text-sm" title={parameter.key}>
+                        {parameter.key}
+                      </span>
                       {parameter.parameterType === "workflow" ? (
                         <span className="text-sm text-slate-400">
                           {getLabelForWorkflowParameterType(parameter.dataType)}


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Truncate long parameter names in `WorkflowParametersPanel.tsx` for better readability and add hover tooltip for full name display.
> 
>   - **UI Improvement**:
>     - Truncate long parameter names in `WorkflowParametersPanel.tsx` using `truncate` class on `<span>` to improve readability.
>     - Add `title` attribute to display full parameter name on hover.
>   - **Layout**:
>     - Add `min-w-0` to flex container to ensure proper truncation behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for cb25cecf0188c61d136b1f36382b551fbed5f2ac. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->