### PR TITLE
add index to runnable_id in persistent_browser_sessions table

### DIFF
--- a/skyvern/forge/sdk/db/models.py
+++ b/skyvern/forge/sdk/db/models.py
@@ -630,7 +630,7 @@ class PersistentBrowserSessionModel(Base):
     persistent_browser_session_id = Column(String, primary_key=True, default=generate_persistent_browser_session_id)
     organization_id = Column(String, nullable=False, index=True)
     runnable_type = Column(String, nullable=True)
-    runnable_id = Column(String, nullable=True)
+    runnable_id = Column(String, nullable=True, index=True)
     browser_id = Column(String, nullable=True)
     browser_address = Column(String, nullable=True)
     status = Column(String, nullable=True, default="created")


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add index to `runnable_id` in `PersistentBrowserSessionModel` to improve query performance.
> 
>   - **Database Schema**:
>     - Add index to `runnable_id` in `PersistentBrowserSessionModel` in `models.py` to improve query performance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ba3922f74f583f21d7a1f282c90a11b9b40d71ba. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->