### PR TITLE
add session pool

### DIFF
--- a/skyvern/schemas/browser_sessions.py
+++ b/skyvern/schemas/browser_sessions.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, Field
 
 MIN_TIMEOUT = 5
-MAX_TIMEOUT = 10080
+MAX_TIMEOUT = 120
 DEFAULT_TIMEOUT = 60
 
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reduces `MAX_TIMEOUT` to 120 in `skyvern/schemas/browser_sessions.py`, affecting session timeout limits in `CreateBrowserSessionRequest`.
> 
>   - **Behavior**:
>     - Reduces `MAX_TIMEOUT` from 10080 to 120 in `skyvern/schemas/browser_sessions.py`.
>     - Affects `CreateBrowserSessionRequest` class, limiting session timeout to a maximum of 120 minutes.
>   - **Documentation**:
>     - Updates `timeout` field description in `CreateBrowserSessionRequest` to reflect new `MAX_TIMEOUT`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 66cefda61466bc7b3f29b3077f07317d4e5025f2. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->