### PR TITLE
update evals

### DIFF
--- a/skyvern-frontend/src/components/SwitchBar.tsx
+++ b/skyvern-frontend/src/components/SwitchBar.tsx
@@ -7,12 +7,13 @@ type Option = {
 
 type Props = {
   className?: string;
+  highlight?: boolean;
   options: Option[];
   value: string;
   onChange: (value: string) => void;
 };
 
-function SwitchBar({ className, options, value, onChange }: Props) {
+function SwitchBar({ className, highlight, options, value, onChange }: Props) {
   return (
     <div
       className={cn(
@@ -28,6 +29,7 @@ function SwitchBar({ className, options, value, onChange }: Props) {
             className={cn(
               "flex cursor-pointer items-center whitespace-nowrap rounded-sm px-3 py-2 text-xs hover:bg-slate-700",
               {
+                "bg-slate-700/40": highlight && !selected,
                 "bg-slate-700": selected,
               },
             )}


### PR DESCRIPTION
Closes https://linear.app/skyvern/issue/SKY-5271/web-bench-page-needs-separators-between-the-names-its-pretty-jarring

Closes https://linear.app/skyvern/issue/SKY-5272/evalskyverncom-add-horizontal-lines-or-alternating-colors-to-table-to

Closes https://linear.app/skyvern/issue/SKY-5274/rename-web-bench-items-so-the-names-are-a-bit-cleaner

Closes ["g is cutoff"](https://skyvern.slack.com/archives/C087G85M1UZ/p1747890692470549)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `highlight` prop to `SwitchBar` for improved UI readability and item separation.
> 
>   - **Behavior**:
>     - Adds `highlight` prop to `SwitchBar` in `SwitchBar.tsx` to change background color of unselected options when true.
>     - Addresses UI improvements for better readability and separation of items.
>   - **Misc**:
>     - Closes issues SKY-5271, SKY-5272, SKY-5274, and "g is cutoff" from Slack.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 967d3c09782879ce36ba8f70f8589ff4753fff7a. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->