### PR TITLE
Disable connection pooler if env specifies it

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -32,6 +32,7 @@ class Settings(BaseSettings):
     DEBUG_MODE: bool = False
     DATABASE_STRING: str = "postgresql+psycopg://skyvern@localhost/skyvern"
     DATABASE_STATEMENT_TIMEOUT_MS: int = 60000
+    DISABLE_CONNECTION_POOL: bool = False
     PROMPT_ACTION_HISTORY_WINDOW: int = 1
     TASK_RESPONSE_ACTION_SCREENSHOT_COUNT: int = 3
 

--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from typing import Any, List, Optional, Sequence
 
 import structlog
-from sqlalchemy import and_, delete, distinct, func, select, tuple_, update
+from sqlalchemy import and_, delete, distinct, func, pool, select, tuple_, update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
@@ -113,6 +113,7 @@ class AgentDB:
             database_string,
             json_serializer=_custom_json_serializer,
             connect_args=DB_CONNECT_ARGS,
+            poolclass=pool.NullPool if settings.DISABLE_CONNECTION_POOL else None,
         )
         self.Session = async_sessionmaker(bind=self.engine)
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `DISABLE_CONNECTION_POOL` setting to disable connection pooling in `AgentDB` if specified in environment.
> 
>   - **Behavior**:
>     - Adds `DISABLE_CONNECTION_POOL` setting in `Settings` class in `skyvern/config.py` to control connection pooling.
>     - In `AgentDB` class in `client.py`, sets `poolclass` to `pool.NullPool` if `DISABLE_CONNECTION_POOL` is true, disabling connection pooling.
>   - **Misc**:
>     - Imports `pool` from `sqlalchemy` in `client.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 7fafd9b55fedfa7d5a1a31e229f130f3b9cb76e9. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->