### PR TITLE
Fix credential naming in UI to use 'credentials', 'credentials_1', etc.

### DIFF
--- a/skyvern-frontend/src/routes/credentials/CredentialsModal.tsx
+++ b/skyvern-frontend/src/routes/credentials/CredentialsModal.tsx
@@ -10,7 +10,7 @@ import {
   CredentialModalTypes,
 } from "./useCredentialModalState";
 import { PasswordCredentialContent } from "./PasswordCredentialContent";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { CreditCardCredentialContent } from "./CreditCardCredentialContent";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -20,6 +20,7 @@ import { useCredentialGetter } from "@/hooks/useCredentialGetter";
 import { toast } from "@/components/ui/use-toast";
 import { AxiosError } from "axios";
 import { ReloadIcon } from "@radix-ui/react-icons";
+import { useCredentialsQuery } from "@/routes/workflows/hooks/useCredentialsQuery";
 
 const PASSWORD_CREDENTIAL_INITIAL_VALUES = {
   name: "",
@@ -37,6 +38,24 @@ const CREDIT_CARD_CREDENTIAL_INITIAL_VALUES = {
   cardHolderName: "",
 };
 
+// Function to generate a unique credential name
+function generateDefaultCredentialName(existingNames: string[]): string {
+  const baseName = "credentials";
+
+  // Check if "credentials" is available
+  if (!existingNames.includes(baseName)) {
+    return baseName;
+  }
+
+  // Find the next available number
+  let counter = 1;
+  while (existingNames.includes(`${baseName}_${counter}`)) {
+    counter++;
+  }
+
+  return `${baseName}_${counter}`;
+}
+
 type Props = {
   onCredentialCreated?: (id: string) => void;
 };
@@ -45,12 +64,30 @@ function CredentialsModal({ onCredentialCreated }: Props) {
   const credentialGetter = useCredentialGetter();
   const queryClient = useQueryClient();
   const { isOpen, type, setIsOpen } = useCredentialModalState();
+  const { data: credentials } = useCredentialsQuery();
   const [passwordCredentialValues, setPasswordCredentialValues] = useState(
     PASSWORD_CREDENTIAL_INITIAL_VALUES,
   );
   const [creditCardCredentialValues, setCreditCardCredentialValues] = useState(
     CREDIT_CARD_CREDENTIAL_INITIAL_VALUES,
   );
+
+  // Set default name when modal opens
+  useEffect(() => {
+    if (isOpen && credentials) {
+      const existingNames = credentials.map((cred) => cred.name);
+      const defaultName = generateDefaultCredentialName(existingNames);
+
+      setPasswordCredentialValues((prev) => ({
+        ...prev,
+        name: defaultName,
+      }));
+      setCreditCardCredentialValues((prev) => ({
+        ...prev,
+        name: defaultName,
+      }));
+    }
+  }, [isOpen, credentials]);
 
   function reset() {
     setPasswordCredentialValues(PASSWORD_CREDENTIAL_INITIAL_VALUES);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds unique credential name generation in `CredentialsModal.tsx` using `generateDefaultCredentialName()` and `useEffect`.
> 
>   - **Behavior**:
>     - Adds `generateDefaultCredentialName()` to generate unique credential names in `CredentialsModal.tsx`.
>     - Uses `useEffect` to set default credential names when the modal opens, ensuring uniqueness by appending numbers (e.g., 'credentials', 'credentials_1').
>   - **Imports**:
>     - Adds `useEffect` and `useCredentialsQuery` to `CredentialsModal.tsx` for handling credential data and side effects.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 82af4bbb4c1c8843bee70246eb953912c76ce240. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->