### PR TITLE
fix shadown DOM parsing

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1446,14 +1446,15 @@ async function buildElementTree(
     }
 
     let children = [];
+    // sometimes the shadowRoot is not visible, but the elemnets in the shadowRoot are visible
+    if (element.shadowRoot) {
+      children = getChildElements(element.shadowRoot);
+    }
     const isVisible = isElementVisible(element);
     if (isVisible && !isHidden(element) && !isScriptOrStyle(element)) {
       const interactable = isInteractable(element, hoverStylesMap);
       let elementObj = null;
       let isParentSVG = null;
-      if (element.shadowRoot) {
-        children = getChildElements(element.shadowRoot);
-      }
       if (interactable) {
         elementObj = await buildElementObject(frame, element, interactable);
       } else if (


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes shadow DOM parsing in `buildElementTree()` in `domUtils.js` to correctly process visible child elements within a shadow root.
> 
>   - **Behavior**:
>     - Fixes shadow DOM parsing in `buildElementTree()` in `domUtils.js` by ensuring child elements in `shadowRoot` are processed before visibility checks.
>     - Handles cases where `shadowRoot` is not visible, but its child elements are visible.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d2f79553e4a0f853cd245051e2f1cced013d4315. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->