### PR TITLE
shu/fallback to skyvern actions when cua returns no action

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1319,7 +1319,7 @@ class ForgeAgent:
             incremental_cached_tokens=cached_tokens if cached_tokens > 0 else None,
         )
 
-        return parse_cua_actions(task, step, current_response), current_response
+        return await parse_cua_actions(task, step, current_response), current_response
 
     @staticmethod
     async def complete_verify(page: Page, scraped_page: ScrapedPage, task: Task, step: Step) -> CompleteVerifyResult:

--- a/skyvern/forge/prompts/skyvern/cua-fallback-action.j2
+++ b/skyvern/forge/prompts/skyvern/cua-fallback-action.j2
@@ -1,0 +1,21 @@
+The user is trying to achieve a goal in the browser assisted by an browser AI assistant.
+
+According to the AI assistant's feedback, including reasoning and its message, there's no immediate action the assistant can take in the website.
+
+Help the user decide what to do next based on the assistant's message. Here's the list of available actions:
+- solve_captcha: the task is blocked by captcha and the assistant is asking the user to solve the captcha
+- complete: the user goal has been achieved
+- terminate: the user goal cannot be achieved. Terminate the task. Examples: 1) there's not enough data provided to achieve the goal and the assistant is asking the user to provide more information. For examples: login is required and the user has not provided the login credentials or incorrect credentials are provided; a form needs to be filled and a required field is missing. 2) The site is stuck or not loading after multiple attempts
+- get_verification_code: the assistant is asking the user to provide a verification code (2FA, MFA or TOTP code)
+- other: the assistant is asking the user to do something else
+
+Return the action to take next in the following JSON format:
+{
+    "action": str // complete, terminate, solve_captcha, get_verification_code
+}
+
+User goal: {{ navigation_goal }}
+
+Assistant reasoning: {{ assistant_reasoning }}
+
+Assistant message: {{ assistant_message }}

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1479,6 +1479,8 @@ async def run_task(
         )
         url = url or task_generation.url
         navigation_goal = task_generation.navigation_goal or run_request.prompt
+        if run_request.engine == RunEngine.openai_cua:
+            navigation_goal = run_request.prompt
         navigation_payload = task_generation.navigation_payload
         data_extraction_goal = task_generation.data_extraction_goal
         data_extraction_schema = data_extraction_schema or task_generation.extracted_information_schema

--- a/skyvern/services/run_service.py
+++ b/skyvern/services/run_service.py
@@ -136,7 +136,7 @@ async def cancel_run(run_id: str, organization_id: str | None = None, api_key: s
             detail=f"Run not found {run_id}",
         )
 
-    if run.task_run_type == RunType.task_v1:
+    if run.task_run_type in [RunType.task_v1, RunType.openai_cua]:
         await cancel_task_v1(run_id, organization_id=organization_id, api_key=api_key)
     elif run.task_run_type == RunType.task_v2:
         await cancel_task_v2(run_id, organization_id=organization_id)


### PR DESCRIPTION
- cua-fallback-action
- cua-fallback-action

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> This PR adds a fallback mechanism to use Skyvern actions when CUA returns no actions, updates task handling for `openai_cua`, and introduces a new prompt for fallback actions.
> 
>   - **Behavior**:
>     - Introduces fallback to Skyvern actions when CUA returns no actions in `parse_cua_actions()` in `parse_actions.py`.
>     - Updates `run_task()` in `agent_protocol.py` to set `navigation_goal` to `run_request.prompt` for `openai_cua` engine.
>     - Updates `cancel_run()` in `run_service.py` to handle `openai_cua` tasks.
>   - **Functions**:
>     - Changes `parse_cua_actions()` to handle empty action responses by generating fallback actions using a new prompt `cua-fallback-action.j2`.
>     - Modifies `_generate_cua_actions()` in `agent.py` to await `parse_cua_actions()`.
>   - **Prompts**:
>     - Adds `cua-fallback-action.j2` to define fallback actions when no CUA actions are available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e2fbd0a7b79a2e367c4add6d97ccbc0a6b9c22a7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->