### PR TITLE
no to build full tree but still adding structure representive div

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1424,7 +1424,7 @@ async function buildTreeFromBody(
 async function buildElementTree(
   starter = document.body,
   frame,
-  full_tree = true,
+  full_tree = false,
   needContext = true,
   hoverStylesMap = undefined,
 ) {
@@ -1514,6 +1514,8 @@ async function buildElementTree(
       ) {
         // if elemnet is the children of the <svg> with an unique_id
         elementObj = await buildElementObject(frame, element, interactable);
+      } else if (tagName === "div" && isDOMNodeRepresentDiv(element)) {
+        elementObj = await buildElementObject(frame, element, interactable);
       } else if (
         getElementText(element).length > 0 &&
         getElementText(element).length <= 5000
@@ -1528,10 +1530,7 @@ async function buildElementTree(
           interactable,
           true,
         );
-        if (
-          elementObj.text.length > 0 ||
-          (elementObj.tagName === "div" && isDOMNodeRepresentDiv(element))
-        ) {
+        if (elementObj.text.length > 0) {
           elementObj.purgeable = false;
         }
       }


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change `buildElementTree()` to not build a full tree by default and include tree-structure `div` elements in `domUtils.js`.
> 
>   - **Behavior**:
>     - Change default `full_tree` parameter to `false` in `buildElementTree()` in `domUtils.js`.
>     - Add condition to include `div` elements that represent a tree structure in `buildElementTree()`.
>   - **Logic**:
>     - Remove check for `div` elements in `if` condition for `elementObj.purgeable` in `buildElementTree()`.
>   - **Misc**:
>     - Minor adjustments to logic for handling text length in `buildElementTree()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for bde25a54e03adba6c8d63f3e069991065017a7ca. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->