### PR TITLE
only take up to 1 screenshot if the html too big

### DIFF
--- a/skyvern/constants.py
+++ b/skyvern/constants.py
@@ -32,3 +32,4 @@ class ScrapeType(StrEnum):
 
 
 SCRAPE_TYPE_ORDER = [ScrapeType.NORMAL, ScrapeType.NORMAL, ScrapeType.RELOAD]
+DEFAULT_MAX_TOKENS = 100000

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -55,7 +55,7 @@ from skyvern.forge.sdk.workflow.models.yaml import (
 from skyvern.schemas.runs import ProxyLocation, RunType
 from skyvern.utils.prompt_engine import load_prompt_with_elements
 from skyvern.webeye.browser_factory import BrowserState
-from skyvern.webeye.scraper.scraper import ElementTreeFormat, ScrapedPage, scrape_website
+from skyvern.webeye.scraper.scraper import ScrapedPage, scrape_website
 from skyvern.webeye.utils.page import SkyvernFrame
 
 LOG = structlog.get_logger()
@@ -453,7 +453,6 @@ async def run_task_v2_helper(
                     app.AGENT_FUNCTION.cleanup_element_tree_factory(),
                     scrape_exclude=app.scrape_exclude,
                 )
-                element_tree_in_prompt: str = scraped_page.build_element_tree(ElementTreeFormat.HTML)
                 if page is None:
                     page = await browser_state.get_working_page()
             except Exception:
@@ -545,7 +544,7 @@ async def run_task_v2_helper(
                     workflow_permanent_id=workflow.workflow_permanent_id,
                     workflow_run_id=workflow_run_id,
                     current_url=current_url,
-                    element_tree_in_prompt=element_tree_in_prompt,
+                    scraped_page=scraped_page,
                     data_extraction_goal=plan,
                     task_history=task_history,
                 )
@@ -1084,20 +1083,22 @@ async def _generate_extraction_task(
     workflow_permanent_id: str,
     workflow_run_id: str,
     current_url: str,
-    element_tree_in_prompt: str,
+    scraped_page: ScrapedPage,
     data_extraction_goal: str,
     task_history: list[dict] | None = None,
 ) -> tuple[ExtractionBlock, list[BLOCK_YAML_TYPES], list[PARAMETER_YAML_TYPES]]:
     LOG.info("Generating extraction task", data_extraction_goal=data_extraction_goal, current_url=current_url)
     # extract the data
     context = skyvern_context.ensure_context()
-    generate_extraction_task_prompt = prompt_engine.load_prompt(
-        "task_v2_generate_extraction_task",
+    generate_extraction_task_prompt = load_prompt_with_elements(
+        scraped_page=scraped_page,
+        prompt_engine=prompt_engine,
+        template_name="task_v2_generate_extraction_task",
         current_url=current_url,
-        elements=element_tree_in_prompt,
         data_extraction_goal=data_extraction_goal,
         local_datetime=datetime.now(context.tz_info).isoformat(),
     )
+
     generate_extraction_task_response = await app.LLM_API_HANDLER(
         generate_extraction_task_prompt,
         task_v2=task_v2,

--- a/skyvern/utils/prompt_engine.py
+++ b/skyvern/utils/prompt_engine.py
@@ -2,11 +2,11 @@ from typing import Any
 
 import structlog
 
+from skyvern.constants import DEFAULT_MAX_TOKENS
 from skyvern.forge.sdk.prompting import PromptEngine
 from skyvern.utils.token_counter import count_tokens
 from skyvern.webeye.scraper.scraper import ScrapedPage
 
-DEFAULT_MAX_TOKENS = 100000
 LOG = structlog.get_logger()
 
 
@@ -14,13 +14,20 @@ def load_prompt_with_elements(
     scraped_page: ScrapedPage,
     prompt_engine: PromptEngine,
     template_name: str,
+    html_need_skyvern_attrs: bool = True,
     **kwargs: Any,
 ) -> str:
-    prompt = prompt_engine.load_prompt(template_name, elements=scraped_page.build_element_tree(), **kwargs)
+    prompt = prompt_engine.load_prompt(
+        template_name,
+        elements=scraped_page.build_element_tree(html_need_skyvern_attrs=html_need_skyvern_attrs),
+        **kwargs,
+    )
     token_count = count_tokens(prompt)
     if token_count > DEFAULT_MAX_TOKENS:
         # get rid of all the secondary elements like SVG, etc
-        economy_elements_tree = scraped_page.build_economy_elements_tree()
+        economy_elements_tree = scraped_page.build_economy_elements_tree(
+            html_need_skyvern_attrs=html_need_skyvern_attrs
+        )
         prompt = prompt_engine.load_prompt(template_name, elements=economy_elements_tree, **kwargs)
         economy_token_count = count_tokens(prompt)
         LOG.warning(
@@ -33,7 +40,10 @@ def load_prompt_with_elements(
         if economy_token_count > DEFAULT_MAX_TOKENS:
             # !!! HACK alert
             # dump the last 1/3 of the html context and keep the first 2/3 of the html context
-            economy_elements_tree_dumped = scraped_page.build_economy_elements_tree(percent_to_keep=2 / 3)
+            economy_elements_tree_dumped = scraped_page.build_economy_elements_tree(
+                html_need_skyvern_attrs=html_need_skyvern_attrs,
+                percent_to_keep=2 / 3,
+            )
             prompt = prompt_engine.load_prompt(template_name, elements=economy_elements_tree_dumped, **kwargs)
             token_count_after_dump = count_tokens(prompt)
             LOG.warning(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Optimize screenshot-taking in web scraping by limiting to 1 screenshot if HTML is too large, and refactor related code for efficiency.
> 
>   - **Behavior**:
>     - Limit screenshots to 1 if HTML token count exceeds `DEFAULT_MAX_TOKENS` in `scrape_web_unsafe()` in `scraper.py`.
>     - Adjust `take_split_screenshots()` call to respect new screenshot limit.
>   - **Refactoring**:
>     - Remove `ElementTreeFormat` import and usage in `task_v2_service.py` and `handler.py`.
>     - Replace `element_tree_in_prompt` with `scraped_page` in `_generate_extraction_task()` in `task_v2_service.py`.
>   - **Functions**:
>     - Update `load_prompt_with_elements()` in `prompt_engine.py` to handle `html_need_skyvern_attrs` parameter consistently across calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e0fddf3fb3d17c3c858d64591cbed5b1c43e3403. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->