### PR TITLE
add ec2 to aws client

### DIFF
--- a/skyvern/forge/sdk/api/aws.py
+++ b/skyvern/forge/sdk/api/aws.py
@@ -4,6 +4,7 @@ from urllib.parse import urlparse
 
 import aioboto3
 import structlog
+from types_boto3_ec2.client import EC2Client
 from types_boto3_ecs.client import ECSClient
 from types_boto3_s3.client import S3Client
 from types_boto3_secretsmanager.client import SecretsManagerClient
@@ -29,6 +30,7 @@ class AWSClientType(StrEnum):
     S3 = "s3"
     SECRETS_MANAGER = "secretsmanager"
     ECS = "ecs"
+    EC2 = "ec2"
 
 
 class AsyncAWSClient:
@@ -56,6 +58,9 @@ class AsyncAWSClient:
 
     def _s3_client(self) -> S3Client:
         return self.session.client(AWSClientType.S3, region_name=self.region_name, endpoint_url=self._endpoint_url)
+
+    def _ec2_client(self) -> EC2Client:
+        return self.session.client(AWSClientType.EC2, region_name=self.region_name, endpoint_url=self._endpoint_url)
 
     def _create_tag_string(self, tags: dict[str, str]) -> str:
         return "&".join([f"{k}={v}" for k, v in tags.items()])
@@ -311,6 +316,12 @@ class AsyncAWSClient:
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ecs/client/deregister_task_definition.html
         async with self._ecs_client() as client:
             return await client.deregister_task_definition(taskDefinition=task_definition)
+
+    ###### EC2 ######
+    async def describe_network_interfaces(self, network_interface_ids: list[str]) -> dict:
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/describe_network_interfaces.html
+        async with self._ec2_client() as client:
+            return await client.describe_network_interfaces(NetworkInterfaceIds=network_interface_ids)
 
 
 class S3Uri:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add EC2 client support to `AsyncAWSClient` in `aws.py`, including a method to describe network interfaces.
> 
>   - **EC2 Client Addition**:
>     - Import `EC2Client` from `types_boto3_ec2.client` in `aws.py`.
>     - Add `EC2` to `AWSClientType` enum.
>     - Implement `_ec2_client()` method in `AsyncAWSClient` to create EC2 client.
>   - **New Functionality**:
>     - Add `describe_network_interfaces()` method in `AsyncAWSClient` to describe EC2 network interfaces using `describe_network_interfaces` API.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c3ac9281fefadb9d53ffd943ebe17d46aacfffb5. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->