### PR TITLE
Revert "revert webhook schema updates"

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -2125,7 +2125,7 @@ class ForgeAgent:
             payload_dict = json.loads(payload_json)
             if task_run_response_json:
                 payload_dict.update(json.loads(task_run_response_json))
-            payload = json.dumps(payload_dict)
+            payload = json.dumps(payload_dict, separators=(",", ":"), ensure_ascii=False)
             headers = generate_skyvern_webhook_headers(payload=payload, api_key=api_key)
             LOG.info(
                 "Sending task response to webhook callback url",

--- a/skyvern/forge/sdk/services/org_auth_service.py
+++ b/skyvern/forge/sdk/services/org_auth_service.py
@@ -119,7 +119,7 @@ async def _get_current_org_cached(x_api_key: str, db: AgentDB) -> Organization:
         organization_id=organization.organization_id,
         token_type=OrganizationAuthTokenType.api,
         token=x_api_key,
-        valid=True,
+        valid=None,
     )
     if not api_key_db_obj:
         raise HTTPException(

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -1250,7 +1250,7 @@ class WorkflowService:
         payload_dict = json.loads(workflow_run_status_response.model_dump_json())
         workflow_run_response_dict = json.loads(workflow_run_response.model_dump_json())
         payload_dict.update(workflow_run_response_dict)
-        payload = json.dumps(payload_dict, default=str)
+        payload = json.dumps(payload_dict, separators=(",", ":"), ensure_ascii=False)
         headers = generate_skyvern_webhook_headers(
             payload=payload,
             api_key=api_key,

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -1666,7 +1666,7 @@ async def send_task_v2_webhook(task_v2: TaskV2) -> None:
         payload_json = task_v2.model_dump_json(by_alias=True)
         payload_dict = json.loads(payload_json)
         payload_dict.update(json.loads(task_run_response_json))
-        payload = json.dumps(payload_dict)
+        payload = json.dumps(payload_dict, separators=(",", ":"), ensure_ascii=False)
         headers = generate_skyvern_webhook_headers(payload=payload, api_key=api_key.token)
         LOG.info(
             "Sending task v2 response to webhook callback url",


### PR DESCRIPTION
Reverts Skyvern-AI/skyvern#2479
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reverts previous changes to re-enable sending task and workflow responses to webhook callback URLs with correct payloads and headers.
> 
>   - **Behavior**:
>     - Re-enables sending task responses to webhook callback URLs in `execute_task_webhook()` in `agent.py`.
>     - Re-enables sending workflow responses to webhook callback URLs in `execute_workflow_webhook()` in `service.py`.
>     - Re-enables sending task v2 responses to webhook callback URLs in `send_task_v2_webhook()` in `task_v2_service.py`.
>   - **Payload Construction**:
>     - Constructs payloads by merging task or workflow responses with additional backward-compatible data.
>     - Uses `json.dumps` with specific separators and `ensure_ascii=False` for payload serialization.
>   - **Headers**:
>     - Generates headers using `generate_skyvern_webhook_headers()` with the constructed payload and API key.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 179e7401bbdaf2ba1693af9366033c24be7bb167. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->