### PR TITLE
resize screenshots to make it compatible with anthropic CUA

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -385,7 +385,7 @@ class ForgeAgent:
                 # llm_caller = LLMCaller(llm_key="BEDROCK_ANTHROPIC_CLAUDE3.5_SONNET_INFERENCE_PROFILE")
                 llm_caller = LLMCallerManager.get_llm_caller(task.task_id)
                 if not llm_caller:
-                    llm_caller = LLMCaller(llm_key=settings.ANTHROPIC_CUA_LLM_KEY)
+                    llm_caller = LLMCaller(llm_key=settings.ANTHROPIC_CUA_LLM_KEY, screenshot_scaling_enabled=True)
                     LLMCallerManager.set_llm_caller(task.task_id, llm_caller)
             step, detailed_output = await self.agent_step(
                 task,
@@ -1450,7 +1450,13 @@ class ForgeAgent:
         assistant_content = llm_response["content"]
         llm_caller.message_history.append({"role": "assistant", "content": assistant_content})
 
-        actions = await parse_anthropic_actions(task, step, assistant_content)
+        actions = await parse_anthropic_actions(
+            task,
+            step,
+            assistant_content,
+            llm_caller.browser_window_dimension,
+            llm_caller.screenshot_resize_target_dimension,
+        )
         return actions
 
     @staticmethod

--- a/skyvern/utils/image_resizer.py
+++ b/skyvern/utils/image_resizer.py
@@ -1,0 +1,59 @@
+import io
+from typing import TypedDict
+
+from PIL import Image
+
+
+class Resolution(TypedDict):
+    width: int
+    height: int
+
+
+MAX_SCALING_TARGETS_ANTHROPIC_CUA: dict[str, Resolution] = {
+    "XGA": Resolution(width=1024, height=768),  # 4:3
+    "WXGA": Resolution(width=1280, height=800),  # 16:10
+    "FWXGA": Resolution(width=1366, height=768),  # ~16:9
+}
+
+
+def get_resize_target_dimension(
+    window_size: Resolution, max_scaling_targets: dict[str, Resolution] = MAX_SCALING_TARGETS_ANTHROPIC_CUA
+) -> Resolution:
+    ratio = window_size["width"] / window_size["height"]
+    for dimension in max_scaling_targets.values():
+        if abs(dimension["width"] / dimension["height"] - ratio) < 0.02:
+            return dimension
+    return window_size
+
+
+def resize_screenshots(screenshots: list[bytes], target_dimension: Resolution) -> list[bytes]:
+    """
+    The image scaling logic is originated from anthropic's quickstart guide:
+    https://github.com/anthropics/anthropic-quickstarts/blob/81c4085944abb1734db411f05290b538fdc46dcd/computer-use-demo/computer_use_demo/tools/computer.py#L49-L60
+    """
+    new_screenshots = []
+    for screenshot in screenshots:
+        # Convert bytes to PIL Image
+        img = Image.open(io.BytesIO(screenshot))
+
+        # Resize image to target dimensions
+        resized_img = img.resize((target_dimension["width"], target_dimension["height"]), Image.Resampling.LANCZOS)
+
+        # Convert back to bytes
+        img_byte_arr = io.BytesIO()
+        resized_img.save(img_byte_arr, format="PNG")
+        img_byte = img_byte_arr.getvalue()
+
+        new_screenshots.append(img_byte)
+    return new_screenshots
+
+
+def scale_coordinates(
+    current_coordinates: tuple[int, int],
+    current_dimension: Resolution,
+    target_dimension: Resolution,
+) -> tuple[int, int]:
+    return (
+        int(current_coordinates[0] * target_dimension["width"] / current_dimension["width"]),
+        int(current_coordinates[1] * target_dimension["height"] / current_dimension["height"]),
+    )


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add screenshot resizing for Anthropic CUA compatibility, updating `LLMCaller` and `parse_anthropic_actions()` to handle scaled images and coordinates.
> 
>   - **Behavior**:
>     - Enable screenshot scaling in `LLMCaller` when `screenshot_scaling_enabled` is `True`.
>     - Resize screenshots in `call()` method of `LLMCaller` if scaling is enabled.
>     - Update `parse_anthropic_actions()` to scale coordinates from resized screenshots to browser dimensions.
>   - **Utilities**:
>     - Add `image_resizer.py` with `resize_screenshots()` and `scale_coordinates()` functions.
>     - Define `Resolution` type and `MAX_SCALING_TARGETS_ANTHROPIC_CUA` for target dimensions.
>   - **Misc**:
>     - Modify `execute_step()` in `agent.py` to pass dimensions to `parse_anthropic_actions()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a57cc8bad2e06ebb771e4f75b6241e8c06395f73. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->