### PR TITLE
skip llm artifact creation when empty prompt

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -586,15 +586,16 @@ class LLMCaller:
                         tool["display_width_px"] = target_dimension["width"]
             screenshots = resize_screenshots(screenshots, target_dimension)
 
-        await app.ARTIFACT_MANAGER.create_llm_artifact(
-            data=prompt.encode("utf-8") if prompt else b"",
-            artifact_type=ArtifactType.LLM_PROMPT,
-            screenshots=screenshots,
-            step=step,
-            task_v2=task_v2,
-            thought=thought,
-            ai_suggestion=ai_suggestion,
-        )
+        if prompt:
+            await app.ARTIFACT_MANAGER.create_llm_artifact(
+                data=prompt.encode("utf-8"),
+                artifact_type=ArtifactType.LLM_PROMPT,
+                screenshots=screenshots,
+                step=step,
+                task_v2=task_v2,
+                thought=thought,
+                ai_suggestion=ai_suggestion,
+            )
 
         if not self.llm_config.supports_vision:
             screenshots = None


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Skip LLM artifact creation in `call()` in `api_handler_factory.py` when the prompt is empty.
> 
>   - **Behavior**:
>     - In `call()` in `api_handler_factory.py`, skip LLM artifact creation if `prompt` is empty.
>     - Previously, an empty prompt would still trigger artifact creation with empty data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 1c7815a9457af4449b6b23e41464cf09825dc851. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->