### PR TITLE
closes SKY-155 - adds autopan to workflow editor

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -30,7 +30,7 @@ import {
 import "@xyflow/react/dist/style.css";
 import { AxiosError } from "axios";
 import { nanoid } from "nanoid";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useBlocker, useParams } from "react-router-dom";
 import { stringify as convertToYAML } from "yaml";
 import {
@@ -85,6 +85,7 @@ import {
   startNode,
 } from "./workflowEditorUtils";
 import { parameterIsBitwardenCredential, ParametersState } from "./types";
+import { useAutoPan } from "./useAutoPan";
 
 function convertToParametersYAML(
   parameters: ParametersState,
@@ -494,6 +495,10 @@ function FlowRenderer({
     doLayout(newNodesWithUpdatedParameters, newEdges);
   }
 
+  const editorElementRef = useRef<HTMLDivElement>(null);
+
+  useAutoPan(editorElementRef, nodes);
+
   return (
     <>
       <Dialog
@@ -542,6 +547,7 @@ function FlowRenderer({
       >
         <DeleteNodeCallbackContext.Provider value={deleteNode}>
           <ReactFlow
+            ref={editorElementRef}
             nodes={nodes}
             edges={edges}
             onNodesChange={(changes) => {

--- a/skyvern-frontend/src/routes/workflows/editor/useAutoPan.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/useAutoPan.ts
@@ -1,0 +1,58 @@
+import { useReactFlow } from "@xyflow/react";
+import { useLayoutEffect } from "react";
+
+import { AppNode } from "./nodes";
+
+/**
+ * Some facts:
+ *   - the workflow editor is rendered as an infinite canvas
+ *   - nodes in the editor can have text fields
+ *   - users type in those text fields
+ *   - the browser will automatically attempt to scroll to a caret position when
+ *     the caret leaves the viewport, because it is Being A Good Browser(tm)
+ *   - this causes layout artifacts on the infinite canvas
+ *
+ * `useAutoPan` detects when the viewport is scrolled. (But it should never have
+ * a scroll, as it is an infinite canvas!) If a scroll value is detected, then
+ * we pan the viewport to counteract the scroll, and set the scroll to 0.
+ *
+ * The end result is that:
+ *   - if a user is typing in any textual HTML element, and they scroll beyond
+ *     the viewport, the viewport will animate-pan to counteract the scroll
+ *   - if the user pastes large amounts of text into any textual HTML element,
+ *     the viewport will animate-pan to counteract the scroll
+ *
+ * `editorElementRef`: a ref to the top-level editor element (the top-level div
+ * for react-flow, at time of writing)
+ *
+ * `nodes`: `AppNode`s; but could be anything that carries state indicative of a
+ * change in the editor
+ */
+const useAutoPan = (
+  editorElementRef: React.RefObject<HTMLDivElement>,
+  nodes: AppNode[],
+) => {
+  const { setViewport, getViewport } = useReactFlow();
+
+  useLayoutEffect(() => {
+    const editorElement = editorElementRef.current;
+    if (editorElement) {
+      const scrollTop = editorElement.scrollTop;
+
+      if (scrollTop === 0) {
+        return;
+      }
+
+      editorElement.scrollTop = 0;
+      const { x, y, zoom } = getViewport();
+      const panAmount = editorElement.clientHeight * 0.3;
+
+      setViewport(
+        { x, y: y - (scrollTop + panAmount), zoom },
+        { duration: 300 },
+      );
+    }
+  }, [nodes, editorElementRef, setViewport, getViewport]);
+};
+
+export { useAutoPan };


### PR DESCRIPTION
See https://linear.app/skyvern/issue/SKY-5155/long-text-pasted-into-goal-text-area-causes-react-flow-to-zoom-out-and
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `useAutoPan` to auto-pan the workflow editor viewport when text input causes scrolling.
> 
>   - **Behavior**:
>     - Adds `useAutoPan` hook in `useAutoPan.ts` to handle viewport scrolling in the workflow editor.
>     - Integrates `useAutoPan` in `FlowRenderer` to auto-pan the viewport when text input causes scrolling.
>   - **Implementation**:
>     - `useAutoPan` detects scroll in `editorElementRef` and adjusts viewport using `setViewport` from `useReactFlow`.
>     - Pans viewport by `0.3` of the editor's height over `300ms` if scroll is detected.
>   - **Misc**:
>     - Adds `editorElementRef` to `ReactFlow` component in `FlowRenderer.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d893b296a976fce899a1856b9d6bc670cabc1685. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->