### PR TITLE
support only selectable input element

### DIFF
--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -301,6 +301,10 @@ class SkyvernElement:
         return self.__static_element
 
     def get_selectable(self) -> bool:
+        if self.get_tag_name() == InteractiveElement.INPUT:
+            input_type = self.get_attr("type", mode="static")
+            if input_type == "select-one" or input_type == "select-multiple":
+                return True
         return self._selectable
 
     def get_tag_name(self) -> str:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `get_selectable()` in `SkyvernElement` to support only `input` elements with type `select-one` or `select-multiple`.
> 
>   - **Behavior**:
>     - Update `get_selectable()` in `SkyvernElement` to return `True` only for `input` elements with type `select-one` or `select-multiple`.
>   - **Misc**:
>     - No changes to other files or functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f729e31ca5f94570eb3ce40464822190d165f6f7. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->