### PR TITLE
add n8n credential test + migrate to new API endpoint

### DIFF
--- a/integrations/n8n/credentials/SkyvernApi.credentials.ts
+++ b/integrations/n8n/credentials/SkyvernApi.credentials.ts
@@ -1,5 +1,6 @@
 import {
 	IAuthenticateGeneric,
+	ICredentialTestRequest,
 	ICredentialType,
 	INodeProperties,
 } from 'n8n-workflow';
@@ -33,6 +34,12 @@ export class SkyvernApi implements ICredentialType {
                 'x-api-key': '={{$credentials.apiKey}}',
                 'Content-Type': 'application/json',
             }
+		},
+	};
+	test: ICredentialTestRequest = {
+		request: {
+			baseURL: '={{$credentials?.baseUrl}}',
+			url: '/api/v1/organizations',
 		},
 	};
 }

--- a/integrations/n8n/nodes/Skyvern/Skyvern.node.ts
+++ b/integrations/n8n/nodes/Skyvern/Skyvern.node.ts
@@ -123,7 +123,7 @@ export class Skyvern implements INodeType {
                     request: {
                         baseURL: '={{$credentials.baseUrl}}',
                         method: '={{ $value === "dispatch" ? "POST" : "GET" }}' as IHttpRequestMethods,
-                        url: '={{"/api/" + ($parameter["taskOptions"]["engine"] ? $parameter["taskOptions"]["engine"] : "v2") + "/tasks"}}',
+                        url: '={{"/v1/run/tasks"}}',
                     },
                     send: {
                         preSend: [
@@ -132,46 +132,11 @@ export class Skyvern implements INodeType {
                                 if (taskOperation === "get") return requestOptions;
 
                                 const taskOptions: IDataObject = this.getNodeParameter('taskOptions') as IDataObject;
-                                if (taskOptions["engine"] !== "v1") return requestOptions;
-
-                                const credentials = await this.getCredentials('skyvernApi');
-                                const userPrompt = this.getNodeParameter('userPrompt');
-
-                                // *** capture optional webhook URL ***
-                                let webhookUrl: string | undefined;
-                                try {
-                                    webhookUrl = this.getNodeParameter('webhookUrl') as string;
-                                } catch (e) {
-                                    webhookUrl = undefined;
-                                }
-
-                                const generateBody: IDataObject = {
-                                    prompt: userPrompt,
-                                };
-
-                                const response = await makeRequest(credentials['baseUrl'] + '/api/v1/generate/task', {
-                                    method: 'POST',
-                                    headers: {
-                                        'Content-Type': 'application/json',
-                                        'x-api-key': credentials['apiKey'],
-                                    },
-                                    body: JSON.stringify(generateBody),
-                                });
-                                if (!response.ok) {
-                                    throw new Error('Request to generate Task V1 failed'); // eslint-disable-line
-                                }
-
-                                const data = await response.json();
-                                requestOptions.body = {
-                                    url: data.url,
-                                    navigation_goal: data.navigation_goal,
-                                    navigation_payload: data.navigation_payload,
-                                    data_extraction_goal: data.data_extraction_goal,
-                                    extracted_information_schema: data.extracted_information_schema,
-                                } as IDataObject;
-
-                                if (webhookUrl) {
-                                    (requestOptions.body as IDataObject)['webhook_callback_url'] = webhookUrl;
+                                const legacy_engine = taskOptions["engine"] as string | null
+                                if (legacy_engine === "v1") {
+                                    (requestOptions.body as IDataObject)['engine'] = "skyvern-1.0";
+                                }else if (legacy_engine === "v2") {
+                                    (requestOptions.body as IDataObject)['engine'] = "skyvern-2.0";
                                 }
                                 return requestOptions;
                             },
@@ -196,7 +161,7 @@ export class Skyvern implements INodeType {
                 routing: {
                     request: {
                         body: {
-                            user_prompt: '={{$value}}',
+                            prompt: '={{$value}}',
                         },
                     },
                 },
@@ -222,7 +187,6 @@ export class Skyvern implements INodeType {
                     },
                 },
             },
-            // *** New property: optional webhook URL for Task dispatch ***
             {
                 displayName: 'Webhook Callback URL',
                 description: 'Optional URL that Skyvern will call when the task finishes',
@@ -239,7 +203,7 @@ export class Skyvern implements INodeType {
                 routing: {
                     request: {
                         body: {
-                            webhook_callback_url: '={{$value ? $value : undefined}}',
+                            webhook_url: '={{$value ? $value : null}}',
                         },
                     },
                 },
@@ -260,7 +224,7 @@ export class Skyvern implements INodeType {
                 routing: {
                     request: {
                         method: 'GET',
-                        url: '={{"/api/" + ($parameter["taskOptions"]["engine"] ? $parameter["taskOptions"]["engine"] : "v2") + "/tasks/" + $value}}',
+                        url: '={{"/v1/runs/" + $value}}',
                     },
                 },
             },
@@ -273,10 +237,12 @@ export class Skyvern implements INodeType {
                 default: {},
                 options: [
                     {
-                        displayName: 'Engine',
+                        displayName: 'Engine(Deprecated)',
+                        description: 'Deprecated: please migrate to use "Engine" option',
                         name: 'engine',
                         type: 'options',
-                        default: 'v2',
+                        default: '',
+                        required: false,
                         options: [
                             {
                                 name: 'TaskV1',
@@ -286,12 +252,45 @@ export class Skyvern implements INodeType {
                                 name: 'TaskV2',
                                 value: 'v2',
                             },
+
                         ],
                     },
+                    {
+                        displayName: 'Engine',
+                        name: 'runEngine',
+                        type: 'options',
+                        default: 'skyvern-2.0',
+                        options: [
+                            {
+                                name: 'Skyvern 1.0',
+                                value: 'skyvern-1.0',
+                            },
+                            {
+                                name: 'Skyvern 2.0',
+                                value: 'skyvern-2.0',
+                            },
+                            {
+                                name: 'OpenAI CUA',
+                                value: 'openai-cua',
+                            },
+                            {
+                                name: 'Anthropic CUA',
+                                value: 'anthropic-cua',
+                            }
+                        ],
+                        routing: {
+                            request: {
+                                body: {
+                                    engine: '={{$value}}',
+                                },
+                            },
+                        },
+                    }
                 ],
                 displayOptions: {
                     show: {
                         resource: ['task'],
+                        taskOperation: ['dispatch'],
                     },
                 },
             },
@@ -400,7 +399,6 @@ export class Skyvern implements INodeType {
                     },
                 },
             },
-            // *** New property: optional webhook URL for Workflow dispatch ***
             {
                 displayName: 'Webhook Callback URL',
                 description: 'Optional URL that Skyvern will call when the workflow run finishes',
@@ -417,7 +415,7 @@ export class Skyvern implements INodeType {
                 routing: {
                     request: {
                         body: {
-                            webhook_callback_url: '={{$value ? $value : undefined}}',
+                            webhook_callback_url: '={{$value ? $value : null}}',
                         },
                     },
                 },

--- a/integrations/n8n/package.json
+++ b/integrations/n8n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-skyvern",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Skyvern Node for n8n",
   "keywords": [
     "n8n-community-node-package"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add credential test and migrate Skyvern API to new endpoint with updated node properties.
> 
>   - **Credential Test**:
>     - Adds `ICredentialTestRequest` to `SkyvernApi.credentials.ts` for testing credentials against `/api/v1/organizations`.
>   - **API Endpoint Migration**:
>     - Updates task dispatch URL to `/v1/run/tasks` in `Skyvern.node.ts`.
>     - Updates task retrieval URL to `/v1/runs/` in `Skyvern.node.ts`.
>   - **Node Properties**:
>     - Renames `user_prompt` to `prompt` and `webhook_callback_url` to `webhook_url` in `Skyvern.node.ts`.
>     - Adds new `Engine` option with values `skyvern-1.0`, `skyvern-2.0`, `openai-cua`, `anthropic-cua`.
>     - Deprecates old `Engine` option in `Skyvern.node.ts`.
>   - **Misc**:
>     - Updates version in `package.json` to `0.0.5`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2b6a7253698880fb90402576502ee24ae10cac68. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->