### PR TITLE
Fix OnePassword parameter labeling to show 'credential' instead of 'onepassword'

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParametersPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParametersPanel.tsx
@@ -141,7 +141,9 @@ function WorkflowParametersPanel() {
                         </span>
                       ) : (
                         <span className="text-sm text-slate-400">
-                          {parameter.parameterType}
+                          {parameter.parameterType === "onepassword"
+                            ? "credential"
+                            : parameter.parameterType}
                         </span>
                       )}
                     </div>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change label from `onepassword` to `credential` for parameter type display in `WorkflowParametersPanel`.
> 
>   - **Behavior**:
>     - In `WorkflowParametersPanel`, change label from `onepassword` to `credential` for `parameter.parameterType` when rendering parameter type.
>     - Affects display of parameter type in UI, ensuring consistency with expected terminology.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d43f231e5fea254e62a0b29e7de7dd88b6c1da1d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->