### PR TITLE
Poc/forward user clicks to running browser

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -360,3 +360,24 @@ export type CreditCardCredential = {
   card_brand: string;
   card_holder_name: string;
 };
+
+export interface Position {
+  x: number;
+  y: number;
+}
+
+export interface UserEventClick {
+  event: "click";
+  detail: {
+    pos: Position;
+  };
+}
+
+export interface UserEventX {
+  event: "X";
+  detail: null;
+}
+
+export type UserEvent = UserEventClick | UserEventX;
+
+export type UserEventType = UserEvent["event"];

--- a/skyvern-frontend/src/components/ZoomableImage.tsx
+++ b/skyvern-frontend/src/components/ZoomableImage.tsx
@@ -1,11 +1,39 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import clsx from "clsx";
+import * as apiTypes from "@/api/types";
 
-type HTMLImageElementProps = React.ComponentProps<"img">;
+interface ZoomableImageProps extends React.ComponentProps<"img"> {
+  captureClick?: (pos: apiTypes.Position) => void;
+}
 
-function ZoomableImage(props: HTMLImageElementProps) {
+function ZoomableImage({ captureClick, ...props }: ZoomableImageProps) {
   const [modalOpen, setModalOpen] = useState(false);
   const [zoom, setZoom] = useState(false);
+  const imgRef = useRef<HTMLImageElement>(null);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+
+  const classes = {
+    img: clsx("cursor-zoom-in object-contain", props.className),
+    modalCloseButton:
+      "absolute right-4 top-4 cursor-pointer text-4xl text-white",
+    modalContainer: clsx(
+      "fixed inset-0 z-50 flex justify-center overflow-auto bg-black bg-opacity-75 p-16",
+      {
+        "items-center": !zoom,
+        "items-baseline": zoom,
+      },
+    ),
+    modalImg: captureClick
+      ? clsx(
+          "m-0 h-full max-h-full min-h-full w-full max-w-full object-contain",
+        )
+      : clsx({
+          "m-0 h-full max-h-full min-h-full w-full max-w-full cursor-zoom-in object-contain":
+            !zoom,
+          "m-0 ml-auto mr-auto max-h-none min-h-full max-w-none cursor-zoom-out object-contain":
+            zoom,
+        }),
+  };
 
   const openModal = () => {
     setZoom(false);
@@ -14,6 +42,75 @@ function ZoomableImage(props: HTMLImageElementProps) {
 
   const closeModal = () => {
     setModalOpen(false);
+  };
+
+  const sendClick = () => {
+    captureClick?.(position);
+  };
+
+  /**
+   * The image is shown via `object-fit: contain`, and so the bounding box is
+   * incorrect. Have to adjust it. If the styling changes, this function will
+   * either no longer be needed, or have to be adjusted.
+   */
+  const getContainedImageSize = (img: HTMLImageElement) => {
+    const containerRect = img.getBoundingClientRect();
+    const containerWidth = containerRect.width;
+    const containerHeight = containerRect.height;
+
+    const naturalWidth = img.naturalWidth;
+    const naturalHeight = img.naturalHeight;
+
+    const containerRatio = containerWidth / containerHeight;
+    const imageRatio = naturalWidth / naturalHeight;
+
+    let renderedWidth, renderedHeight;
+
+    if (imageRatio > containerRatio) {
+      renderedWidth = containerWidth;
+      renderedHeight = containerWidth / imageRatio;
+    } else {
+      renderedHeight = containerHeight;
+      renderedWidth = containerHeight * imageRatio;
+    }
+
+    const left = containerRect.left + (containerWidth - renderedWidth) / 2;
+    const top = containerRect.top + (containerHeight - renderedHeight) / 2;
+
+    return {
+      width: renderedWidth,
+      height: renderedHeight,
+      left: left,
+      top: top,
+      right: left + renderedWidth,
+      bottom: top + renderedHeight,
+    };
+  };
+
+  /**
+   * NOTE(jdo): These are constant offsets to make the click events happen at
+   * the correct location in the running browser. I believe the `y` component
+   * is the height of the browser chrome (address bar, buttons, etc.).
+   */
+  const magicConstants = {
+    x: 0,
+    y: 0.08173690932311624,
+  };
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLImageElement>) => {
+    const img = imgRef.current;
+
+    if (!img) {
+      return;
+    }
+
+    const rect = getContainedImageSize(img);
+    const x = (e.clientX - rect.left) / rect.width - magicConstants.x;
+    const y = (e.clientY - rect.top) / rect.height - magicConstants.y;
+    const clampedX = Math.max(0, Math.min(1, x));
+    const clampedY = Math.max(0, Math.min(1, y));
+
+    setPosition({ x: clampedX, y: clampedY });
   };
 
   useEffect(() => {
@@ -30,37 +127,28 @@ function ZoomableImage(props: HTMLImageElementProps) {
 
   return (
     <div>
-      <img
-        {...props}
-        onClick={openModal}
-        className={clsx("cursor-zoom-in object-contain", props.className)}
-      />
+      <img {...props} onClick={openModal} className={classes.img} />
       {modalOpen && (
-        <div
-          className={clsx(
-            "fixed inset-0 z-50 flex justify-center overflow-auto bg-black bg-opacity-75 p-16",
-            {
-              "items-center": !zoom,
-              "items-baseline": zoom,
-            },
-          )}
-        >
-          <span
-            className="absolute right-4 top-4 cursor-pointer text-4xl text-white"
-            onClick={closeModal}
-          >
+        <div className={classes.modalContainer}>
+          <span className={classes.modalCloseButton} onClick={closeModal}>
             &times;
           </span>
-          <img
-            {...props}
-            onClick={() => setZoom(!zoom)}
-            className={clsx({
-              "m-0 h-full max-h-full min-h-full w-full max-w-full cursor-zoom-in object-contain":
-                !zoom,
-              "m-0 ml-auto mr-auto max-h-none min-h-full max-w-none cursor-zoom-out object-contain":
-                zoom,
-            })}
-          />
+
+          {captureClick ? (
+            <img
+              {...props}
+              ref={imgRef}
+              className={classes.modalImg}
+              onClick={sendClick}
+              onMouseMove={handleMouseMove}
+            />
+          ) : (
+            <img
+              {...props}
+              className={classes.modalImg}
+              onClick={() => setZoom(!zoom)}
+            />
+          )}
         </div>
       )}
     </div>

--- a/skyvern/forge/sdk/routes/user_protocol.py
+++ b/skyvern/forge/sdk/routes/user_protocol.py
@@ -1,0 +1,57 @@
+import random
+import structlog
+
+from skyvern import app
+
+LOG = structlog.get_logger()
+
+
+async def click(workflow_run_id: str, x: int | float, y: int | float):
+    browser_state = app.BROWSER_MANAGER.pages.get(workflow_run_id)
+
+    if not browser_state:
+        LOG.error(f"No browser state for {workflow_run_id}")
+        return
+
+    page = await browser_state.get_working_page()
+
+    if not page:
+        LOG.error(f"No page for {workflow_run_id}")
+        return
+
+    viewport = page.viewport_size
+
+    if not viewport:
+        viewport = await page.evaluate(
+            "() => ({ width: window.innerWidth, height: window.innerHeight })"
+        )
+
+    px = x * viewport['width']
+    py = y * viewport['height']
+
+    await page.mouse.click(px, py)
+
+    LOG.info("We have clicked", px=px, py=py, viewport=viewport)
+
+    r = random.randint(0, 255)
+    g = random.randint(0, 255)
+    b = random.randint(0, 255)
+    size = 48
+
+    expr = f"""() => {{
+        const el = document.createElement('div');
+        el.style.position = 'absolute';
+        el.style.left = '{px - size / 2}px';
+        el.style.top = '{py - size / 2}px';
+        el.style.width = '{size}px';
+        el.style.height = '{size}px';
+        el.style.backgroundColor = 'rgb({r}, {g}, {b})';
+        el.style.borderRadius = '50%';
+        el.style.zIndex = '10000';
+        document.body.appendChild(el);
+        setTimeout(() => el.remove(), 10000);
+    }}"""
+
+    await page.evaluate(expr)
+
+    LOG.info("We have inserted an element.", expr=expr)


### PR DESCRIPTION
Hello, Skyvern!

## What 

POC for sending user click events to the running (headful/cdp) browser.

## Why 

Because it's neat/useful.

## Details 

### DX

I could not get a development flow that had both of these reqs:
- showed the live stream of the browser, in-app
- fast iteration for code updates 

The local development, per the instructions in the `README.md`, created a setup where the stream of the browser was missing. This is kind of important for iteration speed. Having it not be there is a non-starter.

The docker compose scenario, as outlined in the `README.md`, created a setup where local code changes (to the frontend) were not honored. Nor could I run `vite` in dev mode (`npm run dev`), as `npm run start` was baked into the cached image.

So here is what I used:

```yaml
services:
  postgres:
    image: postgres:14-alpine
    restart: always
    volumes:
      - ./postgres-data:/var/lib/postgresql/data
    environment:
      - PGDATA=/var/lib/postgresql/data/pgdata
      - POSTGRES_USER=skyvern
      - POSTGRES_PASSWORD=skyvern
      - POSTGRES_DB=skyvern
    healthcheck:
      test: ["CMD-SHELL", "pg_isready -U skyvern"]
      interval: 5s
      timeout: 5s
      retries: 5

  skyvern:
    image: public.ecr.aws/skyvern/skyvern:latest
    restart: on-failure
    ports:
      - 8000:8000
    volumes:
      - ./artifacts:/data/artifacts
      - ./videos:/data/videos
      - ./har:/data/har
      - ./log:/data/log
      - ./.streamlit:/app/.streamlit
      - ./skyvern:/app/skyvern
      - ./alembic:/app/alembic
    environment:
      - DATABASE_STRING=postgresql+psycopg://skyvern:skyvern@postgres:5432/skyvern
      - BROWSER_TYPE=chromium-headful
      - ENABLE_OPENAI=true
      - LLM_KEY=OPENAI_GPT4O
      - OPENAI_API_KEY=<your-llm-api-key>
    depends_on:
      postgres:
        condition: service_healthy
    healthcheck:
      test: ["CMD", "test", "-f", "/app/.streamlit/secrets.toml"]
      interval: 5s
      timeout: 5s
      retries: 5

  skyvern-ui:
    image: public.ecr.aws/skyvern/skyvern-ui:latest
    restart: on-failure
    ports:
      - 8080:8080
      - 9090:9090
    volumes:
      - ./artifacts:/data/artifacts
      - ./videos:/data/videos
      - ./har:/data/har
      - ./.streamlit:/app/.streamlit
      - ./skyvern-frontend/src:/app/src
    environment:
      - VITE_WSS_BASE_URL=ws://localhost:8000/api/v1
      - VITE_SKYVERN_API_KEY=<copy-from-streamlit/secrets.toml>
    depends_on:
      skyvern:
        condition: service_healthy
    command: ./node_modules/vite/bin/vite.js --host=0.0.0.0 & npm run run-artifact-server
```

This took me a while to figure out (multiple sit-downs). There were other blockers, but I've banished them from my working memory. On to the juice!

### In Short

- capture 0-1 coords over streamed browser image; save 'em
  - account for CSS transforms (`object-fit`)
  - account for browser chrome (address bar, buttons, etc.) 
- when image is clicked, send a WebSocket message to the backend
  - allow existing backend WS to receive messages (was only sending them)
- use existing `BrowserManager` to send Playwright message

### Again, with Images

Run a workflow:

 <img width="1371" alt="0" src="https://github.com/user-attachments/assets/1545ed2d-4ef7-4dd6-a0a6-ac3c118bed94" />

Click on the browser to zoom in:

<img width="1369" alt="1" src="https://github.com/user-attachments/assets/a452566a-5729-4dd5-9eee-9c3c793b43f7" />

Click around the browser. Circular debug divs are added. They'll disappear 10 seconds after insertion:

<img width="1358" alt="3" src="https://github.com/user-attachments/assets/fb67d762-732a-439a-80f2-69293f06ec1c" />

## Notes 

- not intended to merge; just a POC
- keyboard events look trivial to add
- looks slow/laggy; but stream is slow; pretty sure events themselves are "fast enough"
- current WS loop is non-optimal
- I hacked the `BrowserManager` API - maybe there's some preferred way to use it - not sure