### PR TITLE
fix credentials get api lint

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1707,7 +1707,7 @@ async def cancel_run(
     await run_service.cancel_run(run_id, organization_id=current_org.organization_id, api_key=x_api_key)
 
 
-@legacy_base_router.get( "/credentials")
+@legacy_base_router.get("/credentials")
 @legacy_base_router.get("/credentials/", include_in_schema=False)
 @base_router.get(
     "/credentials",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix linting issue by removing extra space in `/credentials` route decorator in `agent_protocol.py`.
> 
>   - **Linting Fix**:
>     - Remove extra space in `@legacy_base_router.get("/credentials")` route decorator in `agent_protocol.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f6a6b06a5e9cdacfc0f1aa9da0ed758be6099743. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->