### PR TITLE
refresh options before doing select

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -3193,6 +3193,7 @@ async def normal_select(
         step_id=step.step_id,
     )
 
+    await skyvern_element.refresh_select_options()
     options_html = skyvern_element.build_HTML()
     field_information = (
         input_or_select_context.field if not input_or_select_context.intention else input_or_select_context.intention

--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -795,6 +795,18 @@ class SkyvernElement:
             LOG.warning("Failed to navigate to the <a> href link", exc_info=True, href=href, current_url=page.url)
             raise
 
+    async def refresh_select_options(self) -> tuple[list, str] | None:
+        if self.get_tag_name() != InteractiveElement.SELECT:
+            return None
+
+        frame = await SkyvernFrame.create_instance(self.get_frame())
+        options, selected_value = await frame.get_select_options(await self.get_element_handler())
+        self.__static_element["options"] = options
+        if "attributes" in self.__static_element:
+            self.__static_element["attributes"]["selected"] = selected_value
+            self._attributes = self.__static_element["attributes"]
+        return options, selected_value
+
 
 class DomUtil:
     """

--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -291,3 +291,7 @@ class SkyvernFrame:
     async def remove_target_attr(self, element: ElementHandle) -> None:
         js_script = "(element) => element.removeAttribute('target')"
         return await self.evaluate(frame=self.frame, expression=js_script, arg=element)
+
+    async def get_select_options(self, element: ElementHandle) -> tuple[list, str]:
+        js_script = "([element]) => getSelectOptions(element)"
+        return await self.evaluate(frame=self.frame, expression=js_script, arg=[element])


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds functionality to refresh select options in `SkyvernElement` before performing select actions in `normal_select()` using a new JavaScript function `getSelectOptions`.
> 
>   - **Behavior**:
>     - Adds `refresh_select_options()` method to `SkyvernElement` in `dom.py` to update select options and selected value.
>     - Calls `refresh_select_options()` in `normal_select()` in `handler.py` before building HTML for select options.
>   - **JavaScript**:
>     - Adds `getSelectOptions()` function in `page.py` to retrieve select options and selected value from the DOM.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for a70fae6c63442c6d0c31ed719de8611988df4747. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->