### PR TITLE
Support multiple artifact types in get_artifacts method

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -1092,7 +1092,7 @@ class AgentDB:
         self,
         *,
         organization_id: str | None,
-        artifact_type: ArtifactType | None = None,
+        artifact_types: list[ArtifactType] | None = None,
         task_id: str | None = None,
         step_id: str | None = None,
         workflow_run_id: str | None = None,
@@ -1105,8 +1105,8 @@ class AgentDB:
                 # Build base query
                 query = select(ArtifactModel)
 
-                if artifact_type is not None:
-                    query = query.filter_by(artifact_type=artifact_type)
+                if artifact_types is not None:
+                    query = query.filter(ArtifactModel.artifact_type.in_(artifact_types))
                 if task_id is not None:
                     query = query.filter_by(task_id=task_id)
                 if step_id is not None:
@@ -1151,7 +1151,7 @@ class AgentDB:
     ) -> Artifact | None:
         artifacts = await self.get_artifacts_by_entity_id(
             organization_id=organization_id,
-            artifact_type=artifact_type,
+            artifact_types=[artifact_type],
             task_id=task_id,
             step_id=step_id,
             workflow_run_id=workflow_run_id,

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1169,6 +1169,7 @@ async def get_steps(
 async def get_artifacts(
     entity_type: EntityType,
     entity_id: str,
+    artifact_type: Annotated[list[ArtifactType] | None, Query()] = None,
     current_org: Organization = Depends(org_auth_service.get_current_org),
 ) -> Response:
     """
@@ -1177,6 +1178,7 @@ async def get_artifacts(
     Args:
         entity_type: Type of entity to fetch artifacts for
         entity_id: ID of the entity
+        artifact_type: Optional list of artifact types to filter by
         current_org: Current organization from auth
 
     Returns:
@@ -1196,7 +1198,11 @@ async def get_artifacts(
     params = {
         entity_type_to_param[entity_type]: entity_id,
     }
-    artifacts = await app.DATABASE.get_artifacts_by_entity_id(organization_id=current_org.organization_id, **params)  # type: ignore
+    artifacts = await app.DATABASE.get_artifacts_by_entity_id(
+        organization_id=current_org.organization_id, 
+        artifact_types=artifact_type,
+        **params
+    )  # type: ignore
 
     if settings.ENV != "local" or settings.GENERATE_PRESIGNED_URLS:
         signed_urls = await app.ARTIFACT_MANAGER.get_share_links(artifacts)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Support multiple artifact types in `get_artifacts_by_entity_id` by changing `artifact_type` to `artifact_types` list in `client.py` and `agent_protocol.py`.
> 
>   - **Behavior**:
>     - `get_artifacts_by_entity_id` in `client.py` now accepts `artifact_types` (list) instead of `artifact_type` (single) to filter artifacts by multiple types.
>     - `get_artifact_by_entity_id` in `client.py` updated to pass a list with a single `artifact_type` to `get_artifacts_by_entity_id`.
>     - `get_artifacts` in `agent_protocol.py` updated to accept `artifact_type` as a list for filtering.
>   - **Misc**:
>     - Adjusted query logic in `get_artifacts_by_entity_id` to use `in_` for filtering by multiple artifact types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 8d239bd6589dc996c20b4c3dc13898898db7abe2. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->