### PR TITLE
extend auto completion coverage

### DIFF
--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -148,12 +148,16 @@ class SkyvernElement:
         if tag_name != InteractiveElement.INPUT:
             return False
 
-        autocomplete = await self.get_attr("aria-autocomplete")
-        if autocomplete and autocomplete == "list":
+        data_bind: str | None = await self.get_attr("data-x-bind")
+        if data_bind and "autocomplete" in data_bind.lower():
+            return True
+
+        autocomplete: str | None = await self.get_attr("aria-autocomplete")
+        if autocomplete and autocomplete.lower() == "list":
             return True
 
         class_name: str | None = await self.get_attr("class")
-        if class_name and "autocomplete-input" in class_name:
+        if class_name and "autocomplete-input" in class_name.lower():
             return True
 
         return False


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Extend `is_auto_completion_input()` in `SkyvernElement` to include `data-x-bind` attribute and case-insensitive class name check.
> 
>   - **Behavior**:
>     - Extend `is_auto_completion_input()` in `SkyvernElement` to consider `data-x-bind` attribute containing 'autocomplete'.
>     - Make class name check case-insensitive for 'autocomplete-input'.
>   - **Misc**:
>     - Minor refactoring in `is_auto_completion_input()` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 91f6ce8ee694ba882b49b7f78231b0a0abf11845. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->