### PR TITLE
fix interactable parsing

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -603,15 +603,15 @@ function isInteractable(element, hoverStylesMap) {
     return false;
   }
 
+  if (hasWidgetRole(element)) {
+    return true;
+  }
+
   // element with pointer-events: none should not be considered as interactable
   // https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events#none
   const elementPointerEvent = getElementComputedStyle(element)?.pointerEvents;
   if (elementPointerEvent === "none") {
     return false;
-  }
-
-  if (hasWidgetRole(element)) {
-    return true;
   }
 
   if (isInteractableInput(element)) {


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reorders `isInteractable()` in `domUtils.js` to prioritize elements with widget roles as interactable, even if they have `pointer-events: none`.
> 
>   - **Behavior**:
>     - In `isInteractable()` in `domUtils.js`, the check for `hasWidgetRole(element)` is moved before the check for `pointer-events: none`.
>     - This prioritizes elements with widget roles as interactable, even if they have `pointer-events: none`.
>   - **Misc**:
>     - No other files or functions are affected by this change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c438d5cab79800d05a017ce7c0be5422226e6ceb. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->