### PR TITLE
implement an endpoint for running one or more labelled blocks in a workflow

### DIFF
--- a/skyvern/exceptions.py
+++ b/skyvern/exceptions.py
@@ -128,6 +128,11 @@ class UnknownBlockType(SkyvernException):
         super().__init__(f"Unknown block type {block_type}")
 
 
+class BlockNotFound(SkyvernException):
+    def __init__(self, block_label: str) -> None:
+        super().__init__(f"Block {block_label} not found")
+
+
 class WorkflowNotFound(SkyvernHTTPException):
     def __init__(
         self,

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -10,6 +10,7 @@ from skyvern import analytics
 from skyvern.config import settings
 from skyvern.constants import GET_DOWNLOADED_FILES_TIMEOUT, SAVE_DOWNLOADED_FILES_TIMEOUT
 from skyvern.exceptions import (
+    BlockNotFound,
     BrowserSessionNotFound,
     FailedToSendWebhook,
     InvalidCredentialId,
@@ -252,6 +253,7 @@ class WorkflowService:
         workflow_run_id: str,
         api_key: str,
         organization: Organization,
+        block_labels: list[str] | None = None,
         browser_session_id: str | None = None,
     ) -> WorkflowRun:
         """Execute a workflow."""
@@ -326,8 +328,32 @@ class WorkflowService:
             )
             return workflow_run
 
+        all_blocks = workflow.workflow_definition.blocks
+
+        if block_labels and len(block_labels):
+            blocks: list[BlockTypeVar] = []
+            all_labels = {block.label: block for block in all_blocks}
+
+            for label in block_labels:
+                if label not in all_labels:
+                    raise BlockNotFound(block_label=label)
+
+                blocks.append(all_labels[label])
+
+            LOG.info(
+                "Executing workflow blocks via whitelist",
+                workflow_run_id=workflow_run.workflow_run_id,
+                block_cnt=len(blocks),
+                block_labels=block_labels,
+            )
+
+        else:
+            blocks = all_blocks
+
+        if not blocks:
+            raise SkyvernException(f"No blocks found for the given block labels: {block_labels}")
+
         # Execute workflow blocks
-        blocks = workflow.workflow_definition.blocks
         blocks_cnt = len(blocks)
         block_result = None
         for block_idx, block in enumerate(blocks):

--- a/skyvern/schemas/runs.py
+++ b/skyvern/schemas/runs.py
@@ -357,6 +357,13 @@ class WorkflowRunRequest(BaseModel):
         return validate_url(url)
 
 
