### PR TITLE
support extra_headers in SkyvernAgent

### DIFF
--- a/skyvern/agent/agent.py
+++ b/skyvern/agent/agent.py
@@ -30,7 +30,9 @@ class SkyvernAgent:
         cdp_url: str | None = None,
         browser_path: str | None = None,
         browser_type: str | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> None:
+        self.extra_headers = extra_headers
         self.client: SkyvernClient | None = None
         if base_url is None and api_key is None:
             # TODO: run at the root wherever the code is initiated
@@ -69,7 +71,7 @@ class SkyvernAgent:
             self.client = SkyvernClient(
                 base_url=base_url,
                 api_key=api_key,
-                extra_headers={"X-User-Agent": "skyvern-mcp"},
+                extra_headers=self.extra_headers,
             )
         else:
             raise ValueError("base_url and api_key must be both provided")

--- a/skyvern/agent/client.py
+++ b/skyvern/agent/client.py
@@ -13,7 +13,12 @@ class SkyvernClient:
         self.base_url = base_url
         self.api_key = api_key
         self.client = AsyncSkyvern(base_url=base_url, api_key=api_key)
-        self.extra_headers = extra_headers
+        self.extra_headers = extra_headers or {}
+        self.user_agent = None
+        if "X-User-Agent" in self.extra_headers:
+            self.user_agent = self.extra_headers["X-User-Agent"]
+        elif "x-user-agent" in self.extra_headers:
+            self.user_agent = self.extra_headers["x-user-agent"]
 
     async def run_task(
         self,
@@ -43,6 +48,7 @@ class SkyvernClient:
             max_steps=max_steps,
             browser_session_id=browser_session_id,
             publish_workflow=publish_workflow,
+            user_agent=self.user_agent,
         )
         return TaskRunResponse.model_validate(task_run_obj.dict())
 
@@ -66,6 +72,7 @@ class SkyvernClient:
             totp_url=totp_url,
             browser_session_id=browser_session_id,
             template=template,
+            user_agent=self.user_agent,
         )
         return WorkflowRunResponse.model_validate(workflow_run_obj.dict())
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for `extra_headers` in `SkyvernAgent` and `SkyvernClient`, allowing custom headers including user-agent to be specified.
> 
>   - **Behavior**:
>     - Add `extra_headers` parameter to `SkyvernAgent` and `SkyvernClient` constructors.
>     - Pass `extra_headers` to `SkyvernClient` in `SkyvernAgent` constructor.
>     - Extract `X-User-Agent` or `x-user-agent` from `extra_headers` in `SkyvernClient` and store in `user_agent`.
>     - Include `user_agent` in `run_task` and `run_workflow` methods in `client.py`.
>   - **Misc**:
>     - Modify `SkyvernClient` to default `extra_headers` to an empty dictionary if not provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2dd26b0d31022c0c333c045405c586f487b10ed2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->