### PR TITLE
task v2 doesn't have failure_reason

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -2558,7 +2558,12 @@ class TaskV2Block(Block):
         # Determine block status from task status using module-level mapping
         block_status = TASKV2_TO_BLOCK_STATUS.get(task_v2.status, BlockStatus.failed)
         success = task_v2.status == TaskV2Status.completed
-        failure_reason = task_v2.failure_reason
+        failure_reason: str | None = None
+        task_v2_workflow_run_id = task_v2.workflow_run_id
+        if task_v2_workflow_run_id:
+            task_v2_workflow_run = await app.DATABASE.get_workflow_run(task_v2_workflow_run_id, organization_id)
+            if task_v2_workflow_run:
+                failure_reason = task_v2_workflow_run.failure_reason
 
         # If continue_on_failure is True, we treat the block as successful even if the task failed
         # This allows the workflow to continue execution despite this block's failure


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Retrieve `failure_reason` from `task_v2_workflow_run` in `TaskV2Block` to improve error handling when `task_v2` fails.
> 
>   - **Behavior**:
>     - In `execute()` of `TaskV2Block`, `failure_reason` is now retrieved from `task_v2_workflow_run` if `task_v2.workflow_run_id` is present.
>     - This change ensures `failure_reason` is populated when `task_v2` fails, improving error handling.
>   - **Misc**:
>     - Adds type hint `str | None` for `failure_reason` in `execute()` of `TaskV2Block`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9ce96c73c707d36dbb431fa669a0d9a8c1c8dd29. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->