### PR TITLE
fix uncontrolled data used in path expression

### DIFF
--- a/skyvern/forge/sdk/artifact/storage/local.py
+++ b/skyvern/forge/sdk/artifact/storage/local.py
@@ -120,9 +120,14 @@ class LocalStorage(BaseStorage):
     async def get_streaming_file(self, organization_id: str, file_name: str) -> bytes | None:
         # make the directory if it doesn't exist
         Path(f"{get_skyvern_temp_dir()}/{organization_id}").mkdir(parents=True, exist_ok=True)
-        file_path = Path(f"{get_skyvern_temp_dir()}/{organization_id}/{file_name}")
+        base_dir = Path(get_skyvern_temp_dir()) / organization_id
+        file_path = base_dir / file_name
+        normalized_path = file_path.resolve()
+        if not str(normalized_path).startswith(str(base_dir.resolve())):
+            LOG.warning("Attempted access to an invalid file path", file_path=file_path)
+            return None
         try:
-            with open(file_path, "rb") as f:
+            with open(normalized_path, "rb") as f:
                 return f.read()
         except Exception:
             return None


### PR DESCRIPTION
https://github.com/Skyvern-AI/skyvern/blob/dc032e8a55c132573d6664654d8e0147b1982916/skyvern/forge/sdk/artifact/storage/local.py#L120-L125

Accessing files using paths constructed from user-controlled data can allow an attacker to access unexpected resources. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.

Fix the issue, the `file_name` parameter should be validated to ensure it does not contain malicious input. The best approach is to normalize the constructed path using `os.path.normpath` and verify that it resides within the intended directory (`get_skyvern_temp_dir()`).

Steps to implement the fix:
1. Normalize the constructed path using `os.path.normpath`.
2. Verify that the normalized path starts with the base directory returned by `get_skyvern_temp_dir()`.
3. Raise an exception or return `None` if the validation fails.

#### References
[werkzeug.utils.secure_filename](http://werkzeug.pocoo.org/docs/utils/#werkzeug.utils.secure_filename)
