### PR TITLE
Automatically write workflow_run_id if one isn't specified for a specific artifact

### DIFF
--- a/skyvern/forge/sdk/artifact/manager.py
+++ b/skyvern/forge/sdk/artifact/manager.py
@@ -6,6 +6,7 @@ import structlog
 
 from skyvern.forge import app
 from skyvern.forge.sdk.artifact.models import Artifact, ArtifactType, LogEntityType
+from skyvern.forge.sdk.core import skyvern_context
 from skyvern.forge.sdk.db.id import generate_artifact_id
 from skyvern.forge.sdk.models import Step
 from skyvern.forge.sdk.schemas.ai_suggestions import AISuggestion
@@ -25,6 +26,7 @@ class ArtifactManager:
         artifact_id: str,
         artifact_type: ArtifactType,
         uri: str,
+        organization_id: str,
         step_id: str | None = None,
         task_id: str | None = None,
         workflow_run_id: str | None = None,
@@ -32,7 +34,6 @@ class ArtifactManager:
         thought_id: str | None = None,
         task_v2_id: str | None = None,
         ai_suggestion_id: str | None = None,
-        organization_id: str | None = None,
         data: bytes | None = None,
         path: str | None = None,
     ) -> str:
@@ -40,6 +41,13 @@ class ArtifactManager:
             raise ValueError("Either data or path must be provided to create an artifact.")
         if data and path:
             raise ValueError("Both data and path cannot be provided to create an artifact.")
+
+        if not workflow_run_id:
+            context = skyvern_context.current()
+
+            if context:
+                workflow_run_id = context.workflow_run_id
+
         artifact = await app.DATABASE.create_artifact(
             artifact_id,
             artifact_type,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Automatically sets `workflow_run_id` in `_create_artifact()` using `skyvern_context` if not provided.
> 
>   - **Behavior**:
>     - Automatically sets `workflow_run_id` in `_create_artifact()` in `manager.py` using `skyvern_context` if not provided.
>   - **Imports**:
>     - Adds import for `skyvern_context` in `manager.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for b30595e9c6a0cfe7e00361e91a6b92faf3d1f4e2. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->