### PR TITLE
handle null organization_id in artifact queries for backward compatibility

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from typing import Any, List, Sequence
 
 import structlog
-from sqlalchemy import and_, delete, distinct, func, pool, select, tuple_, update, or_
+from sqlalchemy import and_, delete, distinct, func, or_, pool, select, tuple_, update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
 
@@ -1098,7 +1098,6 @@ class AgentDB:
         thought_id: str | None = None,
         task_v2_id: str | None = None,
     ) -> list[Artifact]:
-
         try:
             async with self.Session() as session:
                 # Build base query


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `get_artifacts_by_entity_id` in `client.py` to handle `None` `organization_id` for backward compatibility by using `or_` condition.
> 
>   - **Behavior**:
>     - Update `get_artifacts_by_entity_id` in `client.py` to handle `None` `organization_id` for backward compatibility.
>     - Uses `or_` condition to include artifacts with `NULL` `organization_id`.
>   - **Imports**:
>     - Add `or_` import from `sqlalchemy` in `client.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c6c057eb48edfafab50a1ad4f28045f50ca3f252. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->