### PR TITLE
remove deprecated pydantic field.example

### DIFF
--- a/skyvern/forge/sdk/routes/credentials.py
+++ b/skyvern/forge/sdk/routes/credentials.py
@@ -213,7 +213,7 @@ async def delete_credential(
     credential_id: str = Path(
         ...,
         description="The unique identifier of the credential to delete",
-        example="cred_1234567890",
+        examples=["cred_1234567890"],
         openapi_extra={"x-fern-sdk-parameter-name": "credential_id"},
     ),
     current_org: Organization = Depends(org_auth_service.get_current_org),
@@ -259,7 +259,7 @@ async def get_credential(
     credential_id: str = Path(
         ...,
         description="The unique identifier of the credential",
-        example="cred_1234567890",
+        examples=["cred_1234567890"],
         openapi_extra={"x-fern-sdk-parameter-name": "credential_id"},
     ),
     current_org: Organization = Depends(org_auth_service.get_current_org),
@@ -329,14 +329,14 @@ async def get_credentials(
         1,
         ge=1,
         description="Page number for pagination",
-        example=1,
+        examples=[1],
         openapi_extra={"x-fern-sdk-parameter-name": "page"},
     ),
     page_size: int = Query(
         10,
         ge=1,
         description="Number of items per page",
-        example=10,
+        examples=[10],
         openapi_extra={"x-fern-sdk-parameter-name": "page_size"},
     ),
 ) -> list[CredentialResponse]:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace deprecated `example` with `examples` in `credentials.py` for OpenAPI documentation.
> 
>   - **Behavior**:
>     - Replace deprecated `example` with `examples` in `Path` and `Query` parameters in `credentials.py`.
>     - Affects `delete_credential`, `get_credential`, and `get_credentials` functions.
>   - **Misc**:
>     - No functional changes, only OpenAPI documentation updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c0f70131afa6838db86e922e9d030f03c0239197. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->