### PR TITLE
Add organization_name and workflow_permanent_id to skyvern context, pass workflow_permanet_id when deciding which identifier to use with which llm

### DIFF
--- a/skyvern/agent/agent.py
+++ b/skyvern/agent/agent.py
@@ -119,6 +119,7 @@ class SkyvernAgent:
             skyvern_context.set(
                 SkyvernContext(
                     organization_id=organization.organization_id,
+                    organization_name=organization.organization_name,
                     task_id=task.task_id,
                     max_steps_override=max_steps,
                 )

--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -2657,7 +2657,7 @@ class ForgeAgent:
         )
 
         data_extraction_summary_resp = await app.SECONDARY_LLM_API_HANDLER(
-            prompt=prompt, step=step, screenshots=scraped_page.screenshots, prompt_name="data-extraction-summary"
+            prompt=prompt, step=step, prompt_name="data-extraction-summary"
         )
         return ExtractAction(
             reasoning=data_extraction_summary_resp.get("summary", "Extracting information from the page"),

--- a/skyvern/forge/sdk/core/skyvern_context.py
+++ b/skyvern/forge/sdk/core/skyvern_context.py
@@ -9,8 +9,10 @@ from playwright.async_api import Frame
 class SkyvernContext:
     request_id: str | None = None
     organization_id: str | None = None
+    organization_name: str | None = None
     task_id: str | None = None
     workflow_id: str | None = None
+    workflow_permanent_id: str | None = None
     workflow_run_id: str | None = None
     task_v2_id: str | None = None
     max_steps_override: int | None = None

--- a/skyvern/forge/sdk/executor/async_executor.py
+++ b/skyvern/forge/sdk/executor/async_executor.py
@@ -7,6 +7,7 @@ from skyvern.exceptions import OrganizationNotFound
 from skyvern.forge import app
 from skyvern.forge.sdk.core import skyvern_context
 from skyvern.forge.sdk.core.skyvern_context import SkyvernContext
+from skyvern.forge.sdk.schemas.organizations import Organization
 from skyvern.forge.sdk.schemas.task_v2 import TaskV2Status
 from skyvern.forge.sdk.schemas.tasks import TaskStatus
 from skyvern.forge.sdk.workflow.models.workflow import WorkflowRunStatus
@@ -36,7 +37,7 @@ class AsyncExecutor(abc.ABC):
         self,
         request: Request | None,
         background_tasks: BackgroundTasks,
-        organization_id: str,
+        organization: Organization,
         workflow_id: str,
         workflow_run_id: str,
         max_steps_override: int | None,
@@ -120,7 +121,7 @@ class BackgroundTaskExecutor(AsyncExecutor):
         self,
         request: Request | None,
         background_tasks: BackgroundTasks | None,
-        organization_id: str,
+        organization: Organization,
         workflow_id: str,
         workflow_run_id: str,
         max_steps_override: int | None,
@@ -132,10 +133,6 @@ class BackgroundTaskExecutor(AsyncExecutor):
             "Executing workflow using background task executor",
             workflow_run_id=workflow_run_id,
         )
