### PR TITLE
use run_id for fullpage screenshot flag

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1666,7 +1666,8 @@ class ForgeAgent:
                 scrolling_number=scrolling_number,
                 use_playwright_fullpage=app.EXPERIMENTATION_PROVIDER.is_feature_enabled_cached(
                     "ENABLE_PLAYWRIGHT_FULLPAGE",
-                    str(task.organization_id),
+                    task.workflow_run_id or task.task_id,
+                    properties={"organization_id": task.organization_id},
                 ),
             )
             await app.ARTIFACT_MANAGER.create_artifact(
@@ -2151,7 +2152,8 @@ class ForgeAgent:
                     screenshot = await browser_state.take_fullpage_screenshot(
                         use_playwright_fullpage=app.EXPERIMENTATION_PROVIDER.is_feature_enabled_cached(
                             "ENABLE_PLAYWRIGHT_FULLPAGE",
-                            str(task.organization_id),
+                            task.workflow_run_id or task.task_id,
+                            properties={"organization_id": task.organization_id},
                         )
                     )
                     await app.ARTIFACT_MANAGER.create_artifact(

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -310,7 +310,8 @@ class Block(BaseModel, abc.ABC):
                 screenshot = await browser_state.take_fullpage_screenshot(
                     use_playwright_fullpage=app.EXPERIMENTATION_PROVIDER.is_feature_enabled_cached(
                         "ENABLE_PLAYWRIGHT_FULLPAGE",
-                        str(organization_id),
+                        workflow_run_id,
+                        properties={"organization_id": str(organization_id)},
                     )
                 )
                 if screenshot:
@@ -580,7 +581,8 @@ class BaseTaskBlock(Block):
                     screenshot = await browser_state.take_fullpage_screenshot(
                         use_playwright_fullpage=app.EXPERIMENTATION_PROVIDER.is_feature_enabled_cached(
                             "ENABLE_PLAYWRIGHT_FULLPAGE",
-                            str(organization_id),
+                            workflow_run_id,
+                            properties={"organization_id": str(organization_id)},
                         )
                     )
                     if screenshot:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update feature flag checks to use `workflow_run_id` or `task_id` for full-page screenshot logic in `agent.py` and `block.py`.
> 
>   - **Behavior**:
>     - Update `is_feature_enabled_cached` calls in `record_artifacts_after_action()` and `clean_up_task()` in `agent.py` to use `workflow_run_id` or `task_id` instead of `organization_id`.
>     - Update `is_feature_enabled_cached` calls in `execute_safe()` and `execute()` in `block.py` to use `workflow_run_id` instead of `organization_id`.
>   - **Misc**:
>     - Add `properties` parameter to `is_feature_enabled_cached` calls to include `organization_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 220bd58e8e8e219e1a967a36c1d4735013d7e400. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->