### PR TITLE
Jon/eval update

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -671,10 +671,19 @@ class WorkflowService:
         )
 
     async def get_workflow_runs(
-        self, organization_id: str, page: int = 1, page_size: int = 10, status: list[WorkflowRunStatus] | None = None
+        self,
+        organization_id: str,
+        page: int = 1,
+        page_size: int = 10,
+        status: list[WorkflowRunStatus] | None = None,
+        ordering: tuple[str, str] | None = None,
     ) -> list[WorkflowRun]:
         return await app.DATABASE.get_workflow_runs(
-            organization_id=organization_id, page=page, page_size=page_size, status=status
+            organization_id=organization_id,
+            page=page,
+            page_size=page_size,
+            status=status,
+            ordering=ordering,
         )
 
     async def get_workflow_runs_count(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add ordering functionality to `get_workflow_runs()` in `client.py` and `service.py` to allow sorting by `created_at` or `status`.
> 
>   - **Behavior**:
>     - Add `ordering` parameter to `get_workflow_runs()` in `client.py` and `service.py` to allow ordering by `created_at` or `status`.
>     - Default ordering is by `created_at` in descending order.
>     - Validates `ordering` tuple to ensure it contains valid field and direction.
>   - **Functions**:
>     - Update `get_workflow_runs()` in `client.py` to include ordering logic.
>     - Update `get_workflow_runs()` in `service.py` to pass `ordering` parameter to database call.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 8fc39eeecb6d9f6491ed27f764cf271f41f33f2b. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->