### PR TITLE
add error handle for click event check

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -818,11 +818,15 @@ function isInteractable(element, hoverStylesMap) {
     return true;
   }
 
-  if (window.jQuery && window.jQuery._data) {
-    const events = window.jQuery._data(element, "events");
-    if (events && "click" in events) {
-      return true;
+  try {
+    if (window.jQuery && window.jQuery._data) {
+      const events = window.jQuery._data(element, "events");
+      if (events && "click" in events) {
+        return true;
+      }
     }
+  } catch (e) {
+    _jsConsoleError("Error getting jQuery click events:", e);
   }
 
   return false;


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add error handling for jQuery click event checks in `isInteractable` function in `domUtils.js`.
> 
>   - **Error Handling**:
>     - Add `try-catch` block in `isInteractable` function in `domUtils.js` to handle errors when accessing jQuery click events.
>     - Logs error to `_jsConsoleError` if accessing jQuery click events fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 7eeda85e8303ec869a640340b89b9d361a4261de. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->