### PR TITLE
fix new tab a issue

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1378,6 +1378,15 @@ async function buildElementObject(
       isSelect2MultiChoice(element),
   };
 
+  // if element is an "a" tag and has a target="_blank" attribute, remove the target attribute but keep it in the elementObj
+  // We're doing this so that skyvern can do all the navigation in a single page/tab and not open new tab
+  if (elementTagNameLower === "a") {
+    if (element.getAttribute("target") === "_blank") {
+      elementObj.target = "_blank";
+      element.removeAttribute("target");
+    }
+  }
+
   let isInShadowRoot = element.getRootNode() instanceof ShadowRoot;
   if (isInShadowRoot) {
     let shadowHostEle = element.getRootNode().host;
@@ -1470,14 +1479,6 @@ async function buildElementTree(
         "[" +
         current_node_index +
         "]";
-    }
-
-    // if element is an "a" tag and has a target="_blank" attribute, remove the target attribute
-    // We're doing this so that skyvern can do all the navigation in a single page/tab and not open new tab
-    if (tagName === "a") {
-      if (element.getAttribute("target") === "_blank") {
-        element.removeAttribute("target");
-      }
     }
 
     let shadowDOMchildren = [];

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -869,6 +869,9 @@ def trim_element(element: dict) -> dict:
         if "afterPseudoText" in queue_ele and not queue_ele.get("afterPseudoText"):
             del queue_ele["afterPseudoText"]
 
+        if "target" in queue_ele:
+            del queue_ele["target"]
+
     return element
 
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix handling of `target="_blank"` links to open in the same tab by modifying `domUtils.js` and `SkyvernElement` in `dom.py`.
> 
>   - **Behavior**:
>     - Modify `handle_click_action()` in `handler.py` to use `navigate_to_a_href()` for links with `target="_blank"`.
>     - Update `handle_click_to_download_file_action()` and `fc_func()` in `handler.py` to check `navigate_to_a_href()` before clicking.
>   - **JavaScript**:
>     - In `domUtils.js`, update `buildElementObject()` to remove `target="_blank"` from `a` tags and store it in `elementObj`.
>   - **Python**:
>     - Add `should_use_navigation_instead_click()` and `navigate_to_a_href()` methods in `SkyvernElement` in `dom.py` to handle navigation for `a` tags with `target="_blank"`.
>     - Update `trim_element()` in `scraper.py` to remove `target` attribute from elements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 089674647f83c3bd0ac7d1de732682c7be61a3a3. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->