### PR TITLE
fix task v2 doc

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -71,6 +71,8 @@ navigation:
           path: running-tasks/introduction.mdx
         - page: Tasks API
           path: running-tasks/api-spec.mdx
+        - page: Tasks V2 API
+          path: running-tasks/api-v2-spec.mdx
         - api: Endpoints
           paginated: true
           snippets: 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `Tasks V2 API` page to documentation navigation in `docs.yml`.
> 
>   - **Documentation**:
>     - Adds `Tasks V2 API` page to the navigation in `docs.yml`, located at `running-tasks/api-v2-spec.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c02bce450be88ef8e0667c5eda1e84fe85039178. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->