### PR TITLE
support cross domain css sheet parse

### DIFF
--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -725,7 +725,7 @@ class IncrementalScrapePage:
         return self.element_tree_trimmed
 
     async def start_listen_dom_increment(self, element: ElementHandle | None = None) -> None:
-        js_script = "(element) => startGlobalIncrementalObserver(element)"
+        js_script = "async (element) => await startGlobalIncrementalObserver(element)"
         await SkyvernFrame.evaluate(frame=self.skyvern_frame.get_frame(), expression=js_script, arg=element)
 
     async def stop_listen_dom_increment(self) -> None:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enable cross-domain CSS parsing for hover styles by modifying `getHoverStylesMap` to handle CORS restrictions in `domUtils.js`.
> 
>   - **Behavior**:
>     - `getHoverStylesMap` in `domUtils.js` now handles cross-domain stylesheets by recreating link elements with a cache-busting query parameter.
>     - `buildElementTree` and `startGlobalIncrementalObserver` in `domUtils.js` updated to call `getHoverStylesMap` asynchronously.
>     - `start_listen_dom_increment` in `scraper.py` updated to call `startGlobalIncrementalObserver` asynchronously.
>   - **Functions**:
>     - `getHoverStylesMap` modified to handle SecurityError by recreating link elements for cross-domain stylesheets.
>     - `parseCssSheet` function added to encapsulate CSS rule parsing logic.
>   - **Misc**:
>     - Minor logging improvements in `domUtils.js` for debugging stylesheet access issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c8863a730aa4791331f1b498e91a88c655fd0275. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->