### PR TITLE
add shadow host element into interactable detecting list

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -590,9 +590,6 @@ function isValidCSSSelector(selector) {
 }
 
 function isInteractable(element, hoverStylesMap) {
-  if (element.shadowRoot) {
-    return false;
-  }
   if (!isElementVisible(element)) {
     return false;
   }


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Removes exclusion of shadow DOM elements from being interactable in `isInteractable()` in `domUtils.js`.
> 
>   - **Behavior**:
>     - Removes check for `element.shadowRoot` in `isInteractable()` in `domUtils.js`, allowing elements with shadow DOM to be considered interactable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b9e78dea4b7eb0b2d3438391bad554c15d2dd4d1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->