-
-        organization = await app.DATABASE.get_organization(organization_id)
-        if organization is None:
-            raise OrganizationNotFound(organization_id)
 
         if background_tasks:
             background_tasks.add_task(

--- a/skyvern/forge/sdk/forge_log.py
+++ b/skyvern/forge/sdk/forge_log.py
@@ -27,12 +27,16 @@ def add_kv_pairs_to_msg(logger: logging.Logger, method_name: str, event_dict: Ev
             event_dict["request_id"] = context.request_id
         if context.organization_id:
             event_dict["organization_id"] = context.organization_id
+        if context.organization_name:
+            event_dict["organization_name"] = context.organization_name
         if context.task_id:
             event_dict["task_id"] = context.task_id
         if context.workflow_id:
             event_dict["workflow_id"] = context.workflow_id
         if context.workflow_run_id:
             event_dict["workflow_run_id"] = context.workflow_run_id
+        if context.workflow_permanent_id:
+            event_dict["workflow_permanent_id"] = context.workflow_permanent_id
         if context.task_v2_id:
             event_dict["task_v2_id"] = context.task_v2_id
         if context.browser_session_id:

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -667,7 +667,7 @@ async def run_workflow_legacy(
 
     workflow_run = await workflow_service.run_workflow(
         workflow_id=workflow_id,
-        organization_id=current_org.organization_id,
+        organization=current_org,
         workflow_request=workflow_request,
         template=template,
         version=version,
@@ -1634,7 +1634,7 @@ async def run_workflow(
     )
     workflow_run = await workflow_service.run_workflow(
         workflow_id=workflow_id,
-        organization_id=current_org.organization_id,
+        organization=current_org,
         workflow_request=legacy_workflow_request,
         template=template,
         version=None,

--- a/skyvern/forge/sdk/services/org_auth_service.py
+++ b/skyvern/forge/sdk/services/org_auth_service.py
@@ -128,4 +128,5 @@ async def _get_current_org_cached(x_api_key: str, db: AgentDB) -> Organization:
     context = skyvern_context.current()
     if context:
         context.organization_id = organization.organization_id
+        context.organization_name = organization.organization_name
     return organization

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -2497,6 +2497,9 @@ class TaskV2Block(Block):
             skyvern_context.set(
                 skyvern_context.SkyvernContext(
                     organization_id=organization_id,
+                    organization_name=organization.organization_name,
+                    workflow_id=workflow_run.workflow_id,
+                    workflow_permanent_id=workflow_run.workflow_permanent_id,
                     workflow_run_id=workflow_run_id,
                     browser_session_id=browser_session_id,
                 )

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -102,7 +102,7 @@ class WorkflowService:
         request_id: str | None,
         workflow_request: WorkflowRequestBody,
         workflow_permanent_id: str,
-        organization_id: str,
+        organization: Organization,
         is_template_workflow: bool = False,
         version: int | None = None,
         max_steps_override: int | None = None,
@@ -121,7 +121,7 @@ class WorkflowService:
         # Validate the workflow and the organization
         workflow = await self.get_workflow_by_permanent_id(
             workflow_permanent_id=workflow_permanent_id,
-            organization_id=None if is_template_workflow else organization_id,
+            organization_id=None if is_template_workflow else organization.organization_id,
             version=version,
         )
         if workflow is None:
@@ -137,7 +137,7 @@ class WorkflowService:
             workflow_request=workflow_request,
             workflow_permanent_id=workflow_permanent_id,
             workflow_id=workflow_id,
-            organization_id=organization_id,
+            organization_id=organization.organization_id,
             parent_workflow_run_id=parent_workflow_run_id,
         )
         LOG.info(
@@ -151,7 +151,8 @@ class WorkflowService:
         )
         skyvern_context.set(
             SkyvernContext(
-                organization_id=organization_id,
+                organization_id=organization.organization_id,
+                organization_name=organization.organization_name,
                 request_id=request_id,
                 workflow_id=workflow_id,
                 workflow_run_id=workflow_run.workflow_run_id,

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -211,7 +211,7 @@ async def initialize_task_v2(
             request_id=None,
             workflow_request=WorkflowRequestBody(),
             workflow_permanent_id=new_workflow.workflow_permanent_id,
-            organization_id=organization.organization_id,
+            organization=organization,
             version=None,
             max_steps_override=max_steps_override,
             parent_workflow_run_id=parent_workflow_run_id,
@@ -1491,7 +1491,6 @@ async def _summarize_task_v2(
     )
     task_v2_summary_resp = await app.LLM_API_HANDLER(
         prompt=task_v2_summary_prompt,
-        screenshots=screenshots,
         thought=thought,
         prompt_name="task_v2_summary",
     )


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `organization_name` and `workflow_permanent_id` to `skyvern_context` and update functions to use `workflow_permanent_id` for LLM identifier decisions.
> 
>   - **Context Updates**:
>     - Add `organization_name` and `workflow_permanent_id` to `SkyvernContext` in `skyvern_context.py`.
>     - Update `add_kv_pairs_to_msg()` in `forge_log.py` to include `organization_name` and `workflow_permanent_id`.
>   - **Function Updates**:
>     - Modify `execute_workflow()` in `cloud_async_executor.py` and `async_executor.py` to use `Organization` object instead of `organization_id`.
>     - Update `run_workflow()` in `agent_protocol.py` and `workflow_service.py` to pass `workflow_permanent_id`.
>   - **Miscellaneous**:
>     - Add `organization_name` to `SkyvernContext` in `org_auth_service.py`.
>     - Update `execute()` in `block.py` to set `workflow_permanent_id` in context.
>     - Add new LLM identifier `gemini-2.5-pro-preview-03-25` in `skyvern_run_script_helper.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 9ed1f4be642ec9f0501e73eb63e4dc2fa320421f. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->