### PR TITLE
added it in UI

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -273,6 +273,8 @@ export type WorkflowRunApiResponse = {
   workflow_id: string;
   workflow_permanent_id: string;
   workflow_run_id: string;
+  queue_time: number | null;
+  execution_time: number | null;
   workflow_title: string | null;
 };
 
@@ -284,6 +286,8 @@ export type WorkflowRunStatusApiResponse = {
   webhook_callback_url: string | null;
   created_at: string;
   modified_at: string;
+  queue_time: number | null;
+  execution_time: number | null;
   parameters: Record<string, unknown>;
   screenshot_urls: Array<string> | null;
   recording_url: string | null;

--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -39,6 +39,14 @@ import { ScrollArea, ScrollAreaViewport } from "@/components/ui/scroll-area";
 import { CopyApiCommandDropdown } from "@/components/CopyApiCommandDropdown";
 import { type ApiCommandOptions } from "@/util/apiCommands";
 
+function formatDuration(duration?: number | null) {
+  if (duration === null || typeof duration === "undefined") {
+    return "N/A";
+  }
+  const seconds = duration > 1000 ? duration / 1000 : duration;
+  return `${seconds.toFixed(2)} sec`;
+}
+
 function WorkflowRun() {
   const [searchParams, setSearchParams] = useSearchParams();
   const active = searchParams.get("active");
@@ -256,6 +264,17 @@ function WorkflowRun() {
           )}
         </div>
       </header>
+      <div className="w-fit space-y-2 rounded bg-slate-elevation1 p-4">
+        <h2 className="text-lg font-bold">Run Info</h2>
+        <div className="flex justify-between gap-4 text-sm">
+          <span className="text-slate-400">Queue Time</span>
+          <span>{formatDuration(workflowRun?.queue_time)}</span>
+        </div>
+        <div className="flex justify-between gap-4 text-sm">
+          <span className="text-slate-400">Execution Time</span>
+          <span>{formatDuration(workflowRun?.execution_time)}</span>
+        </div>
+      </div>
       {showOutputSection && (
         <div
           className={cn("grid gap-4 rounded-lg bg-slate-elevation1 p-4", {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add queue and execution time display to the `WorkflowRun` UI with formatted duration.
> 
>   - **UI Enhancements**:
>     - Add `queue_time` and `execution_time` to `WorkflowRunApiResponse` and `WorkflowRunStatusApiResponse` in `types.ts`.
>     - Display `Queue Time` and `Execution Time` in `WorkflowRun.tsx` using `formatDuration()`.
>   - **Functions**:
>     - Add `formatDuration()` in `WorkflowRun.tsx` to format time durations in seconds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 741d58d6543291d7fc19bca7814cdbf9c085f105. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->