### PR TITLE
cua keypress combo

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -1483,13 +1483,46 @@ async def handle_keypress_action(
     task: Task,
     step: Step,
 ) -> list[ActionResult]:
+    updated_keys = []
     for key in action.keys:
         if key.lower() == "enter":
-            await page.keyboard.press("Enter")
+            updated_keys.append("Enter")
         elif key.lower() == "space":
-            await page.keyboard.press(" ")
+            updated_keys.append(" ")
+        elif key.lower() == "ctrl":
+            updated_keys.append("Control")
+        elif key.lower() == "backspace":
+            updated_keys.append("Backspace")
+        elif key.lower() == "pagedown":
+            updated_keys.append("PageDown")
+        elif key.lower() == "pageup":
+            updated_keys.append("PageUp")
+        elif key.lower() == "tab":
+            updated_keys.append("Tab")
+        elif key.lower() == "shift":
+            updated_keys.append("Shift")
+        elif key.lower() == "arrowleft":
+            updated_keys.append("ArrowLeft")
+        elif key.lower() == "arrowright":
+            updated_keys.append("ArrowRight")
+        elif key.lower() == "arrowup":
+            updated_keys.append("ArrowUp")
+        elif key.lower() == "arrowdown":
+            updated_keys.append("ArrowDown")
+        elif key.lower() == "home":
+            updated_keys.append("Home")
+        elif key.lower() == "end":
+            updated_keys.append("End")
+        elif key.lower() == "delete":
+            updated_keys.append("Delete")
+        elif key.lower() == "ecs":
+            updated_keys.append("Escape")
+        elif key.lower() == "alt":
+            updated_keys.append("Alt")
         else:
-            await page.keyboard.press(key)
+            updated_keys.append(key)
+    keypress_str = "+".join(updated_keys)
+    await page.keyboard.press(keypress_str)
     return [ActionSuccess()]
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `handle_keypress_action` in `handler.py` to support simultaneous key combinations by concatenating keys with "+".
> 
>   - **Behavior**:
>     - Modify `handle_keypress_action` in `handler.py` to support key combinations by concatenating keys with "+" and pressing them together.
>     - Handles keys like "Enter", "Space", "Ctrl", "Backspace", "PageDown", "PageUp", "Tab", "Shift", "ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End", "Delete", "Escape", "Alt", and others.
>   - **Misc**:
>     - Refactor key handling logic to build a `keypress_str` and press it once, instead of pressing each key individually.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 8c2f37cc8ed05b132e81510667b9d2a1ee682375. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->