### PR TITLE
Lockdown streaming browser sessions

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -79,6 +79,7 @@ class Settings(BaseSettings):
     BROWSER_TIMEZONE: str = "America/New_York"
     BROWSER_WIDTH: int = 1920
     BROWSER_HEIGHT: int = 1080
+    BROWSER_POLICY_FILE: str = "/etc/chromium/policies/managed/policies.json"
 
     # Add extension folders name here to load extension in your browser
     EXTENSIONS_BASE_PATH: str = "./extensions"


### PR DESCRIPTION
- blocks URLS (chrome://, file://, 127.0.0.1, etc.)
- blocks other things, via policies.json file
- disallows ctrl-O to open files (vnc-level)
- disallows RMB (vnc-level)
- fixes viewport ratio (full 1920x1080 inside vnc)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances security of streaming browser sessions by blocking certain URLs, disallowing file opening and RMB actions, and fixing viewport ratio.
> 
>   - **Security Enhancements**:
>     - Blocks URLs like `chrome://`, `file://`, `127.0.0.1` using `policies.json` in `config.py`.
>     - Disallows `Ctrl-O` for opening files and right mouse button (RMB) actions at VNC level in `streaming_vnc.py`.
>   - **Code Changes**:
>     - Adds `KeyState` class in `streaming_vnc.py` to track key states and block forbidden key combinations.
>     - Implements `is_ctrl_o()` in `KeyState` to prevent file opening.
>     - Adds `Mouse.Up.Right` to block RMB actions.
>   - **Configuration**:
>     - Adds `BROWSER_POLICY_FILE` setting in `config.py` to specify path to `policies.json`.
>   - **Miscellaneous**:
>     - Fixes viewport ratio to ensure full 1920x1080 resolution inside VNC in `streaming_vnc.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 80487488b5621e88033a6cd3c33e27ace30deddc. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->