### PR TITLE
add download filename rule for supabase

### DIFF
--- a/skyvern/forge/sdk/api/files.py
+++ b/skyvern/forge/sdk/api/files.py
@@ -7,7 +7,7 @@ import shutil
 import tempfile
 import zipfile
 from pathlib import Path
-from urllib.parse import unquote, urlparse
+from urllib.parse import parse_qsl, unquote, urlparse
 
 import aiohttp
 import structlog
@@ -98,7 +98,16 @@ async def download_file(url: str, max_size_mb: int | None = None) -> str:
                 # Get the file name
                 temp_dir = make_temp_directory(prefix="skyvern_downloads_")
 
-                file_name = os.path.basename(a.path)
+                # Check for download parameter in Supabase URLs
+                if "supabase.co" in a.netloc:
+                    query_params = dict(parse_qsl(a.query))
+                    if "download" in query_params:
+                        file_name = query_params["download"]
+                    else:
+                        file_name = os.path.basename(a.path)
+                else:
+                    file_name = os.path.basename(a.path)
+
                 # if no suffix in the URL, we need to parse it from HTTP headers
                 if not Path(file_name).suffix:
                     LOG.info("No file extension detected, trying to retrieve it from HTTP headers")

--- a/skyvern/forge/sdk/api/files.py
+++ b/skyvern/forge/sdk/api/files.py
@@ -99,14 +99,14 @@ async def download_file(url: str, max_size_mb: int | None = None) -> str:
                 temp_dir = make_temp_directory(prefix="skyvern_downloads_")
 
                 # Check for download parameter in Supabase URLs
-                if "supabase.co" in a.netloc:
+                file_name = os.path.basename(a.path)
+                if "supabase.co" in a.netloc.lower():
                     query_params = dict(parse_qsl(a.query))
                     if "download" in query_params:
                         file_name = query_params["download"]
                     else:
                         file_name = os.path.basename(a.path)
-                else:
-                    file_name = os.path.basename(a.path)
+                file_name = sanitize_filename(file_name)
 
                 # if no suffix in the URL, we need to parse it from HTTP headers
                 if not Path(file_name).suffix:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add logic in `download_file()` to handle Supabase URLs by checking for 'download' parameter to determine filename.
> 
>   - **Behavior**:
>     - In `download_file()` in `files.py`, added logic to check for 'download' parameter in Supabase URLs to determine filename.
>     - If 'download' parameter is absent, defaults to using the basename of the path.
>   - **Imports**:
>     - Added `parse_qsl` to handle query string parsing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d4a3cf28dd759e334a724e072b3a5366e6c2bb9e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->