### PR TITLE
use browser session id in taskv2 POST

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1821,6 +1821,7 @@ async def run_task_v2(
             extracted_information_schema=data.extracted_information_schema,
             error_code_mapping=data.error_code_mapping,
             max_screenshot_scrolling_times=data.max_screenshot_scrolling_times,
+            browser_session_id=data.browser_session_id,
         )
     except MissingBrowserAddressError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -166,6 +166,7 @@ async def initialize_task_v2(
     create_task_run: bool = False,
     model: dict[str, Any] | None = None,
     max_screenshot_scrolling_times: int | None = None,
+    browser_session_id: str | None = None,
 ) -> TaskV2:
     task_v2 = await app.DATABASE.create_task_v2(
         prompt=user_prompt,
@@ -226,6 +227,7 @@ async def initialize_task_v2(
             request_id=None,
             workflow_request=WorkflowRequestBody(
                 max_screenshot_scrolling_times=max_screenshot_scrolling_times,
+                browser_session_id=browser_session_id,
             ),
             workflow_permanent_id=new_workflow.workflow_permanent_id,
             organization=organization,


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-5431/add-browser-session-id-to-task-settings

Precedes https://github.com/Skyvern-AI/skyvern-cloud/pull/5235
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `browser_session_id` parameter to `run_task_v2` and `initialize_task_v2` for better browser session management.
> 
>   - **Behavior**:
>     - Add `browser_session_id` parameter to `run_task_v2` in `agent_protocol.py` and `initialize_task_v2` in `task_v2_service.py`.
>     - `browser_session_id` is used to manage browser sessions during task execution.
>   - **Functions**:
>     - Update `run_task_v2` in `agent_protocol.py` to pass `browser_session_id` to `task_v2_service.initialize_task_v2`.
>     - Update `initialize_task_v2` in `task_v2_service.py` to accept and utilize `browser_session_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 90e303ffb8c776ecf948afbe6e5a864d7349e209. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->