### PR TITLE
add max limit for dom listner

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -2194,6 +2194,15 @@ function asyncSleepFor(ms) {
 }
 
 async function addIncrementalNodeToMap(parentNode, childrenNode) {
+  const maxParsedElement = 3000;
+  if ((await window.globalParsedElementCounter.get()) > maxParsedElement) {
+    console.warn(
+      "Too many elements parsed, stopping the observer to parse the elements",
+    );
+    await window.globalParsedElementCounter.add();
+    return;
+  }
+
   // make the dom parser async
   await waitForNextFrame();
   if (window.globalListnerFlag) {


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a 3000-element limit to `addIncrementalNodeToMap` in `domUtils.js`, logging a warning and stopping parsing if exceeded.
> 
>   - **Behavior**:
>     - Adds a limit of 3000 elements to `addIncrementalNodeToMap` in `domUtils.js`.
>     - Logs a warning and stops parsing if the limit is exceeded.
>   - **Functions**:
>     - Modifies `addIncrementalNodeToMap` to include element count check and warning log.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 174bcd5a1ce238e2f80dd21f47e1597ae40adb1d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->