### PR TITLE
fix interactable parsing

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -626,9 +626,10 @@ function isInteractable(element, hoverStylesMap) {
   }
 
   // element with pointer-events: none should not be considered as interactable
+  // but for elements which are disabled, we should not use this logic to test the interactable
   // https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events#none
   const elementPointerEvent = getElementComputedStyle(element)?.pointerEvents;
-  if (elementPointerEvent === "none") {
+  if (elementPointerEvent === "none" && !element.disabled) {
     return false;
   }
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix `isInteractable` function in `domUtils.js` to correctly handle disabled elements with `pointer-events: none`.
> 
>   - **Behavior**:
>     - Fix `isInteractable` function in `domUtils.js` to consider elements with `pointer-events: none` as non-interactable only if they are not disabled.
>     - Ensures disabled elements with `pointer-events: none` are still considered interactable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d0f9635f7011801d966b1e37966b90ca41d6d0f2. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->