### PR TITLE
Enhanced Workflow Templates & Editor Cancel Button

### DIFF
--- a/skyvern-frontend/src/routes/discover/RepoSettings.tsx
+++ b/skyvern-frontend/src/routes/discover/RepoSettings.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  setWorkflowTemplatesRepo,
+  setWorkflowTemplatesDir,
+} from "./hooks/useLocalWorkflowTemplates";
+
+interface RepoSettingsProps {
+  currentRepo: string;
+  currentDir: string;
+  onSettingsChange: () => void;
+}
+
+export function RepoSettings({
+  currentRepo,
+  currentDir,
+  onSettingsChange,
+}: RepoSettingsProps) {
+  const [repo, setRepo] = useState(currentRepo);
+  const [dir, setDir] = useState(currentDir);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleSave = () => {
+    setWorkflowTemplatesRepo(repo);
+    setWorkflowTemplatesDir(dir);
+    onSettingsChange();
+    setIsOpen(false);
+  };
+
+  if (!isOpen) {
+    return (
+      <button
+        onClick={() => setIsOpen(true)}
+        className="shrink-0 text-xs text-slate-400 transition-colors hover:text-slate-300"
+        title="Change repository and directory"
+      >
+        📁 {currentRepo}/{currentDir}
+      </button>
+    );
+  }
+
+  return (
+    <div className="relative shrink-0">
+      {/* Hidden placeholder to maintain layout */}
+      <div className="invisible text-xs">
+        📁 {currentRepo}/{currentDir}
+      </div>
+
+      {/* Actual form positioned absolutely */}
+      <div className="absolute right-0 top-0 z-10 flex min-w-[300px] flex-col gap-2 rounded border bg-slate-800 p-3 shadow-lg">
+        <div className="text-xs font-medium text-slate-300">
+          Workflow Templates Source
+        </div>
+
+        <div>
+          <label className="mb-1 block text-xs text-slate-400">
+            Repository (owner/name)
+          </label>
+          <Input
+            value={repo}
+            onChange={(e) => setRepo(e.target.value)}
+            placeholder="owner/repository"
+            className="h-8 text-xs"
+          />
+        </div>
+
+        <div>
+          <label className="mb-1 block text-xs text-slate-400">Directory</label>
+          <Input
+            value={dir}
+            onChange={(e) => setDir(e.target.value)}
+            placeholder="path/to/templates"
+            className="h-8 text-xs"
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button onClick={handleSave} size="sm" className="h-8">
+            Save
+          </Button>
+          <Button
+            onClick={() => setIsOpen(false)}
+            variant="outline"
+            size="sm"
+            className="h-8"
+          >
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/skyvern-frontend/src/routes/discover/WorkflowTemplateCard.tsx
+++ b/skyvern-frontend/src/routes/discover/WorkflowTemplateCard.tsx
@@ -2,22 +2,60 @@ type Props = {
   title: string;
   image: string;
   onClick: () => void;
+  description?: string;
+  onSave?: () => void;
+  showSaveButton?: boolean;
 };
 
-function WorkflowTemplateCard({ title, image, onClick }: Props) {
+function WorkflowTemplateCard({
+  title,
+  image,
+  onClick,
+  description,
+  onSave,
+  showSaveButton = false,
+}: Props) {
   return (
-    <div className="h-48 w-56 cursor-pointer rounded-xl" onClick={onClick}>
-      <div className="h-28 rounded-t-xl bg-slate-elevation1 px-6 pt-6">
+    <div className="h-56 w-56 cursor-pointer rounded-xl">
+      <div
+        className="h-28 rounded-t-xl bg-slate-elevation1 px-6 pt-6"
+        onClick={onClick}
+      >
         <img src={image} alt={title} className="h-full w-full object-contain" />
       </div>
-      <div className="h-20 space-y-1 rounded-b-xl bg-slate-elevation2 p-3">
+      <div className="h-28 space-y-2 rounded-b-xl bg-slate-elevation2 p-3">
         <h1
-          className="overflow-hidden text-ellipsis whitespace-nowrap"
+          className="overflow-hidden text-ellipsis whitespace-nowrap font-medium"
           title={title}
+          onClick={onClick}
         >
           {title}
         </h1>
-        <p className="text-sm text-slate-400">Template</p>
+        {description ? (
+          <p
+            className="line-clamp-2 text-xs text-slate-400"
+            title={description}
+            onClick={onClick}
+          >
+            {description}
+          </p>
+        ) : (
+          <p className="text-sm text-slate-400" onClick={onClick}>
+            Template
+          </p>
+        )}
+
+        {showSaveButton && onSave && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onSave();
+            }}
+            className="mt-2 w-full rounded bg-blue-600 px-3 py-1.5 text-sm text-white transition-colors hover:bg-blue-700"
+          >
+            Save to Workflows
+          </button>
+        )}
       </div>
     </div>
   );

--- a/skyvern-frontend/src/routes/discover/WorkflowTemplatePreview.tsx
+++ b/skyvern-frontend/src/routes/discover/WorkflowTemplatePreview.tsx
@@ -1,0 +1,63 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { WorkflowTemplate } from "./hooks/useLocalWorkflowTemplates";
+
+interface WorkflowTemplatePreviewProps {
+  template: WorkflowTemplate | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onSave?: () => void;
+}
+
+export function WorkflowTemplatePreview({
+  template,
+  isOpen,
+  onClose,
+  onSave,
+}: WorkflowTemplatePreviewProps) {
+  if (!template) return null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="flex max-h-[80vh] max-w-4xl flex-col">
+        <DialogHeader>
+          <DialogTitle>{template.title}</DialogTitle>
+          <DialogDescription>{template.description}</DialogDescription>
+        </DialogHeader>
+
+        <div className="min-h-0 flex-1">
+          <div className="h-full rounded-md border">
+            <div className="border-b bg-slate-100 px-3 py-2 dark:bg-slate-800">
+              <span className="font-mono text-xs text-slate-600 dark:text-slate-400">
+                {template.name}.yaml
+              </span>
+            </div>
+            <div className="h-full overflow-auto p-4">
+              <pre className="whitespace-pre-wrap font-mono text-sm text-slate-900 dark:text-slate-100">
+                {template.content}
+              </pre>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter className="flex gap-2">
+          <Button variant="outline" onClick={onClose}>
+            Close
+          </Button>
+          {onSave && (
+            <Button onClick={onSave} className="bg-blue-600 hover:bg-blue-700">
+              Save to Workflows
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/skyvern-frontend/src/routes/discover/WorkflowTemplates.tsx
+++ b/skyvern-frontend/src/routes/discover/WorkflowTemplates.tsx
@@ -1,48 +1,187 @@
 import { Skeleton } from "@/components/ui/skeleton";
 import { useGlobalWorkflowsQuery } from "../workflows/hooks/useGlobalWorkflowsQuery";
+import {
+  useLocalWorkflowTemplates,
+  getCurrentRepo,
+  getCurrentTemplatesDir,
+  WorkflowTemplate,
+} from "./hooks/useLocalWorkflowTemplates";
+import { RepoSettings } from "./RepoSettings";
+import { WorkflowTemplatePreview } from "./WorkflowTemplatePreview";
 import { useNavigate } from "react-router-dom";
 import { WorkflowTemplateCard } from "./WorkflowTemplateCard";
 import testImg from "@/assets/promptBoxBg.png";
 import { TEMPORARY_TEMPLATE_IMAGES } from "./TemporaryTemplateImages";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCredentialGetter } from "@/hooks/useCredentialGetter";
+import { getClient } from "@/api/AxiosClient";
+import { toast } from "@/components/ui/use-toast";
+import { WorkflowApiResponse } from "../workflows/types/workflowTypes";
+import { useState } from "react";
 
 function WorkflowTemplates() {
-  const { data: workflowTemplates, isLoading } = useGlobalWorkflowsQuery();
+  const { data: workflowTemplates, isLoading: workflowsLoading } =
+    useGlobalWorkflowsQuery();
+  const {
+    data: githubTemplates,
+    isLoading: templatesLoading,
+    refetch,
+  } = useLocalWorkflowTemplates();
   const navigate = useNavigate();
+  const credentialGetter = useCredentialGetter();
+  const queryClient = useQueryClient();
 
-  if (isLoading) {
+  // Get current repository and directory
+  const currentRepo = getCurrentRepo();
+  const currentDir = getCurrentTemplatesDir();
+
+  // State for template preview modal
+  const [previewTemplate, setPreviewTemplate] =
+    useState<WorkflowTemplate | null>(null);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+
+  // Mutation to save template as workflow
+  const saveTemplateMutation = useMutation({
+    mutationFn: async (yamlContent: string) => {
+      const client = await getClient(credentialGetter);
+      return client.post<string, { data: WorkflowApiResponse }>(
+        "/workflows",
+        yamlContent,
+        {
+          headers: {
+            "Content-Type": "text/plain",
+          },
+        },
+      );
+    },
+    onSuccess: (response) => {
+      queryClient.invalidateQueries({
+        queryKey: ["workflows"],
+      });
+      toast({
+        variant: "success",
+        title: "Template saved",
+        description: "Template has been saved to your workflows",
+      });
+      navigate(`/workflows/${response.data.workflow_permanent_id}/edit`);
+    },
+    onError: (error) => {
+      toast({
+        variant: "destructive",
+        title: "Failed to save template",
+        description: error.message || "An error occurred",
+      });
+    },
+  });
+
+  // Helper functions for template preview
+  const openTemplatePreview = (template: WorkflowTemplate) => {
+    setPreviewTemplate(template);
+    setIsPreviewOpen(true);
+  };
+
+  const closeTemplatePreview = () => {
+    setIsPreviewOpen(false);
+    setPreviewTemplate(null);
+  };
+
+  const savePreviewedTemplate = () => {
+    if (previewTemplate) {
+      saveTemplateMutation.mutate(previewTemplate.content);
+      closeTemplatePreview();
+    }
+  };
+
+  if (workflowsLoading || templatesLoading) {
     return (
-      <div className="flex gap-6">
-        <Skeleton className="h-48 w-56 rounded-xl" />
-        <Skeleton className="h-48 w-56 rounded-xl" />
-        <Skeleton className="h-48 w-56 rounded-xl" />
+      <div className="space-y-5">
+        <h1 className="text-xl">Explore Workflows</h1>
+        <div className="flex gap-6">
+          <Skeleton className="h-56 w-56 rounded-xl" />
+          <Skeleton className="h-56 w-56 rounded-xl" />
+          <Skeleton className="h-56 w-56 rounded-xl" />
+        </div>
       </div>
     );
   }
 
-  if (!workflowTemplates) {
-    return null;
-  }
-
   return (
-    <div className="space-y-5">
+    <div className="space-y-8">
       <h1 className="text-xl">Explore Workflows</h1>
-      <div className="flex gap-6">
-        {workflowTemplates.map((workflow) => {
-          return (
-            <WorkflowTemplateCard
-              key={workflow.workflow_permanent_id}
-              title={workflow.title}
-              image={
-                TEMPORARY_TEMPLATE_IMAGES[workflow.workflow_permanent_id] ??
-                testImg
-              }
-              onClick={() => {
-                navigate(`/workflows/${workflow.workflow_permanent_id}/edit`);
-              }}
-            />
-          );
-        })}
+
+      {/* GitHub Templates Section */}
+      <div className="space-y-4">
+        <div className="flex min-h-[32px] items-start justify-between">
+          <h2 className="text-lg font-medium text-slate-300">
+            Community Templates
+          </h2>
+          <RepoSettings
+            currentRepo={currentRepo}
+            currentDir={currentDir}
+            onSettingsChange={() => refetch()}
+          />
+        </div>
+
+        {githubTemplates && githubTemplates.length > 0 ? (
+          <div className="flex gap-6 overflow-x-auto pb-2">
+            {githubTemplates.map((template) => (
+              <WorkflowTemplateCard
+                key={template.name}
+                title={template.title}
+                description={template.description}
+                image={testImg}
+                showSaveButton={true}
+                onSave={() => saveTemplateMutation.mutate(template.content)}
+                onClick={() => openTemplatePreview(template)}
+              />
+            ))}
+          </div>
+        ) : templatesLoading ? (
+          <div className="flex gap-6">
+            {[1, 2, 3].map((i) => (
+              <Skeleton key={i} className="h-48 w-80" />
+            ))}
+          </div>
+        ) : (
+          <div className="py-4 text-center text-slate-500">
+            <p>No templates found in the configured repository.</p>
+            <p className="mt-1 text-sm">
+              Check your repository and directory settings above.
+            </p>
+          </div>
+        )}
       </div>
+
+      {/* Your Workflows Section */}
+      {/* Your Workflows Section */}
+      {workflowTemplates && workflowTemplates.length > 0 && (
+        <div className="space-y-4">
+          <h2 className="text-lg font-medium text-slate-300">Your Workflows</h2>
+          <div className="flex gap-6 overflow-x-auto pb-2">
+            {workflowTemplates.map((workflow) => (
+              <WorkflowTemplateCard
+                key={workflow.workflow_permanent_id}
+                title={workflow.title}
+                image={
+                  TEMPORARY_TEMPLATE_IMAGES[workflow.workflow_permanent_id] ??
+                  testImg
+                }
+                onClick={() => {
+                  navigate(`/workflows/${workflow.workflow_permanent_id}/edit`);
+                }}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Template Preview Modal */}
+      <WorkflowTemplatePreview
+        template={previewTemplate}
+        isOpen={isPreviewOpen}
+        onClose={closeTemplatePreview}
+        onSave={savePreviewedTemplate}
+      />
     </div>
   );
 }

--- a/skyvern-frontend/src/routes/discover/hooks/useLocalWorkflowTemplates.ts
+++ b/skyvern-frontend/src/routes/discover/hooks/useLocalWorkflowTemplates.ts
@@ -1,0 +1,124 @@
+import { useQuery } from "@tanstack/react-query";
+
+export interface WorkflowTemplate {
+  name: string;
+  title: string;
+  description: string;
+  content: string; // Raw YAML content
+}
+
+// Default repo and directory - can be configured
+const DEFAULT_REPO = "dvloper-Iustin/skyvern";
+const DEFAULT_TEMPLATES_DIR = "skyvern-frontend/workflow-templates";
+
+function getRepoUrl(): string {
+  // Get from localStorage or use default
+  if (typeof window !== "undefined") {
+    return localStorage.getItem("workflow-templates-repo") || DEFAULT_REPO;
+  }
+  return DEFAULT_REPO;
+}
+
+function getTemplatesDir(): string {
+  // Get from localStorage or use default
+  if (typeof window !== "undefined") {
+    return (
+      localStorage.getItem("workflow-templates-dir") || DEFAULT_TEMPLATES_DIR
+    );
+  }
+  return DEFAULT_TEMPLATES_DIR;
+}
+
+async function fetchWorkflowTemplates(): Promise<WorkflowTemplate[]> {
+  try {
+    const repo = getRepoUrl();
+    const templatesDir = getTemplatesDir();
+
+    // Fetch directory contents from GitHub API
+    const response = await fetch(
+      `https://api.github.com/repos/${repo}/contents/${templatesDir}`,
+    );
+
+    if (!response.ok) {
+      console.warn("No workflow templates directory found");
+      return [];
+    }
+
+    const files = await response.json();
+
+    if (!Array.isArray(files)) {
+      return [];
+    }
+
+    const templates: WorkflowTemplate[] = [];
+
+    // Fetch each YAML file
+    for (const file of files) {
+      if (file.type === "file" && file.name.endsWith(".yaml")) {
+        try {
+          // Fetch raw content
+          const contentResponse = await fetch(
+            `https://raw.githubusercontent.com/${repo}/main/${templatesDir}/${file.name}`,
+          );
+
+          if (contentResponse.ok) {
+            const content = await contentResponse.text();
+
+            // Parse title and description from YAML
+            const titleMatch = content.match(/^title:\s*(.+)$/m);
+            const descriptionMatch = content.match(/^description:\s*(.+)$/m);
+
+            const name = file.name.replace(/\.yaml$/, "");
+
+            templates.push({
+              name,
+              title: titleMatch?.[1]?.trim() || name.replace(/[-_]/g, " "),
+              description: descriptionMatch?.[1]?.trim() || "No description",
+              content,
+            });
+          }
+        } catch (error) {
+          console.warn(`Failed to load template ${file.name}:`, error);
+        }
+      }
+    }
+
+    return templates;
+  } catch (error) {
+    console.warn("Failed to fetch workflow templates:", error);
+    return [];
+  }
+}
+
+export function useLocalWorkflowTemplates() {
+  return useQuery<WorkflowTemplate[]>({
+    queryKey: ["localWorkflowTemplates", getRepoUrl(), getTemplatesDir()],
+    queryFn: fetchWorkflowTemplates,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    gcTime: 30 * 60 * 1000, // 30 minutes
+  });
+}
+
+// Function to update the repository
+export function setWorkflowTemplatesRepo(repo: string): void {
+  if (typeof window !== "undefined") {
+    localStorage.setItem("workflow-templates-repo", repo);
+  }
+}
+
+// Function to update the templates directory
+export function setWorkflowTemplatesDir(dir: string): void {
+  if (typeof window !== "undefined") {
+    localStorage.setItem("workflow-templates-dir", dir);
+  }
+}
+
+// Function to get current repository (for UI)
+export function getCurrentRepo(): string {
+  return getRepoUrl();
+}
+
+// Function to get current templates directory (for UI)
+export function getCurrentTemplatesDir(): string {
+  return getTemplatesDir();
+}

--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -35,7 +35,7 @@ import "@xyflow/react/dist/style.css";
 import { AxiosError } from "axios";
 import { nanoid } from "nanoid";
 import { useEffect, useRef, useState } from "react";
-import { useBlocker, useParams } from "react-router-dom";
+import { useBlocker, useNavigate, useParams } from "react-router-dom";
 import { stringify as convertToYAML } from "yaml";
 import {
   AWSSecretParameter,
@@ -262,6 +262,7 @@ function FlowRenderer({
   const reactFlowInstance = useReactFlow();
   const debugStore = useDebugStore();
   const { workflowPermanentId } = useParams();
+  const navigate = useNavigate();
   const credentialGetter = useCredentialGetter();
   const queryClient = useQueryClient();
   const { workflowPanelState, setWorkflowPanelState, closeWorkflowPanel } =
@@ -801,6 +802,12 @@ function FlowRenderer({
                     return;
                   }
                   await handleSave();
+                }}
+                onCancel={() => {
+                  // Reset hasChanges to prevent the beforeunload warning
+                  setHasChanges(false);
+                  // Navigate back to the workflow runs page
+                  navigate(`/workflows/${workflow.workflow_permanent_id}/runs`);
                 }}
               />
             </Panel>

--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
@@ -10,6 +10,7 @@ import {
   ChevronDownIcon,
   ChevronUpIcon,
   CopyIcon,
+  Cross2Icon,
   Crosshair1Icon,
   PlayIcon,
   ReloadIcon,
@@ -28,6 +29,7 @@ type Props = {
   parametersPanelOpen: boolean;
   onParametersClick: () => void;
   onSave: () => void;
+  onCancel: () => void;
   onTitleChange: (title: string) => void;
   saving: boolean;
 };
@@ -38,6 +40,7 @@ function WorkflowHeader({
   parametersPanelOpen,
   onParametersClick,
   onSave,
+  onCancel,
   onTitleChange,
   saving,
 }: Props) {
@@ -132,6 +135,24 @@ function WorkflowHeader({
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>Save</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="icon"
+                    variant="tertiary"
+                    className="size-10"
+                    disabled={isGlobalWorkflow}
+                    onClick={() => {
+                      onCancel();
+                    }}
+                  >
+                    <Cross2Icon className="size-6" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Cancel</TooltipContent>
               </Tooltip>
             </TooltipProvider>
             <Button variant="tertiary" size="lg" onClick={onParametersClick}>


### PR DESCRIPTION
Adds configurable GitHub workflow templates and a cancel button for the workflow editor to improve the development workflow experience.

- GitHub Templates Integration: Configure any GitHub repo/directory to fetch workflow templates
- Template Preview: Click templates to preview YAML content before importing
- One-Click Import: Save templates directly to workflows with "Save to Workflows" button
- Editor Cancel Button: Discard unsaved changes without auto-saving when exiting editor
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance workflow editor with GitHub template integration and a cancel button to discard unsaved changes.
> 
>   - **GitHub Workflow Templates**:
>     - Add `RepoSettings` component to configure GitHub repo and directory for workflow templates.
>     - Add `WorkflowTemplateCard` to display templates with preview and save options.
>     - Add `WorkflowTemplatePreview` for YAML content preview before importing.
>     - Fetch templates from GitHub in `useLocalWorkflowTemplates` hook.
>   - **Editor Enhancements**:
>     - Add cancel button in `WorkflowHeader` to discard unsaved changes in `FlowRenderer`.
>     - Update `FlowRenderer` to handle cancel action by navigating back to workflow runs.
>   - **Misc**:
>     - Add mutation in `WorkflowTemplates.tsx` to save templates as workflows.
>     - Update `WorkflowTemplates.tsx` to include GitHub templates section with preview and save functionalities.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9b3ff03e4fd36b2814d34ea32aa4d0c7ea41f505. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->