### PR TITLE
feat: add run_time_seconds field to task and workflow run responses

### DIFF
--- a/fern/openapi/skyvern_openapi.json
+++ b/fern/openapi/skyvern_openapi.json
@@ -7094,6 +7094,15 @@
               "2025-01-01T00:05:00Z"
             ]
           },
+          "run_time_seconds": {
+            "type": "integer",
+            "title": "Run Time Seconds",
+            "description": "Total run time in seconds",
+            "examples": [
+              60,
+              120
+            ]
+          },
           "app_url": {
             "anyOf": [
               {
@@ -9177,6 +9186,15 @@
             "description": "Timestamp when this run was last modified",
             "examples": [
               "2025-01-01T00:05:00Z"
+            ]
+          },
+          "run_time_seconds": {
+            "type": "integer",
+            "title": "Run Time Seconds",
+            "description": "Total run time in seconds",
+            "examples": [
+              60,
+              120
             ]
           },
           "app_url": {

--- a/skyvern/client/types/get_run_response.py
+++ b/skyvern/client/types/get_run_response.py
@@ -25,6 +25,7 @@ class GetRunResponse_TaskV1(UniversalBaseModel):
     failure_reason: typing.Optional[str] = None
     created_at: dt.datetime
     modified_at: dt.datetime
+    run_time_seconds: typing.Optional[int] = None
     app_url: typing.Optional[str] = None
     run_request: typing.Optional[TaskRunRequest] = None
 
@@ -49,6 +50,7 @@ class GetRunResponse_TaskV2(UniversalBaseModel):
     failure_reason: typing.Optional[str] = None
     created_at: dt.datetime
     modified_at: dt.datetime
+    run_time_seconds: typing.Optional[int] = None
     app_url: typing.Optional[str] = None
     run_request: typing.Optional[TaskRunRequest] = None
 
@@ -73,6 +75,7 @@ class GetRunResponse_OpenaiCua(UniversalBaseModel):
     failure_reason: typing.Optional[str] = None
     created_at: dt.datetime
     modified_at: dt.datetime
+    run_time_seconds: typing.Optional[int] = None
     app_url: typing.Optional[str] = None
     run_request: typing.Optional[TaskRunRequest] = None
 
@@ -97,6 +100,7 @@ class GetRunResponse_AnthropicCua(UniversalBaseModel):
     failure_reason: typing.Optional[str] = None
     created_at: dt.datetime
     modified_at: dt.datetime
+    run_time_seconds: typing.Optional[int] = None
     app_url: typing.Optional[str] = None
     run_request: typing.Optional[TaskRunRequest] = None
 
@@ -121,6 +125,7 @@ class GetRunResponse_WorkflowRun(UniversalBaseModel):
     failure_reason: typing.Optional[str] = None
     created_at: dt.datetime
     modified_at: dt.datetime
+    run_time_seconds: typing.Optional[int] = None
     app_url: typing.Optional[str] = None
     run_request: typing.Optional[WorkflowRunRequest] = None
 

--- a/skyvern/client/types/task_run_response.py
+++ b/skyvern/client/types/task_run_response.py
@@ -57,6 +57,11 @@ class TaskRunResponse(UniversalBaseModel):
     Timestamp when this run was last modified
     """
 
+    run_time_seconds: typing.Optional[int] = pydantic.Field(default=None)
+    """
+    Total run time in seconds
+    """
+
     app_url: typing.Optional[str] = pydantic.Field(default=None)
     """
     URL to the application UI where the run can be viewed

--- a/skyvern/client/types/workflow_run_response.py
+++ b/skyvern/client/types/workflow_run_response.py
@@ -57,6 +57,11 @@ class WorkflowRunResponse(UniversalBaseModel):
     Timestamp when this run was last modified
     """
 
+    run_time_seconds: typing.Optional[int] = pydantic.Field(default=None)
+    """
+    Total run time in seconds
+    """
+
     app_url: typing.Optional[str] = pydantic.Field(default=None)
     """
     URL to the application UI where the run can be viewed

--- a/skyvern/schemas/runs.py
+++ b/skyvern/schemas/runs.py
@@ -357,6 +357,11 @@ class BaseRunResponse(BaseModel):
     modified_at: datetime = Field(
         description="Timestamp when this run was last modified", examples=["2025-01-01T00:05:00Z"]
     )
+    run_time_seconds: int | None = Field(
+        default=None,
+        description="Total run time in seconds",
+        examples=[60, 120],
+    )
     app_url: str | None = Field(
         default=None,
         description="URL to the application UI where the run can be viewed",

--- a/skyvern/services/run_service.py
+++ b/skyvern/services/run_service.py
@@ -46,6 +46,11 @@ async def get_run_response(run_id: str, organization_id: str | None = None) -> R
             failure_reason=task_v1_response.failure_reason,
             created_at=task_v1_response.created_at,
             modified_at=task_v1_response.modified_at,
+            run_time_seconds=int(
+                (
+                    task_v1_response.modified_at - task_v1_response.created_at
+                ).total_seconds()
+            ),
             app_url=f"{settings.SKYVERN_APP_URL.rstrip('/')}/tasks/{task_v1_response.task_id}",
             recording_url=task_v1_response.recording_url,
             screenshot_urls=task_v1_response.action_screenshot_urls,

--- a/skyvern/services/run_service.py
+++ b/skyvern/services/run_service.py
@@ -46,11 +46,7 @@ async def get_run_response(run_id: str, organization_id: str | None = None) -> R
             failure_reason=task_v1_response.failure_reason,
             created_at=task_v1_response.created_at,
             modified_at=task_v1_response.modified_at,
-            run_time_seconds=int(
-                (
-                    task_v1_response.modified_at - task_v1_response.created_at
-                ).total_seconds()
-            ),
+            run_time_seconds=int((task_v1_response.modified_at - task_v1_response.created_at).total_seconds()),
             app_url=f"{settings.SKYVERN_APP_URL.rstrip('/')}/tasks/{task_v1_response.task_id}",
             recording_url=task_v1_response.recording_url,
             screenshot_urls=task_v1_response.action_screenshot_urls,

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -1628,9 +1628,7 @@ async def build_task_v2_run_response(task_v2: TaskV2) -> TaskRunResponse:
         failure_reason=workflow_run_resp.failure_reason if workflow_run_resp else None,
         created_at=task_v2.created_at,
         modified_at=task_v2.modified_at,
-        run_time_seconds=int(
-            (task_v2.modified_at - task_v2.created_at).total_seconds()
-        ),
+        run_time_seconds=int((task_v2.modified_at - task_v2.created_at).total_seconds()),
         recording_url=workflow_run_resp.recording_url if workflow_run_resp else None,
         screenshot_urls=workflow_run_resp.screenshot_urls if workflow_run_resp else None,
         downloaded_files=workflow_run_resp.downloaded_files if workflow_run_resp else None,

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -1628,6 +1628,9 @@ async def build_task_v2_run_response(task_v2: TaskV2) -> TaskRunResponse:
         failure_reason=workflow_run_resp.failure_reason if workflow_run_resp else None,
         created_at=task_v2.created_at,
         modified_at=task_v2.modified_at,
+        run_time_seconds=int(
+            (task_v2.modified_at - task_v2.created_at).total_seconds()
+        ),
         recording_url=workflow_run_resp.recording_url if workflow_run_resp else None,
         screenshot_urls=workflow_run_resp.screenshot_urls if workflow_run_resp else None,
         downloaded_files=workflow_run_resp.downloaded_files if workflow_run_resp else None,

--- a/skyvern/services/workflow_service.py
+++ b/skyvern/services/workflow_service.py
@@ -86,6 +86,9 @@ async def get_workflow_run_response(
         app_url=app_url,
         created_at=workflow_run.created_at,
         modified_at=workflow_run.modified_at,
+        run_time_seconds=int(
+            (workflow_run.modified_at - workflow_run.created_at).total_seconds()
+        ),
         run_request=WorkflowRunRequest(
             workflow_id=workflow_run.workflow_permanent_id,
             title=workflow_run_resp.workflow_title,

--- a/skyvern/services/workflow_service.py
+++ b/skyvern/services/workflow_service.py
@@ -86,9 +86,7 @@ async def get_workflow_run_response(
         app_url=app_url,
         created_at=workflow_run.created_at,
         modified_at=workflow_run.modified_at,
-        run_time_seconds=int(
-            (workflow_run.modified_at - workflow_run.created_at).total_seconds()
-        ),
+        run_time_seconds=int((workflow_run.modified_at - workflow_run.created_at).total_seconds()),
         run_request=WorkflowRunRequest(
             workflow_id=workflow_run.workflow_permanent_id,
             title=workflow_run_resp.workflow_title,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `run_time_seconds` field to task and workflow run responses to track total run time.
> 
>   - **Behavior**:
>     - Add `run_time_seconds` field to task and workflow run responses in `skyvern_openapi.json`.
>     - Calculate `run_time_seconds` as the difference between `modified_at` and `created_at` in `run_service.py`, `task_v2_service.py`, and `workflow_service.py`.
>   - **Models**:
>     - Add `run_time_seconds` to `GetRunResponse_TaskV1`, `GetRunResponse_TaskV2`, `GetRunResponse_OpenaiCua`, `GetRunResponse_AnthropicCua`, `GetRunResponse_WorkflowRun` in `get_run_response.py`.
>     - Add `run_time_seconds` to `TaskRunResponse` in `task_run_response.py` and `WorkflowRunResponse` in `workflow_run_response.py`.
>     - Add `run_time_seconds` to `BaseRunResponse` in `runs.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1ed76947ea451fca9fc2dc553bc116fcedb0ccdc. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->