### PR TITLE
Webhook callback url -> webhook url

### DIFF
--- a/fern/integrations/workato.mdx
+++ b/fern/integrations/workato.mdx
@@ -61,7 +61,7 @@ slug: integrations/workato
 
 5. *(optional) Extracted Information Schema:* if you have a data extraction goal, some users need it formatted in a certain way for internal purposes. Navigation payload accepts JSON formatted specifications for how the data should be returned
 
-6. *(optional) Webhook Callback URL:* This URL can be specified if you would like Skyvern to notify you when it’s finished executing
+6. *(optional) Webhook URL:* This URL can be specified if you would like Skyvern to notify you when it’s finished executing
 
 7. *(optional) Max Steps:* some users want to cap cost through the number of steps the task can take
 

--- a/fern/integrations/zapier.mdx
+++ b/fern/integrations/zapier.mdx
@@ -40,7 +40,7 @@ slug: integrations/zapier
 
 5. *(optional) Extracted Information Schema:* if you have a data extraction goal, some users need it formatted in a certain way for internal purposes. Navigation payload accepts JSON formatted specifications for how the data should be returned
 
-6. *(optional) Webhook Callback URL:* This URL can be specified if you would like Skyvern to notify you when it’s finished executing
+6. *(optional) Webhook URL:* This URL can be specified if you would like Skyvern to notify you when it’s finished executing
 
 7. *(optional) Max Steps:* some users want to cap cost through the number of steps the task can take
    ![image](../images/zapier/z.3.png)

--- a/fern/openapi/skyvern_openapi.json
+++ b/fern/openapi/skyvern_openapi.json
@@ -9350,7 +9350,7 @@
                 "type": "null"
               }
             ],
-            "title": "Webhook Callback Url"
+            "title": "Webhook Url"
           },
           "totp_verification_url": {
             "anyOf": [
@@ -9493,7 +9493,7 @@
                 "type": "null"
               }
             ],
