### PR TITLE
fix bug

### DIFF
--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -739,9 +739,9 @@ if settings.ENABLE_NOVITA:
 # Set the value of my_vertex_credentials as the environment variable VERTEX_CREDENTIALS
 if settings.ENABLE_VERTEX_AI:
     LLMConfigRegistry.register_config(
-        "VERTEX_GEMINI_2.5_PRO_EXP_03_25",
+        "VERTEX_GEMINI_2.5_FLASH_PREVIEW_04_17",
         LLMConfig(
-            "vertex_ai/gemini-2.5-pro-preview-03-25",
+            "vertex_ai/gemini-2.5-flash-preview-04-17",
             ["VERTEX_CREDENTIALS"],
             supports_vision=True,
             add_assistant_prefix=False,

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -2464,7 +2464,7 @@ async def select_from_emerging_elements(
         task_id=task.task_id,
     )
 
-    action_type_str: str = json_response.get("action_type", "")
+    action_type_str: str = json_response.get("action_type", "") or ""
     action_type = ActionType(action_type_str.lower())
     element_id: str | None = json_response.get("id", None)
     if not element_id or action_type not in [ActionType.CLICK, ActionType.INPUT_TEXT]:
@@ -2590,7 +2590,7 @@ async def select_from_dropdown(
         task_id=task.task_id,
     )
 
-    action_type: str = json_response.get("action_type", "")
+    action_type: str = json_response.get("action_type", "") or ""
     action_type = action_type.lower()
     single_select_result.action_type = ActionType(action_type)
     element_id: str | None = json_response.get("id", None)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix configuration key rename and ensure default string for missing JSON keys in `config_registry.py` and `handler.py`.
> 
>   - **Configuration Update**:
>     - Rename `VERTEX_GEMINI_2.5_PRO_EXP_03_25` to `VERTEX_GEMINI_2.5_FLASH_PREVIEW_04_17` in `config_registry.py`.
>     - Update path from `vertex_ai/gemini-2.5-pro-preview-03-25` to `vertex_ai/gemini-2.5-flash-preview-04-17` in `config_registry.py`.
>   - **Bug Fix**:
>     - Ensure `action_type_str` defaults to an empty string if `action_type` key is missing in JSON response in `select_from_emerging_elements()` and `select_from_dropdown()` in `handler.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c3987dea834a57309fe99ca4e86012acf636604f. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->