### PR TITLE
Fix Claude 4 model names to use specific versions instead of -latest suffix

### DIFF
--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -253,7 +253,7 @@ if settings.ENABLE_ANTHROPIC:
     LLMConfigRegistry.register_config(
         "ANTHROPIC_CLAUDE4_OPUS",
         LLMConfig(
-            "anthropic/claude-opus-4-latest",
+            "anthropic/claude-opus-4-20250514",
             ["ANTHROPIC_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=True,
@@ -263,7 +263,7 @@ if settings.ENABLE_ANTHROPIC:
     LLMConfigRegistry.register_config(
         "ANTHROPIC_CLAUDE4_SONNET",
         LLMConfig(
-            "anthropic/claude-sonnet-4-latest",
+            "anthropic/claude-sonnet-4-20250514",
             ["ANTHROPIC_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=True,


### PR DESCRIPTION
Updates Claude 4 model configurations to use specific version identifiers instead of unsupported -latest suffix. According to [Anthropic's model documentation](https://docs.anthropic.com/en/docs/about-claude/models/overview#model-names), the `-latest` suffix is not supported by the Claude 4 family models. Using the unsupported suffix leads to 404 API errors