### PR TITLE
chore: update pre-commit hooks and add Python version check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.11
+  python: python3
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -13,9 +13,11 @@ repos:
       - id: check-symlinks
       - id: debug-statements
       - id: detect-private-key
+      - id: check-python-version
+        args: ['--min-version=3.11', '--max-version=3.13']
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.1
+    rev: v0.11.12
     hooks:
       # Run the linter.
       - id: ruff
@@ -30,7 +32,7 @@ repos:
     rev: 6.0.1
     hooks:
       - id: isort
-        language_version: python3.11
+        language_version: python3
         exclude: |
           (?x)(
             ^skyvern/client/.*|
@@ -49,7 +51,7 @@ repos:
     rev: v1.14.1
     hooks:
       - id: mypy
-        args: [--show-error-codes, --warn-unused-configs, --disallow-untyped-calls, --disallow-untyped-defs, --disallow-incomplete-defs, --check-untyped-defs, --python-version=3.11]
+        args: [--show-error-codes, --warn-unused-configs, --disallow-untyped-calls, --disallow-untyped-defs, --disallow-incomplete-defs, --check-untyped-defs]
         additional_dependencies:
           - requests
           - types-requests


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update pre-commit hooks to use flexible Python version and add Python version check.
> 
>   - **Pre-commit Configuration**:
>     - Change `default_language_version` for Python from `python3.11` to `python3` in `.pre-commit-config.yaml`.
>     - Add `check-python-version` hook with args `--min-version=3.11` and `--max-version=3.13`.
>   - **Hook Updates**:
>     - Update `ruff-pre-commit` hook version from `v0.9.1` to `v0.11.12`.
>     - Remove `--python-version=3.11` from `mypy` hook args.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 93c0429d2ea543af952dea8c7851fb7acca98e90. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->