### PR TITLE
shu/make timeout optional field in create browser session

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1715,7 +1715,7 @@ async def cancel_run(
     response_model=list[CredentialResponse],
     summary="Get all credentials",
     description="Retrieves a paginated list of credentials for the current organization",
-    tags=["credentials"],
+    tags=["Credentials"],
     openapi_extra={
         "x-fern-sdk-group-name": "credentials",
         "x-fern-sdk-method-name": "get_credentials",
@@ -1785,7 +1785,7 @@ async def get_credentials(
     response_model=CredentialResponse,
     summary="Get credential by ID",
     description="Retrieves a specific credential by its ID",
-    tags=["credentials"],
+    tags=["Credentials"],
     openapi_extra={
         "x-fern-sdk-group-name": "credentials",
         "x-fern-sdk-method-name": "get_credential",
@@ -1847,7 +1847,7 @@ async def get_credential(
     status_code=204,
     summary="Delete credential",
     description="Deletes a specific credential by its ID",
-    tags=["credentials"],
+    tags=["Credentials"],
     openapi_extra={
         "x-fern-sdk-group-name": "credentials",
         "x-fern-sdk-method-name": "delete_credential",
@@ -1888,7 +1888,7 @@ async def delete_credential(
     status_code=201,
     summary="Create credential",
     description="Creates a new credential for the current organization",
-    tags=["credentials"],
+    tags=["Credentials"],
     openapi_extra={
         "x-fern-sdk-group-name": "credentials",
         "x-fern-sdk-method-name": "create_credential",

--- a/skyvern/schemas/browser_sessions.py
+++ b/skyvern/schemas/browser_sessions.py
@@ -6,7 +6,7 @@ DEFAULT_TIMEOUT = 60
 
 
 class CreateBrowserSessionRequest(BaseModel):
-    timeout: int = Field(
+    timeout: int | None = Field(
         default=DEFAULT_TIMEOUT,
         description=f"Timeout in minutes for the session. Timeout is applied after the session is started. Must be between {MIN_TIMEOUT} and {MAX_TIMEOUT}. Defaults to {DEFAULT_TIMEOUT}.",
         ge=MIN_TIMEOUT,


### PR DESCRIPTION
- make timeout an optional field in create_browser_session endpoint
- credential endpoints tag: credentials -> Credentials

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `timeout` optional in `CreateBrowserSessionRequest` and update credential API tags to `Credentials`.
> 
>   - **Behavior**:
>     - `timeout` in `CreateBrowserSessionRequest` in `browser_sessions.py` is now optional, defaulting to `DEFAULT_TIMEOUT` if not provided.
>   - **API Tags**:
>     - Change API tags from `credentials` to `Credentials` in `agent_protocol.py` for endpoints: `get_credentials`, `get_credential`, `delete_credential`, `create_credential`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 7815689e92c4c65495d5da2fda0af93edcd52ddc. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->