### PR TITLE
fix some prompts missing current date

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1204,6 +1204,7 @@ class ForgeAgent:
             navigation_goal=task.navigation_goal,
             navigation_payload=task.navigation_payload,
             complete_criterion=task.complete_criterion,
+            local_datetime=datetime.now(skyvern_context.ensure_context().tz_info).isoformat(),
         )
 
         # this prompt is critical to our agent so let's use the primary LLM API handler
@@ -2155,6 +2156,7 @@ class ForgeAgent:
                 navigation_goal=task.navigation_goal,
                 navigation_payload=task.navigation_payload,
                 steps=steps_results,
+                local_datetime=datetime.now(skyvern_context.ensure_context().tz_info).isoformat(),
             )
             json_response = await app.LLM_API_HANDLER(
                 prompt=prompt, screenshots=screenshots, step=step, prompt_name="summarize-max-steps-reason"

--- a/skyvern/forge/prompts/skyvern/auto-completion-choose-option.j2
+++ b/skyvern/forge/prompts/skyvern/auto-completion-choose-option.j2
@@ -50,3 +50,8 @@ HTML elements:
 ```
 {{ elements }}
 ```
+
+Current datetime, ISO format:
+```
+{{ local_datetime }}
+```

--- a/skyvern/forge/prompts/skyvern/auto-completion-potential-answers.j2
+++ b/skyvern/forge/prompts/skyvern/auto-completion-potential-answers.j2
@@ -37,3 +37,8 @@ User details:
 ```
 {{ navigation_payload_str }}
 ```
+
+Current datetime, ISO format:
+```
+{{ local_datetime }}
+```

--- a/skyvern/forge/prompts/skyvern/auto-completion-tweak-value.j2
+++ b/skyvern/forge/prompts/skyvern/auto-completion-tweak-value.j2
@@ -46,3 +46,8 @@ Popped up elements:
 ```
 {{ popped_up_elements }}
 ```
+
+Current datetime, ISO format:
+```
+{{ local_datetime }}
+```

--- a/skyvern/forge/prompts/skyvern/check-user-goal.j2
+++ b/skyvern/forge/prompts/skyvern/check-user-goal.j2
@@ -28,3 +28,8 @@ Elements on the page:
 ```
 {{ elements }}
 ```
+
+Current datetime, ISO format:
+```
+{{ local_datetime }}
+```

--- a/skyvern/forge/prompts/skyvern/normal-select.j2
+++ b/skyvern/forge/prompts/skyvern/normal-select.j2
@@ -37,3 +37,8 @@ Option list:
 ```
 {{ options }}
 ```
+
+Current datetime, ISO format:
+```
+{{ local_datetime }}
+```

--- a/skyvern/forge/prompts/skyvern/summarize-max-steps-reason.j2
+++ b/skyvern/forge/prompts/skyvern/summarize-max-steps-reason.j2
@@ -16,3 +16,8 @@ User Details:
 Actions Taken In Each Step:
 {% for step in steps %}Step {{ step.order }} -- {{ step.actions_result }}
 {% endfor %}
+
+Current datetime, ISO format:
+```
+{{ local_datetime }}
+```

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -60,6 +60,7 @@ from skyvern.forge.sdk.api.files import (
     wait_for_download_finished,
 )
 from skyvern.forge.sdk.api.llm.exceptions import LLMProviderError
+from skyvern.forge.sdk.core import skyvern_context
 from skyvern.forge.sdk.core.aiohttp_helper import aiohttp_post
 from skyvern.forge.sdk.core.security import generate_skyvern_signature
 from skyvern.forge.sdk.core.skyvern_context import ensure_context
@@ -1668,6 +1669,7 @@ async def choose_auto_completion_dropdown(
             navigation_goal=task.navigation_goal,
             navigation_payload_str=json.dumps(task.navigation_payload),
             elements=html,
+            local_datetime=datetime.now(skyvern_context.ensure_context().tz_info).isoformat(),
         )
         LOG.info(
             "Confirm if it's an auto completion dropdown",
@@ -1825,6 +1827,7 @@ async def input_or_auto_complete_input(
             current_value=current_value,
             navigation_goal=task.navigation_goal,
             navigation_payload_str=json.dumps(task.navigation_payload),
+            local_datetime=datetime.now(skyvern_context.ensure_context().tz_info).isoformat(),
         )
 
         LOG.info(
@@ -1888,6 +1891,7 @@ async def input_or_auto_complete_input(
                 navigation_payload_str=json.dumps(task.navigation_payload),
                 tried_values=json.dumps(tried_values),
                 popped_up_elements="".join([json_to_html(element) for element in cleaned_new_elements]),
+                local_datetime=datetime.now(skyvern_context.ensure_context().tz_info).isoformat(),
             )
             json_respone = await app.SECONDARY_LLM_API_HANDLER(
                 prompt=prompt, step=step, prompt_name="auto-completion-tweak-value"
@@ -2644,6 +2648,7 @@ async def normal_select(
         navigation_goal=task.navigation_goal,
         navigation_payload_str=json.dumps(task.navigation_payload),
         options=options_html,
+        local_datetime=datetime.now(skyvern_context.ensure_context().tz_info).isoformat(),
     )
 
     json_response = await app.SELECT_AGENT_LLM_API_HANDLER(prompt=prompt, step=step, prompt_name="custom-select")


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add current date to prompts in `agent.py`, `handler.py`, and various templates to ensure time-sensitive operations include the current date.
> 
>   - **Behavior**:
>     - Add `local_datetime` to `complete_verify()` and `summary_failure_reason_for_max_steps()` in `agent.py` to include current date in prompts.
>     - Add `local_datetime` to `choose_auto_completion_dropdown()` and `input_or_auto_complete_input()` in `handler.py` for date inclusion in prompts.
>   - **Templates**:
>     - Add `Current datetime, ISO format` section to `auto-completion-choose-option.j2`, `auto-completion-potential-answers.j2`, `auto-completion-tweak-value.j2`, `check-user-goal.j2`, `normal-select.j2`, and `summarize-max-steps-reason.j2` to display current date.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 7c3686fcfe3652da64496dde45e200ca084c22c4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->