### PR TITLE
add totp url to various editor nodes; update tooltip

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/helpContent.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/helpContent.ts
@@ -18,7 +18,7 @@ export const baseHelpTooltipContent = {
   errorCodeMapping:
     "Knowing about why a block terminated can be important, specify error messages here.",
   totpVerificationUrl:
-    "If you have an internal system for storing TOTP codes, link the endpoint here.",
+    "If you do not have a TOTP Identifier at hand, but do have an internal system for storing TOTP codes, link the endpoint here.",
   totpIdentifier:
     "If you are running multiple workflows at once, you will need to give the block an identifier to know that this TOTP goes with this block.",
   continueOnFailure:

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/ActionNode/ActionNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/ActionNode/ActionNode.tsx
@@ -329,6 +329,25 @@ function ActionNode({ id, data }: NodeProps<ActionNode>) {
                     className="nopan text-xs"
                   />
                 </div>
+                <div className="space-y-2">
+                  <div className="flex gap-2">
+                    <Label className="text-xs text-slate-300">
+                      2FA Verification URL
+                    </Label>
+                    <HelpTooltip
+                      content={helpTooltips["task"]["totpVerificationUrl"]}
+                    />
+                  </div>
+                  <WorkflowBlockInputTextarea
+                    nodeId={id}
+                    onChange={(value) => {
+                      handleChange("totpVerificationUrl", value);
+                    }}
+                    value={inputs.totpVerificationUrl ?? ""}
+                    placeholder={placeholders["task"]["totpVerificationUrl"]}
+                    className="nopan text-xs"
+                  />
+                </div>
               </div>
             </AccordionContent>
           </AccordionItem>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/FileDownloadNode/FileDownloadNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/FileDownloadNode/FileDownloadNode.tsx
@@ -311,6 +311,25 @@ function FileDownloadNode({ id, data }: NodeProps<FileDownloadNode>) {
                     className="nopan text-xs"
                   />
                 </div>
+                <div className="space-y-2">
+                  <div className="flex gap-2">
+                    <Label className="text-xs text-slate-300">
+                      2FA Verification URL
+                    </Label>
+                    <HelpTooltip
+                      content={helpTooltips["task"]["totpVerificationUrl"]}
+                    />
+                  </div>
+                  <WorkflowBlockInputTextarea
+                    nodeId={id}
+                    onChange={(value) => {
+                      handleChange("totpVerificationUrl", value);
+                    }}
+                    value={inputs.totpVerificationUrl ?? ""}
+                    placeholder={placeholders["task"]["totpVerificationUrl"]}
+                    className="nopan text-xs"
+                  />
+                </div>
               </div>
             </AccordionContent>
           </AccordionItem>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/NavigationNode/NavigationNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/NavigationNode/NavigationNode.tsx
@@ -352,6 +352,25 @@ function NavigationNode({ id, data }: NodeProps<NavigationNode>) {
                     className="nopan text-xs"
                   />
                 </div>
+                <div className="space-y-2">
+                  <div className="flex gap-2">
+                    <Label className="text-xs text-slate-300">
+                      2FA Verification URL
+                    </Label>
+                    <HelpTooltip
+                      content={helpTooltips["task"]["totpVerificationUrl"]}
+                    />
+                  </div>
+                  <WorkflowBlockInputTextarea
+                    nodeId={id}
+                    onChange={(value) => {
+                      handleChange("totpVerificationUrl", value);
+                    }}
+                    value={inputs.totpVerificationUrl ?? ""}
+                    placeholder={placeholders["task"]["totpVerificationUrl"]}
+                    className="nopan text-xs"
+                  />
+                </div>
               </div>
             </AccordionContent>
           </AccordionItem>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/Taskv2Node/Taskv2Node.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/Taskv2Node/Taskv2Node.tsx
@@ -165,6 +165,25 @@ function Taskv2Node({ id, data, type }: NodeProps<Taskv2Node>) {
                     className="nopan text-xs"
                   />
                 </div>
+                <div className="space-y-2">
+                  <div className="flex gap-2">
+                    <Label className="text-xs text-slate-300">
+                      2FA Verification URL
+                    </Label>
+                    <HelpTooltip
+                      content={helpTooltips["task"]["totpVerificationUrl"]}
+                    />
+                  </div>
+                  <WorkflowBlockInputTextarea
+                    nodeId={id}
+                    onChange={(value) => {
+                      handleChange("totpVerificationUrl", value);
+                    }}
+                    value={inputs.totpVerificationUrl ?? ""}
+                    placeholder={placeholders["task"]["totpVerificationUrl"]}
+                    className="nopan text-xs"
+                  />
+                </div>
               </div>
             </AccordionContent>
           </AccordionItem>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add TOTP verification URL input field to multiple node components and update tooltip content in the workflow editor.
> 
>   - **Behavior**:
>     - Add `totpVerificationUrl` input field to `ActionNode`, `FileDownloadNode`, `NavigationNode`, and `Taskv2Node` components.
>     - Update tooltip content for `totpVerificationUrl` in `helpContent.ts`.
>   - **UI**:
>     - Add `WorkflowBlockInputTextarea` for `totpVerificationUrl` in `ActionNode`, `FileDownloadNode`, `NavigationNode`, and `Taskv2Node`.
>     - Update placeholder text for `totpVerificationUrl` in `helpContent.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for a2cd04256295a0a6b2812c46d38e7f063c131de7. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->