### PR TITLE
set task_id in skyvern_context when task block starts

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -48,6 +48,7 @@ from skyvern.forge.sdk.api.files import (
 )
 from skyvern.forge.sdk.api.llm.api_handler_factory import LLMAPIHandlerFactory
 from skyvern.forge.sdk.artifact.models import ArtifactType
+from skyvern.forge.sdk.core import skyvern_context
 from skyvern.forge.sdk.db.enums import TaskType
 from skyvern.forge.sdk.schemas.files import FileInfo
 from skyvern.forge.sdk.schemas.task_v2 import TaskV2Status
@@ -612,6 +613,8 @@ class BaseTaskBlock(Block):
                         raise e
 
             try:
+                current_context = skyvern_context.ensure_context()
+                current_context.task_id = task.task_id
                 await app.agent.execute_step(
                     organization=organization,
                     task=task,
@@ -630,6 +633,8 @@ class BaseTaskBlock(Block):
                     failure_reason=str(e),
                 )
                 raise e
+            finally:
+                current_context.task_id = None
 
             # Check task status
             updated_task = await app.DATABASE.get_task(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Sets and clears `task_id` in `skyvern_context` during task execution in `block.py` to manage task context accurately.
> 
>   - **Behavior**:
>     - Sets `task_id` in `skyvern_context` when a task block starts in `execute()` of `block.py`.
>     - Clears `task_id` in `skyvern_context` after task execution completes or fails.
>   - **Context Management**:
>     - Uses `skyvern_context.ensure_context()` to obtain the current context and set `task_id`.
>     - Ensures `task_id` is reset to `None` in the `finally` block to prevent stale context data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0107beaafa69cd2c648cb317947af43992ed338f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->