### PR TITLE
mark task v2 timed_out

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -770,6 +770,18 @@ class WorkflowService:
             status=WorkflowRunStatus.canceled,
         )
 
+    async def mark_workflow_run_as_timed_out(self, workflow_run_id: str, failure_reason: str | None = None) -> None:
+        LOG.info(
+            f"Marking workflow run {workflow_run_id} as timed out",
+            workflow_run_id=workflow_run_id,
+            workflow_status="timed_out",
+        )
+        await app.DATABASE.update_workflow_run(
+            workflow_run_id=workflow_run_id,
+            status=WorkflowRunStatus.timed_out,
+            failure_reason=failure_reason,
+        )
+
     async def get_workflow_run(self, workflow_run_id: str, organization_id: str | None = None) -> WorkflowRun:
         workflow_run = await app.DATABASE.get_workflow_run(
             workflow_run_id=workflow_run_id,

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -1320,6 +1320,23 @@ async def mark_task_v2_as_terminated(
     return task_v2
 
 
+async def mark_task_v2_as_timed_out(
+    task_v2_id: str,
+    workflow_run_id: str | None = None,
+    organization_id: str | None = None,
+    failure_reason: str | None = None,
+) -> TaskV2:
+    task_v2 = await app.DATABASE.update_task_v2(
+        task_v2_id,
+        organization_id=organization_id,
+        status=TaskV2Status.timed_out,
+    )
+    if workflow_run_id:
+        await app.WORKFLOW_SERVICE.mark_workflow_run_as_timed_out(workflow_run_id, failure_reason)
+    await send_task_v2_webhook(task_v2)
+    return task_v2
+
+
 def _get_extracted_data_from_block_result(
     block_result: BlockResult,
     task_type: str,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add functionality to mark tasks and workflow runs as timed out in `service.py` and `task_v2_service.py`.
> 
>   - **Behavior**:
>     - Adds `mark_workflow_run_as_timed_out()` in `service.py` to update workflow run status to `timed_out`.
>     - Adds `mark_task_v2_as_timed_out()` in `task_v2_service.py` to update task v2 status to `timed_out` and trigger workflow run timeout if applicable.
>   - **Logging**:
>     - Logs status change to `timed_out` in both `mark_workflow_run_as_timed_out()` and `mark_task_v2_as_timed_out()`.
>   - **Database**:
>     - Updates workflow run and task v2 status to `timed_out` in the database in respective functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 4e4c506ba56b815855727834e8f56da0dddc938a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->