### PR TITLE
Revert "Revert "set task_id in skyvern_context when task block starts""

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -613,6 +613,8 @@ class BaseTaskBlock(Block):
                         raise e
 
             try:
+                current_context = skyvern_context.ensure_context()
+                current_context.task_id = task.task_id
                 await app.agent.execute_step(
                     organization=organization,
                     task=task,
@@ -631,6 +633,8 @@ class BaseTaskBlock(Block):
                     failure_reason=str(e),
                 )
                 raise e
+            finally:
+                current_context.task_id = None
 
             # Check task status
             updated_task = await app.DATABASE.get_task(


### PR DESCRIPTION
Reverts Skyvern-AI/skyvern#2161
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts a previous change to set and reset `task_id` in `skyvern_context` during task execution in `block.py`.
> 
>   - **Behavior**:
>     - Sets `task_id` in `skyvern_context` at the start of task execution in `execute()` in `block.py`.
>     - Resets `task_id` to `None` in `finally` block after task execution in `execute()` in `block.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 61a63b501ed859db9eff2d09285a825794d50ed5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->