### PR TITLE
handle 'Exception: Can't Skyvern element rect' error

### DIFF
--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -661,12 +661,9 @@ class SkyvernElement:
         timeout: float = settings.BROWSER_ACTION_TIMEOUT_MS,
     ) -> float:
         self_rect = await self.get_locator().bounding_box(timeout=timeout)
-        if self_rect is None:
-            raise Exception("Can't Skyvern element rect")
-
         target_rect = await target_locator.bounding_box(timeout=timeout)
         if self_rect is None or target_rect is None:
-            raise Exception("Can't get the target element rect")
+            return float("inf")  # Return infinity as the distance when element rect is not available
 
         y_1 = self_rect["y"] + self_rect["height"] - target_rect["y"]
         y_2 = self_rect["y"] - (target_rect["y"] + target_rect["height"])
@@ -686,12 +683,9 @@ class SkyvernElement:
         timeout: float = settings.BROWSER_ACTION_TIMEOUT_MS,
     ) -> float:
         self_rect = await self.get_locator().bounding_box(timeout=timeout)
-        if self_rect is None:
-            raise Exception("Can't Skyvern element rect")
-
         target_rect = await target_locator.bounding_box(timeout=timeout)
         if self_rect is None or target_rect is None:
-            raise Exception("Can't get the target element rect")
+            return float("inf")  # Return infinity as the distance when element rect is not available
 
         x_1 = self_rect["x"] + self_rect["width"] - target_rect["x"]
         x_2 = self_rect["x"] - (target_rect["x"] + target_rect["width"])


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Return infinity instead of raising exceptions for missing element bounding boxes in distance calculations in `dom.py`.
> 
>   - **Behavior**:
>     - In `calculate_min_y_distance_to()` and `calculate_min_x_distance_to()` in `dom.py`, return `float('inf')` instead of raising exceptions when element bounding boxes are unavailable.
>   - **Error Handling**:
>     - Removes exception raising for missing element bounding boxes in the above functions, improving robustness.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 62bb2bc7f25d3eb1628803499bcfc01ec372a745. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->