### PR TITLE
Jon/browser session view

### DIFF
--- a/skyvern-frontend/src/components/browser-stream.css
+++ b/skyvern-frontend/src/components/browser-stream.css
@@ -86,6 +86,10 @@
   animation: skyvern-anim-fadeIn 1s ease-in forwards;
 }
 
+.browser-stream > div {
+  background: transparent !important;
+}
+
 @keyframes skyvern-anim-fadeIn {
   from {
     opacity: 0;

--- a/skyvern-frontend/src/router.tsx
+++ b/skyvern-frontend/src/router.tsx
@@ -1,4 +1,5 @@
 import { Navigate, Outlet, createBrowserRouter } from "react-router-dom";
+import { BrowserSession } from "@/routes/browserSession/BrowserSession";
 import { PageLayout } from "./components/PageLayout";
 import { DiscoverPage } from "./routes/discover/DiscoverPage";
 import { HistoryPage } from "./routes/history/HistoryPage";
@@ -25,6 +26,10 @@ import { WorkflowRunRecording } from "./routes/workflows/workflowRun/WorkflowRun
 import { DebugStoreProvider } from "@/store/DebugStoreContext";
 
 const router = createBrowserRouter([
+  {
+    path: "browser-session/:browserSessionId",
+    element: <BrowserSession />,
+  },
   {
     path: "/",
     element: (

--- a/skyvern-frontend/src/routes/browserSession/BrowserSession.tsx
+++ b/skyvern-frontend/src/routes/browserSession/BrowserSession.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import { BrowserStream } from "@/components/BrowserStream";
+import { getClient } from "@/api/AxiosClient";
+
+import { useQuery } from "@tanstack/react-query";
+import { useCredentialGetter } from "@/hooks/useCredentialGetter";
+
+function BrowserSession() {
+  const { browserSessionId } = useParams();
+  const [hasBrowserSession, setHasBrowserSession] = useState(false);
+
+  const credentialGetter = useCredentialGetter();
+
+  const query = useQuery({
+    queryKey: ["browserSession", browserSessionId],
+    queryFn: async () => {
+      const client = await getClient(credentialGetter, "sans-api-v1");
+
+      try {
+        await client.get(`/browser_sessions/${browserSessionId}`);
+        setHasBrowserSession(true);
+      } catch (error) {
+        setHasBrowserSession(false);
+      }
+    },
+  });
+
+  if (query.isLoading) {
+    return (
+      <div className="h-screen w-full gap-4 p-6">
+        <div className="flex h-full w-full items-center justify-center">
+          {/* we need nice artwork here */}
+          Loading...
+        </div>
+      </div>
+    );
+  }
+
+  if (!hasBrowserSession) {
+    return (
+      <div className="h-screen w-full gap-4 p-6">
+        <div className="flex h-full w-full items-center justify-center">
+          {/* we need nice artwork here */}
+          No browser session found.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-screen w-full gap-4 p-6">
+      <div className="flex h-full w-full items-center justify-center">
+        <BrowserStream browserSessionId={browserSessionId} />
+      </div>
+    </div>
+  );
+}
+
+export { BrowserSession };


### PR DESCRIPTION
Follows https://github.com/Skyvern-AI/skyvern-cloud/pull/5447

- adds `/browser-session/{browserSessionId}` route 
- shows live stream, if it exists

![image](https://github.com/user-attachments/assets/058b05db-b6f0-41aa-9acb-49161e346a59)

If it doesn't exist, then a plain "Browser session not found." is shown. We need some nice artwork, there.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `/browser-session/:browserSessionId` route and updates components to handle browser sessions with live streaming support.
> 
>   - **Routing**:
>     - Adds `/browser-session/:browserSessionId` route in `router.tsx`.
>   - **Components**:
>     - Updates `BrowserStream.tsx` to handle `browserSessionId` and show live stream if available.
>     - Adds `BrowserSession.tsx` to handle fetching and displaying browser session data.
>   - **CSS**:
>     - Updates `browser-stream.css` to ensure transparent background for `.browser-stream > div`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 04e1b6396f70245af40c22f872b5b44a415925d4. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->