### PR TITLE
generate totp code right before input

### DIFF
--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -28,6 +28,7 @@ from skyvern.webeye.scraper.scraper import IncrementalScrapePage, ScrapedPage, j
 from skyvern.webeye.utils.page import SkyvernFrame
 
 LOG = structlog.get_logger()
+COMMON_INPUT_TAGS = {"input", "textarea", "select"}
 
 TEXT_INPUT_DELAY = 10  # 10ms between each character input
 TEXT_PRESS_MAX_LENGTH = 20
@@ -589,6 +590,12 @@ class SkyvernElement:
 
     async def press_fill(self, text: str, timeout: float = settings.BROWSER_ACTION_TIMEOUT_MS) -> None:
         await self.get_locator().press_sequentially(text, delay=TEXT_INPUT_DELAY, timeout=timeout)
+
+    async def input(self, text: str, timeout: float = settings.BROWSER_ACTION_TIMEOUT_MS) -> None:
+        if self.get_tag_name().lower() not in COMMON_INPUT_TAGS:
+            await self.input_fill(text, timeout=timeout)
+            return
+        await self.input_sequentially(text=text, default_timeout=timeout)
 
     async def input_fill(self, text: str, timeout: float = settings.BROWSER_ACTION_TIMEOUT_MS) -> None:
         await self.get_locator().fill(text, timeout=timeout)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Generate TOTP codes right before input actions in `handle_input_text_action()` and refactor related logic in `handler.py` and `dom.py`.
> 
>   - **Behavior**:
>     - Generate TOTP codes right before input in `handle_input_text_action()` in `handler.py`.
>     - Add `generate_totp_value()` function in `handler.py` to encapsulate TOTP generation logic.
>   - **Utils**:
>     - Move `COMMON_INPUT_TAGS` definition from `handler.py` to `dom.py`.
>     - Add `input()` method to `SkyvernElement` in `dom.py` for handling text input.
>   - **Misc**:
>     - Refactor `get_actual_value_of_parameter_if_secret()` in `handler.py` to remove TOTP generation logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for bbdff21c6f61bdbad5872cb8be9da6e6a2a36c9a. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->