### PR TITLE
Update .gitignore to exclude Chrome >= 136 user profile directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ tags
 tags.lock
 tags.temp
 tags.temp.tmp
+
+# copy of Chrome user profile from Chrome >= 136
+tmp/user_data_dir


### PR DESCRIPTION
## Summary
• Adds `tmp/user_data_dir` to .gitignore to prevent Chrome user profile copies from being committed

## Background
Chrome 136+ creates user profile copies in the `tmp/user_data_dir` directory during browser automation. As documented in [Skyvern's browser documentation](https://docs.skyvern.com/running-tasks/run-tasks#control-your-own-browser-chrome), these temporary files should be excluded from version control to avoid cluttering the repository with large binary files.