### PR TITLE
Don't allow None for org id (partial mypy only change) more to come

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -210,7 +210,7 @@ class ForgeAgent:
         )
         return task, step
 
-    async def create_task(self, task_request: TaskRequest, organization_id: str | None = None) -> Task:
+    async def create_task(self, task_request: TaskRequest, organization_id: str) -> Task:
         webhook_callback_url = str(task_request.webhook_callback_url) if task_request.webhook_callback_url else None
         totp_verification_url = str(task_request.totp_verification_url) if task_request.totp_verification_url else None
         task = await app.DATABASE.create_task(

--- a/skyvern/forge/agent_functions.py
+++ b/skyvern/forge/agent_functions.py
@@ -463,7 +463,7 @@ class AgentFunction:
         return
 
     async def validate_task_execution(
-        self, organization_id: str | None = None, task_id: str | None = None, task_version: str | None = None
+        self, organization_id: str, task_id: str | None = None, task_version: str | None = None
     ) -> None:
         return
 

--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -312,7 +312,7 @@ class AgentDB:
             LOG.error("UnexpectedError", exc_info=True)
             raise
 
-    async def get_task_steps(self, task_id: str, organization_id: str | None = None) -> list[Step]:
+    async def get_task_steps(self, task_id: str, organization_id: str) -> list[Step]:
         try:
             async with self.Session() as session:
                 if steps := (

--- a/skyvern/forge/sdk/models.py
+++ b/skyvern/forge/sdk/models.py
@@ -49,7 +49,7 @@ class Step(BaseModel):
     order: int
     is_last: bool
     retry_index: int = 0
-    organization_id: str | None = None
+    organization_id: str
     input_token_count: int = 0
     output_token_count: int = 0
     reasoning_token_count: int | None = None

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -231,7 +231,7 @@ class Task(TaskBase):
         None,
         description="The reason for the task failure.",
     )
-    organization_id: str | None = None
+    organization_id: str
     workflow_run_id: str | None = None
     workflow_permanent_id: str | None = None
     order: int | None = None


### PR DESCRIPTION
it seems that we should allow this.
partial change since in a lot of places org id is kwarg with a default value.
will make more changes down the line.

this is a mypy only change so should be very safe.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enforce non-null `organization_id` in function signatures and class attributes across multiple files for mypy type checking.
> 
>   - **Function Signatures**:
>     - Change `organization_id` from `str | None` to `str` in `create_task()` in `agent.py`.
>     - Change `organization_id` from `str | None` to `str` in `validate_task_execution()` in `agent_functions.py`.
>     - Change `organization_id` from `str | None` to `str` in `get_task_steps()` in `client.py`.
>   - **Class Attributes**:
>     - Change `organization_id` from `str | None` to `str` in `Step` in `models.py`.
>     - Change `organization_id` from `str | None` to `str` in `Task` in `schemas/tasks.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d17a9d89aa253bf796f23ce755d758d8d487a68b. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->