### PR TITLE
Add RESIDENTIAL_AU proxy support for Australia

### DIFF
--- a/skyvern/client/types/proxy_location.py
+++ b/skyvern/client/types/proxy_location.py
@@ -20,6 +20,7 @@ ProxyLocation = typing.Union[
         "RESIDENTIAL_NZ",
         "RESIDENTIAL_ZA",
         "RESIDENTIAL_AR",
+        "RESIDENTIAL_AU",
         "RESIDENTIAL_ISP",
         "NONE",
     ],

--- a/skyvern/client/types/workflow_run_request.py
+++ b/skyvern/client/types/workflow_run_request.py
@@ -40,6 +40,7 @@ class WorkflowRunRequest(UniversalBaseModel):
     - RESIDENTIAL_NZ: New Zealand
     - RESIDENTIAL_ZA: South Africa
     - RESIDENTIAL_AR: Argentina
+    - RESIDENTIAL_AU: Australia
     - RESIDENTIAL_ISP: ISP proxy
     - US-CA: California
     - US-NY: New York

--- a/skyvern/schemas/docs/doc_strings.py
+++ b/skyvern/schemas/docs/doc_strings.py
@@ -25,6 +25,7 @@ Available geotargeting options:
 - RESIDENTIAL_NZ: New Zealand
 - RESIDENTIAL_ZA: South Africa
 - RESIDENTIAL_AR: Argentina
+- RESIDENTIAL_AU: Australia
 - RESIDENTIAL_ISP: ISP proxy
 - US-CA: California
 - US-NY: New York

--- a/skyvern/schemas/runs.py
+++ b/skyvern/schemas/runs.py
@@ -50,6 +50,7 @@ class ProxyLocation(StrEnum):
     RESIDENTIAL_NZ = "RESIDENTIAL_NZ"
     RESIDENTIAL_ZA = "RESIDENTIAL_ZA"
     RESIDENTIAL_AR = "RESIDENTIAL_AR"
+    RESIDENTIAL_AU = "RESIDENTIAL_AU"
     RESIDENTIAL_ISP = "RESIDENTIAL_ISP"
     NONE = "NONE"
 
@@ -81,6 +82,7 @@ class ProxyLocation(StrEnum):
             cls.RESIDENTIAL_NZ,
             cls.RESIDENTIAL_ZA,
             cls.RESIDENTIAL_AR,
+            cls.RESIDENTIAL_AU,
         }
 
     @staticmethod
@@ -97,6 +99,7 @@ class ProxyLocation(StrEnum):
             ProxyLocation.RESIDENTIAL_NZ: 2000,
             ProxyLocation.RESIDENTIAL_ZA: 2000,
             ProxyLocation.RESIDENTIAL_AR: 2000,
+            ProxyLocation.RESIDENTIAL_AU: 2000,
         }
         return counts.get(proxy_location, 10000)
 
@@ -114,6 +117,7 @@ class ProxyLocation(StrEnum):
             ProxyLocation.RESIDENTIAL_NZ: "NZ",
             ProxyLocation.RESIDENTIAL_ZA: "ZA",
             ProxyLocation.RESIDENTIAL_AR: "AR",
+            ProxyLocation.RESIDENTIAL_AU: "AU",
         }
         return mapping.get(proxy_location, "US")
 
@@ -169,6 +173,9 @@ def get_tzinfo_from_proxy(proxy_location: ProxyLocation) -> ZoneInfo | None:
 
     if proxy_location == ProxyLocation.RESIDENTIAL_AR:
         return ZoneInfo("America/Argentina/Buenos_Aires")
+
+    if proxy_location == ProxyLocation.RESIDENTIAL_AU:
+        return ZoneInfo("Australia/Sydney")
 
     if proxy_location == ProxyLocation.RESIDENTIAL_ISP:
         return ZoneInfo("America/New_York")


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for `RESIDENTIAL_AU` proxy location across enums, functions, and documentation.
> 
>   - **Proxy Location Support**:
>     - Add `RESIDENTIAL_AU` to `ProxyLocation` enum in `runs.py`.
>     - Update `residential_country_locations()` in `runs.py` to include `RESIDENTIAL_AU`.
>     - Update `get_proxy_count()` in `runs.py` to return 2000 for `RESIDENTIAL_AU`.
>     - Update `get_country_code()` in `runs.py` to return "AU" for `RESIDENTIAL_AU`.
>     - Update `get_tzinfo_from_proxy()` in `runs.py` to return `ZoneInfo("Australia/Sydney")` for `RESIDENTIAL_AU`.
>   - **Documentation**:
>     - Add `RESIDENTIAL_AU` to docstrings in `workflow_run_request.py` and `doc_strings.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 26bca99fa2ee5066926522b966fbdfbe8f96329a. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->