+class BlockRunRequest(WorkflowRunRequest):
+    block_labels: list[str] = Field(
+        description="Labels of the blocks to execute",
+        examples=["block_1", "block_2"],
+    )
+
+
 class BaseRunResponse(BaseModel):
     run_id: str = Field(
         description="Unique identifier for this run. Run ID starts with `tsk_` for task runs and `wr_` for workflow runs.",
@@ -415,3 +422,7 @@ class WorkflowRunResponse(BaseRunResponse):
 
 
 RunResponse = Annotated[Union[TaskRunResponse, WorkflowRunResponse], Field(discriminator="run_type")]
+
+
+class BlockRunResponse(WorkflowRunResponse):
+    block_labels: list[str] = Field(description="A whitelist of block labels; only these blocks will execute")

--- a/skyvern/services/block_service.py
+++ b/skyvern/services/block_service.py
@@ -1,0 +1,72 @@
+import structlog
+
+from skyvern.forge import app
+from skyvern.forge.sdk.core import skyvern_context
+from skyvern.forge.sdk.schemas.organizations import Organization
+from skyvern.forge.sdk.workflow.models.workflow import WorkflowRequestBody, WorkflowRun
+from skyvern.schemas.runs import WorkflowRunRequest
+from skyvern.services import workflow_service
+
+LOG = structlog.get_logger()
+
+
+async def ensure_workflow_run(
+    organization: Organization,
+    template: bool,
+    workflow_permanent_id: str,
+    workflow_run_request: WorkflowRunRequest,
+    x_max_steps_override: int | None = None,
+) -> WorkflowRun:
+    context = skyvern_context.ensure_context()
+
+    legacy_workflow_request = WorkflowRequestBody(
+        data=workflow_run_request.parameters,
+        proxy_location=workflow_run_request.proxy_location,
+        webhook_callback_url=workflow_run_request.webhook_url,
+        totp_identifier=workflow_run_request.totp_identifier,
+        totp_verification_url=workflow_run_request.totp_url,
+        browser_session_id=workflow_run_request.browser_session_id,
+        max_screenshot_scrolls=workflow_run_request.max_screenshot_scrolls,
+        extra_http_headers=workflow_run_request.extra_http_headers,
+    )
+
+    workflow_run = await workflow_service.prepare_workflow(
+        workflow_id=workflow_permanent_id,
+        organization=organization,
+        workflow_request=legacy_workflow_request,
+        template=template,
+        version=None,
+        max_steps=x_max_steps_override,
+        request_id=context.request_id,
+    )
+
+    return workflow_run
+
+
+async def execute_blocks(
+    api_key: str,
+    block_labels: list[str],
+    workflow_run_id: str,
+    organization: Organization,
+    browser_session_id: str | None = None,
+) -> WorkflowRun:
+    """
+    Runs one or more blocks of a workflow.
+    """
+
+    LOG.info(
+        "Executing block(s)",
+        organization_id=organization.organization_id,
+        workflow_run_id=workflow_run_id,
+        block_labels=block_labels,
+    )
+
+    workflow_run = await app.WORKFLOW_SERVICE.execute_workflow(
+        workflow_run_id=workflow_run_id,
+        api_key=api_key,
+        organization=organization,
+        block_labels=block_labels,
+        browser_session_id=browser_session_id,
+    )
+
+    return workflow_run


### PR DESCRIPTION
	To test:

```bash
curl -X POST "http://localhost:8000/v1/run/workflows/blocks" \
-H "Content-Type: application/json" \
-H "x-max-steps-override: 10" \
-H "x-api-key: <YOUR-API-KEY>" \
-d '{
    "block_labels": ["block_x"],
    "workflow_id": "wpid_xxx"
}'
```

You should see a return value like below, and the agent should run the workflow with just the block label(s) specified.

```
{"run_id":"wr_411475487289618612","status":"created","output":null,"downloaded_files":null,"recording_url":null,"screenshot_urls":null,"failure_reason":null,"created_at":"2025-07-02T20:15:02.819704","modified_at":"2025-07-02T20:15:02.819707","queued_at":null,"started_at":null,"finished_at":null,"app_url":"http://localhost:8080/workflows/wpid_408874995188108760/wr_411475487289618612","browser_session_id":null,"max_screenshot_scrolling_times":null,"run_type":"workflow_run","run_request":{"workflow_id":"wpid_408874995188108760","parameters":{},"title":null,"proxy_location":null,"webhook_url":null,"totp_url":null,"totp_identifier":null,"browser_session_id":null,"max_screenshot_scrolling_times":null,"extra_http_headers":null},"block_labels":["block_2"]}%
```

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `run_block` endpoint to execute specific blocks in a workflow, with supporting changes in services, schemas, and exceptions.
> 
>   - **Endpoints**:
>     - Add `run_block` endpoint in `agent_protocol.py` to execute specific blocks in a workflow.
>   - **Services**:
>     - Implement `ensure_workflow_run()` and `execute_blocks()` in `block_service.py` to manage block execution.
>     - Modify `execute_workflow()` in `workflow_service.py` to handle block labels.
>   - **Schemas**:
>     - Add `BlockRunRequest` and `BlockRunResponse` in `runs.py` for block execution requests and responses.
>   - **Exceptions**:
>     - Add `BlockNotFound` exception in `exceptions.py` for missing block labels.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 5588d16a84667808d783d436501f2cec2bd1db94. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->