### PR TITLE
log duration and prompt_name in llm failure log

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -149,24 +149,33 @@ class LLMAPIHandlerFactory:
             except litellm.exceptions.APIError as e:
                 raise LLMProviderErrorRetryableTask(local_llm_key) from e
             except litellm.exceptions.ContextWindowExceededError as e:
+                duration_seconds = time.time() - start_time
                 LOG.exception(
                     "Context window exceeded",
                     llm_key=local_llm_key,
                     model=main_model_group,
+                    prompt_name=prompt_name,
+                    duration_seconds=duration_seconds,
                 )
                 raise SkyvernContextWindowExceededError() from e
             except ValueError as e:
+                duration_seconds = time.time() - start_time
                 LOG.exception(
                     "LLM token limit exceeded",
                     llm_key=local_llm_key,
                     model=main_model_group,
+                    prompt_name=prompt_name,
+                    duration_seconds=duration_seconds,
                 )
                 raise LLMProviderErrorRetryableTask(local_llm_key) from e
             except Exception as e:
+                duration_seconds = time.time() - start_time
                 LOG.exception(
                     "LLM request failed unexpectedly",
                     llm_key=local_llm_key,
                     model=main_model_group,
+                    prompt_name=prompt_name,
+                    duration_seconds=duration_seconds,
                 )
                 raise LLMProviderError(local_llm_key) from e
 
@@ -352,10 +361,13 @@ class LLMAPIHandlerFactory:
             except litellm.exceptions.APIError as e:
                 raise LLMProviderErrorRetryableTask(local_llm_key) from e
             except litellm.exceptions.ContextWindowExceededError as e:
+                duration_seconds = time.time() - start_time
                 LOG.exception(
                     "Context window exceeded",
                     llm_key=local_llm_key,
                     model=model_name,
+                    prompt_name=prompt_name,
+                    duration_seconds=duration_seconds,
                 )
                 raise SkyvernContextWindowExceededError() from e
             except CancelledError:
@@ -364,11 +376,19 @@ class LLMAPIHandlerFactory:
                     "LLM request got cancelled",
                     llm_key=local_llm_key,
                     model=model_name,
+                    prompt_name=prompt_name,
                     duration=t_llm_cancelled - t_llm_request,
                 )
                 raise LLMProviderError(local_llm_key)
             except Exception as e:
-                LOG.exception("LLM request failed unexpectedly", llm_key=local_llm_key)
+                duration_seconds = time.time() - start_time
+                LOG.exception(
+                    "LLM request failed unexpectedly",
+                    llm_key=local_llm_key,
+                    model=model_name,
+                    prompt_name=prompt_name,
+                    duration_seconds=duration_seconds,
+                )
                 raise LLMProviderError(local_llm_key) from e
 
             await app.ARTIFACT_MANAGER.create_llm_artifact(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance logging in `llm_api_handler_with_router_and_fallback` and `llm_api_handler` by including `prompt_name` and `duration_seconds` in exception logs.
> 
>   - **Logging Enhancements**:
>     - In `llm_api_handler_with_router_and_fallback` and `llm_api_handler`, log `prompt_name` and `duration_seconds` in exception handling for `ContextWindowExceededError`, `ValueError`, and generic `Exception`.
>     - Calculate `duration_seconds` using `time.time() - start_time` at the point of exception.
>   - **Functions Affected**:
>     - `llm_api_handler_with_router_and_fallback` in `api_handler_factory.py`.
>     - `llm_api_handler` in `api_handler_factory.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a53f1c050fbc15dea9fa166c096a3f828210f71c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->