### PR TITLE
avoid running kill of skyvern is not running

### DIFF
--- a/run_skyvern.sh
+++ b/run_skyvern.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-kill $(lsof -t -i :8000)
+pid=$(lsof -t -i :8000)
+if [ ! -z "$pid" ]; then
+  kill $pid
+fi
 
 if [ ! -f .env ]; then
   cp .env.example .env

--- a/run_ui.sh
+++ b/run_ui.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-kill $(lsof -t -i :8080)
+pid=$(lsof -t -i :8080)
+if [ ! -z "$pid" ]; then
+  kill $pid
+fi
 
 cd skyvern-frontend
 


### PR DESCRIPTION
avoid the kill usage message:
![Screenshot 2025-05-21 at 4 22 37 PM](https://github.com/user-attachments/assets/39e86522-1516-4b85-8f4f-789cc81cbdd7)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add checks in `run_skyvern.sh` and `run_ui.sh` to avoid killing non-existent processes on ports 8000 and 8080.
> 
>   - **Behavior**:
>     - In `run_skyvern.sh`, check if a process is running on port 8000 before attempting to kill it.
>     - In `run_ui.sh`, check if a process is running on port 8080 before attempting to kill it.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for db9b506877a1d0ae6a8b369246c5cac02ef68738. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->