### PR TITLE
rename taskv2 block to navigationv2

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/Taskv2Node/Taskv2Node.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/Taskv2Node/Taskv2Node.tsx
@@ -79,7 +79,9 @@ function Taskv2Node({ id, data, type }: NodeProps<Taskv2Node>) {
                 titleClassName="text-base"
                 inputClassName="text-base"
               />
-              <span className="text-xs text-slate-400">Task v2 Block</span>
+              <span className="text-xs text-slate-400">
+                Navigation v2 Block
+              </span>
             </div>
           </div>
           <NodeActionMenu

--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
@@ -44,8 +44,8 @@ const nodeLibraryItems: Array<{
         className="size-6"
       />
     ),
-    title: "Task v2 Block",
-    description: "Runs a Skyvern 2.0 Task",
+    title: "Navigation v2 Block",
+    description: "Navigate on the page with Skyvern 2.0",
   },
   {
     nodeType: "action",


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Renames "Task v2 Block" to "Navigation v2 Block" in `Taskv2Node.tsx` and `WorkflowNodeLibraryPanel.tsx`, updating the title and description.
> 
>   - **Renaming**:
>     - Renames "Task v2 Block" to "Navigation v2 Block" in `Taskv2Node.tsx` and `WorkflowNodeLibraryPanel.tsx`.
>     - Updates description from "Runs a Skyvern 2.0 Task" to "Navigate on the page with Skyvern 2.0" in `WorkflowNodeLibraryPanel.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 80ba6c1b8c4f8749610910e958adee2b4789185d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->