### PR TITLE
do not close the tab when download is not triggered

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -534,6 +534,7 @@ async def handle_click_action(
             step_id=step.step_id,
             workflow_run_id=task.workflow_run_id,
         )
+        results: list[ActionResult] = []
         try:
             results = await handle_click_to_download_file_action(action, page, scraped_page, task, step)
         except Exception:
@@ -555,21 +556,30 @@ async def handle_click_action(
                 workflow_run_id=task.workflow_run_id,
             )
             if page_count_after_download > initial_page_count and browser_state and browser_state.browser_context:
-                LOG.info(
-                    "Extra page opened after download, closing it",
-                    task_id=task.task_id,
-                    step_id=step.step_id,
-                    workflow_run_id=task.workflow_run_id,
-                )
-                if page == browser_state.browser_context.pages[-1]:
-                    LOG.warning(
-                        "The extra page is the current page, closing it",
+                if results and results[-1].download_triggered:
+                    LOG.info(
+                        "Download triggered, closing the extra page",
                         task_id=task.task_id,
                         step_id=step.step_id,
                         workflow_run_id=task.workflow_run_id,
                     )
-                # close the extra page
-                await browser_state.browser_context.pages[-1].close()
+
+                    if page == browser_state.browser_context.pages[-1]:
+                        LOG.warning(
+                            "The extra page is the current page, closing it",
+                            task_id=task.task_id,
+                            step_id=step.step_id,
+                            workflow_run_id=task.workflow_run_id,
+                        )
+                    # close the extra page
+                    await browser_state.browser_context.pages[-1].close()
+                else:
+                    LOG.info(
+                        "No download triggered, not closing the extra page",
+                        task_id=task.task_id,
+                        step_id=step.step_id,
+                        workflow_run_id=task.workflow_run_id,
+                    )
     else:
         results = await chain_click(
             task,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modify `handle_click_action` in `handler.py` to prevent closing the tab when no download is triggered, with added logging.
> 
>   - **Behavior**:
>     - In `handle_click_action`, prevent closing the tab if no download is triggered by checking `results[-1].download_triggered`.
>     - Log message added to indicate when no download is triggered and the extra page is not closed.
>   - **Misc**:
>     - Initialize `results` as an empty list before `try` block in `handle_click_action`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 4380945910eabe98399888bc3ccc9592803e58af. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->