### PR TITLE
fix multi level selection issue

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -2286,6 +2286,7 @@ async def sequentially_select_from_dropdown(
     dropdown_menu_element: SkyvernElement | None = None,
     force_select: bool = False,
     target_value: str = "",
+    continue_until_click: bool = False,
 ) -> CustomSingleSelectResult | None:
     """
     TODO: support to return all values retrieved from the sequentially select
@@ -2406,6 +2407,14 @@ async def sequentially_select_from_dropdown(
         if single_select_result.action_type is not None and single_select_result.action_type == ActionType.INPUT_TEXT:
             LOG.info(
                 "It's an input mini action, going to continue the select action",
+                step_id=step.step_id,
+                task_id=task.task_id,
+            )
+            continue
+
+        if continue_until_click:
+            LOG.info(
+                "Continue the selecting until the dropdown menu is closed",
                 step_id=step.step_id,
                 task_id=task.task_id,
             )


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `continue_until_click` parameter to `sequentially_select_from_dropdown()` in `handler.py` to handle multi-level dropdown selections until closure.
> 
>   - **Behavior**:
>     - Adds `continue_until_click` parameter to `sequentially_select_from_dropdown()` in `handler.py` to continue selection until dropdown menu is closed.
>     - Logs a message when `continue_until_click` is active, indicating continuation until dropdown closure.
>   - **Misc**:
>     - No changes to existing logic or other functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f47208d5ea35dbe6851666929a4e92742100db4e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->