### PR TITLE
update latest openai model configs for azure & openai

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -164,6 +164,34 @@ class Settings(BaseSettings):
     AZURE_O3_MINI_API_BASE: str | None = None
     AZURE_O3_MINI_API_VERSION: str | None = None
 
+    # AZURE gpt-4.1
+    ENABLE_AZURE_GPT4_1: bool = False
+    AZURE_GPT4_1_DEPLOYMENT: str = "gpt-4.1"
+    AZURE_GPT4_1_API_KEY: str | None = None
+    AZURE_GPT4_1_API_BASE: str | None = None
+    AZURE_GPT4_1_API_VERSION: str = "2025-01-01-preview"
+
+    # AZURE gpt-4.1 mini
+    ENABLE_AZURE_GPT4_1_MINI: bool = False
+    AZURE_GPT4_1_MINI_DEPLOYMENT: str = "gpt-4.1-mini"
+    AZURE_GPT4_1_MINI_API_KEY: str | None = None
+    AZURE_GPT4_1_MINI_API_BASE: str | None = None
+    AZURE_GPT4_1_MINI_API_VERSION: str = "2025-01-01-preview"
+
+    # AZURE gpt-4.1 nano
+    ENABLE_AZURE_GPT4_1_NANO: bool = False
+    AZURE_GPT4_1_NANO_DEPLOYMENT: str = "gpt-4.1-nano"
+    AZURE_GPT4_1_NANO_API_KEY: str | None = None
+    AZURE_GPT4_1_NANO_API_BASE: str | None = None
+    AZURE_GPT4_1_NANO_API_VERSION: str = "2025-01-01-preview"
+
+    # AZURE o4-mini
+    ENABLE_AZURE_O4_MINI: bool = False
+    AZURE_O4_MINI_DEPLOYMENT: str = "o4-mini"
+    AZURE_O4_MINI_API_KEY: str | None = None
+    AZURE_O4_MINI_API_BASE: str | None = None
+    AZURE_O4_MINI_API_VERSION: str = "2025-01-01-preview"
+
     # GEMINI
     GEMINI_API_KEY: str | None = None
 

--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -192,6 +192,13 @@ class Settings(BaseSettings):
     AZURE_O4_MINI_API_BASE: str | None = None
     AZURE_O4_MINI_API_VERSION: str = "2025-01-01-preview"
 
+    # AZURE o3
+    ENABLE_AZURE_O3: bool = False
+    AZURE_O3_DEPLOYMENT: str = "o3"
+    AZURE_O3_API_KEY: str | None = None
+    AZURE_O3_API_BASE: str | None = None
+    AZURE_O3_API_VERSION: str = "2025-01-01-preview"
+
     # GEMINI
     GEMINI_API_KEY: str | None = None
 

--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -153,7 +153,7 @@ if settings.ENABLE_OPENAI:
         LLMConfig(
             "o4-mini",
             ["OPENAI_API_KEY"],
-            supports_vision=False,
+            supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=100000,
             temperature=None,  # Temperature isn't supported in the O-model series
@@ -168,7 +168,7 @@ if settings.ENABLE_OPENAI:
         LLMConfig(
             "o3",
             ["OPENAI_API_KEY"],
-            supports_vision=False,
+            supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=100000,
             temperature=None,  # Temperature isn't supported in the O-model series
@@ -464,12 +464,35 @@ if settings.ENABLE_AZURE_O4_MINI:
                 api_version=settings.AZURE_O4_MINI_API_VERSION,
                 model_info={"model_name": "azure/o4-mini"},
             ),
-            supports_vision=False,
+            supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=100000,
         ),
     )
 
