### PR TITLE
shu/fix cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "skyvern"
-version = "0.1.70"
+version = "0.1.71"
 description = ""
 authors = ["Skyvern AI <info@skyvern.com>"]
 readme = "README.md"

--- a/skyvern/cli/commands.py
+++ b/skyvern/cli/commands.py
@@ -404,7 +404,10 @@ async def _setup_local_organization() -> str:
     """
     Returns the API key for the local organization generated
     """
-    skyvern_agent = SkyvernAgent()
+    skyvern_agent = SkyvernAgent(
+        base_url=settings.SKYVERN_BASE_URL,
+        api_key=settings.SKYVERN_API_KEY,
+    )
     organization = await skyvern_agent.get_organization()
 
     org_auth_token = await app.DATABASE.get_valid_org_auth_token(
@@ -693,6 +696,7 @@ def setup_mcp() -> None:
 @run_app.command(name="server")
 def run_server() -> None:
     load_dotenv()
+    load_dotenv(".env")
     from skyvern.config import settings
 
     port = settings.PORT


### PR DESCRIPTION
- fix skyvern run server environment
- version bump

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix CLI server environment setup by loading `.env` in `run_server()` and bump version to `0.1.71`.
> 
>   - **CLI Fix**:
>     - In `commands.py`, `run_server()` now explicitly loads `.env` file to ensure environment variables are set correctly.
>   - **Version Update**:
>     - Bump version in `pyproject.toml` from `0.1.70` to `0.1.71`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 8b62de5f04a7e207b21ca33d4aa1cdfa858ec9c5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->