### PR TITLE
no to build full tree but still adding structure representive div

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1424,7 +1424,7 @@ async function buildTreeFromBody(
 async function buildElementTree(
   starter = document.body,
   frame,
-  full_tree = true,
+  full_tree = false,
   needContext = true,
   hoverStylesMap = undefined,
 ) {
@@ -1519,6 +1519,8 @@ async function buildElementTree(
         getElementText(element).length <= 5000
       ) {
         elementObj = await buildElementObject(frame, element, interactable);
+      } else if (tagName === "div" && isDOMNodeRepresentDiv(element)) {
+        elementObj = await buildElementObject(frame, element, interactable);
       } else if (full_tree) {
         // when building full tree, we only get text from element itself
         // elements without text are purgeable
@@ -1528,10 +1530,7 @@ async function buildElementTree(
           interactable,
           true,
         );
-        if (
-          elementObj.text.length > 0 ||
-          (elementObj.tagName === "div" && isDOMNodeRepresentDiv(element))
-        ) {
+        if (elementObj.text.length > 0) {
           elementObj.purgeable = false;
         }
       }


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change `buildElementTree` default to not build full tree and handle structure-representing `div` elements in `domUtils.js`.
> 
>   - **Behavior**:
>     - Change default `full_tree` parameter to `false` in `buildElementTree()` in `domUtils.js`.
>     - Add condition to handle `div` elements with `isDOMNodeRepresentDiv()` in `buildElementTree()`.
>   - **Logic**:
>     - Remove check for `div` elements in `if` condition for `full_tree` in `buildElementTree()`.
>     - Ensure `div` elements are processed if they represent a structure, even when not building a full tree.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c7ac5bb90c2c82bd6400b426e60bf095e1c18327. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->