### PR TITLE
Show continue_on_failure in loop node

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/LoopNode/LoopNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/LoopNode/LoopNode.tsx
@@ -139,20 +139,34 @@ function LoopNode({ id, data }: NodeProps<LoopNode>) {
             </div>
             <div className="space-y-2">
               <div className="space-y-2">
-                <div className="flex gap-4">
-                  <div className="flex gap-2">
+                <div className="flex justify-between">
+                  <div className="flex items-center gap-2">
+                    <Checkbox
+                      checked={data.completeIfEmpty}
+                      disabled={!data.editable}
+                      onCheckedChange={(checked) => {
+                        handleChange("completeIfEmpty", checked);
+                      }}
+                    />
                     <Label className="text-xs text-slate-300">
-                      Complete if Empty
+                      Continue if Empty
                     </Label>
-                    <HelpTooltip content="When checked, this block will successfully complete when the loop value is an empty list" />
+                    <HelpTooltip content="When checked, the for loop block will successfully complete and workflow execution will continue if the loop value is empty" />
                   </div>
-                  <Checkbox
-                    checked={data.completeIfEmpty}
-                    disabled={!data.editable}
-                    onCheckedChange={(checked) => {
-                      handleChange("completeIfEmpty", checked);
-                    }}
-                  />
+
+                  <div className="flex items-center gap-2">
+                    <Checkbox
+                      checked={data.continueOnFailure}
+                      disabled={!data.editable}
+                      onCheckedChange={(checked) => {
+                        handleChange("continueOnFailure", checked);
+                      }}
+                    />
+                    <Label className="text-xs text-slate-300">
+                      Continue on Failure
+                    </Label>
+                    <HelpTooltip content="When checked, the loop will continue executing even if one of its iterations fails" />
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/06d6ac81-2c33-43f0-b106-9d3ba7e91e08)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `continueOnFailure` option to `LoopNode` in `LoopNode.tsx`, allowing loops to continue on iteration failure.
> 
>   - **Behavior**:
>     - Adds `continueOnFailure` checkbox to `LoopNode` in `LoopNode.tsx`.
>     - When checked, loop continues execution even if an iteration fails.
>   - **UI**:
>     - Updates layout to include `continueOnFailure` checkbox next to `completeIfEmpty`.
>     - Adds `HelpTooltip` for `continueOnFailure` explaining its functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 274ba7087d07243fc5161c6af49adc2e64145101. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->