### PR TITLE
new sdk v0.1.74

### DIFF
--- a/fern/openapi/skyvern_openapi.json
+++ b/fern/openapi/skyvern_openapi.json
@@ -5571,7 +5571,8 @@
         "type": "string",
         "enum": [
           "skyvern-1.0",
-          "skyvern-2.0"
+          "skyvern-2.0",
+          "openai-cua"
         ],
         "title": "RunEngine"
       },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "skyvern"
-version = "0.1.73"
+version = "0.1.74"
 description = ""
 authors = ["Skyvern AI <info@skyvern.com>"]
 readme = "README.md"

--- a/skyvern/client/core/client_wrapper.py
+++ b/skyvern/client/core/client_wrapper.py
@@ -24,7 +24,7 @@ class BaseClientWrapper:
         headers: typing.Dict[str, str] = {
             "X-Fern-Language": "Python",
             "X-Fern-SDK-Name": "skyvern",
-            "X-Fern-SDK-Version": "0.1.70",
+            "X-Fern-SDK-Version": "0.1.74",
         }
         if self._api_key is not None:
             headers["x-api-key"] = self._api_key

--- a/skyvern/client/types/run_engine.py
+++ b/skyvern/client/types/run_engine.py
@@ -2,4 +2,4 @@
 
 import typing
 
-RunEngine = typing.Union[typing.Literal["skyvern-1.0", "skyvern-2.0"], typing.Any]
+RunEngine = typing.Union[typing.Literal["skyvern-1.0", "skyvern-2.0", "openai-cua"], typing.Any]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `openai-cua` to `RunEngine` and update SDK version to `0.1.74`.
> 
>   - **OpenAPI Specification**:
>     - Added `openai-cua` to `RunEngine` enum in `skyvern_openapi.json`.
>   - **Versioning**:
>     - Updated version to `0.1.74` in `pyproject.toml` and `client_wrapper.py`.
>   - **Client Types**:
>     - Updated `RunEngine` type in `run_engine.py` to include `openai-cua`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for dddff615e5f8e5e0d8da6ca99c1a64994c568997. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->