### PR TITLE
handle unexpected llm error in task v2 runner and clean up browser

### DIFF
--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -278,6 +278,12 @@ async def run_task_v2(
             organization_id=organization_id,
         )
     finally:
+        if task_v2.workflow_id and not workflow:
+            workflow = await app.WORKFLOW_SERVICE.get_workflow(task_v2.workflow_id, organization_id=organization_id)
+        if task_v2.workflow_run_id and not workflow_run:
+            workflow_run = await app.WORKFLOW_SERVICE.get_workflow_run(
+                task_v2.workflow_run_id, organization_id=organization_id
+            )
         if workflow and workflow_run and workflow_run.parent_workflow_run_id is None:
             await app.WORKFLOW_SERVICE.clean_up_workflow(
                 workflow=workflow,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance error handling in `run_task_v2()` to ensure `workflow` and `workflow_run` are fetched for cleanup if not initialized after an exception.
> 
>   - **Error Handling**:
>     - In `run_task_v2()`, added logic to fetch `workflow` and `workflow_run` if they are not initialized after an exception.
>     - Ensures cleanup can proceed by calling `get_workflow()` and `get_workflow_run()` if needed.
>   - **Misc**:
>     - No changes to existing functionality, only added error handling to improve robustness.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9827d50e05b65da5473c3ce6461804df5dbb7ad1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->