-            "title": "Webhook Callback Url"
+            "title": "Webhook Url"
           },
           "totp_verification_url": {
             "anyOf": [

--- a/integrations/n8n/nodes/Skyvern/Skyvern.node.ts
+++ b/integrations/n8n/nodes/Skyvern/Skyvern.node.ts
@@ -209,7 +209,7 @@ export class Skyvern implements INodeType {
                 },
             },
             {
-                displayName: 'Webhook Callback URL',
+                displayName: 'Webhook URL',
                 description: 'Optional URL that Skyvern will call when the task finishes',
                 name: 'webhookUrl',
                 type: 'string',
@@ -392,7 +392,7 @@ export class Skyvern implements INodeType {
                 },
             },
             {
-                displayName: 'Webhook Callback URL',
+                displayName: 'Webhook URL',
                 description: 'Optional URL that Skyvern will call when the workflow run finishes',
                 name: 'webhookCallbackUrl',
                 type: 'string',

--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -516,7 +516,7 @@ function CreateNewTaskForm({ initialValues }: Props) {
                       <div className="flex gap-16">
                         <FormLabel>
                           <div className="w-72">
-                            <h1 className="text-lg">Webhook Callback URL</h1>
+                            <h1 className="text-lg">Webhook URL</h1>
                             <h2 className="text-base text-slate-400">
                               The URL of a webhook endpoint to send the
                               extracted information

--- a/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
@@ -372,7 +372,7 @@ function PromptBox() {
                   <header>Advanced Settings</header>
                   <div className="flex gap-16">
                     <div className="w-48 shrink-0">
-                      <div className="text-sm">Webhook Callback URL</div>
+                      <div className="text-sm">Webhook URL</div>
                       <div className="text-xs text-slate-400">
                         The URL of a webhook endpoint to send the extracted
                         information

--- a/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
@@ -618,7 +618,7 @@ function SavedTaskForm({ initialValues }: Props) {
                       <div className="flex gap-16">
                         <FormLabel>
                           <div className="w-72">
-                            <h1 className="text-lg">Webhook Callback URL</h1>
+                            <h1 className="text-lg">Webhook URL</h1>
                             <h2 className="text-base text-slate-400">
                               The URL of a webhook endpoint to send the
                               extracted information

--- a/skyvern-frontend/src/routes/tasks/detail/TaskParameters.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/TaskParameters.tsx
@@ -138,7 +138,7 @@ function TaskParameters() {
       </div>
       <div className="flex gap-16">
         <div className="w-72">
-          <h1 className="text-lg">Webhook Callback URL</h1>
+          <h1 className="text-lg">Webhook URL</h1>
           <h2 className="text-base text-slate-400">
             The URL of a webhook endpoint to send the extracted information
           </h2>

--- a/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
+++ b/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
@@ -331,7 +331,7 @@ function RunWorkflowForm({
                     <FormLabel>
                       <div className="w-72">
                         <div className="flex items-center gap-2 text-lg">
-                          Webhook Callback URL
+                          Webhook URL
                         </div>
                         <h2 className="text-sm text-slate-400">
                           The URL of a webhook endpoint to send the details of

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
@@ -105,7 +105,7 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
                     </div>
                     <div className="space-y-2">
                       <div className="flex gap-2">
-                        <Label>Webhook Callback URL</Label>
+                        <Label>Webhook URL</Label>
                         <HelpTooltip content="The URL of a webhook endpoint to send the workflow results" />
                       </div>
                       <Input

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowPostRunParameters.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowPostRunParameters.tsx
@@ -137,7 +137,7 @@ function WorkflowPostRunParameters() {
           <h1 className="text-lg font-bold">Other Workflow Parameters</h1>
           <div className="flex gap-16">
             <div className="w-80">
-              <h1 className="text-lg">Webhook Callback URL</h1>
+              <h1 className="text-lg">Webhook URL</h1>
             </div>
             <Input value={webhookCallbackUrl ?? ""} readOnly />
           </div>

--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -2149,7 +2149,7 @@ class ForgeAgent:
         browser_session_id: str | None = None,
     ) -> None:
         """
-        send the task response to the webhook callback url
+        send the task response to the webhook url
         """
         # refresh the task from the db to get the latest status
         try:
@@ -2258,7 +2258,7 @@ class ForgeAgent:
 
         if not task.webhook_callback_url:
             LOG.warning(
-                "Task has no webhook callback url. Not sending task response",
+                "Task has no webhook url. Not sending task response",
                 task_id=task.task_id,
             )
             return
@@ -2274,7 +2274,7 @@ class ForgeAgent:
             if run_response is not None:
                 task_run_response_json = run_response.model_dump_json(exclude={"run_request"})
 
-            # send task_response to the webhook callback url
+            # send task_response to the webhook url
             payload_json = task_response.model_dump_json(exclude={"request"})
             payload_dict = json.loads(payload_json)
             if task_run_response_json:
@@ -2282,7 +2282,7 @@ class ForgeAgent:
             payload = json.dumps(payload_dict, separators=(",", ":"), ensure_ascii=False)
             headers = generate_skyvern_webhook_headers(payload=payload, api_key=api_key)
             LOG.info(
-                "Sending task response to webhook callback url",
+                "Sending task response to webhook url",
                 task_id=task.task_id,
                 webhook_callback_url=task.webhook_callback_url,
                 payload=payload,
@@ -2420,7 +2420,7 @@ class ForgeAgent:
         This function should handle exceptions gracefully.
         If errors are raised and not caught inside this function, please catch and handle them.
         """
-        # We need to close the browser even if there is no webhook callback url or api key
+        # We need to close the browser even if there is no webhook url or api key
         browser_state = await app.BROWSER_MANAGER.cleanup_for_task(
             task.task_id,
             close_browser_on_completion,

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -1319,7 +1319,7 @@ class WorkflowService:
 
         if not workflow_run.webhook_callback_url:
             LOG.warning(
-                "Workflow has no webhook callback url. Not sending workflow response",
+                "Workflow has no webhook url. Not sending workflow response",
                 workflow_id=workflow_id,
                 workflow_run_id=workflow_run.workflow_run_id,
             )
@@ -1369,7 +1369,7 @@ class WorkflowService:
             api_key=api_key,
         )
         LOG.info(
-            "Sending webhook run status to webhook callback url",
+            "Sending webhook run status to webhook url",
             workflow_id=workflow_id,
             workflow_run_id=workflow_run.workflow_run_id,
             webhook_callback_url=workflow_run.webhook_callback_url,

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -1693,7 +1693,7 @@ async def send_task_v2_webhook(task_v2: TaskV2) -> None:
         payload = json.dumps(payload_dict, separators=(",", ":"), ensure_ascii=False)
         headers = generate_skyvern_webhook_headers(payload=payload, api_key=api_key.token)
         LOG.info(
-            "Sending task v2 response to webhook callback url",
+            "Sending task v2 response to webhook url",
             task_v2_id=task_v2.observer_cruise_id,
             webhook_callback_url=task_v2.webhook_callback_url,
             payload=payload,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename 'Webhook Callback URL' to 'Webhook URL' across documentation, frontend, and backend for consistency.
> 
>   - **Renames**:
>     - Rename 'Webhook Callback URL' to 'Webhook URL' in `fern/integrations/workato.mdx`, `fern/integrations/zapier.mdx`, and `skyvern_openapi.json`.
>     - Update `displayName` and `description` in `Skyvern.node.ts`.
>     - Change labels in `CreateNewTaskForm.tsx`, `PromptBox.tsx`, `SavedTaskForm.tsx`, `TaskParameters.tsx`, `RunWorkflowForm.tsx`, `StartNode.tsx`, and `WorkflowPostRunParameters.tsx`.
>     - Update comments and logging messages in `agent.py` and `service.py`.
>   - **Behavior**:
>     - No functional changes; purely a terminology update for clarity and consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 53a1224de3b1c2e9a320a7b7536a38e6d4b00369. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->