### PR TITLE
fallback to take screenshot with animation allowed

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParametersPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParametersPanel.tsx
@@ -141,7 +141,9 @@ function WorkflowParametersPanel() {
                         </span>
                       ) : (
                         <span className="text-sm text-slate-400">
-                          {parameter.parameterType}
+                          {parameter.parameterType === "onepassword"
+                            ? "credential"
+                            : parameter.parameterType}
                         </span>
                       )}
                     </div>

--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParametersPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParametersPanel.tsx
@@ -141,9 +141,7 @@ function WorkflowParametersPanel() {
                         </span>
                       ) : (
                         <span className="text-sm text-slate-400">
-                          {parameter.parameterType === "onepassword"
-                            ? "credential"
-                            : parameter.parameterType}
+                          {parameter.parameterType}
                         </span>
                       )}
                     </div>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `_page_screenshot_helper` to retry screenshots with animations allowed on timeout in `page.py`.
> 
>   - **Behavior**:
>     - Adds `_page_screenshot_helper` to `page.py` to retry screenshots with animations allowed on timeout.
>     - Integrates `_page_screenshot_helper` into `_current_viewpoint_screenshot_helper` to handle timeouts.
>   - **Logging**:
>     - Logs timeout errors and retry attempts in `_page_screenshot_helper`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 31421b09663a50ea7ecb86ccc79163354422a588. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->