### PR TITLE
fix llm_key - render every llm_key for cua in the execute_step

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -174,6 +174,7 @@ class ForgeAgent:
             max_steps_per_run=task_block.max_steps_per_run,
             error_code_mapping=task_block.error_code_mapping,
             include_action_history_in_verification=task_block.include_action_history_in_verification,
+            model=task_block.model,
         )
         LOG.info(
             "Created a new task for workflow run",
@@ -387,7 +388,10 @@ class ForgeAgent:
                 llm_caller = LLMCallerManager.get_llm_caller(task.task_id)
                 if not llm_caller:
                     # if not, create a new llm_caller
-                    llm_caller = LLMCaller(llm_key=settings.ANTHROPIC_CUA_LLM_KEY, screenshot_scaling_enabled=True)
+                    llm_key = task.llm_key
+                    llm_caller = LLMCaller(
+                        llm_key=llm_key or settings.ANTHROPIC_CUA_LLM_KEY, screenshot_scaling_enabled=True
+                    )
 
             # TODO: remove the code after migrating everything to llm callers
             # currently, only anthropic cua tasks use llm_caller

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -46,7 +46,7 @@ from skyvern.forge.sdk.api.files import (
     download_from_s3,
     get_path_for_workflow_download_directory,
 )
-from skyvern.forge.sdk.api.llm.api_handler_factory import LLMAPIHandlerFactory, LLMCaller
+from skyvern.forge.sdk.api.llm.api_handler_factory import LLMAPIHandlerFactory
 from skyvern.forge.sdk.artifact.models import ArtifactType
 from skyvern.forge.sdk.core import skyvern_context
 from skyvern.forge.sdk.db.enums import TaskType
@@ -628,16 +628,6 @@ class BaseTaskBlock(Block):
             try:
                 current_context = skyvern_context.ensure_context()
                 current_context.task_id = task.task_id
-                llm_key = workflow.determine_llm_key(block=self)
-                screenshot_scaling_enabled = False
-                if self.engine == RunEngine.anthropic_cua:
-                    screenshot_scaling_enabled = True
-                llm_caller = (
-                    None
-                    if not llm_key
-                    else LLMCaller(llm_key=llm_key, screenshot_scaling_enabled=screenshot_scaling_enabled)
-                )
-
                 await app.agent.execute_step(
                     organization=organization,
                     task=task,
@@ -647,7 +637,6 @@ class BaseTaskBlock(Block):
                     close_browser_on_completion=browser_session_id is None,
                     complete_verification=self.complete_verification,
                     engine=self.engine,
-                    llm_caller=llm_caller,
                 )
             except Exception as e:
                 # Make sure the task is marked as failed in the database before raising the exception


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `llm_key` handling in `execute_step()` in `agent.py` to use task-specific keys when available.
> 
>   - **Behavior**:
>     - Fix `llm_key` handling in `execute_step()` in `agent.py` by using `task.llm_key` if available, otherwise defaulting to `settings.ANTHROPIC_CUA_LLM_KEY`.
>     - Remove `llm_caller` instantiation from `execute_task()` in `async_executor.py`.
>   - **Misc**:
>     - Remove unused import of `LLMCaller` in `async_executor.py`.
>     - Remove `LLMCaller` import from `block.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 313b2cc38b74d779f93ff3d0b4c9a5f2cb92ac5b. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->