### PR TITLE
fix open ai client initialization issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "skyvern"
-version = "0.1.75"
+version = "0.1.76"
 description = ""
 authors = ["Skyvern AI <info@skyvern.com>"]
 readme = "README.md"

--- a/skyvern/forge/app.py
+++ b/skyvern/forge/app.py
@@ -33,7 +33,7 @@ ARTIFACT_MANAGER = ArtifactManager()
 BROWSER_MANAGER = BrowserManager()
 EXPERIMENTATION_PROVIDER: BaseExperimentationProvider = NoOpExperimentationProvider()
 LLM_API_HANDLER = LLMAPIHandlerFactory.get_llm_api_handler(SettingsManager.get_settings().LLM_KEY)
-OPENAI_CLIENT = AsyncOpenAI(api_key=SettingsManager.get_settings().OPENAI_API_KEY)
+OPENAI_CLIENT = AsyncOpenAI(api_key=SettingsManager.get_settings().OPENAI_API_KEY or "")
 if SettingsManager.get_settings().ENABLE_AZURE_CUA:
     OPENAI_CLIENT = AsyncAzureOpenAI(
         api_key=SettingsManager.get_settings().AZURE_CUA_API_KEY,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes OpenAI client initialization issue by using a default empty string for the API key in `app.py`.
> 
>   - **Behavior**:
>     - Fixes OpenAI client initialization in `app.py` by using an empty string as a default for `api_key` if `OPENAI_API_KEY` is not set.
>   - **Versioning**:
>     - Bumps version in `pyproject.toml` from `0.1.75` to `0.1.76`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 83dfd169c2a890dee4c3144a18e36492c165f4fc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->