### PR TITLE
shu/cua other action

### DIFF
--- a/skyvern/forge/prompts/skyvern/cua-fallback-action.j2
+++ b/skyvern/forge/prompts/skyvern/cua-fallback-action.j2
@@ -11,7 +11,7 @@ Help the user decide what to do next based on the assistant's message. Here's th
 
 Return the action to take next in the following JSON format:
 {
-    "action": str // complete, terminate, solve_captcha, get_verification_code
+    "action": str // complete, terminate, solve_captcha, get_verification_code, other
     "useful_information": str // If there is any useful information the assistant has provided that contributes to the user goal, put it here.
 }
 

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -1439,6 +1439,12 @@ async def handle_complete_action(
             workflow_run_id=task.workflow_run_id,
         )
         action.verified = True
+        if not task.data_extraction_goal and verification_result.thoughts:
+            await app.DATABASE.update_task(
+                task.task_id,
+                organization_id=task.organization_id,
+                extracted_information=verification_result.thoughts,
+            )
 
     return [ActionSuccess()]
 


### PR DESCRIPTION
- cua other action in the prompt is missing
- add completion thoughts to the extracted_information when there's no data extraction goal

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `other` action to CUA fallback prompt and store completion thoughts in `extracted_information` when no data extraction goal in `handle_complete_action()`.
> 
>   - **Prompt update**:
>     - Add `other` to the list of possible `action` values in `cua-fallback-action.j2`.
>   - **Behavior change in complete action**:
>     - In `handle_complete_action()` in `handler.py`, if `task.data_extraction_goal` is falsy and `verification_result.thoughts` is present, store `verification_result.thoughts` in `extracted_information` via `app.DATABASE.update_task()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6f674c531f07db03624a03b6ff14d8b32d42b2ac. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->