### PR TITLE
Add RESIDENTIAL_AU frontend support for Australia proxies

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -41,6 +41,7 @@ export const ProxyLocation = {
   ResidentialNZ: "RESIDENTIAL_NZ",
   ResidentialZA: "RESIDENTIAL_ZA",
   ResidentialAR: "RESIDENTIAL_AR",
+  ResidentialAU: "RESIDENTIAL_AU",
   ResidentialISP: "RESIDENTIAL_ISP",
   None: "NONE",
 } as const;

--- a/skyvern-frontend/src/components/ProxySelector.tsx
+++ b/skyvern-frontend/src/components/ProxySelector.tsx
@@ -27,14 +27,14 @@ function ProxySelector({ value, onChange, className }: Props) {
         <SelectItem value={ProxyLocation.ResidentialAR}>
           Residential (Argentina)
         </SelectItem>
-        <SelectItem value={ProxyLocation.ResidentialDE}>
-          Residential (Germany)
+        <SelectItem value={ProxyLocation.ResidentialAU}>
+          Residential (Australia)
         </SelectItem>
         <SelectItem value={ProxyLocation.ResidentialFR}>
           Residential (France)
         </SelectItem>
-        <SelectItem value={ProxyLocation.ResidentialGB}>
-          Residential (United Kingdom)
+        <SelectItem value={ProxyLocation.ResidentialDE}>
+          Residential (Germany)
         </SelectItem>
         <SelectItem value={ProxyLocation.ResidentialIN}>
           Residential (India)
@@ -48,11 +48,14 @@ function ProxySelector({ value, onChange, className }: Props) {
         <SelectItem value={ProxyLocation.ResidentialNZ}>
           Residential (New Zealand)
         </SelectItem>
+        <SelectItem value={ProxyLocation.ResidentialZA}>
+          Residential (South Africa)
+        </SelectItem>
         <SelectItem value={ProxyLocation.ResidentialES}>
           Residential (Spain)
         </SelectItem>
-        <SelectItem value={ProxyLocation.ResidentialZA}>
-          Residential (South Africa)
+        <SelectItem value={ProxyLocation.ResidentialGB}>
+          Residential (United Kingdom)
         </SelectItem>
       </SelectContent>
     </Select>


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `ResidentialAU` proxy support to frontend by updating `ProxyLocation` and `ProxySelector`.
> 
>   - **Proxy Location**:
>     - Add `ResidentialAU` to `ProxyLocation` in `types.ts`.
>   - **Proxy Selector**:
>     - Add `Residential (Australia)` option in `ProxySelector` in `ProxySelector.tsx`.
>     - Reorder proxy options in `ProxySelector.tsx` for better organization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f1bfa7687d2f07cc2452a8bc1a97a93533237b48. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->