### PR TITLE
feat: Add opt-out option for automatic PostgreSQL container startup

### DIFF
--- a/skyvern/cli/commands.py
+++ b/skyvern/cli/commands.py
@@ -110,7 +110,17 @@ def is_postgres_container_exists() -> bool:
 
 
 def setup_postgresql(no_postgres: bool = False) -> None:
-    print("Setting up PostgreSQL...")
+    """Set up PostgreSQL database for Skyvern.
+
+    This function checks if a PostgreSQL server is running locally or in Docker.
+    If no PostgreSQL server is found, it offers to start a Docker container
+    running PostgreSQL (unless explicitly opted out).
+
+    Args:
+        no_postgres: When True, skips starting a PostgreSQL container even if no
+                    local PostgreSQL server is detected. Useful when planning to
+                    use Docker Compose, which provides its own PostgreSQL service.
+    """
 
     if command_exists("psql") and is_postgres_running():
         print("PostgreSQL is already running locally.")
@@ -133,8 +143,14 @@ def setup_postgresql(no_postgres: bool = False) -> None:
         print("PostgreSQL is already running in a Docker container.")
     else:
         if not no_postgres:
-            start_postgres = input("No local Postgres detected. Start a disposable container now? (Y/n) [Y]\n[Tip: choose \"n\" if you plan to run Skyvern via Docker Compose instead of `skyvern run server`] ").strip().lower()
-            if start_postgres in ['n', 'no']:
+            start_postgres = (
+                input(
+                    'No local Postgres detected. Start a disposable container now? (Y/n) [Y]\n[Tip: choose "n" if you plan to run Skyvern via Docker Compose instead of `skyvern run server`] '
+                )
+                .strip()
+                .lower()
+            )
+            if start_postgres in ["n", "no"]:
                 print("Skipping PostgreSQL container setup.")
                 print("If you plan to use Docker Compose, its Postgres service will start automatically.")
                 return
@@ -583,7 +599,7 @@ def setup_windsurf_config(host_system: str, path_to_env: str) -> bool:
     skyvern_api_key = os.environ.get("SKYVERN_API_KEY", "")
     if not skyvern_base_url or not skyvern_api_key:
         print(
-            "Error: SKYVERN_BASE_URL and SKYVERN_API_KEY must be set in .env file to set up Windsurf MCP. Please open {path_windsurf_config} and set the these variables manually."
+            "Error: SKYVERN_BASE_URL and SKYVERN_API_KEY must be set in .env file to set up Windsurf MCP. Please open {path_windsurf_config} and set these variables manually."
         )
 
     try:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `--no-postgres` option to `init` command to allow skipping PostgreSQL container startup in `commands.py`.
> 
>   - **Behavior**:
>     - Add `--no-postgres` option to `init` command in `commands.py` to skip PostgreSQL container startup.
>     - Modify `setup_postgresql()` in `commands.py` to handle `no_postgres` flag, skipping container setup if true.
>     - If `no_postgres` is true, inform user that Docker Compose will handle PostgreSQL startup.
>   - **Functions**:
>     - Update `setup_postgresql()` to include `no_postgres` parameter.
>     - Update `init()` to pass `no_postgres` option to `setup_postgresql()`.
>   - **Misc**:
>     - Add user prompts and messages to guide through the new opt-out process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for fcabfb5d61d40132a5685df6a3bac797c7a8e134. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->