### PR TITLE
fix file exists issue in create_folder_if_not_exist

### DIFF
--- a/skyvern/forge/sdk/api/files.py
+++ b/skyvern/forge/sdk/api/files.py
@@ -238,9 +238,7 @@ def calculate_sha256_for_file(file_path: str) -> str:
 
 def create_folder_if_not_exist(dir: str) -> None:
     path = Path(dir)
-    if path.exists():
-        return
-    path.mkdir(parents=True)
+    path.mkdir(parents=True, exist_ok=True)
 
 
 def get_skyvern_temp_dir() -> str:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `create_folder_if_not_exist()` in `files.py` to prevent race conditions by using `mkdir(parents=True, exist_ok=True)`.
> 
>   - **Behavior**:
>     - Fix `create_folder_if_not_exist()` in `files.py` to use `mkdir(parents=True, exist_ok=True)` instead of checking `path.exists()` before `mkdir`.
>     - This change prevents potential race conditions when creating directories.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 7c9c432a9b878ec3ba5b59b34abbd1b164929c09. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->