### PR TITLE
add get run under workflows api doc

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -162,6 +162,8 @@ navigation:
             contents:
               - POST /v1/run/workflows
               - GET /v1/runs/{run_id}
+              - POST /v1/runs/{run_id}/cancel
+              - POST /v1/runs/{run_id}/retry_webhook
               - GET /v1/workflows
               - POST /v1/workflows
               - POST /v1/workflows/{workflow_id}

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -161,6 +161,7 @@ navigation:
           - section: Workflows
             contents:
               - POST /v1/run/workflows
+              - GET /v1/runs/{run_id}
               - GET /v1/workflows
               - POST /v1/workflows
               - POST /v1/workflows/{workflow_id}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `GET /v1/runs/{run_id}` endpoint to Workflows API documentation in `fern/docs.yml`.
> 
>   - **API Documentation**:
>     - Added `GET /v1/runs/{run_id}` to the Workflows section in `fern/docs.yml` to document the endpoint for retrieving run details by `run_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 80440f084075feff6776308cb4001b14813be7bc. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->