### PR TITLE
update cua fallback action prompt to not return get_verification_code action if code has not been sent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "skyvern"
-version = "0.1.76"
+version = "0.1.77"
 description = ""
 authors = ["Skyvern AI <info@skyvern.com>"]
 readme = "README.md"

--- a/skyvern/forge/prompts/skyvern/cua-fallback-action.j2
+++ b/skyvern/forge/prompts/skyvern/cua-fallback-action.j2
@@ -5,7 +5,7 @@ According to the AI assistant's feedback, including reasoning and its message, t
 Help the user decide what to do next based on the assistant's message. Here's the list of available actions:
 - solve_captcha: the task is blocked by captcha and the assistant is asking the user to solve the captcha
 - complete: the user goal has been achieved
-- get_verification_code: the assistant is asking the user to provide a verification code (2FA, MFA or TOTP code)
+- get_verification_code: the assistant is asking the user to provide a verification code (2FA, MFA or TOTP code). At this point, the code should have been sent to the user. If code hasn't been sent, do not return get_verification_code action.
 - terminate: the user goal cannot be achieved. Terminate the task. Examples: 1) there's not enough data provided to achieve the goal and the assistant is asking the user to provide more information. For examples: login is required and the user has not provided the login credentials or incorrect credentials are provided; a form needs to be filled and a required field is missing. 2) The site is stuck or not loading after multiple attempts. Do not terminate if receiving verification code is an option which has not been sent.
 - other: the assistant is asking the user to do something else
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `get_verification_code` action in `cua-fallback-action.j2` to only return if the verification code has been sent to the user.
> 
>   - **Behavior**:
>     - Update `get_verification_code` action in `cua-fallback-action.j2` to only return if the verification code has been sent to the user.
>     - Prevents returning `get_verification_code` action if the code has not been sent, ensuring accurate task flow.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5609e22d8830c285514919b0d929a78859f2f609. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->