### PR TITLE
fix timeout for svg and css LLM call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "skyvern"
-version = "0.2.1"
+version = "0.2.0"
 description = ""
 authors = ["Skyvern AI <info@skyvern.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "skyvern"
-version = "0.2.0"
+version = "0.2.1"
 description = ""
 authors = ["Skyvern AI <info@skyvern.com>"]
 readme = "README.md"

--- a/skyvern/forge/agent_functions.py
+++ b/skyvern/forge/agent_functions.py
@@ -26,6 +26,7 @@ from skyvern.webeye.utils.page import SkyvernFrame
 
 LOG = structlog.get_logger()
 
+_LLM_CALL_TIMEOUT_SECONDS = 60  # 1m
 USELESS_SHAPE_ATTRIBUTE = [SKYVERN_ID_ATTR, "id", "aria-describedby"]
 SVG_SHAPE_CONVERTION_ATTEMPTS = 3
 CSS_SHAPE_CONVERTION_ATTEMPTS = 1
@@ -212,9 +213,10 @@ async def _convert_svg_to_string(
 
         for retry in range(SVG_SHAPE_CONVERTION_ATTEMPTS):
             try:
-                json_response = await app.SECONDARY_LLM_API_HANDLER(
-                    prompt=svg_convert_prompt, step=step, prompt_name="svg-convert"
-                )
+                async with asyncio.Timeout(_LLM_CALL_TIMEOUT_SECONDS):
+                    json_response = await app.SECONDARY_LLM_API_HANDLER(
+                        prompt=svg_convert_prompt, step=step, prompt_name="svg-convert"
+                    )
                 svg_shape = json_response.get("shape", "")
                 recognized = json_response.get("recognized", False)
                 if not svg_shape or not recognized:
@@ -236,6 +238,13 @@ async def _convert_svg_to_string(
                     # set the invalid css shape to cache to avoid retry in the near future
                     await app.CACHE.set(svg_key, INVALID_SHAPE, ex=timedelta(hours=1))
                 await asyncio.sleep(3)
+            except asyncio.TimeoutError:
+                LOG.warning(
+                    "Timeout to call LLM to parse SVG. Going to stop retrying",
+                    element_id=element_id,
+                    key=svg_key,
+                )
+                break
             except Exception:
                 LOG.info(
                     "Failed to convert SVG to string shape by secondary llm. Will retry if haven't met the max try attempt after 3s.",
@@ -358,9 +367,10 @@ async def _convert_css_shape_to_string(
             # TODO: we don't retry the css shape conversion today
             for retry in range(CSS_SHAPE_CONVERTION_ATTEMPTS):
                 try:
-                    json_response = await app.SECONDARY_LLM_API_HANDLER(
-                        prompt=prompt, screenshots=[screenshot], step=step, prompt_name="css-shape-convert"
-                    )
+                    async with asyncio.Timeout(_LLM_CALL_TIMEOUT_SECONDS):
+                        json_response = await app.SECONDARY_LLM_API_HANDLER(
+                            prompt=prompt, screenshots=[screenshot], step=step, prompt_name="css-shape-convert"
+                        )
                     css_shape = json_response.get("shape", "")
                     recognized = json_response.get("recognized", False)
                     if not css_shape or not recognized:
@@ -382,6 +392,13 @@ async def _convert_css_shape_to_string(
                         # set the invalid css shape to cache to avoid retry in the near future
                         await app.CACHE.set(shape_key, INVALID_SHAPE, ex=timedelta(hours=1))
                     await asyncio.sleep(3)
+                except asyncio.TimeoutError:
+                    LOG.warning(
+                        "Timeout to call LLM to parse css shape. Going to stop retrying",
+                        element_id=element_id,
+                        key=shape_key,
+                    )
+                    break
                 except Exception:
                     LOG.info(
                         "Failed to convert css shape to string shape by secondary llm. Will retry if haven't met the max try attempt after 3s.",

--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -145,7 +145,9 @@ class LLMAPIHandlerFactory:
                 ai_suggestion=ai_suggestion,
             )
             try:
-                response = await router.acompletion(model=main_model_group, messages=messages, **parameters)
+                response = await router.acompletion(
+                    model=main_model_group, messages=messages, timeout=settings.LLM_CONFIG_TIMEOUT, **parameters
+                )
             except litellm.exceptions.APIError as e:
                 raise LLMProviderErrorRetryableTask(local_llm_key) from e
             except litellm.exceptions.ContextWindowExceededError as e:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a 60-second timeout for LLM calls in SVG and CSS conversion functions, with logging for timeout errors, to improve system stability.
> 
>   - **Timeout Implementation**:
>     - Introduces `_LLM_CALL_TIMEOUT_SECONDS` set to 60 seconds in `agent_functions.py`.
>     - Applies `asyncio.Timeout` to LLM calls in `_convert_svg_to_string()` and `_convert_css_shape_to_string()` in `agent_functions.py`.
>     - Handles `asyncio.TimeoutError` by logging a warning and breaking the retry loop in both functions.
>   - **API Handler Changes**:
>     - Adds `timeout=settings.LLM_CONFIG_TIMEOUT` to `router.acompletion()` in `llm_api_handler_with_router_and_fallback()` in `api_handler_factory.py`.
>     - Ensures consistent timeout handling across LLM API calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 929be89659c928aca99540a1d0a2217069ba8ab8. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->