### PR TITLE
fix jinja runtime leak

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -20,7 +20,7 @@ from urllib.parse import quote
 import filetype
 import structlog
 from email_validator import EmailNotValidError, validate_email
-from jinja2 import Template
+from jinja2.sandbox import SandboxedEnvironment
 from playwright.async_api import Page
 from pydantic import BaseModel, Field
 from pypdf import PdfReader
@@ -77,6 +77,7 @@ from skyvern.webeye.browser_factory import BrowserState
 from skyvern.webeye.utils.page import SkyvernFrame
 
 LOG = structlog.get_logger()
+jinja_sandbox_env = SandboxedEnvironment()
 
 
 class BlockType(StrEnum):
@@ -184,7 +185,7 @@ class Block(BaseModel, abc.ABC):
     ) -> str:
         if not potential_template:
             return potential_template
-        template = Template(potential_template)
+        template = jinja_sandbox_env.from_string(potential_template)
 
         block_reference_data: dict[str, Any] = workflow_run_context.get_block_metadata(self.label)
         template_data = workflow_run_context.values.copy()


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replace `jinja2.Template` with `jinja2.sandbox.SandboxedEnvironment` in `block.py` to prevent runtime code execution vulnerabilities.
> 
>   - **Security**:
>     - Replace `jinja2.Template` with `jinja2.sandbox.SandboxedEnvironment` in `block.py` to prevent runtime code execution vulnerabilities.
>     - Initialize `jinja_sandbox_env` as a `SandboxedEnvironment` instance.
>   - **Functionality**:
>     - Update `format_block_parameter_template_from_workflow_run_context()` to use `jinja_sandbox_env.from_string()` instead of `Template()` for rendering templates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0ca985a377335e6cf29eddd9f6847a1029d53339. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->