### PR TITLE
Jon/browser stream component

### DIFF
--- a/skyvern-frontend/src/components/browser-stream.css
+++ b/skyvern-frontend/src/components/browser-stream.css
@@ -1,4 +1,4 @@
-.workflow-run-stream-vnc {
+.browser-stream {
   position: relative;
   width: 100%;
   height: 100%;
@@ -9,11 +9,11 @@
   transition: padding 0.2s ease-in-out;
 }
 
-.workflow-run-stream-vnc.user-is-controlling {
+.browser-stream.user-is-controlling {
   padding: 0rem;
 }
 
-.workflow-run-stream-vnc .overlay-container {
+.browser-stream .overlay-container {
   position: absolute;
   top: 0;
   left: 0;
@@ -24,7 +24,7 @@
   justify-content: center;
 }
 
-.workflow-run-stream-vnc .overlay {
+.browser-stream .overlay {
   position: relative;
   height: auto;
   width: 100%;
@@ -36,15 +36,15 @@
   justify-content: center;
 }
 
-.workflow-run-stream-vnc.user-is-controlling .overlay {
+.browser-stream.user-is-controlling .overlay {
   pointer-events: none;
 }
 
-.workflow-run-stream-vnc.user-is-controlling .overlay-container {
+.browser-stream.user-is-controlling .overlay-container {
   pointer-events: none;
 }
 
-.workflow-run-stream-vnc .take-control {
+.browser-stream .take-control {
   transform: translateY(0);
   transition:
     transform 0.2s ease-in-out,
@@ -52,17 +52,17 @@
   opacity: 0.3;
 }
 
-.workflow-run-stream-vnc .take-control:not(.hide):hover {
+.browser-stream .take-control:not(.hide):hover {
   opacity: 1;
 }
 
-.workflow-run-stream-vnc .take-control.hide {
+.browser-stream .take-control.hide {
   transform: translateY(100%);
   opacity: 0;
   pointer-events: none;
 }
 
-.workflow-run-stream-vnc .relinquish-control {
+.browser-stream .relinquish-control {
   transform: translateY(0);
   transition:
     transform 0.2s ease-in-out,
@@ -71,17 +71,17 @@
   pointer-events: all;
 }
 
-.workflow-run-stream-vnc .relinquish-control:not(.hide):hover {
+.browser-stream .relinquish-control:not(.hide):hover {
   opacity: 1;
 }
 
-.workflow-run-stream-vnc .relinquish-control.hide {
+.browser-stream .relinquish-control.hide {
   transform: translateY(100%);
   opacity: 0;
   pointer-events: none;
 }
 
-.workflow-run-stream-vnc > div > canvas {
+.browser-stream > div > canvas {
   opacity: 0;
   animation: skyvern-anim-fadeIn 1s ease-in forwards;
 }

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunOverview.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunOverview.tsx
@@ -1,8 +1,10 @@
 import { ActionsApiResponse } from "@/api/types";
+import { BrowserStream } from "@/components/BrowserStream";
 import { AspectRatio } from "@/components/ui/aspect-ratio";
 import { ActionScreenshot } from "@/routes/tasks/detail/ActionScreenshot";
 import { statusIsFinalized } from "@/routes/tasks/types";
 import { useWorkflowRunQuery } from "../hooks/useWorkflowRunQuery";
+import { useParams } from "react-router-dom";
 import { useWorkflowRunTimelineQuery } from "../hooks/useWorkflowRunTimelineQuery";
 import {
   isAction,
@@ -14,10 +16,11 @@ import {
 import { ObserverThoughtScreenshot } from "./ObserverThoughtScreenshot";
 import { WorkflowRunBlockScreenshot } from "./WorkflowRunBlockScreenshot";
 import { WorkflowRunStream } from "./WorkflowRunStream";
-import { WorkflowRunStreamVnc } from "./WorkflowRunStreamVnc";
 import { useSearchParams } from "react-router-dom";
 import { findActiveItem } from "./workflowTimelineUtils";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
 
 export type ActionItem = {
   block: WorkflowRunBlock;
@@ -34,11 +37,32 @@ export type WorkflowRunOverviewActiveElement =
 function WorkflowRunOverview() {
   const [searchParams] = useSearchParams();
   const active = searchParams.get("active");
+  const { workflowPermanentId } = useParams<{
+    workflowPermanentId: string;
+  }>();
+  const queryClient = useQueryClient();
   const { data: workflowRun, isLoading: workflowRunIsLoading } =
     useWorkflowRunQuery();
 
   const { data: workflowRunTimeline, isLoading: workflowRunTimelineIsLoading } =
     useWorkflowRunTimelineQuery();
+
+  const invalidateQueries = useCallback(() => {
+    if (workflowRun) {
+      queryClient.invalidateQueries({
+        queryKey: [
+          "workflowRun",
+          workflowPermanentId,
+          workflowRun.workflow_run_id,
+        ],
+      });
+      queryClient.invalidateQueries({ queryKey: ["workflowRuns"] });
+      queryClient.invalidateQueries({
+        queryKey: ["workflowTasks", workflowRun.workflow_run_id],
+      });
+      queryClient.invalidateQueries({ queryKey: ["runs"] });
+    }
+  }, [queryClient, workflowPermanentId, workflowRun]);
 
   if (workflowRunIsLoading || workflowRunTimelineIsLoading) {
     return (
@@ -64,7 +88,10 @@ function WorkflowRunOverview() {
   );
 
   const streamingComponent = workflowRun.browser_session_id ? (
-    <WorkflowRunStreamVnc />
+    <BrowserStream
+      workflow={{ run: workflowRun }}
+      onClose={() => invalidateQueries()}
+    />
   ) : (
     <WorkflowRunStream />
   );


### PR DESCRIPTION
Generalizes `WorkflowRunStreamVnc` component --> `BrowserStream` component. Can accept either a workflow or a task.

NOTE: I did this because I assumed we'd need to use this component against _tasks_, as well as workflows. But, now my half-understanding is that v2 tasks are executing as workflows anyhow. Which is what blocks would be doing. Well, we'll see.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Generalizes `WorkflowRunStreamVnc` to `BrowserStream` for handling tasks and workflows, updating logic, file names, and integrating with `WorkflowRunOverview`.
> 
>   - **Component Generalization**:
>     - `WorkflowRunStreamVnc` component generalized to `BrowserStream` to handle both tasks and workflows.
>     - Updated logic in `BrowserStream.tsx` to determine entity type and manage WebSocket connections accordingly.
>   - **File Renames**:
>     - `WorkflowRunStreamVnc.tsx` renamed to `BrowserStream.tsx`.
>     - `workflow-run-stream-vnc.css` renamed to `browser-stream.css`.
>   - **CSS Updates**:
>     - Updated class names in `browser-stream.css` to reflect new component name.
>   - **WorkflowRunOverview Integration**:
>     - Replaced `WorkflowRunStreamVnc` with `BrowserStream` in `WorkflowRunOverview.tsx`.
>     - Added logic to invalidate queries on stream close in `WorkflowRunOverview.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 49ac0b01ab0c5ed91017df51c56e00f9094dbdd6. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->