### PR TITLE
shu/remove max completion tokens for ollama

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -430,10 +430,12 @@ class LLMAPIHandlerFactory:
     @staticmethod
     def get_api_parameters(llm_config: LLMConfig | LLMRouterConfig) -> dict[str, Any]:
         params: dict[str, Any] = {}
-        if llm_config.max_completion_tokens is not None:
-            params["max_completion_tokens"] = llm_config.max_completion_tokens
-        elif llm_config.max_tokens is not None:
-            params["max_tokens"] = llm_config.max_tokens
+        if not llm_config.model_name.startswith("ollama/"):
+            # OLLAMA does not support max_completion_tokens
+            if llm_config.max_completion_tokens is not None:
+                params["max_completion_tokens"] = llm_config.max_completion_tokens
+            elif llm_config.max_tokens is not None:
+                params["max_tokens"] = llm_config.max_tokens
 
         if llm_config.temperature is not None:
             params["temperature"] = llm_config.temperature

--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -815,7 +815,6 @@ if settings.ENABLE_OLLAMA:
                 ["OLLAMA_SERVER_URL", "OLLAMA_MODEL"],
                 supports_vision=False,  # Ollama does not support vision yet
                 add_assistant_prefix=False,
-                max_completion_tokens=settings.LLM_CONFIG_MAX_TOKENS,
                 litellm_params=LiteLLMParams(
                     api_base=settings.OLLAMA_SERVER_URL,
                     api_key=None,


### PR DESCRIPTION
- remove max_completion_tokens for ollama config
- do not set max_tokens for ollama

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `max_completion_tokens` for Ollama models and ensure no `max_tokens` are set for them in `api_handler_factory.py` and `config_registry.py`.
> 
>   - **Behavior**:
>     - Remove `max_completion_tokens` for Ollama models in `api_handler_factory.py`.
>     - Do not set `max_tokens` for models with names starting with `ollama/` in `get_api_parameters()`.
>   - **Config**:
>     - Remove `max_completion_tokens` from Ollama configuration in `config_registry.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 217606bc2b578adce6f6e30eb0b02281a9b1d26b. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->