### PR TITLE
disable complete verification when CUA engine

### DIFF
--- a/skyvern/forge/sdk/db/models.py
+++ b/skyvern/forge/sdk/db/models.py
@@ -573,13 +573,14 @@ class WorkflowRunBlockModel(Base):
     parent_workflow_run_block_id = Column(String, nullable=True)
     organization_id = Column(String, nullable=True)
     description = Column(String, nullable=True)
-    task_id = Column(String, nullable=True)
+    task_id = Column(String, index=True, nullable=True)
     label = Column(String, nullable=True)
     block_type = Column(String, nullable=False)
     status = Column(String, nullable=False)
     output = Column(JSON, nullable=True)
     continue_on_failure = Column(Boolean, nullable=False, default=False)
     failure_reason = Column(String, nullable=True)
+    engine = Column(String, nullable=True)
 
     # for loop block
     loop_values = Column(JSON, nullable=True)

--- a/skyvern/forge/sdk/db/utils.py
+++ b/skyvern/forge/sdk/db/utils.py
@@ -460,6 +460,7 @@ def convert_to_workflow_run_block(
         output=workflow_run_block_model.output,
         continue_on_failure=workflow_run_block_model.continue_on_failure,
         failure_reason=workflow_run_block_model.failure_reason,
+        engine=workflow_run_block_model.engine,
         task_id=workflow_run_block_model.task_id,
         loop_values=workflow_run_block_model.loop_values,
         current_value=workflow_run_block_model.current_value,

--- a/skyvern/forge/sdk/schemas/workflow_runs.py
+++ b/skyvern/forge/sdk/schemas/workflow_runs.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from skyvern.forge.sdk.schemas.task_v2 import Thought
 from skyvern.forge.sdk.workflow.models.block import BlockType
+from skyvern.schemas.runs import RunEngine
 from skyvern.webeye.actions.actions import Action
 
 
@@ -24,6 +25,7 @@ class WorkflowRunBlock(BaseModel):
     output: dict | list | str | None = None
     continue_on_failure: bool = False
     failure_reason: str | None = None
+    engine: RunEngine | None = None
     task_id: str | None = None
     url: str | None = None
     navigation_goal: str | None = None

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -288,7 +288,11 @@ class Block(BaseModel, abc.ABC):
         **kwargs: dict,
     ) -> BlockResult:
         workflow_run_block_id = None
+        engine: RunEngine | None = None
         try:
+            if isinstance(self, BaseTaskBlock):
+                engine = self.engine
+
             workflow_run_block = await app.DATABASE.create_workflow_run_block(
                 workflow_run_id=workflow_run_id,
                 organization_id=organization_id,
@@ -296,6 +300,7 @@ class Block(BaseModel, abc.ABC):
                 label=self.label,
                 block_type=self.block_type,
                 continue_on_failure=self.continue_on_failure,
+                engine=engine,
             )
             workflow_run_block_id = workflow_run_block.workflow_run_block_id
 

--- a/skyvern/services/task_v1_service.py
+++ b/skyvern/services/task_v1_service.py
@@ -14,7 +14,7 @@ from skyvern.forge.sdk.executor.factory import AsyncExecutorFactory
 from skyvern.forge.sdk.schemas.organizations import Organization
 from skyvern.forge.sdk.schemas.task_generations import TaskGeneration, TaskGenerationBase
 from skyvern.forge.sdk.schemas.tasks import Task, TaskRequest, TaskResponse, TaskStatus
-from skyvern.schemas.runs import RunEngine, RunType
+from skyvern.schemas.runs import CUA_ENGINES, CUA_RUN_TYPES, RunEngine, RunType
 
 LOG = structlog.get_logger()
 
@@ -148,3 +148,28 @@ async def get_task_v1_response(task_id: str, organization_id: str | None = None)
     return await app.agent.build_task_response(
         task=task_obj, last_step=latest_step, failure_reason=failure_reason, need_browser_log=True
     )
+
+
+async def is_cua_task(
+    *,
+    task: Task,
+) -> bool:
+    """Return True if the run, engine, or task indicates a CUA task."""
+
+    if task.workflow_run_id:
+        # it's a task based block, should look up the block run to see if it's a CUA task
+        block = await app.DATABASE.get_workflow_run_block_by_task_id(
+            task_id=task.task_id,
+            organization_id=task.organization_id,
+        )
+        if block.engine is not None and block.engine in CUA_ENGINES:
+            return True
+
+    run = await app.DATABASE.get_run(
+        run_id=task.task_id,
+        organization_id=task.organization_id,
+    )
+    if run and run.task_run_type in CUA_RUN_TYPES:
+        return True
+
+    return False

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -71,7 +71,7 @@ from skyvern.forge.sdk.models import Step
 from skyvern.forge.sdk.schemas.tasks import Task
 from skyvern.forge.sdk.services.bitwarden import BitwardenConstants
 from skyvern.forge.sdk.services.credentials import OnePasswordConstants
-from skyvern.schemas.runs import CUA_RUN_TYPES
+from skyvern.services.task_v1_service import is_cua_task
 from skyvern.utils.prompt_engine import CheckPhoneNumberFormatResponse, load_prompt_with_elements
 from skyvern.webeye.actions import actions, handler_utils
 from skyvern.webeye.actions.action_types import ActionType
@@ -3377,9 +3377,8 @@ async def extract_information_for_navigation_goal(
         local_datetime=datetime.now(context.tz_info).isoformat(),
     )
 
-    task_run = await app.DATABASE.get_run(run_id=task.task_id, organization_id=task.organization_id)
     llm_key_override = task.llm_key
-    if task_run and task_run.task_run_type in CUA_RUN_TYPES:
+    if await is_cua_task(task=task):
         # CUA tasks should use the default data extraction llm key
         llm_key_override = None
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Disable complete verification for CUA tasks and add 'engine' column to 'workflow_run_blocks', using `is_cua_task()` for CUA task checks.
> 
>   - **Behavior**:
>     - Disable complete verification for CUA tasks in `agent.py` and `action_complete.py`.
>     - Use `is_cua_task()` to determine if a task is CUA in `agent.py`, `action_complete.py`, and `handler.py`.
>   - **Database**:
>     - Add `engine` column to `workflow_run_blocks` in `add_engine_to_workflow_run_block.py`.
>     - Update `create_workflow_run_block()` and `update_workflow_run_block()` in `client.py` to handle `engine`.
>   - **Functions**:
>     - Add `is_cua_task()` in `task_v1_service.py` to check if a task is CUA.
>   - **Misc**:
>     - Remove `CUA_RUN_TYPES` import from `agent.py` and `action_complete.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 36e91c6e12a5c95950eb5829f6349447327ff7b3. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->