### PR TITLE
increase max step for datapicker agent

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -2447,13 +2447,15 @@ async def sequentially_select_from_dropdown(
         return None
 
     # TODO: only support the third-level dropdown selection now, but for date picker, we need to support more levels as it will move the month, year, etc.
-    MAX_SELECT_DEPTH = 5 if input_or_select_context.is_date_related else 3
+    MAX_DATEPICKER_DEPTH = 30
+    MAX_SELECT_DEPTH = 3
+    max_depth = MAX_DATEPICKER_DEPTH if input_or_select_context.is_date_related else MAX_SELECT_DEPTH
     values: list[str | None] = []
     select_history: list[CustomSingleSelectResult] = []
     single_select_result: CustomSingleSelectResult | None = None
 
     check_filter_funcs: list[CheckFilterOutElementIDFunc] = [check_existed_but_not_option_element_in_dom_factory(dom)]
-    for i in range(MAX_SELECT_DEPTH):
+    for i in range(max_depth):
         single_select_result = await select_from_dropdown(
             context=input_or_select_context,
             page=page,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Increase maximum depth for date picker dropdowns to 30 in `sequentially_select_from_dropdown()` in `handler.py`.
> 
>   - **Behavior**:
>     - Increase maximum depth for date picker dropdowns to 30 in `sequentially_select_from_dropdown()` in `handler.py`.
>     - Retain maximum depth of 3 for non-date picker dropdowns.
>   - **Constants**:
>     - Introduce `MAX_DATEPICKER_DEPTH` set to 30.
>     - Retain `MAX_SELECT_DEPTH` set to 3.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 98330b8f20809d85fa946778ef79982bc9eb1278. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->