### PR TITLE
Remove x-api-key from logs

### DIFF
--- a/skyvern/forge/request_logging.py
+++ b/skyvern/forge/request_logging.py
@@ -14,7 +14,7 @@ if typing.TYPE_CHECKING:  # pragma: no cover - import only for type hints
 
 LOG = structlog.get_logger()
 
-_SENSITIVE_HEADERS = {"authorization", "cookie"}
+_SENSITIVE_HEADERS = {"authorization", "cookie", "x-api-key"}
 _MAX_BODY_LENGTH = 1000
 _BINARY_PLACEHOLDER = "<binary>"
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `"x-api-key"` to `_SENSITIVE_HEADERS` in `request_logging.py` to prevent logging of this sensitive header.
> 
>   - **Security**:
>     - Add `"x-api-key"` to `_SENSITIVE_HEADERS` in `request_logging.py` to prevent logging of this sensitive header.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 37632b64df1f964d01bcad6782bbfad287e10516. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->