### PR TITLE
shu/gemini 2.5 pro support

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -109,7 +109,13 @@ setup_llm_providers() {
         else
             update_or_add_env_var "GEMINI_API_KEY" "$gemini_api_key"
             update_or_add_env_var "ENABLE_GEMINI" "true"
-            model_options+=("GEMINI_PRO")
+            model_options+=(
+                "GEMINI_FLASH_2_0"
+                "GEMINI_FLASH_2_0_LITE"
+                "GEMINI_PRO"
+                "GEMINI_2.5_PRO_PREVIEW_03_25"
+                "GEMINI_2.5_PRO_EXP_03_25"
+            )
         fi
     else
         update_or_add_env_var "ENABLE_GEMINI" "false"

--- a/skyvern/cli/commands.py
+++ b/skyvern/cli/commands.py
@@ -279,7 +279,15 @@ def setup_llm_providers() -> None:
         else:
             update_or_add_env_var("GEMINI_API_KEY", gemini_api_key)
             update_or_add_env_var("ENABLE_GEMINI", "true")
-            model_options.extend(["GEMINI_FLASH_2_0", "GEMINI_FLASH_2_0_LITE", "GEMINI_PRO"])
+            model_options.extend(
+                [
+                    "GEMINI_FLASH_2_0",
+                    "GEMINI_FLASH_2_0_LITE",
+                    "GEMINI_PRO",
+                    "GEMINI_2.5_PRO_PREVIEW_03_25",
+                    "GEMINI_2.5_PRO_EXP_03_25",
+                ]
+            )
     else:
         update_or_add_env_var("ENABLE_GEMINI", "false")
 

--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -348,6 +348,27 @@ if settings.ENABLE_GEMINI:
             max_completion_tokens=8192,
         ),
     )
+    LLMConfigRegistry.register_config(
+        "GEMINI_2.5_PRO_PREVIEW_03_25",
+        LLMConfig(
+            "gemini/gemini-2.5-pro-preview-03-25",
+            ["GEMINI_API_KEY"],
+            supports_vision=True,
+            add_assistant_prefix=False,
+            max_completion_tokens=1048576,
+        ),
+    )
+    LLMConfigRegistry.register_config(
+        "GEMINI_2.5_PRO_EXP_03_25",
+        LLMConfig(
+            "gemini/gemini-2.5-pro-exp-03-25",
+            ["GEMINI_API_KEY"],
+            supports_vision=True,
+            add_assistant_prefix=False,
+            max_completion_tokens=1048576,
+        ),
+    )
+
 
 if settings.ENABLE_NOVITA:
     LLMConfigRegistry.register_config(


### PR DESCRIPTION
- support gemini 2.5 pro
- support GEMINI 2.5 PRO in setup scripts

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for Gemini 2.5 Pro models in setup scripts and configuration registry.
> 
>   - **Behavior**:
>     - Adds support for `GEMINI_2.5_PRO_PREVIEW_03_25` and `GEMINI_2.5_PRO_EXP_03_25` models in `setup.sh` and `commands.py`.
>     - Updates `setup_llm_providers()` in both `setup.sh` and `commands.py` to include new Gemini models.
>   - **Configuration**:
>     - Registers `GEMINI_2.5_PRO_PREVIEW_03_25` and `GEMINI_2.5_PRO_EXP_03_25` in `config_registry.py` with `max_completion_tokens` set to 1048576.
>   - **Misc**:
>     - Updates environment variable handling for Gemini models in `setup.sh` and `commands.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c88895c6939e4e9bd3345726473203061b24d87f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->