### PR TITLE
Fix pre-commit hook id

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: check-symlinks
       - id: debug-statements
       - id: detect-private-key
-      - id: check-python-version
+      - id: check-python-versions
         args: ['--min-version=3.11', '--max-version=3.13']
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.


### PR DESCRIPTION
## Summary
- correct the Python version check hook id in `.pre-commit-config.yaml`

## Testing
- `pre-commit run --all-files` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684193d0bd40832ba3dca05197406e35
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix typo in pre-commit hook ID for Python version check in `.pre-commit-config.yaml`.
> 
>   - **Pre-commit Configuration**:
>     - Fix typo in hook ID from `check-python-version` to `check-python-versions` in `.pre-commit-config.yaml`.
>     - Ensures correct execution of Python version checks with specified arguments `--min-version=3.11` and `--max-version=3.13`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d10e7d3c73352332eafb08996bc37989b50bc759. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->