### PR TITLE
Revert "Revert "chore: update pre-commit hooks and add Python version check""

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.11
+  python: python3
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -13,9 +13,11 @@ repos:
       - id: check-symlinks
       - id: debug-statements
       - id: detect-private-key
+      - id: check-python-version
+        args: ['--min-version=3.11', '--max-version=3.13']
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.1
+    rev: v0.11.12
     hooks:
       # Run the linter.
       - id: ruff
@@ -30,7 +32,7 @@ repos:
     rev: 6.0.1
     hooks:
       - id: isort
-        language_version: python3.11
+        language_version: python3
         exclude: |
           (?x)(
             ^skyvern/client/.*|
@@ -47,7 +49,7 @@ repos:
     rev: v1.14.1
     hooks:
       - id: mypy
-        args: [--show-error-codes, --warn-unused-configs, --disallow-untyped-calls, --disallow-untyped-defs, --disallow-incomplete-defs, --check-untyped-defs, --python-version=3.11]
+        args: [--show-error-codes, --warn-unused-configs, --disallow-untyped-calls, --disallow-untyped-defs, --disallow-incomplete-defs, --check-untyped-defs]
         additional_dependencies:
           - requests
           - types-requests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,11 +13,9 @@ repos:
       - id: check-symlinks
       - id: debug-statements
       - id: detect-private-key
-      - id: check-python-version
-        args: ['--min-version=3.11', '--max-version=3.13']
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.12
+    rev: v0.11.13
     hooks:
       # Run the linter.
       - id: ruff
@@ -46,7 +44,7 @@ repos:
       - id: python-no-log-warn
       - id: python-use-type-annotations
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.16.0
     hooks:
       - id: mypy
         args: [--show-error-codes, --warn-unused-configs, --disallow-untyped-calls, --disallow-untyped-defs, --disallow-incomplete-defs, --check-untyped-defs]


### PR DESCRIPTION
Reverts Skyvern-AI/skyvern#2607
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reapply updates to pre-commit hooks and Python version specifications in `.pre-commit-config.yaml`.
> 
>   - **Pre-commit Configuration**:
>     - Change `default_language_version` from `python3.11` to `python3` in `.pre-commit-config.yaml`.
>     - Update `ruff-pre-commit` hook version from `v0.9.1` to `v0.11.13`.
>     - Update `mypy` hook version from `v1.14.1` to `v1.16.0` and remove `--python-version=3.11` argument.
>     - Change `isort` `language_version` from `python3.11` to `python3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 919e4d00ca35678367f065af9e14984b36f97fe7. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->