### PR TITLE
Add cron support to workflows

### DIFF
--- a/alembic/versions/2025_05_30_0000-7722c4e1bcd0_add_cron_to_workflows_table.py
+++ b/alembic/versions/2025_05_30_0000-7722c4e1bcd0_add_cron_to_workflows_table.py
@@ -1,0 +1,26 @@
+"""Add cron column to workflows table
+
+Revision ID: 7722c4e1bcd0
+Revises: af49ca791fc7
+Create Date: 2025-05-30 00:00:00.000000+00:00
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7722c4e1bcd0"
+down_revision: Union[str, None] = "af49ca791fc7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("workflows", sa.Column("cron", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("workflows", "cron")

--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -1182,6 +1182,7 @@ class AgentDB:
         totp_identifier: str | None = None,
         persist_browser_session: bool = False,
         model: dict[str, Any] | None = None,
+        cron: str | None = None,
         workflow_permanent_id: str | None = None,
         version: int | None = None,
         is_saved_task: bool = False,
@@ -1197,6 +1198,7 @@ class AgentDB:
                 webhook_callback_url=webhook_callback_url,
                 totp_verification_url=totp_verification_url,
                 totp_identifier=totp_identifier,
+                cron=cron,
                 persist_browser_session=persist_browser_session,
                 model=model,
                 is_saved_task=is_saved_task,
@@ -1379,6 +1381,7 @@ class AgentDB:
         description: str | None = None,
         workflow_definition: dict[str, Any] | None = None,
         version: int | None = None,
+        cron: str | None = None,
     ) -> Workflow:
         try:
             async with self.Session() as session:
@@ -1396,6 +1399,8 @@ class AgentDB:
                         workflow.workflow_definition = workflow_definition
                     if version:
                         workflow.version = version
+                    if cron is not None:
+                        workflow.cron = cron
                     await session.commit()
                     await session.refresh(workflow)
                     return convert_to_workflow(workflow, self.debug_enabled)

--- a/skyvern/forge/sdk/db/models.py
+++ b/skyvern/forge/sdk/db/models.py
@@ -215,6 +215,7 @@ class WorkflowModel(Base):
     webhook_callback_url = Column(String)
     totp_verification_url = Column(String)
     totp_identifier = Column(String)
+    cron = Column(String)
     persist_browser_session = Column(Boolean, default=False, nullable=False)
     model = Column(JSON, nullable=True)
     status = Column(String, nullable=False, default="published")

--- a/skyvern/forge/sdk/db/utils.py
+++ b/skyvern/forge/sdk/db/utils.py
@@ -184,6 +184,7 @@ def convert_to_workflow(workflow_model: WorkflowModel, debug_enabled: bool = Fal
         webhook_callback_url=workflow_model.webhook_callback_url,
         totp_verification_url=workflow_model.totp_verification_url,
         totp_identifier=workflow_model.totp_identifier,
+        cron=workflow_model.cron,
         persist_browser_session=workflow_model.persist_browser_session,
         model=workflow_model.model,
         proxy_location=(ProxyLocation(workflow_model.proxy_location) if workflow_model.proxy_location else None),

--- a/skyvern/forge/sdk/workflow/models/workflow.py
+++ b/skyvern/forge/sdk/workflow/models/workflow.py
@@ -74,6 +74,7 @@ class Workflow(BaseModel):
     webhook_callback_url: str | None = None
     totp_verification_url: str | None = None
     totp_identifier: str | None = None
+    cron: str | None = None
     persist_browser_session: bool = False
     model: dict[str, Any] | None = None
     status: WorkflowStatus = WorkflowStatus.published

--- a/skyvern/forge/sdk/workflow/models/yaml.py
+++ b/skyvern/forge/sdk/workflow/models/yaml.py
@@ -415,6 +415,7 @@ class WorkflowCreateYAMLRequest(BaseModel):
     totp_identifier: str | None = None
     persist_browser_session: bool = False
     model: dict[str, Any] | None = None
+    cron: str | None = None
     workflow_definition: WorkflowDefinitionYAML
     is_saved_task: bool = False
     status: WorkflowStatus = WorkflowStatus.published

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -553,6 +553,7 @@ class WorkflowService:
         totp_identifier: str | None = None,
         persist_browser_session: bool = False,
         model: dict[str, Any] | None = None,
+        cron: str | None = None,
         workflow_permanent_id: str | None = None,
         version: int | None = None,
         is_saved_task: bool = False,
@@ -569,6 +570,7 @@ class WorkflowService:
             totp_identifier=totp_identifier,
             persist_browser_session=persist_browser_session,
             model=model,
+            cron=cron,
             workflow_permanent_id=workflow_permanent_id,
             version=version,
             is_saved_task=is_saved_task,
@@ -647,6 +649,7 @@ class WorkflowService:
         title: str | None = None,
         description: str | None = None,
         workflow_definition: WorkflowDefinition | None = None,
+        cron: str | None = None,
     ) -> Workflow:
         if workflow_definition:
             workflow_definition.validate()
@@ -657,6 +660,7 @@ class WorkflowService:
             organization_id=organization_id,
             description=description,
             workflow_definition=(workflow_definition.model_dump() if workflow_definition else None),
+            cron=cron,
         )
 
     async def delete_workflow_by_permanent_id(
@@ -1409,6 +1413,7 @@ class WorkflowService:
                     totp_identifier=request.totp_identifier,
                     persist_browser_session=request.persist_browser_session,
                     model=request.model,
+                    cron=request.cron,
                     workflow_permanent_id=workflow_permanent_id,
                     version=existing_version + 1,
                     is_saved_task=request.is_saved_task,
@@ -1426,6 +1431,7 @@ class WorkflowService:
                     totp_identifier=request.totp_identifier,
                     persist_browser_session=request.persist_browser_session,
                     model=request.model,
+                    cron=request.cron,
                     is_saved_task=request.is_saved_task,
                     status=request.status,
                 )
@@ -1595,6 +1601,7 @@ class WorkflowService:
                 workflow_id=workflow.workflow_id,
                 organization_id=organization_id,
                 workflow_definition=workflow_definition,
+                cron=request.cron,
             )
             LOG.info(
                 f"Created workflow from request, title: {request.title}",

--- a/tests/unit_tests/test_workflow_cron.py
+++ b/tests/unit_tests/test_workflow_cron.py
@@ -1,0 +1,28 @@
+import pytest
+
+from skyvern.forge.sdk.db.client import AgentDB
+from skyvern.forge.sdk.db.models import Base
+from skyvern.forge.sdk.workflow.models.workflow import WorkflowStatus
+
+
+@pytest.mark.asyncio
+async def test_workflow_cron_saved_and_updated() -> None:
+    db = AgentDB("sqlite+aiosqlite:///:memory:")
+    async with db.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    workflow = await db.create_workflow(
+        title="cron-test",
+        workflow_definition={"parameters": [], "blocks": []},
+        cron="0 5 * * *",
+        status=WorkflowStatus.published,
+    )
+
+    fetched = await db.get_workflow(workflow.workflow_id)
+    assert fetched is not None
+    assert fetched.cron == "0 5 * * *"
+
+    updated = await db.update_workflow(workflow.workflow_id, cron="0 6 * * *")
+    assert updated.cron == "0 6 * * *"
+    fetched_after = await db.get_workflow(workflow.workflow_id)
+    assert fetched_after.cron == "0 6 * * *"


### PR DESCRIPTION
## Summary
- add a `cron` column to `WorkflowModel`
- expose cron on the workflow schema and YAML request model
- pass cron through workflow service and DB layer
- create migration for the new column
- test cron persistence in workflows

## Testing
- `pre-commit run --all-files` *(fails: unable to fetch pre-commit hooks)*
- `pytest -q` *(fails: ModuleNotFoundError for dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_683a4e306c88832498a507cb2a45e23e