+
+if settings.ENABLE_AZURE_O3:
+    LLMConfigRegistry.register_config(
+        "AZURE_OPENAI_O3",
+        LLMConfig(
+            f"azure/{settings.AZURE_O3_DEPLOYMENT}",
+            [
+                "AZURE_O3_DEPLOYMENT",
+                "AZURE_O3_API_KEY",
+                "AZURE_O3_API_BASE",
+                "AZURE_O3_API_VERSION",
+            ],
+            litellm_params=LiteLLMParams(
+                api_base=settings.AZURE_O3_API_BASE,
+                api_key=settings.AZURE_O3_API_KEY,
+                api_version=settings.AZURE_O3_API_VERSION,
+                model_info={"model_name": "azure/o3"},
+            ),
+            supports_vision=True,
+            add_assistant_prefix=False,
+            max_completion_tokens=100000,
+        ),
+    )
 
 if settings.ENABLE_GEMINI:
     LLMConfigRegistry.register_config(

--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -69,7 +69,7 @@ if settings.ENABLE_OPENAI:
             ["OPENAI_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=False,
-            max_completion_tokens=16384,
+            max_completion_tokens=32768,
         ),
     )
     LLMConfigRegistry.register_config(
@@ -79,7 +79,7 @@ if settings.ENABLE_OPENAI:
             ["OPENAI_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=False,
-            max_completion_tokens=16384,
+            max_completion_tokens=32768,
         ),
     )
     LLMConfigRegistry.register_config(
@@ -89,7 +89,7 @@ if settings.ENABLE_OPENAI:
             ["OPENAI_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=False,
-            max_completion_tokens=16384,
+            max_completion_tokens=32768,
         ),
     )
     LLMConfigRegistry.register_config(
@@ -155,7 +155,7 @@ if settings.ENABLE_OPENAI:
             ["OPENAI_API_KEY"],
             supports_vision=False,
             add_assistant_prefix=False,
-            max_completion_tokens=16384,
+            max_completion_tokens=100000,
             temperature=None,  # Temperature isn't supported in the O-model series
             reasoning_effort="high",
             litellm_params=LiteLLMParams(
@@ -170,7 +170,7 @@ if settings.ENABLE_OPENAI:
             ["OPENAI_API_KEY"],
             supports_vision=False,
             add_assistant_prefix=False,
-            max_completion_tokens=16384,
+            max_completion_tokens=100000,
             temperature=None,  # Temperature isn't supported in the O-model series
             reasoning_effort="high",
             litellm_params=LiteLLMParams(
@@ -377,6 +377,100 @@ if settings.ENABLE_AZURE_O3_MINI:
         ),
     )
 
+if settings.ENABLE_AZURE_GPT4_1:
+    LLMConfigRegistry.register_config(
+        "AZURE_OPENAI_GPT4_1",
+        LLMConfig(
+            f"azure/{settings.AZURE_GPT4_1_DEPLOYMENT}",
+            [
+                "AZURE_GPT4_1_DEPLOYMENT",
+                "AZURE_GPT4_1_API_KEY",
+                "AZURE_GPT4_1_API_BASE",
+                "AZURE_GPT4_1_API_VERSION",
+            ],
+            litellm_params=LiteLLMParams(
+                api_base=settings.AZURE_GPT4_1_API_BASE,
+                api_key=settings.AZURE_GPT4_1_API_KEY,
+                api_version=settings.AZURE_GPT4_1_API_VERSION,
+                model_info={"model_name": "azure/gpt-4.1"},
+            ),
+            supports_vision=True,
+            add_assistant_prefix=False,
+            max_completion_tokens=32768,
+        ),
+    )
+
+if settings.ENABLE_AZURE_GPT4_1_MINI:
+    LLMConfigRegistry.register_config(
+        "AZURE_OPENAI_GPT4_1_MINI",
+        LLMConfig(
+            f"azure/{settings.AZURE_GPT4_1_MINI_DEPLOYMENT}",
+            [
+                "AZURE_GPT4_1_MINI_DEPLOYMENT",
+                "AZURE_GPT4_1_MINI_API_KEY",
+                "AZURE_GPT4_1_MINI_API_BASE",
+                "AZURE_GPT4_1_MINI_API_VERSION",
+            ],
+            litellm_params=LiteLLMParams(
+                api_base=settings.AZURE_GPT4_1_MINI_API_BASE,
+                api_key=settings.AZURE_GPT4_1_MINI_API_KEY,
+                api_version=settings.AZURE_GPT4_1_MINI_API_VERSION,
+                model_info={"model_name": "azure/gpt-4.1-mini"},
+            ),
+            supports_vision=True,
+            add_assistant_prefix=False,
+            max_completion_tokens=32768,
+        ),
+    )
+
+if settings.ENABLE_AZURE_GPT4_1_NANO:
+    LLMConfigRegistry.register_config(
+        "AZURE_OPENAI_GPT4_1_NANO",
+        LLMConfig(
+            f"azure/{settings.AZURE_GPT4_1_NANO_DEPLOYMENT}",
+            [
+                "AZURE_GPT4_1_NANO_DEPLOYMENT",
+                "AZURE_GPT4_1_NANO_API_KEY",
+                "AZURE_GPT4_1_NANO_API_BASE",
+                "AZURE_GPT4_1_MINI_API_VERSION",
+            ],
+            litellm_params=LiteLLMParams(
+                api_base=settings.AZURE_GPT4_1_NANO_API_BASE,
+                api_key=settings.AZURE_GPT4_1_NANO_API_KEY,
+                api_version=settings.AZURE_GPT4_1_NANO_API_VERSION,
+                model_info={"model_name": "azure/gpt-4.1-nano"},
+            ),
+            supports_vision=True,
+            add_assistant_prefix=False,
+            max_completion_tokens=32768,
+        ),
+    )
+
+
+if settings.ENABLE_AZURE_O4_MINI:
+    LLMConfigRegistry.register_config(
+        "AZURE_OPENAI_O4_MINI",
+        LLMConfig(
+            f"azure/{settings.AZURE_O4_MINI_DEPLOYMENT}",
+            [
+                "AZURE_O4_MINI_DEPLOYMENT",
+                "AZURE_O4_MINI_API_KEY",
+                "AZURE_O4_MINI_API_BASE",
+                "AZURE_O4_MINI_API_VERSION",
+            ],
+            litellm_params=LiteLLMParams(
+                api_base=settings.AZURE_O4_MINI_API_BASE,
+                api_key=settings.AZURE_O4_MINI_API_KEY,
+                api_version=settings.AZURE_O4_MINI_API_VERSION,
+                model_info={"model_name": "azure/o4-mini"},
+            ),
+            supports_vision=False,
+            add_assistant_prefix=False,
+            max_completion_tokens=100000,
+        ),
+    )
+
+
 if settings.ENABLE_GEMINI:
     LLMConfigRegistry.register_config(
         "GEMINI_FLASH_2_0",
@@ -425,7 +519,7 @@ if settings.ENABLE_GEMINI:
             ["GEMINI_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=False,
-            max_completion_tokens=1048576,
+            max_completion_tokens=65536,
         ),
     )
     LLMConfigRegistry.register_config(
@@ -435,7 +529,7 @@ if settings.ENABLE_GEMINI:
             ["GEMINI_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=False,
-            max_completion_tokens=1048576,
+            max_completion_tokens=65536,
         ),
     )
 

--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -432,7 +432,7 @@ if settings.ENABLE_AZURE_GPT4_1_NANO:
                 "AZURE_GPT4_1_NANO_DEPLOYMENT",
                 "AZURE_GPT4_1_NANO_API_KEY",
                 "AZURE_GPT4_1_NANO_API_BASE",
-                "AZURE_GPT4_1_MINI_API_VERSION",
+                "AZURE_GPT4_1_NANO_API_VERSION",
             ],
             litellm_params=LiteLLMParams(
                 api_base=settings.AZURE_GPT4_1_NANO_API_BASE,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update Azure and OpenAI model configurations, adding new Azure models and increasing token limits for OpenAI models.
> 
>   - **Azure Model Configurations**:
>     - Added new Azure models: `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `o4-mini`, and `o3` in `skyvern/config.py` and `config_registry.py`.
>     - Configurations include deployment names, API keys, API bases, and API versions.
>   - **OpenAI Model Configurations**:
>     - Increased `max_completion_tokens` from 16384 to 32768 for several OpenAI models in `config_registry.py`.
>     - Updated `o4-mini` and `o3` models to support vision and increased `max_completion_tokens` to 100000.
>   - **Miscellaneous**:
>     - Reduced `max_completion_tokens` for `GEMINI` models from 1048576 to 65536 in `config_registry.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9f8dfc78f29e0db9b4ac504470a8a99ed1b3c3b9. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->