### PR TITLE
Add any information that helps from the last message of CUA when there's no data extraction goal

### DIFF
--- a/skyvern/forge/prompts/skyvern/cua-fallback-action.j2
+++ b/skyvern/forge/prompts/skyvern/cua-fallback-action.j2
@@ -12,6 +12,7 @@ Help the user decide what to do next based on the assistant's message. Here's th
 Return the action to take next in the following JSON format:
 {
     "action": str // complete, terminate, solve_captcha, get_verification_code
+    "useful_information": str // If there is any useful information the assistant has provided that contributes to the user goal, put it here.
 }
 
 User goal: {{ navigation_goal }}

--- a/skyvern/webeye/actions/parse_actions.py
+++ b/skyvern/webeye/actions/parse_actions.py
@@ -331,12 +331,19 @@ async def parse_cua_actions(
             prompt_name="cua-fallback-action",
         )
         skyvern_action_type = action_response.get("action")
+        useful_information = action_response.get("useful_information")
         action = WaitAction(
             seconds=5,
             reasoning=reasoning,
             intention=reasoning,
         )
         if skyvern_action_type == "complete":
+            if not task.data_extraction_goal and useful_information:
+                await app.DATABASE.update_task(
+                    task.task_id,
+                    organization_id=task.organization_id,
+                    extracted_information=useful_information,
+                )
             action = CompleteAction(
                 reasoning=reasoning,
                 intention=reasoning,


### PR DESCRIPTION
- update generate-task prompt
- update extracted_information with the final message cua provided if there's no data extraction goal for cua

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update prompt templates and action parsing to handle useful information when no data extraction goal is set.
> 
>   - **Prompts**:
>     - Update `cua-fallback-action.j2` to include `useful_information` field in JSON response.
>     - Modify `generate-task.j2` to clarify `data_extraction_reasoning` description.
>   - **Action Parsing**:
>     - In `parse_cua_actions` in `parse_actions.py`, update task with `useful_information` if no `data_extraction_goal` is set and `useful_information` is available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 4faa1d2ed36e240141b2d3bbe91d01bb859e8f8b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->