### PR TITLE
feat: add queue time tracking to task run responses

### DIFF
--- a/skyvern/schemas/runs.py
+++ b/skyvern/schemas/runs.py
@@ -362,6 +362,10 @@ class BaseRunResponse(BaseModel):
         description="URL to the application UI where the run can be viewed",
         examples=["https://app.skyvern.com/tasks/tsk_123", "https://app.skyvern.com/workflows/wpid_123/wr_123"],
     )
+    queue_time_seconds: float | None = Field(
+        default=None,
+        description="Time in seconds the run spent in the task queue before execution",
+    )
 
 
 class TaskRunResponse(BaseRunResponse):

--- a/skyvern/services/run_service.py
+++ b/skyvern/services/run_service.py
@@ -38,6 +38,11 @@ async def get_run_response(run_id: str, organization_id: str | None = None) -> R
         elif run.task_run_type == RunType.anthropic_cua:
             run_engine = RunEngine.anthropic_cua
 
+        first_step = await app.DATABASE.get_first_step(task_id=run.run_id, organization_id=organization_id)
+        queue_time_seconds = None
+        if first_step:
+            queue_time_seconds = (first_step.created_at - run.created_at).total_seconds()
+
         return TaskRunResponse(
             run_id=run.run_id,
             run_type=run.task_run_type,
@@ -50,6 +55,7 @@ async def get_run_response(run_id: str, organization_id: str | None = None) -> R
             recording_url=task_v1_response.recording_url,
             screenshot_urls=task_v1_response.action_screenshot_urls,
             downloaded_files=task_v1_response.downloaded_files,
+            queue_time_seconds=queue_time_seconds,
             run_request=TaskRunRequest(
                 engine=run_engine,
                 prompt=task_v1_response.request.navigation_goal,
@@ -67,7 +73,13 @@ async def get_run_response(run_id: str, organization_id: str | None = None) -> R
         task_v2 = await app.DATABASE.get_task_v2(run.run_id, organization_id=organization_id)
         if not task_v2:
             return None
-        return await task_v2_service.build_task_v2_run_response(task_v2)
+        thoughts = await app.DATABASE.get_thoughts(
+            task_v2_id=task_v2.observer_cruise_id, organization_id=organization_id
+        )
+        queue_time_seconds = None
+        if thoughts:
+            queue_time_seconds = (thoughts[0].created_at - task_v2.created_at).total_seconds()
+        return await task_v2_service.build_task_v2_run_response(task_v2, queue_time_seconds)
     elif run.task_run_type == RunType.workflow_run:
         return await workflow_service.get_workflow_run_response(run.run_id, organization_id=organization_id)
     raise ValueError(f"Invalid task run type: {run.task_run_type}")

--- a/skyvern/services/run_service.py
+++ b/skyvern/services/run_service.py
@@ -41,7 +41,7 @@ async def get_run_response(run_id: str, organization_id: str | None = None) -> R
         first_step = await app.DATABASE.get_first_step(task_id=run.run_id, organization_id=organization_id)
         queue_time_seconds = None
         if first_step:
-            queue_time_seconds = (first_step.created_at - run.created_at).total_seconds()
+            queue_time_seconds = max(0, (first_step.created_at - run.created_at).total_seconds())
 
         return TaskRunResponse(
             run_id=run.run_id,

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -1595,7 +1595,6 @@ async def _summarize_task_v2(
         output=summarized_output,
     )
 
-
 async def build_task_v2_run_response(task_v2: TaskV2, queue_time_seconds: float | None = None) -> TaskRunResponse:
     """Build TaskRunResponse object for webhook backward compatibility."""
     from skyvern.services import workflow_service

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -1595,6 +1595,7 @@ async def _summarize_task_v2(
         output=summarized_output,
     )
 
+
 async def build_task_v2_run_response(task_v2: TaskV2, queue_time_seconds: float | None = None) -> TaskRunResponse:
     """Build TaskRunResponse object for webhook backward compatibility."""
     from skyvern.services import workflow_service


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `queue_time_seconds` to task run responses to track queue time before execution in `runs.py`, `run_service.py`, and `task_v2_service.py`.
> 
>   - **Behavior**:
>     - Add `queue_time_seconds` to `BaseRunResponse` in `runs.py` to track time spent in queue before execution.
>     - Update `get_run_response` in `run_service.py` to calculate `queue_time_seconds` for task_v1 and task_v2 runs.
>     - Update `build_task_v2_run_response` and `send_task_v2_webhook` in `task_v2_service.py` to include `queue_time_seconds` in responses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 3a5e4b84c9289ef6219ff2aec7bad423280769dd. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->