### PR TITLE
more logging when org not found

### DIFF
--- a/skyvern/forge/sdk/services/org_auth_service.py
+++ b/skyvern/forge/sdk/services/org_auth_service.py
@@ -112,6 +112,7 @@ async def _get_current_org_cached(x_api_key: str, db: AgentDB) -> Organization:
 
     organization = await db.get_organization(organization_id=api_key_data.sub)
     if not organization:
+        LOG.warning("Organization not found", organization_id=api_key_data.sub, **payload)
         raise HTTPException(status_code=404, detail="Organization not found")
 
     # check if the token exists in the database


### PR DESCRIPTION
added this to help me debug an issue I am having:
https://discord.com/channels/1212486326352617534/1214296823066534021/1378079677054455990
![Screenshot 2025-06-02 at 11 10 23 AM](https://github.com/user-attachments/assets/818da4bb-c9c9-4ff3-a43d-bf19b32d9893)

IMHO, it is best practice to log a warning on the server side every time an HTTP 4xx error is returned to the client, since it makes it easier to track those issues down when users are having them.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add warning log in `_get_current_org_cached()` when organization not found in `org_auth_service.py`.
> 
>   - **Logging**:
>     - Adds a warning log in `_get_current_org_cached()` in `org_auth_service.py` when an organization is not found in the database.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 367875c50994d4cbbe626cdd54cb9675dc39c11d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->