### PR TITLE
fix run_type for TaskRunResponse

### DIFF
--- a/skyvern/schemas/runs.py
+++ b/skyvern/schemas/runs.py
@@ -217,8 +217,8 @@ class BaseRunResponse(BaseModel):
 
 
 class TaskRunResponse(BaseRunResponse):
-    run_type: Literal[RunType.task_v1, RunType.task_v2] = Field(
-        description="Type of task run - either task_v1 or task_v2"
+    run_type: Literal[RunType.task_v1, RunType.task_v2, RunType.openai_cua] = Field(
+        description="Types of a task run - task_v1, task_v2, openai_cua"
     )
     run_request: TaskRunRequest | None = Field(
         default=None, description="The original request parameters used to start this task run"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `RunType.openai_cua` to `run_type` in `TaskRunResponse` in `runs.py`.
> 
>   - **Behavior**:
>     - Adds `RunType.openai_cua` to `run_type` in `TaskRunResponse` in `runs.py`.
>     - Updates description to include `openai_cua` as a valid task run type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2a13ba92fe75bf2ea9d86fd43e4ad14af3932a35. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->