### PR TITLE
rewrite WS url more robustly

### DIFF
--- a/skyvern-frontend/src/components/BrowserStream.tsx
+++ b/skyvern-frontend/src/components/BrowserStream.tsx
@@ -8,18 +8,14 @@ import { useCredentialGetter } from "@/hooks/useCredentialGetter";
 import { envCredential } from "@/util/env";
 import { toast } from "@/components/ui/use-toast";
 import RFB from "@novnc/novnc/lib/rfb.js";
-import { environment } from "@/util/env";
+import { environment, wssBaseUrl, newWssBaseUrl } from "@/util/env";
 import { cn } from "@/util/utils";
 import { useClientIdStore } from "@/store/useClientIdStore";
 import type {
   TaskApiResponse,
   WorkflowRunStatusApiResponse,
 } from "@/api/types";
-
 import "./browser-stream.css";
-
-const wssBaseUrl = import.meta.env.VITE_WSS_BASE_URL;
-const newWssBaseUrl = wssBaseUrl.replace("/api", "");
 
 interface CommandTakeControl {
   kind: "take-control";

--- a/skyvern-frontend/src/routes/browserSession/BrowserSession.tsx
+++ b/skyvern-frontend/src/routes/browserSession/BrowserSession.tsx
@@ -20,8 +20,10 @@ function BrowserSession() {
       try {
         await client.get(`/browser_sessions/${browserSessionId}`);
         setHasBrowserSession(true);
+        return true;
       } catch (error) {
         setHasBrowserSession(false);
+        return false;
       }
     },
   });

--- a/skyvern-frontend/src/util/env.ts
+++ b/skyvern-frontend/src/util/env.ts
@@ -26,6 +26,19 @@ const lsKeys = {
   optimisticBrowserSession: "skyvern.optimisticBrowserSession",
 };
 
+const wssBaseUrl = import.meta.env.VITE_WSS_BASE_URL;
+
+let newWssBaseUrl = wssBaseUrl;
+try {
+  const url = new URL(wssBaseUrl);
+  if (url.pathname.startsWith("/api")) {
+    url.pathname = url.pathname.replace(/^\/api/, "");
+  }
+  newWssBaseUrl = url.toString();
+} catch (e) {
+  newWssBaseUrl = wssBaseUrl.replace("/api", "");
+}
+
 export {
   apiBaseUrl,
   environment,
@@ -33,4 +46,6 @@ export {
   artifactApiBaseUrl,
   apiPathPrefix,
   lsKeys,
+  wssBaseUrl,
+  newWssBaseUrl,
 };


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Rewrite WebSocket URL handling in `env.ts` for robustness and update `BrowserStream.tsx` to use the new URL logic.
> 
>   - **WebSocket URL Handling**:
>     - Introduced `newWssBaseUrl` in `env.ts` to robustly rewrite WebSocket URLs by removing `/api` prefix if present.
>     - Updated `BrowserStream.tsx` to use `newWssBaseUrl` for `browserSession` WebSocket connections.
>   - **Session Handling**:
>     - Added return values in `useQuery` function in `BrowserSession.tsx` to explicitly return `true` or `false` based on session existence.
>   - **Misc**:
>     - Removed redundant `wssBaseUrl` declaration in `BrowserStream.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0cbc7414b7889c03f31bbadca3d73c8c24c3b2b1. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->