### PR TITLE
decrease svg css timeout to 30s

### DIFF
--- a/skyvern/forge/agent_functions.py
+++ b/skyvern/forge/agent_functions.py
@@ -26,7 +26,7 @@ from skyvern.webeye.utils.page import SkyvernFrame
 
 LOG = structlog.get_logger()
 
-_LLM_CALL_TIMEOUT_SECONDS = 60  # 1m
+_LLM_CALL_TIMEOUT_SECONDS = 30  # 30s
 USELESS_SHAPE_ATTRIBUTE = [SKYVERN_ID_ATTR, "id", "aria-describedby"]
 SVG_SHAPE_CONVERTION_ATTEMPTS = 3
 CSS_SHAPE_CONVERTION_ATTEMPTS = 1


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reduce LLM call timeout from 60 to 30 seconds in `agent_functions.py`, affecting SVG and CSS shape conversion functions.
> 
>   - **Behavior**:
>     - Decrease `_LLM_CALL_TIMEOUT_SECONDS` from 60 to 30 seconds in `agent_functions.py`.
>     - Affects `_convert_svg_to_string()` and `_convert_css_shape_to_string()` functions, which use this timeout for LLM API calls.
>   - **Misc**:
>     - Update comment to reflect new timeout value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 674bc8feeac9b46389b1a9be053bcda870adc874. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->