### PR TITLE
add pytest run to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,11 @@ jobs:
           ENABLE_BEDROCK: "true"
         with:
           args: "run --hook-stage manual alembic-check"
+      - name: trigger tests
+        env:
+          ENABLE_OPENAI: "true"
+          OPENAI_API_KEY: "sk-dummy"
+        run: poetry run pytest tests
 
   fe-lint-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add pytest execution to CI workflow in `ci.yml` with necessary environment variables.
> 
>   - **CI Workflow**:
>     - Adds a new step in `ci.yml` to run `pytest` on the `tests` directory.
>     - Sets environment variables `ENABLE_OPENAI` and `OPENAI_API_KEY` for the pytest run.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ea57f8d8a7fff65f17c79fa73ccb891cebec941d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->