### PR TITLE
Add SQLite memory default for quick start

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,8 +66,8 @@ MAX_STEPS_PER_RUN=50
 # Logging and database configuration:
 # LOG_LEVEL: Control log level (e.g., INFO, DEBUG).
 LOG_LEVEL=INFO
-# DATABASE_STRING: Database connection string.
-DATABASE_STRING="postgresql+psycopg://skyvern@localhost/skyvern"
+# DATABASE_STRING: Database connection string. Defaults to in-memory SQLite.
+DATABASE_STRING="sqlite+aiosqlite:///:memory:"
 # PORT: Port to run the agent on.
 PORT=8000
 

--- a/README.md
+++ b/README.md
@@ -81,14 +81,20 @@ This quickstart guide will walk you through getting Skyvern up and running on yo
 > ⚠️ **REQUIREMENT**: This project requires Python 3.11 ⚠️
 
 1. **Install Skyvern**
-	```bash
-	pip install skyvern
-	```
+        ```bash
+        pip install skyvern
+        ```
 
-2. **Configure Skyvern** Run the setup wizard which will guide you through the configuration process, including Skyvern [MCP](https://github.com/Skyvern-AI/skyvern/blob/main/integrations/mcp/README.md) integration. This will generate a `.env` as the configuration settings file.
-	```bash
-	skyvern init
-	```
+2. **Optional Configuration**
+   Skyvern now defaults to an in-memory SQLite database for quick experimentation.
+   You can skip the initialization step and use the library directly:
+   ```python
+   from skyvern import Skyvern
+   skyvern = Skyvern()
+   await skyvern.run_task(prompt="run a task for me")
+   ```
+   Run `skyvern init` if you need persistent storage or want to customize settings.
+
 
 3. **Launch the Skyvern Server** 
 
@@ -299,7 +305,7 @@ Before you begin, make sure you have the following installed:
 Note: Our setup script does these two for you, but they are here for reference.
 - [Python 3.11](https://www.python.org/downloads/)
     - `poetry env use 3.11`
-- [PostgreSQL 14](https://www.postgresql.org/download/) (if you're on a Mac, setup script will install it for you if you have homebrew installed)
+- [PostgreSQL 14](https://www.postgresql.org/download/) (optional if you want persistent storage)
     - `brew install postgresql`
 
 ## Setup (Contributors)

--- a/alembic.ini
+++ b/alembic.ini
@@ -61,7 +61,7 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 # output_encoding = utf-8
 
 ; sqlalchemy.url = driver://user:pass@localhost/dbname
-sqlalchemy.url = postgresql+psycopg://skyvern@localhost/skyvern
+sqlalchemy.url = sqlite+aiosqlite:///:memory:
 
 
 [post_write_hooks]

--- a/skyvern/cli/llm_setup.py
+++ b/skyvern/cli/llm_setup.py
@@ -40,7 +40,7 @@ def update_or_add_env_var(key: str, value: str) -> None:
             "BROWSER_ACTION_TIMEOUT_MS": "5000",
             "MAX_STEPS_PER_RUN": "50",
             "LOG_LEVEL": "INFO",
-            "DATABASE_STRING": "postgresql+psycopg://skyvern@localhost/skyvern",
+            "DATABASE_STRING": "sqlite+aiosqlite:///:memory:",
             "PORT": "8000",
             "ANALYTICS_ID": "anonymous",
             "ENABLE_LOG_ARTIFACTS": "false",

--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -30,7 +30,7 @@ class Settings(BaseSettings):
     LONG_RUNNING_TASK_WARNING_RATIO: float = 0.95
     MAX_RETRIES_PER_STEP: int = 5
     DEBUG_MODE: bool = False
-    DATABASE_STRING: str = "postgresql+psycopg://skyvern@localhost/skyvern"
+    DATABASE_STRING: str = "sqlite+aiosqlite:///:memory:"
     DATABASE_STATEMENT_TIMEOUT_MS: int = 60000
     DISABLE_CONNECTION_POOL: bool = False
     PROMPT_ACTION_HISTORY_WINDOW: int = 1

--- a/skyvern/library/skyvern.py
+++ b/skyvern/library/skyvern.py
@@ -52,10 +52,8 @@ class Skyvern(AsyncSkyvern):
             httpx_client=httpx_client,
         )
         if base_url is None and api_key is None:
-            if not os.path.exists(".env"):
-                raise Exception("No .env file found. Please run 'skyvern init' first to set up your environment.")
-
-            load_dotenv(".env")
+            if os.path.exists(".env"):
+                load_dotenv(".env")
             migrate_db()
 
         self._api_key = api_key


### PR DESCRIPTION
## Summary
- default the database to in-memory SQLite
- load optional `.env` in library and run migrations automatically
- update CLI defaults and example env
- document new quick start and clarify Postgres is optional

## Testing
- `pre-commit run --files skyvern/config.py skyvern/library/skyvern.py README.md .env.example skyvern/cli/llm_setup.py alembic.ini` *(fails: command not found)*
- `bash run_alembic_check.sh` *(fails: alembic not found)*