### PR TITLE
Jon/browser session stream

### DIFF
--- a/skyvern/forge/sdk/routes/streaming_clients.py
+++ b/skyvern/forge/sdk/routes/streaming_clients.py
@@ -78,7 +78,7 @@ class CommandChannel:
         if self.websocket.client_state not in (WebSocketState.CONNECTED, WebSocketState.CONNECTING):
             return False
 
-        if not self.workflow_run:
+        if not self.workflow_run and not self.browser_session:
             return False
 
         if not get_command_client(self.client_id):
@@ -231,7 +231,7 @@ class Streaming:
         if self.websocket.client_state not in (WebSocketState.CONNECTED, WebSocketState.CONNECTING):
             return False
 
-        if not self.task and not self.workflow_run:
+        if not self.task and not self.workflow_run and not self.browser_session:
             return False
 
         if not get_streaming_client(self.client_id):


### PR DESCRIPTION
Allow the backend to stream a persistent browser given a browser session id. (Currently it only streams if given a workflow_run_id or task_id.)

This will be useful for folks who connect to a persistent browser session via CDP port, and want to look at the live stream.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add functionality to stream browser sessions using a session ID, expanding streaming capabilities beyond workflow runs and tasks.
> 
>   - **Behavior**:
>     - Add support for streaming browser sessions using `browser_session_id` in `streaming_commands.py` and `streaming_vnc.py`.
>     - Modify `is_open()` in `CommandChannel` and `Streaming` classes in `streaming_clients.py` to check for `browser_session`.
>   - **Functions**:
>     - Add `verify_browser_session()` in `streaming_verify.py` to verify browser session existence and usability.
>     - Add `get_commands_for_browser_session()` and `get_streaming_for_browser_session()` in `streaming_commands.py` and `streaming_vnc.py` respectively.
>     - Add `loop_verify_browser_session()` in `streaming_verify.py` to periodically verify browser session.
>   - **Routes**:
>     - Add WebSocket routes `/stream/commands/browser_session/{browser_session_id}` and `/stream/vnc/browser_session/{browser_session_id}` in `streaming_commands.py` and `streaming_vnc.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for a349131cb141f7f2eaeedaa4dbff433a24e88a7e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->