### PR TITLE
change the codeflash CI GHA

### DIFF
--- a/.github/workflows/codeflash.yaml
+++ b/.github/workflows/codeflash.yaml
@@ -1,6 +1,7 @@
 name: Codeflash
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize]
     paths:
       # So that this workflow only runs when code within the target module is modified
       - "skyvern/**"
@@ -19,6 +20,21 @@ jobs:
       CODEFLASH_API_KEY: ${{ secrets.CODEFLASH_API_KEY }}
       CODEFLASH_PR_NUMBER: ${{ github.event.number }}
     steps:
+      - name: Get User Permission
+        id: checkAccess
+        uses: actions-cool/check-user-permission@v2
+        with:
+          require: write
+          username: ${{ github.triggering_actor }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check User Permission
+        if: steps.checkAccess.outputs.require-result == 'false'
+        run: |
+          echo "${{ github.triggering_actor }} does not have permissions on this repo."
+          echo "Current permission level is ${{ steps.checkAccess.outputs.user-permission }}"
+          echo "Job originally triggered by ${{ github.actor }}"
+          exit 1
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
https://michaelheap.com/access-secrets-from-forks/

Basically, when an outside person submits a PR the codeflash will fail, this will make it easier to understand why it fails. After this failure, a member of skyvern-ai GH org can re-run the GHA workflow at which point it could access secrets and run.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modifies Codeflash CI workflow to include user permission checks and allow reruns by authorized users.
> 
>   - **Workflow Trigger**:
>     - Changes trigger from `pull_request` to `pull_request_target` in `codeflash.yaml`.
>     - Adds `types: [opened, synchronize]` to specify when the workflow should run.
>   - **Permission Check**:
>     - Adds `Get User Permission` step using `actions-cool/check-user-permission@v2` to verify if the triggering user has write access.
>     - If permission check fails, logs the user's permission level and exits the workflow.
>   - **Misc**:
>     - Workflow can be rerun by a member of the `skyvern-ai` GitHub organization to access secrets and execute successfully.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a0363be3eeaed956f4eefce6141215e56f34da79. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->