### PR TITLE
disable async operations for CUA agent

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -834,7 +834,8 @@ class ForgeAgent:
                 ):
                     using_cached_action_plan = True
                 else:
-                    self.async_operation_pool.run_operation(task.task_id, AgentPhase.llm)
+                    if engine != RunEngine.openai_cua:
+                        self.async_operation_pool.run_operation(task.task_id, AgentPhase.llm)
                     json_response = await app.LLM_API_HANDLER(
                         prompt=extract_action_prompt,
                         prompt_name="extract-actions",
@@ -996,7 +997,8 @@ class ForgeAgent:
 
                     element_id_to_last_action[action.element_id] = action_idx
 
-                self.async_operation_pool.run_operation(task.task_id, AgentPhase.action)
+                if engine != RunEngine.openai_cua:
+                    self.async_operation_pool.run_operation(task.task_id, AgentPhase.action)
                 current_page = await browser_state.must_get_working_page()
                 if isinstance(action, CompleteAction) and not complete_verification:
                     # Do not verify the complete action when complete_verification is False
@@ -1588,7 +1590,8 @@ class ForgeAgent:
         engine: RunEngine,
     ) -> tuple[ScrapedPage, str]:
         # start the async tasks while running scrape_website
-        self.async_operation_pool.run_operation(task.task_id, AgentPhase.scrape)
+        if engine != RunEngine.openai_cua:
+            self.async_operation_pool.run_operation(task.task_id, AgentPhase.scrape)
 
         # Scrape the web page and get the screenshot and the elements
         # HACK: try scrape_website three time to handle screenshot timeout


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Disables async operations for `openai_cua` engine in `agent_step()` and `build_and_record_step_prompt()` by adding conditional checks.
> 
>   - **Behavior**:
>     - Disables async operations for `openai_cua` engine in `agent_step()` and `build_and_record_step_prompt()`.
>     - Adds conditional checks to prevent `run_operation` calls when `engine` is `RunEngine.openai_cua`.
>   - **Functions**:
>     - Modifies `agent_step()` to skip `run_operation` for `AgentPhase.llm` and `AgentPhase.action` if `engine` is `openai_cua`.
>     - Modifies `build_and_record_step_prompt()` to skip `run_operation` for `AgentPhase.scrape` if `engine` is `openai_cua`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2e0ecd856790fd3d98c18f735847b36219e183c5. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->