### PR TITLE
get_persistent_browser_session_by_runnable_id returns None instead of raising error when no record is found

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -2693,7 +2693,7 @@ class AgentDB:
                 persistent_browser_session = (await session.scalars(query)).first()
                 if persistent_browser_session:
                     return PersistentBrowserSession.model_validate(persistent_browser_session)
-                raise NotFoundError(f"PersistentBrowserSession {runnable_id} not found")
+                return None
         except NotFoundError:
             LOG.error("NotFoundError", exc_info=True)
             raise


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `get_persistent_browser_session_by_runnable_id` in `client.py` now returns `None` instead of raising an error when no session is found.
> 
>   - **Behavior**:
>     - `get_persistent_browser_session_by_runnable_id` in `client.py` now returns `None` instead of raising `NotFoundError` when no session is found.
>   - **Error Handling**:
>     - Removes `NotFoundError` handling for `get_persistent_browser_session_by_runnable_id` in `client.py`.
>     - Adjusts logging to not log `NotFoundError` for this case.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 990b7ccaff55b3f1fb827954c01e0598024f12cc. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->