### PR TITLE
Jon/optimistic browser session id fetch

### DIFF
--- a/skyvern-frontend/src/store/useOptimisticallyRequestBrowserSessionId.ts
+++ b/skyvern-frontend/src/store/useOptimisticallyRequestBrowserSessionId.ts
@@ -1,0 +1,65 @@
+import { create } from "zustand";
+import { AxiosInstance } from "axios";
+
+export interface BrowserSessionData {
+  browser_session_id: string | null;
+  expires_at: number | null; // seconds since epoch
+}
+
+interface OptimisticBrowserSessionIdState extends BrowserSessionData {
+  run: (client: AxiosInstance) => Promise<BrowserSessionData>;
+}
+
+const SESSION_KEY = "skyvern.optimisticBrowserSession";
+const SESSION_TIMEOUT_MINUTES = 60;
+
+export const useOptimisticallyRequestBrowserSessionId =
+  create<OptimisticBrowserSessionIdState>((set) => ({
+    browser_session_id: null,
+    expires_at: null,
+    run: async (client) => {
+      const stored = localStorage.getItem(SESSION_KEY);
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored);
+          const { browser_session_id, expires_at } = parsed;
+          const now = Math.floor(Date.now() / 1000); // seconds since epoch
+
+          if (
+            browser_session_id &&
+            typeof browser_session_id === "string" &&
+            expires_at &&
+            typeof expires_at === "number" &&
+            now < expires_at
+          ) {
+            set({ browser_session_id, expires_at });
+            return { browser_session_id, expires_at };
+          }
+        } catch (e) {
+          // pass
+        }
+      }
+
+      const resp = await client.post("/browser_sessions", {
+        timeout: SESSION_TIMEOUT_MINUTES * 60, // accepts seconds, so have to mult
+      });
+      const { browser_session_id: newBrowserSessionId, timeout } = resp.data;
+      const newExpiresAt = Math.floor(Date.now() / 1000) + timeout * 0.9;
+      set({
+        browser_session_id: newBrowserSessionId,
+        expires_at: newExpiresAt,
+      });
+      localStorage.setItem(
+        SESSION_KEY,
+        JSON.stringify({
+          browser_session_id: newBrowserSessionId,
+          expires_at: newExpiresAt,
+        }),
+      );
+
+      return {
+        browser_session_id: newBrowserSessionId,
+        expires_at: newExpiresAt,
+      };
+    },
+  }));


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `useOptimisticallyRequestBrowserSessionId` hook to manage browser session ID with optimistic local storage check and Axios request.
> 
>   - **New Feature**:
>     - Adds `useOptimisticallyRequestBrowserSessionId` hook in `useOptimisticallyRequestBrowserSessionId.ts`.
>     - Uses Zustand to manage state for `browser_session_id` and `expires_at`.
>     - Checks local storage for existing session data and validates it.
>     - If no valid session, requests new session ID from `/browser_sessions` endpoint using Axios.
>     - Stores new session data in local storage with a timeout of 90% of the server-provided timeout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e7340b5232cce66d7ea488593281ee6c1654a1c4. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->