### PR TITLE
GPT-o4-mini and GPT-o3 support is here

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -57,6 +57,8 @@ setup_llm_providers() {
                 "OPENAI_GPT4_1_MINI"
                 "OPENAI_GPT4_1_NANO"
                 "OPENAI_GPT4O"
+                "OPENAI_O4_MINI"
+                "OPENAI_O3"
             )
         fi
     else

--- a/skyvern/cli/commands.py
+++ b/skyvern/cli/commands.py
@@ -227,6 +227,8 @@ def setup_llm_providers() -> None:
                     "OPENAI_GPT4_1_MINI",
                     "OPENAI_GPT4_1_NANO",
                     "OPENAI_GPT4O",
+                    "OPENAI_O4_MINI",
+                    "OPENAI_O3",
                 ]
             )
     else:

--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -263,7 +263,6 @@ class LLMAPIHandlerFactory:
             active_parameters.update(parameters)
             if llm_config.litellm_params:  # type: ignore
                 active_parameters.update(llm_config.litellm_params)  # type: ignore
-                
 
             context = skyvern_context.current()
             if context and len(context.hashed_href_map) > 0:

--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -263,6 +263,7 @@ class LLMAPIHandlerFactory:
             active_parameters.update(parameters)
             if llm_config.litellm_params:  # type: ignore
                 active_parameters.update(llm_config.litellm_params)  # type: ignore
+                
 
             context = skyvern_context.current()
             if context and len(context.hashed_href_map) > 0:

--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -159,7 +159,7 @@ if settings.ENABLE_OPENAI:
             temperature=None,  # Temperature isn't supported in the O-model series
             reasoning_effort="high",
             litellm_params=LiteLLMParams(
-                drop_params=True,
+                drop_params=True,  # type: ignore
             ),
         ),
     )
@@ -174,7 +174,7 @@ if settings.ENABLE_OPENAI:
             temperature=None,  # Temperature isn't supported in the O-model series
             reasoning_effort="high",
             litellm_params=LiteLLMParams(
-                drop_params=True,
+                drop_params=True,  # type: ignore
             ),
         ),
     )

--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -148,6 +148,36 @@ if settings.ENABLE_OPENAI:
             max_completion_tokens=16384,
         ),
     )
+    LLMConfigRegistry.register_config(
+        "OPENAI_O4_MINI",
+        LLMConfig(
+            "o4-mini",
+            ["OPENAI_API_KEY"],
+            supports_vision=False,
+            add_assistant_prefix=False,
+            max_completion_tokens=16384,
+            temperature=None,  # Temperature isn't supported in the O-model series
+            reasoning_effort="high",
+            litellm_params=LiteLLMParams(
+                drop_params=True,
+            ),
+        ),
+    )
+    LLMConfigRegistry.register_config(
+        "OPENAI_O3",
+        LLMConfig(
+            "o3",
+            ["OPENAI_API_KEY"],
+            supports_vision=False,
+            add_assistant_prefix=False,
+            max_completion_tokens=16384,
+            temperature=None,  # Temperature isn't supported in the O-model series
+            reasoning_effort="high",
+            litellm_params=LiteLLMParams(
+                drop_params=True,
+            ),
+        ),
+    )
 
 
 if settings.ENABLE_ANTHROPIC:
@@ -343,7 +373,7 @@ if settings.ENABLE_AZURE_O3_MINI:
             add_assistant_prefix=False,
             max_completion_tokens=16384,
             temperature=None,  # Temperature isn't supported in the O-model series
-            reasoning_effort="low",
+            reasoning_effort="high",
         ),
     )
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds support for `OPENAI_O4_MINI` and `OPENAI_O3` models, updating setup scripts and configuration registries to integrate these new models.
> 
>   - **Behavior**:
>     - Adds support for `OPENAI_O4_MINI` and `OPENAI_O3` models in `setup.sh`, `commands.py`, and `config_registry.py`.
>     - Updates `setup_llm_providers()` in `setup.sh` and `commands.py` to include new models in the OpenAI configuration options.
>   - **Models**:
>     - Registers `OPENAI_O4_MINI` and `OPENAI_O3` in `LLMConfigRegistry` in `config_registry.py` with specific configurations (e.g., `max_completion_tokens=16384`, `reasoning_effort="high"`).
>   - **Misc**:
>     - Adjusts `reasoning_effort` for `OPENAI_O3_MINI` from "low" to "high" in `config_registry.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e29172917bcc9020ef981f12d0c17c33c869974c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->