### PR TITLE
Add Anthropic Claude 4 and 3.5 Haiku models

### DIFF
--- a/skyvern/cli/llm_setup.py
+++ b/skyvern/cli/llm_setup.py
@@ -95,6 +95,9 @@ def setup_llm_providers() -> None:
                 [
                     "ANTHROPIC_CLAUDE3.5_SONNET",
                     "ANTHROPIC_CLAUDE3.7_SONNET",
+                    "ANTHROPIC_CLAUDE3.5_HAIKU",
+                    "ANTHROPIC_CLAUDE4_OPUS",
+                    "ANTHROPIC_CLAUDE4_SONNET",
                 ]
             )
     else:

--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -236,6 +236,36 @@ if settings.ENABLE_ANTHROPIC:
             max_completion_tokens=8192,
         ),
     )
+    LLMConfigRegistry.register_config(
+        "ANTHROPIC_CLAUDE3.5_HAIKU",
+        LLMConfig(
+            "anthropic/claude-3-5-haiku-latest",
+            ["ANTHROPIC_API_KEY"],
+            supports_vision=True,
+            add_assistant_prefix=True,
+            max_completion_tokens=8192,
+        ),
+    )
+    LLMConfigRegistry.register_config(
+        "ANTHROPIC_CLAUDE4_OPUS",
+        LLMConfig(
+            "anthropic/claude-opus-4-latest",
+            ["ANTHROPIC_API_KEY"],
+            supports_vision=True,
+            add_assistant_prefix=True,
+            max_completion_tokens=8192,
+        ),
+    )
+    LLMConfigRegistry.register_config(
+        "ANTHROPIC_CLAUDE4_SONNET",
+        LLMConfig(
+            "anthropic/claude-sonnet-4-latest",
+            ["ANTHROPIC_API_KEY"],
+            supports_vision=True,
+            add_assistant_prefix=True,
+            max_completion_tokens=8192,
+        ),
+    )
 
 if settings.ENABLE_BEDROCK:
     # Supported through AWS IAM authentication
@@ -267,12 +297,23 @@ if settings.ENABLE_BEDROCK:
         ),
     )
     LLMConfigRegistry.register_config(
+        "BEDROCK_ANTHROPIC_CLAUDE3.5_HAIKU",
+        LLMConfig(
+            "bedrock/anthropic.claude-3-5-haiku-20241022-v1:0",
+            ["AWS_REGION"],
+            supports_vision=True,
+            add_assistant_prefix=True,
+            max_completion_tokens=8192,
+        ),
+    )
+    LLMConfigRegistry.register_config(
         "BEDROCK_ANTHROPIC_CLAUDE3.5_SONNET",
         LLMConfig(
             "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
             ["AWS_REGION"],
             supports_vision=True,
             add_assistant_prefix=True,
+            max_completion_tokens=8192,
         ),
     )
     LLMConfigRegistry.register_config(
@@ -282,6 +323,7 @@ if settings.ENABLE_BEDROCK:
             ["AWS_REGION"],
             supports_vision=True,
             add_assistant_prefix=True,
+            max_completion_tokens=8192,
         ),
     )
     LLMConfigRegistry.register_config(
@@ -306,6 +348,24 @@ if settings.ENABLE_BEDROCK:
         "BEDROCK_AMAZON_NOVA_LITE",
         LLMConfig(
             "bedrock/us.amazon.nova-lite-v1:0",
+            ["AWS_REGION"],
+            supports_vision=True,
+            add_assistant_prefix=True,
+        ),
+    )
+    LLMConfigRegistry.register_config(
+        "BEDROCK_ANTHROPIC_CLAUDE4_OPUS",
+        LLMConfig(
+            "bedrock/anthropic.claude-opus-4-20250514-v1:0",
+            ["AWS_REGION"],
+            supports_vision=True,
+            add_assistant_prefix=True,
+        ),
+    )
+    LLMConfigRegistry.register_config(
+        "BEDROCK_ANTHROPIC_CLAUDE4_SONNET",
+        LLMConfig(
+            "bedrock/anthropic.claude-sonnet-4-20250514-v1:0",
             ["AWS_REGION"],
             supports_vision=True,
             add_assistant_prefix=True,


### PR DESCRIPTION
## Summary
- support new Claude models in `config_registry`
- expose the models via CLI and `setup.sh`
- use latest Anthropc versions for Claude 3.7 Sonnet and Claude 4 models

## Testing
- `ruff check skyvern/forge/sdk/api/llm/config_registry.py skyvern/cli/llm_setup.py`
- `ruff check setup.sh` *(fails: SyntaxError)*
- `pytest -q` *(fails: command not found)*

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add new Anthropic Claude 3.5 Haiku and Claude 4 models to configuration and CLI setup.
> 
>   - **Behavior**:
>     - Add support for `ANTHROPIC_CLAUDE3.5_HAIKU`, `ANTHROPIC_CLAUDE4_OPUS`, and `ANTHROPIC_CLAUDE4_SONNET` models in `config_registry.py`.
>     - Update `setup_llm_providers()` in `llm_setup.py` to include new Anthropic models in the configuration options.
>   - **Configuration**:
>     - Register new models in `LLMConfigRegistry` with appropriate settings like `supports_vision`, `add_assistant_prefix`, and `max_completion_tokens`.
>   - **Testing**:
>     - `ruff check` executed on `config_registry.py` and `llm_setup.py`.
>     - `pytest` command attempted but failed due to command not found.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6bc5969dbc5d7583b21a00ecdee38ac293415e80. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->