### PR TITLE
added new CLi to stof skyvern sever

### DIFF
--- a/skyvern/cli/__init__.py
+++ b/skyvern/cli/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "tasks_app",
     "docs_app",
     "status_app",
+    "stop_app",
     "init_app",
 ]
 
@@ -16,5 +17,6 @@ from .docs import docs_app
 from .quickstart import quickstart_app
 from .run_commands import run_app
 from .status import status_app
+from .stop_commands import stop_app
 from .tasks import tasks_app
 from .workflow import workflow_app

--- a/skyvern/cli/commands.py
+++ b/skyvern/cli/commands.py
@@ -6,6 +6,7 @@ from .init_command import init, init_browser
 from .quickstart import quickstart_app
 from .run_commands import run_app
 from .status import status_app
+from .stop_commands import stop_app
 from .tasks import tasks_app
 from .workflow import workflow_app
 
@@ -23,6 +24,7 @@ cli_app.add_typer(workflow_app, name="workflow", help="Workflow management comma
 cli_app.add_typer(tasks_app, name="tasks", help="Task management commands.")
 cli_app.add_typer(docs_app, name="docs", help="Open Skyvern documentation.")
 cli_app.add_typer(status_app, name="status", help="Check if Skyvern services are running.")
+cli_app.add_typer(stop_app, name="stop", help="Stop Skyvern services like the API server.")
 init_app = typer.Typer(
     invoke_without_command=True,
     help="Interactively configure Skyvern and its dependencies.",

--- a/skyvern/cli/stop_commands.py
+++ b/skyvern/cli/stop_commands.py
@@ -30,4 +30,3 @@ def stop_server(
             return
     kill_pids(pids)
     console.print(Panel(f"Stopped server on port {port}", border_style="red"))
-

--- a/skyvern/cli/stop_commands.py
+++ b/skyvern/cli/stop_commands.py
@@ -18,7 +18,6 @@ def stop_server(
     port = settings.PORT
     with console.status(f"[bold green]Checking for process on port {port}...") as status:
         pids = get_pids_on_port(port)
-        status.stop()
     if not pids:
         console.print(f"[yellow]No process found running on port {port}.[/yellow]")
         return

--- a/skyvern/cli/stop_commands.py
+++ b/skyvern/cli/stop_commands.py
@@ -16,8 +16,8 @@ def stop_server(
 ) -> None:
     """Stop the Skyvern API server running on the configured port."""
     port = settings.PORT
-    with console.status(f"[bold green]Checking for process on port {port}...") as status:
-        pids = get_pids_on_port(port)
+    console.print(f"[bold green]Checking for process on port {port}...[/bold green]")
+    pids = get_pids_on_port(port)
     if not pids:
         console.print(f"[yellow]No process found running on port {port}.[/yellow]")
         return

--- a/skyvern/cli/stop_commands.py
+++ b/skyvern/cli/stop_commands.py
@@ -1,0 +1,33 @@
+import typer
+from rich.panel import Panel
+from rich.prompt import Confirm
+
+from skyvern.config import settings
+
+from .console import console
+from .run_commands import get_pids_on_port, kill_pids
+
+stop_app = typer.Typer(help="Stop Skyvern services like the API server.")
+
+
+@stop_app.command(name="server")
+def stop_server(
+    force: bool = typer.Option(False, "--force", "-f", help="Force kill without confirmation"),
+) -> None:
+    """Stop the Skyvern API server running on the configured port."""
+    port = settings.PORT
+    with console.status(f"[bold green]Checking for process on port {port}...") as status:
+        pids = get_pids_on_port(port)
+        status.stop()
+    if not pids:
+        console.print(f"[yellow]No process found running on port {port}.[/yellow]")
+        return
+    if not force:
+        prompt = f"Process{'es' if len(pids) > 1 else ''} running on port {port}. Kill them?"
+        confirm = Confirm.ask(prompt)
+        if not confirm:
+            console.print("[yellow]Server not stopped.[/yellow]")
+            return
+    kill_pids(pids)
+    console.print(Panel(f"Stopped server on port {port}", border_style="red"))
+


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a new CLI command `stop_app` to stop Skyvern services, specifically the API server, with options for forced termination and user confirmation.
> 
>   - **New CLI Command**:
>     - Adds `stop_app` to `__init__.py` and `commands.py` for stopping Skyvern services.
>     - Implements `stop_server` in `stop_commands.py` to stop the API server on the configured port.
>   - **Functionality**:
>     - `stop_server` checks for processes on the configured port and prompts for confirmation before killing them, unless `--force` is used.
>     - Uses `get_pids_on_port` and `kill_pids` from `run_commands.py` to manage processes.
>   - **User Interaction**:
>     - Provides user feedback via `console` and `rich` library for process status and confirmation prompts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f89231dadd657b0450842ce753405a98941dd2c1. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->