### PR TITLE
add current sha into log

### DIFF
--- a/skyvern/_version.py
+++ b/skyvern/_version.py
@@ -1,0 +1,1 @@
+__version__ = "development"

--- a/skyvern/forge/sdk/forge_log.py
+++ b/skyvern/forge/sdk/forge_log.py
@@ -3,6 +3,7 @@ import logging
 import structlog
 from structlog.typing import EventDict
 
+from skyvern._version import __version__
 from skyvern.config import settings
 from skyvern.forge.sdk.core import skyvern_context
 
@@ -39,6 +40,7 @@ def add_kv_pairs_to_msg(logger: logging.Logger, method_name: str, event_dict: Ev
 
     # Add env to the log
     event_dict["env"] = settings.ENV
+    event_dict["version"] = __version__
 
     if method_name not in ["info", "warning", "error", "critical", "exception"]:
         # Only modify the log for these log levels

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -10,6 +10,7 @@ from fastapi import BackgroundTasks, Depends, Header, HTTPException, Path, Query
 from fastapi.responses import ORJSONResponse
 
 from skyvern import analytics
+from skyvern._version import __version__
 from skyvern.config import settings
 from skyvern.forge import app
 from skyvern.forge.prompts import prompt_engine
@@ -155,7 +156,7 @@ async def heartbeat() -> Response:
     """
     Check if the server is running.
     """
-    return Response(content="Server is running.", status_code=200)
+    return Response(content="Server is running.", status_code=200, headers={"X-Skyvern-API-Version": __version__})
 
 
 @legacy_base_router.post(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds current version to logs and `/heartbeat` response header using `__version__` from `skyvern/_version.py`.
> 
>   - **Behavior**:
>     - Adds `__version__` to log entries in `add_kv_pairs_to_msg()` in `forge_log.py`.
>     - Adds `X-Skyvern-API-Version` header to `/heartbeat` response in `agent_protocol.py`.
>   - **Misc**:
>     - Introduces `skyvern/_version.py` to define `__version__` as "development".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f352bf34d378a36d701a72441c5aadfb2bc38643. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->