### PR TITLE
update run_task to make it possible to expose ecs task publicly

### DIFF
--- a/skyvern/forge/sdk/api/aws.py
+++ b/skyvern/forge/sdk/api/aws.py
@@ -268,6 +268,7 @@ class AsyncAWSClient:
         task_definition: str,
         subnets: list[str],
         security_groups: list[str],
+        assign_public_ip: str = "DISABLED",
     ) -> dict:
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs/client/run_task.html
         async with self._ecs_client() as client:
@@ -279,7 +280,7 @@ class AsyncAWSClient:
                     "awsvpcConfiguration": {
                         "subnets": subnets,
                         "securityGroups": security_groups,
-                        "assignPublicIp": "DISABLED",
+                        "assignPublicIp": assign_public_ip,
                     }
                 },
             )


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `assign_public_ip` parameter to `run_task()` in `aws.py` to allow Fargate tasks to be exposed publicly.
> 
>   - **Behavior**:
>     - Adds `assign_public_ip` parameter to `run_task()` in `aws.py`, defaulting to "DISABLED".
>     - Allows Fargate tasks to be exposed publicly by setting `assign_public_ip` to "ENABLED".
>   - **Misc**:
>     - Updates `run_task()` network configuration to use `assign_public_ip` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a33347417689ea95af935967f5487bd6d0d3779e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->