### PR TITLE
sanitize nul char in totp content

### DIFF
--- a/skyvern/forge/sdk/schemas/totp_codes.py
+++ b/skyvern/forge/sdk/schemas/totp_codes.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from skyvern.forge.sdk.utils.sanitization import sanitize_postgres_text
 
 
 class TOTPCodeBase(BaseModel):
@@ -18,6 +20,12 @@ class TOTPCodeBase(BaseModel):
 class TOTPCodeCreate(TOTPCodeBase):
     totp_identifier: str
     content: str
+
+    @field_validator("content")
+    @classmethod
+    def sanitize_content(cls, value: str) -> str:
+        """Remove NUL (0x00) bytes from content to avoid PostgreSQL DataError."""
+        return sanitize_postgres_text(value)
 
 
 class TOTPCode(TOTPCodeCreate):

--- a/skyvern/forge/sdk/utils/sanitization.py
+++ b/skyvern/forge/sdk/utils/sanitization.py
@@ -1,0 +1,18 @@
+"""
+Utility functions for sanitizing content before storing in the database.
+"""
+
+
+def sanitize_postgres_text(text: str) -> str:
+    """
+    Sanitize text to be stored in PostgreSQL by removing NUL bytes.
+
+    PostgreSQL text fields cannot contain NUL (0x00) bytes, so we remove them.
+
+    Args:
+        text: The text to sanitize
+
+    Returns:
+        The sanitized text without NUL bytes
+    """
+    return text.replace("\0", "")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add NUL byte sanitization for TOTP content to prevent PostgreSQL errors.
> 
>   - **Behavior**:
>     - Adds `sanitize_content` validator to `TOTPCodeCreate` in `totp_codes.py` to remove NUL bytes from `content`.
>     - Uses `sanitize_postgres_text` from `sanitization.py` to perform the sanitization.
>   - **Utilities**:
>     - Introduces `sanitize_postgres_text` in `sanitization.py` to remove NUL bytes from text.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 67b6c819e0ada71f395b7d6e4b3f3fb322778e63. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->