### PR TITLE
fix legacy credentials api prefix

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1707,15 +1707,8 @@ async def cancel_run(
     await run_service.cancel_run(run_id, organization_id=current_org.organization_id, api_key=x_api_key)
 
 
-@legacy_base_router.get(
-    "",
-    tags=["credentials"],
-    openapi_extra={
-        "x-fern-sdk-group-name": "credentials",
-        "x-fern-sdk-method-name": "get_credentials",
-    },
-)
-@legacy_base_router.get("/", include_in_schema=False)
+@legacy_base_router.get( "/credentials")
+@legacy_base_router.get("/credentials/", include_in_schema=False)
 @base_router.get(
     "/credentials",
     response_model=list[CredentialResponse],
@@ -1784,15 +1777,8 @@ async def get_credentials(
     return response_items
 
 
-@legacy_base_router.get(
-    "/{credential_id}",
-    tags=["credentials"],
-    openapi_extra={
-        "x-fern-sdk-group-name": "credentials",
-        "x-fern-sdk-method-name": "get_credential",
-    },
-)
-@legacy_base_router.get("/{credential_id}/", include_in_schema=False)
+@legacy_base_router.get("/credentials/{credential_id}")
+@legacy_base_router.get("/credentials/{credential_id}/", include_in_schema=False)
 @base_router.get(
     "/credentials/{credential_id}",
     response_model=CredentialResponse,
@@ -1853,15 +1839,8 @@ async def get_credential(
     raise HTTPException(status_code=400, detail="Invalid credential type")
 
 
-@legacy_base_router.delete(
-    "/{credential_id}",
-    tags=["credentials"],
-    openapi_extra={
-        "x-fern-sdk-group-name": "credentials",
-        "x-fern-sdk-method-name": "delete_credential",
-    },
-)
-@legacy_base_router.delete("/{credential_id}/", include_in_schema=False)
+@legacy_base_router.delete("/credentials/{credential_id}")
+@legacy_base_router.delete("/credentials/{credential_id}/", include_in_schema=False)
 @base_router.post(
     "/credentials/{credential_id}/delete",
     status_code=204,
@@ -1900,15 +1879,8 @@ async def delete_credential(
     return None
 
 
-@legacy_base_router.post(
-    "",
-    tags=["credentials"],
-    openapi_extra={
-        "x-fern-sdk-group-name": "credentials",
-        "x-fern-sdk-method-name": "create_credential",
-    },
-)
-@legacy_base_router.post("/", include_in_schema=False)
+@legacy_base_router.post("/credentials")
+@legacy_base_router.post("/credentials/", include_in_schema=False)
 @base_router.post(
     "/credentials",
     response_model=CredentialResponse,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix legacy credential API routes in `agent_protocol.py` to include '/credentials' prefix for consistency.
> 
>   - **Routes**:
>     - Updated legacy credential routes in `agent_protocol.py` to include '/credentials' prefix.
>     - Affected endpoints: `get_credentials`, `get_credential`, `delete_credential`, `create_credential`.
>     - Ensures consistency with base routes by aligning path prefixes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f5c3a8e83e3fa3e39779bd8ade34715c1c1c191b. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->