### PR TITLE
add current item in forloop + global forloop reference

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParameterAddPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParameterAddPanel.tsx
@@ -59,6 +59,7 @@ function header(type: WorkflowEditorParameterType) {
 }
 
 function WorkflowParameterAddPanel({ type, onClose, onSave }: Props) {
+  const reservedKeys = ["current_item", "current_value", "current_index"];
   const isCloud = useContext(CloudContext);
   const [key, setKey] = useState("");
   const [urlParameterKey, setUrlParameterKey] = useState("");
@@ -314,6 +315,14 @@ function WorkflowParameterAddPanel({ type, onClose, onSave }: Props) {
                     variant: "destructive",
                     title: "Failed to add parameter",
                     description: "Key is required",
+                  });
+                  return;
+                }
+                if (reservedKeys.includes(key)) {
+                  toast({
+                    variant: "destructive",
+                    title: "Failed to add parameter",
+                    description: `${key} is reserved, please use another key`,
                   });
                   return;
                 }

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -198,6 +198,15 @@ class Block(BaseModel, abc.ABC):
                 )
 
         template_data[self.label] = block_reference_data
+
+        # inject the forloop metadata as global variables
+        if "current_index" in block_reference_data:
+            template_data["current_index"] = block_reference_data["current_index"]
+        if "current_item" in block_reference_data:
+            template_data["current_item"] = block_reference_data["current_item"]
+        if "current_value" in block_reference_data:
+            template_data["current_value"] = block_reference_data["current_value"]
+
         return template.render(template_data)
 
     @classmethod
@@ -948,7 +957,9 @@ class ForLoopBlock(Block):
                 metadata: BlockMetadata = {
                     "current_index": loop_idx,
                     "current_value": loop_over_value,
+                    "current_item": loop_over_value,
                 }
+                workflow_run_context.update_block_metadata(self.label, metadata)
                 workflow_run_context.update_block_metadata(loop_block.label, metadata)
 
                 original_loop_block = loop_block

--- a/skyvern/forge/sdk/workflow/models/parameter.py
+++ b/skyvern/forge/sdk/workflow/models/parameter.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from skyvern.exceptions import InvalidWorkflowParameter
 
+RESERVED_PARAMETER_KEYS = ["current_item", "current_value", "current_index"]
+
 
 class ParameterType(StrEnum):
     WORKFLOW = "workflow"

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -61,6 +61,7 @@ from skyvern.forge.sdk.workflow.models.block import (
 )
 from skyvern.forge.sdk.workflow.models.parameter import (
     PARAMETER_TYPE,
+    RESERVED_PARAMETER_KEYS,
     AWSSecretParameter,
     BitwardenCreditCardDataParameter,
     BitwardenLoginCredentialParameter,
@@ -1448,6 +1449,12 @@ class WorkflowService:
             if any(key in output_parameter_keys for key in parameter_keys):
                 raise WorkflowDefinitionHasReservedParameterKeys(
                     reserved_keys=output_parameter_keys, parameter_keys=parameter_keys
+                )
+
+            if any(key in RESERVED_PARAMETER_KEYS for key in parameter_keys):
+                raise WorkflowDefinitionHasReservedParameterKeys(
+                    reserved_keys=RESERVED_PARAMETER_KEYS,
+                    parameter_keys=parameter_keys,
                 )
 
             # Create output parameters for all blocks


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add reserved keys for workflow parameters and inject for-loop metadata as global variables in workflow blocks.
> 
>   - **Behavior**:
>     - Add reserved keys `current_item`, `current_value`, `current_index` to prevent their use as parameter keys in `WorkflowParameterAddPanel` and `service.py`.
>     - Inject for-loop metadata (`current_index`, `current_item`, `current_value`) as global variables in `format_block_parameter_template_from_workflow_run_context()` in `block.py`.
>   - **Validation**:
>     - Add validation in `WorkflowParameterAddPanel.tsx` to prevent saving parameters with reserved keys.
>     - Raise `WorkflowDefinitionHasReservedParameterKeys` if reserved keys are used in `create_workflow_from_request()` in `service.py`.
>   - **Misc**:
>     - Define `RESERVED_PARAMETER_KEYS` in `parameter.py` and use it across the codebase.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c890d3a37cb225eb783a51a981bc94f3914d2ccd. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->