### PR TITLE
add required action fields for cua fallback actions

### DIFF
--- a/skyvern/webeye/actions/parse_actions.py
+++ b/skyvern/webeye/actions/parse_actions.py
@@ -351,5 +351,12 @@ async def parse_cua_actions(
                 reasoning=reasoning,
                 intention=reasoning,
             )
+
+        action.organization_id = task.organization_id
+        action.workflow_run_id = task.workflow_run_id
+        action.task_id = task.task_id
+        action.step_id = step.step_id
+        action.step_order = step.order
+        action.action_order = 0
         return [action]
     return actions


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add required context fields to actions in `parse_cua_actions` in `parse_actions.py`.
> 
>   - **Behavior**:
>     - In `parse_cua_actions` in `parse_actions.py`, add fields `organization_id`, `workflow_run_id`, `task_id`, `step_id`, `step_order`, and `action_order` to `action` objects.
>     - Fields are populated from `task` and `step` objects to provide context for each action.
>   - **Misc**:
>     - No changes to existing logic or error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 864cc386441684272317f57a84bb3b02c3b78a6a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->