### PR TITLE
fix workflow title bug in get_workflow_run_response

### DIFF
--- a/skyvern/services/workflow_service.py
+++ b/skyvern/services/workflow_service.py
@@ -89,7 +89,7 @@ async def get_workflow_run_response(
         modified_at=workflow_run.modified_at,
         run_request=WorkflowRunRequest(
             workflow_id=workflow_run.workflow_id,
-            title=workflow_run.title,
+            title=workflow_run_resp.workflow_title,
             parameters=workflow_run_resp.parameters,
             proxy_location=workflow_run.proxy_location,
             webhook_url=workflow_run.webhook_callback_url,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix workflow title bug in `get_workflow_run_response()` by changing title source to `workflow_run_resp.workflow_title`.
> 
>   - **Bug Fix**:
>     - In `get_workflow_run_response()` in `workflow_service.py`, fix workflow title bug by changing `title` source from `workflow_run.title` to `workflow_run_resp.workflow_title`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0ff3f863d1294b53d96bc79b3091b9e82b1bddc4. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->