### PR TITLE
remove task v2 api

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -71,8 +71,6 @@ navigation:
           path: running-tasks/introduction.mdx
         - page: Tasks API
           path: running-tasks/api-spec.mdx
-        - page: Tasks V2 API
-          path: running-tasks/api-v2-spec.mdx
         - api: Endpoints
           paginated: true
           snippets: 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `Tasks V2 API` section from documentation navigation in `fern/docs.yml`.
> 
>   - **Documentation**:
>     - Removes `Tasks V2 API` section from `fern/docs.yml` navigation, eliminating the `running-tasks/api-v2-spec.mdx` path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a79b4cb51739c218ff16694d84dd381c35fe653f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->