### PR TITLE
return pbs id on workflow run endpoint

### DIFF
--- a/skyvern/client/types/workflow_run_response.py
+++ b/skyvern/client/types/workflow_run_response.py
@@ -67,6 +67,11 @@ class WorkflowRunResponse(UniversalBaseModel):
     The original request parameters used to start this workflow run
     """
 
+    browser_session_id: typing.Optional[str] = pydantic.Field(default=None)
+    """
+    ID of the Skyvern persistent browser session used for this run
+    """
+
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
     else:

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1357,12 +1357,31 @@ async def get_workflow_run_with_workflow_id(
         include_cost=True,
     )
     return_dict = workflow_run_status_response.model_dump()
+
+    browser_session = await app.DATABASE.get_persistent_browser_session_by_runnable_id(
+        runnable_id=workflow_run_id,
+        organization_id=current_org.organization_id,
+    )
+
+    browser_session_id = browser_session.persistent_browser_session_id if browser_session else None
+
+    LOG.info(
+        "workflow-run.assign-browser-session-id",
+        runnable_id=workflow_run_id,
+        browser_session_id=browser_session_id,
+        organization_id=current_org.organization_id,
+    )
+
+    return_dict["browser_session_id"] = browser_session_id
+
     task_v2 = await app.DATABASE.get_task_v2_by_workflow_run_id(
         workflow_run_id=workflow_run_id,
         organization_id=current_org.organization_id,
     )
+
     if task_v2:
         return_dict["task_v2"] = task_v2.model_dump(by_alias=True)
+
     return return_dict
 
 

--- a/skyvern/forge/sdk/workflow/models/workflow.py
+++ b/skyvern/forge/sdk/workflow/models/workflow.py
@@ -161,3 +161,4 @@ class WorkflowRunResponseBase(BaseModel):
     total_cost: float | None = None
     task_v2: TaskV2 | None = None
     workflow_title: str | None = None
+    browser_session_id: str | None = None

--- a/skyvern/schemas/runs.py
+++ b/skyvern/schemas/runs.py
@@ -365,6 +365,11 @@ class BaseRunResponse(BaseModel):
         description="URL to the application UI where the run can be viewed",
         examples=["https://app.skyvern.com/tasks/tsk_123", "https://app.skyvern.com/workflows/wpid_123/wr_123"],
     )
+    browser_session_id: str | None = Field(
+        default=None,
+        description="ID of the Skyvern persistent browser session used for this run",
+        examples=["pbs_123"],
+    )
 
 
 class TaskRunResponse(BaseRunResponse):


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `browser_session_id` to workflow run responses and update `get_workflow_run_with_workflow_id` to include it in the response.
> 
>   - **Behavior**:
>     - Add `browser_session_id` to `WorkflowRunResponse` in `workflow_run_response.py` and `BaseRunResponse` in `runs.py`.
>     - Update `get_workflow_run_with_workflow_id()` in `agent_protocol.py` to include `browser_session_id` in the response.
>   - **Models**:
>     - Add `browser_session_id` to `WorkflowRunResponseBase` in `workflow.py`.
>   - **Misc**:
>     - Log `browser_session_id` in `get_workflow_run_with_workflow_id()` in `agent_protocol.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c8c78c506ffdc0e6fc2f2f8a180e9fbd9ca927b4. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->