### PR TITLE
Fix Skyvern.node.ts for N8N Community Node

### DIFF
--- a/integrations/n8n/nodes/Skyvern/Skyvern.node.ts
+++ b/integrations/n8n/nodes/Skyvern/Skyvern.node.ts
@@ -1,18 +1,21 @@
 import { FieldType, IDataObject, IExecuteSingleFunctions, IHttpRequestMethods, IHttpRequestOptions, ILoadOptionsFunctions, INodePropertyOptions, INodeType, INodeTypeDescription, NodeConnectionType, ResourceMapperField, ResourceMapperFields } from 'n8n-workflow';
 import https from 'https';
+import http from 'http';
 import { URL } from 'url';
 
 async function makeRequest(url: string, options: any = {}): Promise<any> {
     return new Promise((resolve, reject) => {
         const parsedUrl = new URL(url);
+        const transport = parsedUrl.protocol === 'https:' ? https : http;
         const requestOptions = {
             hostname: parsedUrl.hostname,
             path: parsedUrl.pathname + parsedUrl.search,
+					  port: parsedUrl.port || (parsedUrl.protocol === 'https:' ? 443 : 80),
             method: options.method || 'GET',
             headers: options.headers || {},
         };
 
-        const req = https.request(requestOptions, (res) => {
+        const req = transport.request(requestOptions, (res) => {
             let data = '';
             
             res.on('data', (chunk) => {


### PR DESCRIPTION
Fixes #2193
Allows http and not just https. Also parses url for ports. Code also needs to be updated here:
https://www.npmjs.com/package/n8n-nodes-skyvern?activeTab=code
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `makeRequest` in `Skyvern.node.ts` to support `http` and `https` protocols and parse ports from URLs.
> 
>   - **Behavior**:
>     - `makeRequest` function in `Skyvern.node.ts` now supports both `http` and `https` protocols.
>     - Parses URL for ports, defaulting to 443 for `https` and 80 for `http` if not specified.
>   - **Code Changes**:
>     - Import `http` module in `Skyvern.node.ts`.
>     - Use `transport` variable to select `http` or `https` based on URL protocol.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 04ee6cf2074ad4d6c5fbd3b2b790dd6c517fd4ea. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->