### PR TITLE
map sync pr commenter to their own gh account

### DIFF
--- a/.github/workflows/sync-skyvern-cloud.yml
+++ b/.github/workflows/sync-skyvern-cloud.yml
@@ -17,6 +17,41 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@master
+      - name: Determine Git credentials
+        id: git-creds
+        run: |
+          case "${{ github.event.comment.user.login }}" in
+            wintonzheng)
+              echo "GH_PAT=${{ secrets.SKYVERN_OSS_GH_PAT }}" >> $GITHUB_OUTPUT
+              echo "GIT_EMAIL=shu@skyvern.com" >> $GITHUB_OUTPUT
+              echo "GIT_USERNAME=Shuchang Zheng" >> $GITHUB_OUTPUT
+              ;;
+            LawyZheng)
+              echo "GH_PAT=${{ secrets.LAWY_GH_PAT }}" >> $GITHUB_OUTPUT
+              echo "GIT_EMAIL=lawy@skyvern.com" >> $GITHUB_OUTPUT
+              echo "GIT_USERNAME=Lawy Zheng" >> $GITHUB_OUTPUT
+              ;;
+            suchintan)
+              echo "GH_PAT=${{ secrets.SUCHINTAN_GH_PAT }}" >> $GITHUB_OUTPUT
+              echo "GIT_EMAIL=suchintan@skyvern.com" >> $GITHUB_OUTPUT
+              echo "GIT_USERNAME=Suchintan Singh" >> $GITHUB_OUTPUT
+              ;;
+            jomido)
+              echo "GH_PAT=${{ secrets.JON_GH_PAT }}" >> $GITHUB_OUTPUT
+              echo "GIT_EMAIL=jon@skyvern.com" >> $GITHUB_OUTPUT
+              echo "GIT_USERNAME=Jonathan Dobson" >> $GITHUB_OUTPUT
+              ;;
+            Prakashmaheshwaran)
+              echo "GH_PAT=${{ secrets.KASH_GH_PAT }}" >> $GITHUB_OUTPUT
+              echo "GIT_EMAIL=kash@skyvern.com" >> $GITHUB_OUTPUT
+              echo "GIT_USERNAME=Prakash Maheshwaran" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "GH_PAT=${{ secrets.SKYVERN_OSS_GH_PAT }}" >> $GITHUB_OUTPUT
+              echo "GIT_EMAIL=shu@skyvern.com" >> $GITHUB_OUTPUT
+              echo "GIT_USERNAME=Shuchang Zheng" >> $GITHUB_OUTPUT
+              ;;
+          esac
       - name: Fetch PR details
         id: pr_details
         run: |
@@ -43,9 +78,9 @@ jobs:
       - name: Run GitHub File Sync
         uses: Skyvern-AI/repo-file-sync-action@main
         with:
-          GH_PAT: ${{ secrets.SKYVERN_CLOUD_GH_PAT }}
-          GIT_EMAIL: shu@skyvern.com
-          GIT_USERNAME: Shuchang Zheng
+          GH_PAT: ${{ steps.git-creds.outputs.GH_PAT }}
+          GIT_EMAIL: ${{ steps.git-creds.outputs.GIT_EMAIL }}
+          GIT_USERNAME: ${{ steps.git-creds.outputs.GIT_USERNAME }}
           PR_LABELS: |
             sync
             ${{steps.pr_details.outputs.PR_AUTHOR }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Maps PR commenter's GitHub account to their own credentials in the sync workflow.
> 
>   - **Behavior**:
>     - Maps PR commenter's GitHub account to their own credentials in `sync-skyvern-cloud.yml`.
>     - Sets `GH_PAT`, `GIT_EMAIL`, and `GIT_USERNAME` based on `github.event.comment.user.login`.
>     - Default credentials used if username not matched.
>   - **Workflow**:
>     - Updates `Run GitHub File Sync` step to use credentials from `git-creds` step.
>     - Uses `steps.git-creds.outputs` for `GH_PAT`, `GIT_EMAIL`, and `GIT_USERNAME`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d967898cfeca55923f06f36b0274dedf00fd203a. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->