### PR TITLE
stop removing target attr when scraping

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1378,15 +1378,6 @@ async function buildElementObject(
       isSelect2MultiChoice(element),
   };
 
-  // if element is an "a" tag and has a target="_blank" attribute, remove the target attribute but keep it in the elementObj
-  // We're doing this so that skyvern can do all the navigation in a single page/tab and not open new tab
-  if (elementTagNameLower === "a") {
-    if (element.getAttribute("target") === "_blank") {
-      elementObj.target = "_blank";
-      element.removeAttribute("target");
-    }
-  }
-
   let isInShadowRoot = element.getRootNode() instanceof ShadowRoot;
   if (isInShadowRoot) {
     let shadowHostEle = element.getRootNode().host;

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -869,9 +869,6 @@ def trim_element(element: dict) -> dict:
         if "afterPseudoText" in queue_ele and not queue_ele.get("afterPseudoText"):
             del queue_ele["afterPseudoText"]
 
-        if "target" in queue_ele:
-            del queue_ele["target"]
-
     return element
 
 

--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -287,3 +287,7 @@ class SkyvernFrame:
     async def click_element_in_javascript(self, element: ElementHandle) -> None:
         js_script = "(element) => element.click()"
         return await self.evaluate(frame=self.frame, expression=js_script, arg=element)
+
+    async def remove_target_attr(self, element: ElementHandle) -> None:
+        js_script = "(element) => element.removeAttribute('target')"
+        return await self.evaluate(frame=self.frame, expression=js_script, arg=element)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Stops removing `target` attribute from `<a>` tags during scraping and updates handling logic in `domUtils.js`, `scraper.py`, and `dom.py`.
> 
>   - **Behavior**:
>     - Stops removing `target` attribute from `<a>` tags in `buildElementObject()` in `domUtils.js`.
>     - Retains `target` attribute in `trim_element()` in `scraper.py`.
>     - Adds `_trim_target_attr()` method in `SkyvernElement` in `dom.py` to handle `target` attribute.
>   - **Functions**:
>     - Adds `remove_target_attr()` in `SkyvernFrame` in `page.py` to remove `target` attribute via JavaScript.
>     - Updates `navigate_to_a_href()` and `should_use_navigation_instead_click()` in `SkyvernElement` in `dom.py` to consider `target` attribute.
>   - **Misc**:
>     - Minor logging changes in `dom.py` and `page.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a41270ea935b064de0d9b36605acb286aa84034e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->