### PR TITLE
add taskv2 and task id to artifacts by default if present in context

### DIFF
--- a/skyvern/forge/sdk/artifact/manager.py
+++ b/skyvern/forge/sdk/artifact/manager.py
@@ -42,11 +42,13 @@ class ArtifactManager:
         if data and path:
             raise ValueError("Both data and path cannot be provided to create an artifact.")
 
-        if not workflow_run_id:
-            context = skyvern_context.current()
-
-            if context:
-                workflow_run_id = context.workflow_run_id
+        context = skyvern_context.current()
+        if not workflow_run_id and context:
+            workflow_run_id = context.workflow_run_id
+        if not task_v2_id and context:
+            task_v2_id = context.task_v2_id
+        if not task_id and context:
+            task_id = context.task_id
 
         artifact = await app.DATABASE.create_artifact(
             artifact_id,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Automatically add `task_v2_id` and `task_id` to artifacts in `manager.py` if present in context.
> 
>   - **Behavior**:
>     - In `manager.py`, `_create_artifact()` now automatically includes `task_v2_id` and `task_id` from `skyvern_context` if not provided.
>     - Ensures `task_v2_id` and `task_id` are added to artifacts by default when present in context.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 95b143f9d0f8b902875a597b6185417f6fdc12d7. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->