### PR TITLE
Revert "chore: update pre-commit hooks and add Python version check"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3
+  python: python3.11
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -13,11 +13,9 @@ repos:
       - id: check-symlinks
       - id: debug-statements
       - id: detect-private-key
-      - id: check-python-version
-        args: ['--min-version=3.11', '--max-version=3.13']
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.12
+    rev: v0.9.1
     hooks:
       # Run the linter.
       - id: ruff
@@ -32,7 +30,7 @@ repos:
     rev: 6.0.1
     hooks:
       - id: isort
-        language_version: python3
+        language_version: python3.11
         exclude: |
           (?x)(
             ^skyvern/client/.*|
@@ -51,7 +49,7 @@ repos:
     rev: v1.14.1
     hooks:
       - id: mypy
-        args: [--show-error-codes, --warn-unused-configs, --disallow-untyped-calls, --disallow-untyped-defs, --disallow-incomplete-defs, --check-untyped-defs]
+        args: [--show-error-codes, --warn-unused-configs, --disallow-untyped-calls, --disallow-untyped-defs, --disallow-incomplete-defs, --check-untyped-defs, --python-version=3.11]
         additional_dependencies:
           - requests
           - types-requests


### PR DESCRIPTION
Reverts Skyvern-AI/skyvern#2593
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts Python version and hook updates in `.pre-commit-config.yaml`, removing Python version check and downgrading `ruff-pre-commit`.
> 
>   - **Revert Changes**:
>     - Reverts Python version in `.pre-commit-config.yaml` from `python3.11` to `python3`.
>     - Removes `check-python-version` hook from `.pre-commit-config.yaml`.
>     - Downgrades `ruff-pre-commit` hook version from `v0.11.12` to `v0.9.1` in `.pre-commit-config.yaml`.
>     - Adjusts `mypy` hook arguments to remove `--python-version=3.11` in `.pre-commit-config.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 7468359cb1305f0f300bb8706d5569f7203f9f5a. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->