### PR TITLE
fix 1password totp

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1365,13 +1365,6 @@ async def get_workflow_run_with_workflow_id(
 
     browser_session_id = browser_session.persistent_browser_session_id if browser_session else None
 
-    LOG.info(
-        "workflow-run.assign-browser-session-id",
-        runnable_id=workflow_run_id,
-        browser_session_id=browser_session_id,
-        organization_id=current_org.organization_id,
-    )
-
     return_dict["browser_session_id"] = browser_session_id
 
     task_v2 = await app.DATABASE.get_task_v2_by_workflow_run_id(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improves TOTP handling in 1Password credentials by storing both constants and values, and removes unnecessary logging in `agent_protocol.py`.
> 
>   - **TOTP Handling**:
>     - In `register_onepassword_credential_parameter_value()` and `register_secret_workflow_parameter_value()` in `context_manager.py`, TOTP fields are now processed to store both the TOTP constant and the actual TOTP value.
>     - Introduced `totp_secret_value_key()` to generate keys for storing TOTP values.
>   - **Logging**:
>     - Removed logging of browser session ID in `get_workflow_run_with_workflow_id()` in `agent_protocol.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 63d7bee09d6d4169c501c23a8e42df9332d19658. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->