### PR TITLE
sdk get_run bug fix

### DIFF
--- a/skyvern/agent/client.py
+++ b/skyvern/agent/client.py
@@ -81,7 +81,7 @@ class SkyvernClient:
         run_id: str,
     ) -> RunResponse:
         run_obj = await self.client.agent.get_run(run_id=run_id)
-        if run_obj.run_type in [RunType.task_v1, RunType.task_v2]:
+        if run_obj.run_type in [RunType.task_v1, RunType.task_v2, RunType.openai_cua]:
             return TaskRunResponse.model_validate(run_obj.dict())
         elif run_obj.run_type == RunType.workflow_run:
             return WorkflowRunResponse.model_validate(run_obj.dict())


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix bug in `get_run()` in `client.py` to handle `RunType.openai_cua` as `TaskRunResponse`.
> 
>   - **Bug Fix**:
>     - In `get_run()` method of `SkyvernClient` in `client.py`, added support for `RunType.openai_cua` to be processed as `TaskRunResponse`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0c4781e66735241f9c01dd51d1d1f165a88d0f36. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->