### PR TITLE
Update model selector to use O4 mini

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -278,7 +278,7 @@ class Settings(BaseSettings):
                     "label": "Gemini 2.5 Flash",
                 },
                 "azure/gpt-4.1": {"llm_key": "AZURE_OPENAI_GPT4_1", "label": "GPT 4.1"},
-                "azure/o3-mini": {"llm_key": "AZURE_OPENAI_O3_MINI", "label": "GPT O3 Mini"},
+                "azure/o4-mini": {"llm_key": "AZURE_OPENAI_O4_MINI", "label": "GPT O4 Mini"},
                 "us.anthropic.claude-opus-4-20250514-v1:0": {
                     "llm_key": "BEDROCK_ANTHROPIC_CLAUDE4_OPUS_INFERENCE_PROFILE",
                     "label": "Anthropic Claude 4 Opus",
@@ -297,7 +297,7 @@ class Settings(BaseSettings):
                     "label": "Gemini 2.5 Flash",
                 },
                 "azure/gpt-4.1": {"llm_key": "AZURE_OPENAI_GPT4_1", "label": "GPT 4.1"},
-                "azure/o3-mini": {"llm_key": "AZURE_OPENAI_O3_MINI", "label": "GPT O3 Mini"},
+                "azure/o4-mini": {"llm_key": "AZURE_OPENAI_O4_MINI", "label": "GPT O4 Mini"},
                 "us.anthropic.claude-opus-4-20250514-v1:0": {
                     "llm_key": "BEDROCK_ANTHROPIC_CLAUDE4_OPUS_INFERENCE_PROFILE",
                     "label": "Anthropic Claude 4 Opus",


### PR DESCRIPTION
## Summary
- adjust model selector mapping to prefer Azure O4 mini

## Testing
- `pre-commit run --all-files` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683bd75923c4832b97f0cbc9383cba4d
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update model selector in `skyvern/config.py` to prefer `azure/o4-mini` over `azure/o3-mini`.
> 
>   - **Behavior**:
>     - Update model selector mapping in `get_model_name_to_llm_key()` in `skyvern/config.py` to prefer `azure/o4-mini` over `azure/o3-mini`.
>     - Change applied in both cloud and non-cloud environment mappings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 344e8cea944dbfe5ba0eece32ed8be32738f34ce. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->