### PR TITLE
Update N8N Readme with link to repo, disable doctoc metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,6 +94,7 @@ repos:
     rev: v2.2.0
     hooks:
       - id: doctoc
+        args: [--notitle]
   - repo: local
     hooks:
       - id: alembic-check

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,5 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Code of Conduct - Skyvern](#code-of-conduct---skyvern)
   - [Our Pledge](#our-pledge)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,5 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Contributing to Skyvern](#contributing-to-skyvern)
   - [Table of Contents](#table-of-contents)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,5 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Security Policy](#security-policy)
   - [Supported Versions](#supported-versions)

--- a/alembic/README.md
+++ b/alembic/README.md
@@ -1,6 +1,5 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Creating a new revision](#creating-a-new-revision)
 - [Running migrations](#running-migrations)

--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -1,6 +1,5 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Skyvern Langchain](#skyvern-langchain)
   - [Installation](#installation)

--- a/integrations/llama_index/README.md
+++ b/integrations/llama_index/README.md
@@ -1,6 +1,5 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Skyvern LlamaIndex](#skyvern-llamaindex)
   - [Installation](#installation)

--- a/integrations/n8n/CODE_OF_CONDUCT.md
+++ b/integrations/n8n/CODE_OF_CONDUCT.md
@@ -1,6 +1,5 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Contributor Covenant Code of Conduct](#contributor-covenant-code-of-conduct)
   - [Our Pledge](#our-pledge)

--- a/integrations/n8n/README.md
+++ b/integrations/n8n/README.md
@@ -1,6 +1,5 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [n8n-nodes-skyvern](#n8n-nodes-skyvern)
   - [Installation](#installation)

--- a/integrations/n8n/README.md
+++ b/integrations/n8n/README.md
@@ -43,3 +43,4 @@ Follow the [installation guide](https://docs.n8n.io/integrations/community-nodes
 * [n8n community nodes documentation](https://docs.n8n.io/integrations/community-nodes/)
 * [Skyvern documentation](https://docs.skyvern.com/introduction)
 
+* [n8n integration code](https://github.com/Skyvern-AI/skyvern/tree/main/integrations/n8n)

--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1940,10 +1940,11 @@ class ForgeAgent:
                         )
                         return action_result.data
 
-        LOG.warning(
-            "Failed to find extracted information for task",
-            task_id=task.task_id,
-        )
+        if task.data_extraction_goal:
+            LOG.warning(
+                "Failed to find extracted information for task",
+                task_id=task.task_id,
+            )
         return None
 
     async def get_failure_reason_for_task(self, task: Task) -> str | None:

--- a/skyvern/webeye/README.md
+++ b/skyvern/webeye/README.md
@@ -1,6 +1,5 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [WebHuman Automation Tool](#webhuman-automation-tool)
   - [Getting Started](#getting-started)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update n8n README with repo link, remove doctoc metadata, and add conditional logging in agent.py.
> 
>   - **Documentation**:
>     - Add link to n8n integration code in `integrations/n8n/README.md`.
>     - Remove `doctoc` metadata from `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `SECURITY.md`, `alembic/README.md`, `integrations/langchain/README.md`, `integrations/llama_index/README.md`, `integrations/n8n/CODE_OF_CONDUCT.md`, and `skyvern/webeye/README.md`.
>   - **Configuration**:
>     - Update `.pre-commit-config.yaml` to disable `doctoc` title generation with `--notitle` argument.
>   - **Code**:
>     - Add conditional logging in `get_extracted_information_for_task()` in `agent.py` to log only if `task.data_extraction_goal` is present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a7d3854eb24a287c3593ed80cb62533ea9e730e0. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->