### PR TITLE
trim svg elements when prompt exceeds context window

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6521,4 +6521,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11,<3.12"
-content-hash = "b43cb55e0c18ac83f0e32444132fd7618ef5b8355b0a90dbed55599d068c2892"
+content-hash = "84b211a2b313b852996823fc4105d809b990e34cecd400c61d541561c010afdf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ json-repair = "^0.34.0"
 pypdf = "^5.1.0"
 fastmcp = "^0.4.1"
 psutil = ">=7.0.0"
+tiktoken = ">=0.9.0"
 
 [tool.poetry.group.dev.dependencies]
 isort = "^5.13.2"

--- a/skyvern/forge/agent_functions.py
+++ b/skyvern/forge/agent_functions.py
@@ -139,7 +139,9 @@ async def _convert_svg_to_string(
 
         skyvern_element = SkyvernElement(locator=locater, frame=skyvern_frame.get_frame(), static_element=element)
 
-        _, blocked = await skyvern_frame.get_blocking_element_id(await skyvern_element.get_element_handler())
+        _, blocked = await skyvern_frame.get_blocking_element_id(
+            await skyvern_element.get_element_handler(timeout=1000)
+        )
         if not skyvern_element.is_interactable() and blocked:
             _mark_element_as_dropped(element)
             return

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -53,6 +53,7 @@ from skyvern.forge.sdk.workflow.models.yaml import (
     WorkflowDefinitionYAML,
 )
 from skyvern.schemas.runs import ProxyLocation, RunType
+from skyvern.utils.prompt_engine import load_prompt_with_elements
 from skyvern.webeye.browser_factory import BrowserState
 from skyvern.webeye.scraper.scraper import ElementTreeFormat, ScrapedPage, scrape_website
 from skyvern.webeye.utils.page import SkyvernFrame
@@ -462,10 +463,11 @@ async def run_task_v2_helper(
                 continue
             current_url = current_url if current_url else str(await SkyvernFrame.get_url(frame=page) if page else url)
 
-            task_v2_prompt = prompt_engine.load_prompt(
+            task_v2_prompt = load_prompt_with_elements(
+                scraped_page,
+                prompt_engine,
                 "task_v2",
                 current_url=current_url,
-                elements=element_tree_in_prompt,
                 user_goal=user_prompt,
                 task_history=task_history,
                 local_datetime=datetime.now(context.tz_info).isoformat(),

--- a/skyvern/utils/prompt_engine.py
+++ b/skyvern/utils/prompt_engine.py
@@ -1,0 +1,47 @@
+from typing import Any
+
+import structlog
+
+from skyvern.forge.sdk.prompting import PromptEngine
+from skyvern.utils.token_counter import count_tokens
+from skyvern.webeye.scraper.scraper import ScrapedPage
+
+DEFAULT_MAX_TOKENS = 100000
+LOG = structlog.get_logger()
+
+
+def load_prompt_with_elements(
+    scraped_page: ScrapedPage,
+    prompt_engine: PromptEngine,
+    template_name: str,
+    **kwargs: Any,
+) -> str:
+    prompt = prompt_engine.load_prompt(template_name, elements=scraped_page.build_element_tree(), **kwargs)
+    token_count = count_tokens(prompt)
+    if token_count > DEFAULT_MAX_TOKENS:
+        # get rid of all the secondary elements like SVG, etc
+        economy_elements_tree = scraped_page.build_economy_elements_tree()
+        prompt = prompt_engine.load_prompt(template_name, elements=economy_elements_tree, **kwargs)
+        economy_token_count = count_tokens(prompt)
+        LOG.warning(
+            "Prompt is longer than the max tokens. Going to use the economy elements tree.",
+            template_name=template_name,
+            token_count=token_count,
+            economy_token_count=economy_token_count,
+            max_tokens=DEFAULT_MAX_TOKENS,
+        )
+        if economy_token_count > DEFAULT_MAX_TOKENS:
+            # !!! HACK alert
+            # dump the last 1/3 of the html context and keep the first 2/3 of the html context
+            economy_elements_tree_dumped = scraped_page.build_economy_elements_tree(percent_to_keep=2 / 3)
+            prompt = prompt_engine.load_prompt(template_name, elements=economy_elements_tree_dumped, **kwargs)
+            token_count_after_dump = count_tokens(prompt)
+            LOG.warning(
+                "Prompt is still longer than the max tokens. Will only keep the first 2/3 of the html context.",
+                template_name=template_name,
+                token_count=token_count,
+                economy_token_count=economy_token_count,
+                token_count_after_dump=token_count_after_dump,
+                max_tokens=DEFAULT_MAX_TOKENS,
+            )
+    return prompt

--- a/skyvern/utils/token_counter.py
+++ b/skyvern/utils/token_counter.py
@@ -1,0 +1,5 @@
+import tiktoken
+
+
+def count_tokens(text: str) -> int:
+    return len(tiktoken.encoding_for_model("gpt-4o").encode(text))


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `load_prompt_with_elements` to trim SVG elements in prompts exceeding token limits, updating relevant files and adding `tiktoken` dependency.
> 
>   - **Behavior**:
>     - Introduces `load_prompt_with_elements` in `prompt_engine.py` to handle large prompts by trimming SVG elements when token count exceeds `DEFAULT_MAX_TOKENS`.
>     - Replaces `load_prompt` with `load_prompt_with_elements` in `agent.py`, `agent_functions.py`, and `task_v2_service.py`.
>   - **Utilities**:
>     - Adds `count_tokens` function in `token_counter.py` to count tokens using `tiktoken` library.
>   - **Models**:
>     - Updates `ScrapedPage` in `scraper.py` to support `build_economy_elements_tree` for excluding SVG elements.
>   - **Dependencies**:
>     - Adds `tiktoken` dependency in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f3ce0ff8f7c339907657256d121352d13e324316. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->