### PR TITLE
parameterize data schema in workflow

### DIFF
--- a/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
@@ -271,7 +271,7 @@ export type TaskBlock = WorkflowBlockBase & {
   title: string;
   navigation_goal: string | null;
   data_extraction_goal: string | null;
-  data_schema: Record<string, unknown> | null;
+  data_schema: Record<string, unknown> | string | null;
   complete_criterion: string | null;
   terminate_criterion: string | null;
   error_code_mapping: Record<string, string> | null;
@@ -407,7 +407,7 @@ export type ExtractionBlock = WorkflowBlockBase & {
   data_extraction_goal: string | null;
   url: string | null;
   title: string;
-  data_schema: Record<string, unknown> | null;
+  data_schema: Record<string, unknown> | string | null;
   max_retries?: number;
   max_steps_per_run?: number | null;
   parameters: Array<WorkflowParameter>;

--- a/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
@@ -135,7 +135,7 @@ export type TaskBlockYAML = BlockYAMLBase & {
   title?: string;
   navigation_goal: string | null;
   data_extraction_goal: string | null;
-  data_schema: Record<string, unknown> | null;
+  data_schema: Record<string, unknown> | string | null;
   error_code_mapping: Record<string, string> | null;
   max_retries?: number;
   max_steps_per_run?: number | null;
@@ -210,7 +210,7 @@ export type ExtractionBlockYAML = BlockYAMLBase & {
   url: string | null;
   title?: string;
   data_extraction_goal: string | null;
-  data_schema: Record<string, unknown> | null;
+  data_schema: Record<string, unknown> | string | null;
   max_retries?: number;
   max_steps_per_run?: number | null;
   parameter_keys?: Array<string> | null;

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -392,7 +392,7 @@ class BaseTaskBlock(Block):
     terminate_criterion: str | None = None
     navigation_goal: str | None = None
     data_extraction_goal: str | None = None
-    data_schema: dict[str, Any] | list | None = None
+    data_schema: dict[str, Any] | list | str | None = None
     # error code to error description for the LLM
     error_code_mapping: dict[str, str] | None = None
     max_retries: int = 0
@@ -452,6 +452,11 @@ class BaseTaskBlock(Block):
         if self.data_extraction_goal:
             self.data_extraction_goal = self.format_block_parameter_template_from_workflow_run_context(
                 self.data_extraction_goal, workflow_run_context
+            )
+
+        if isinstance(self.data_schema, str):
+            self.data_schema = self.format_block_parameter_template_from_workflow_run_context(
+                self.data_schema, workflow_run_context
             )
 
         if self.complete_criterion:

--- a/skyvern/forge/sdk/workflow/models/yaml.py
+++ b/skyvern/forge/sdk/workflow/models/yaml.py
@@ -138,7 +138,7 @@ class TaskBlockYAML(BlockYAML):
     engine: RunEngine = RunEngine.skyvern_v1
     navigation_goal: str | None = None
     data_extraction_goal: str | None = None
-    data_schema: dict[str, Any] | list | None = None
+    data_schema: dict[str, Any] | list | str | None = None
     error_code_mapping: dict[str, str] | None = None
     max_retries: int = 0
     max_steps_per_run: int | None = None
@@ -308,7 +308,7 @@ class ExtractionBlockYAML(BlockYAML):
     url: str | None = None
     title: str = ""
     engine: RunEngine = RunEngine.skyvern_v1
-    data_schema: dict[str, Any] | list | None = None
+    data_schema: dict[str, Any] | list | str | None = None
     max_retries: int = 0
     max_steps_per_run: int | None = None
     parameter_keys: list[str] | None = None


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Parameterize `data_schema` to accept both string and JSON formats across workflow components.
> 
>   - **Behavior**:
>     - `dataSchema` in `convertToNode()` in `workflowEditorUtils.ts` now handles both string and JSON formats.
>     - `JSONSafeOrString()` function added to handle parsing of `dataSchema`.
>     - Removed redundant JSON validation for `dataSchema` in `getWorkflowErrors()`.
>   - **Models**:
>     - Updated `data_schema` type to `Record<string, unknown> | string | null` in `TaskBlock`, `ExtractionBlock` in `workflowTypes.ts` and `block.py`.
>     - Updated `data_schema` type in `TaskBlockYAML`, `ExtractionBlockYAML` in `workflowYamlTypes.ts` and `yaml.py`.
>   - **Misc**:
>     - Adjusted `getWorkflowBlock()` to use `JSONSafeOrString()` for `data_schema` parsing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for a0ea836484006535011058bf30a1fe57e8c6decc. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->