### PR TITLE
Add TaskRunResponse data to task v2 webhook

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -72,6 +72,7 @@ from skyvern.forge.sdk.workflow.models.workflow import (
     WorkflowStatus,
 )
 from skyvern.forge.sdk.workflow.models.yaml import WorkflowCreateYAMLRequest
+from skyvern.schemas.artifacts import EntityType, entity_type_to_param
 from skyvern.schemas.runs import (
     CUA_ENGINES,
     RunEngine,
@@ -87,23 +88,6 @@ from skyvern.services import run_service, task_v1_service, task_v2_service, work
 from skyvern.webeye.actions.actions import Action
 
 LOG = structlog.get_logger()
-
-
-class EntityType(str, Enum):
-    STEP = "step"
-    TASK = "task"
-    WORKFLOW_RUN = "workflow_run"
-    WORKFLOW_RUN_BLOCK = "workflow_run_block"
-    THOUGHT = "thought"
-
-
-entity_type_to_param = {
-    EntityType.STEP: "step_id",
-    EntityType.TASK: "task_id",
-    EntityType.WORKFLOW_RUN: "workflow_run_id",
-    EntityType.WORKFLOW_RUN_BLOCK: "workflow_run_block_id",
-    EntityType.THOUGHT: "thought_id",
-}
 
 
 class AISuggestionType(str, Enum):

--- a/skyvern/schemas/artifacts.py
+++ b/skyvern/schemas/artifacts.py
@@ -1,0 +1,18 @@
+from enum import StrEnum
+
+
+class EntityType(StrEnum):
+    STEP = "step"
+    TASK = "task"
+    WORKFLOW_RUN = "workflow_run"
+    WORKFLOW_RUN_BLOCK = "workflow_run_block"
+    THOUGHT = "thought"
+
+
+entity_type_to_param = {
+    EntityType.STEP: "step_id",
+    EntityType.TASK: "task_id",
+    EntityType.WORKFLOW_RUN: "workflow_run_id",
+    EntityType.WORKFLOW_RUN_BLOCK: "workflow_run_block_id",
+    EntityType.THOUGHT: "thought_id",
+}

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -60,7 +60,6 @@ from skyvern.forge.sdk.workflow.models.yaml import (
     WorkflowDefinitionYAML,
 )
 from skyvern.schemas.runs import ProxyLocation, RunEngine, RunType, TaskRunRequest, TaskRunResponse
-from skyvern.services import workflow_service
 from skyvern.utils.prompt_engine import load_prompt_with_elements
 from skyvern.webeye.browser_factory import BrowserState
 from skyvern.webeye.scraper.scraper import ScrapedPage, scrape_website
@@ -1582,6 +1581,8 @@ async def _summarize_task_v2(
 
 async def build_task_v2_run_response(task_v2: TaskV2) -> TaskRunResponse:
     """Build TaskRunResponse object for webhook backward compatibility."""
+    from skyvern.services import workflow_service
+
     workflow_run_resp = None
     if task_v2.workflow_run_id:
         try:


### PR DESCRIPTION
"<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add TaskRunResponse data to task v2 webhook for backward compatibility and refactor EntityType handling.
> 
>   - **Behavior**:
>     - Adds TaskRunResponse data to task v2 webhook in `task_v2_service.py` for backward compatibility.
>     - Includes additional fields like `failure_reason`, `recording_url`, `screenshot_urls`, and `downloaded_files` in the webhook response.
>   - **Refactoring**:
>     - Moves `EntityType` and `entity_type_to_param` from `agent_protocol.py` to a new file `artifacts.py`.
>   - **Misc**:
>     - Imports `workflow_service` locally in `build_task_v2_run_response()` in `task_v2_service.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 64f8bc54c1040c484dea330dc4c27163af209d2c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->\n"