### PR TITLE
TOTP endpoint update - support sending code that's less than or equal to 10 chars directly

### DIFF
--- a/skyvern/forge/sdk/routes/credentials.py
+++ b/skyvern/forge/sdk/routes/credentials.py
@@ -69,11 +69,11 @@ async def send_totp_code(
         task_id=data.task_id,
         workflow_id=data.workflow_id,
     )
-    if len(data.content) <= 10:
-        # We assume the user is sending the code directly
-        code = data.content
-    else:
-        code = await parse_totp_code(data.content)
+    content = data.content.strip()
+    code: str | None = content
+    # We assume the user is sending the code directly when the length of code is less than or equal to 10
+    if len(content) > 10:
+        code = await parse_totp_code(content)
     if not code:
         LOG.error(
             "Failed to parse totp code",

--- a/skyvern/forge/sdk/routes/credentials.py
+++ b/skyvern/forge/sdk/routes/credentials.py
@@ -69,8 +69,20 @@ async def send_totp_code(
         task_id=data.task_id,
         workflow_id=data.workflow_id,
     )
-    code = await parse_totp_code(data.content)
+    if len(data.content) <= 10:
+        # We assume the user is sending the code directly
+        code = data.content
+    else:
+        code = await parse_totp_code(data.content)
     if not code:
+        LOG.error(
+            "Failed to parse totp code",
+            totp_identifier=data.totp_identifier,
+            task_id=data.task_id,
+            workflow_id=data.workflow_id,
+            workflow_run_id=data.workflow_run_id,
+            content=data.content,
+        )
         raise HTTPException(status_code=400, detail="Failed to parse totp code")
     return await app.DATABASE.create_totp_code(
         organization_id=curr_org.organization_id,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> `send_totp_code` now directly uses TOTP codes <= 10 chars, with expanded error logging in `credentials.py`.
> 
>   - **Behavior**:
>     - In `send_totp_code` in `credentials.py`, TOTP codes <= 10 chars are now used directly, bypassing `parse_totp_code()`.
>     - Expanded error logging in `send_totp_code` to include `workflow_run_id` and `content` when parsing fails.
>   - **Misc**:
>     - Strips whitespace from `data.content` before processing in `send_totp_code`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 3fb39162b493b864cfaaa041b7a11e9b55592f4f. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->