### PR TITLE
fix n8n bug

### DIFF
--- a/integrations/n8n/nodes/Skyvern/Skyvern.node.ts
+++ b/integrations/n8n/nodes/Skyvern/Skyvern.node.ts
@@ -242,7 +242,6 @@ export class Skyvern implements INodeType {
                         name: 'engine',
                         type: 'options',
                         default: '',
-                        required: false,
                         options: [
                             {
                                 name: 'TaskV1',
@@ -252,7 +251,10 @@ export class Skyvern implements INodeType {
                                 name: 'TaskV2',
                                 value: 'v2',
                             },
-
+                            {
+                                name: 'THIS FIELD IS DEPRECATED',
+                                value: '',
+                            },
                         ],
                     },
                     {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes bug in `Skyvern.node.ts` by removing `required` from `engine` field and adding a deprecated option.
> 
>   - **Bug Fix**:
>     - Removed `required: false` from `engine` field in `Skyvern.node.ts`.
>     - Added deprecated option `THIS FIELD IS DEPRECATED` to `engine` options in `Skyvern.node.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a86a1657a39511cbb75529833abd2ab0981da157. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->