### PR TITLE
add browser session to debug store; use new cancel endpoint from #5450

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
@@ -267,9 +267,12 @@ function NodeHeader({
 
   const cancelBlock = useMutation({
     mutationFn: async () => {
+      const browserSessionId =
+        debugStore.getCurrentBrowserSessionId() ??
+        "<missing-browser-session-id>";
       const client = await getClient(credentialGetter);
       return client
-        .post(`/workflows/runs/${workflowRunId}/cancel`)
+        .post(`/runs/${browserSessionId}/workflow_run/${workflowRunId}/cancel/`)
         .then((response) => response.data);
     },
     onSuccess: () => {

--- a/skyvern-frontend/src/store/DebugStoreContext.tsx
+++ b/skyvern-frontend/src/store/DebugStoreContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useMemo } from "react";
 import { useLocation } from "react-router-dom";
+import { lsKeys } from "@/util/env";
 
 function useIsDebugMode() {
   const location = useLocation();
@@ -9,8 +10,23 @@ function useIsDebugMode() {
   );
 }
 
+function getCurrentBrowserSessionId() {
+  const stored = localStorage.getItem(lsKeys.optimisticBrowserSession);
+  let browserSessionId: string | null = null;
+  try {
+    const parsed = JSON.parse(stored ?? "");
+    const { browser_session_id } = parsed;
+    browserSessionId = browser_session_id as string;
+  } catch {
+    // pass
+  }
+
+  return browserSessionId;
+}
+
 export type DebugStoreContextType = {
   isDebugMode: boolean;
+  getCurrentBrowserSessionId: () => string | null;
 };
 
 export const DebugStoreContext = createContext<
@@ -23,7 +39,9 @@ export const DebugStoreProvider: React.FC<{ children: React.ReactNode }> = ({
   const isDebugMode = useIsDebugMode();
 
   return (
-    <DebugStoreContext.Provider value={{ isDebugMode }}>
+    <DebugStoreContext.Provider
+      value={{ isDebugMode, getCurrentBrowserSessionId }}
+    >
       {children}
     </DebugStoreContext.Provider>
   );


### PR DESCRIPTION
Follows https://github.com/Skyvern-AI/skyvern-cloud/pull/5450
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Integrate browser session ID retrieval in debug store and update cancel endpoint in `NodeHeader.tsx`.
> 
>   - **Behavior**:
>     - Update `cancelBlock` mutation in `NodeHeader.tsx` to use new cancel endpoint `/runs/{browserSessionId}/workflow_run/{workflowRunId}/cancel/`.
>     - Fetch `browserSessionId` using `getCurrentBrowserSessionId()` from `DebugStoreContext`.
>   - **Debug Store**:
>     - Add `getCurrentBrowserSessionId()` function to `DebugStoreContext.tsx` to retrieve browser session ID from local storage.
>     - Include `getCurrentBrowserSessionId` in `DebugStoreContext` provider value.
>   - **Misc**:
>     - Add import for `lsKeys` in `DebugStoreContext.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2df453dca9f1fd4aecfe90f5eaa5965b6b7d122f. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->