### PR TITLE
Add new webhook schema fields

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -90,7 +90,13 @@ from skyvern.forge.sdk.workflow.models.yaml import (
     WorkflowCreateYAMLRequest,
     WorkflowDefinitionYAML,
 )
-from skyvern.schemas.runs import ProxyLocation
+from skyvern.schemas.runs import (
+    ProxyLocation,
+    RunStatus,
+    RunType,
+    WorkflowRunRequest,
+    WorkflowRunResponse,
+)
 from skyvern.webeye.browser_factory import BrowserState
 
 LOG = structlog.get_logger()
@@ -1214,8 +1220,39 @@ class WorkflowService:
             )
             return
 
-        # send webhook to the webhook callback url
-        payload = workflow_run_status_response.model_dump_json()
+        # build new schema for backward compatible webhook payload
+        app_url = (
+            f"{settings.SKYVERN_APP_URL.rstrip('/')}/workflows/"
+            f"{workflow_run.workflow_permanent_id}/{workflow_run.workflow_run_id}"
+        )
+        workflow_run_response = WorkflowRunResponse(
+            run_id=workflow_run.workflow_run_id,
+            run_type=RunType.workflow_run,
+            status=RunStatus(workflow_run.status),
+            output=workflow_run_status_response.outputs,
+            downloaded_files=workflow_run_status_response.downloaded_files,
+            recording_url=workflow_run_status_response.recording_url,
+            screenshot_urls=workflow_run_status_response.screenshot_urls,
+            failure_reason=workflow_run_status_response.failure_reason,
+            app_url=app_url,
+            created_at=workflow_run.created_at,
+            modified_at=workflow_run.modified_at,
+            run_request=WorkflowRunRequest(
+                workflow_id=workflow_run.workflow_permanent_id,
+                title=workflow_run_status_response.workflow_title,
+                parameters=workflow_run_status_response.parameters,
+                proxy_location=workflow_run.proxy_location,
+                webhook_url=workflow_run.webhook_callback_url or None,
+                totp_url=workflow_run.totp_verification_url or None,
+                totp_identifier=workflow_run.totp_identifier,
+            ),
+        )
+
+        payload_dict = {
+            **workflow_run_status_response.model_dump(),
+            **workflow_run_response.model_dump(by_alias=True, exclude_none=True),
+        }
+        payload = json.dumps(payload_dict, default=str)
         headers = generate_skyvern_webhook_headers(
             payload=payload,
             api_key=api_key,


### PR DESCRIPTION
## Summary
- extend workflow webhook payload to include `WorkflowRunResponse`

## Testing
- `ruff check skyvern/forge/sdk/workflow/service.py --fix`
- `ruff format skyvern/forge/sdk/workflow/service.py`
- `isort skyvern/forge/sdk/workflow/service.py`
- `mypy skyvern/forge/sdk/workflow/service.py`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Extend webhook payload in `service.py` to include `WorkflowRunResponse` for backward compatibility.
> 
>   - **Behavior**:
>     - Extend webhook payload in `execute_workflow_webhook()` to include `WorkflowRunResponse` for backward compatibility.
>     - Constructs `WorkflowRunResponse` with additional fields like `app_url`, `run_request`, and others.
>   - **Imports**:
>     - Add imports for `RunStatus`, `RunType`, `WorkflowRunRequest`, `WorkflowRunResponse` in `service.py`.
>   - **Testing**:
>     - Code formatted and type-checked using `ruff`, `isort`, and `mypy` on `service.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 84bfafcdf59547f1867f479dc149bf37a0052303. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->