### PR TITLE
scroll the element into view when the blocking element is not interac…

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -1036,6 +1036,28 @@ async def handle_select_option_action(
             )
             return await normal_select(action=action, skyvern_element=skyvern_element, dom=dom, task=task, step=step)
 
+        if not exist:
+            return await normal_select(action=action, skyvern_element=skyvern_element, dom=dom, task=task, step=step)
+
+        if blocking_element is None:
+            LOG.info(
+                "Try to scroll the element into view, then detecting the blocking element",
+                step_id=step.step_id,
+            )
+            try:
+                await skyvern_element.scroll_into_view()
+                blocking_element, exist = await skyvern_element.find_blocking_element(dom=dom)
+            except Exception:
+                LOG.warning(
+                    "Failed to find the blocking element when scrolling into view, fallback to normal select",
+                    action=action,
+                    step_id=step.step_id,
+                    exc_info=True,
+                )
+                return await normal_select(
+                    action=action, skyvern_element=skyvern_element, dom=dom, task=task, step=step
+                )
+
         if not exist or blocking_element is None:
             return await normal_select(action=action, skyvern_element=skyvern_element, dom=dom, task=task, step=step)
         LOG.info(


### PR DESCRIPTION
…table
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance `handle_select_option_action` in `handler.py` to scroll elements into view when blocked, improving interaction reliability.
> 
>   - **Behavior**:
>     - In `handle_select_option_action` in `handler.py`, added logic to scroll the element into view if it is blocked and re-check for blocking elements.
>     - If scrolling fails to resolve the blocking, falls back to normal select.
>   - **Logging**:
>     - Added logging to indicate attempts to scroll into view and detect blocking elements, and warnings if scrolling fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 8447759239173bf7c38e9961b4c4a7c3cb2e6d6b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->