### PR TITLE
Add Insurance, Healthcare, and Logistics sections to Skyvern UI

### DIFF
--- a/skyvern-frontend/src/components/icons/DocumentIcon.tsx
+++ b/skyvern-frontend/src/components/icons/DocumentIcon.tsx
@@ -1,0 +1,53 @@
+type Props = {
+  className?: string;
+};
+
+function DocumentIcon({ className }: Props) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+    >
+      <path
+        d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <polyline
+        points="14 2 14 8 20 8"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <line
+        x1="16"
+        y1="13"
+        x2="8"
+        y2="13"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <line
+        x1="16"
+        y1="17"
+        x2="8"
+        y2="17"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export { DocumentIcon };

--- a/skyvern-frontend/src/components/icons/HospitalIcon.tsx
+++ b/skyvern-frontend/src/components/icons/HospitalIcon.tsx
@@ -1,0 +1,51 @@
+type Props = {
+  className?: string;
+};
+
+function HospitalIcon({ className }: Props) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+    >
+      {/* Hospital Building */}
+      <path
+        d="M5 22V8L12 2L19 8V22H5Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+      {/* Door */}
+      <path
+        d="M9 22V16H15V22"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Plus Symbol */}
+      <path
+        d="M12 7V13"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M9 10H15"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export { HospitalIcon };

--- a/skyvern-frontend/src/components/icons/LogisticsIcon.tsx
+++ b/skyvern-frontend/src/components/icons/LogisticsIcon.tsx
@@ -1,0 +1,55 @@
+type Props = {
+  className?: string;
+};
+
+function LogisticsIcon({ className }: Props) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+    >
+      {/* Truck Body */}
+      <path
+        d="M1 8h15v10H1z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Truck Cabin */}
+      <path
+        d="M16 8h4l3 3v7h-7V8z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Front Wheel */}
+      <circle
+        cx="5.5"
+        cy="18.5"
+        r="2.5"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Rear Wheel */}
+      <circle
+        cx="18.5"
+        cy="18.5"
+        r="2.5"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export { LogisticsIcon };

--- a/skyvern-frontend/src/components/icons/PackageIcon.tsx
+++ b/skyvern-frontend/src/components/icons/PackageIcon.tsx
@@ -1,0 +1,43 @@
+type Props = {
+  className?: string;
+};
+
+function PackageIcon({ className }: Props) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      className={className}
+    >
+      <path
+        d="M21 16V8a2 2 0 0 0-1-1.73L12 2 4 6.27A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73L12 22l8-4.27A2 2 0 0 0 21 16Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <polyline
+        points="3.27 6.96 12 12.01 20.73 6.96"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <line
+        x1="12"
+        y1="22"
+        x2="12"
+        y2="12"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export { PackageIcon };


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add new icon components for Insurance, Healthcare, and Logistics sections in Skyvern UI.
> 
>   - **Icons**:
>     - Add `DocumentIcon` component in `DocumentIcon.tsx` for document representation.
>     - Add `HospitalIcon` component in `HospitalIcon.tsx` for healthcare representation.
>     - Add `LogisticsIcon` component in `LogisticsIcon.tsx` for logistics representation.
>     - Add `PackageIcon` component in `PackageIcon.tsx` for package representation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f2b39a45c5e6819606ef5330fb65b3dc81d57ef7. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->