### PR TITLE
Jon/keyed browser session id cache

### DIFF
--- a/skyvern-frontend/src/store/DebugStoreContext.tsx
+++ b/skyvern-frontend/src/store/DebugStoreContext.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useMemo } from "react";
 import { useLocation } from "react-router-dom";
-import { lsKeys } from "@/util/env";
 
 function useIsDebugMode() {
   const location = useLocation();
@@ -10,23 +9,8 @@ function useIsDebugMode() {
   );
 }
 
-function getCurrentBrowserSessionId() {
-  const stored = localStorage.getItem(lsKeys.optimisticBrowserSession);
-  let browserSessionId: string | null = null;
-  try {
-    const parsed = JSON.parse(stored ?? "");
-    const { browser_session_id } = parsed;
-    browserSessionId = browser_session_id as string;
-  } catch {
-    // pass
-  }
-
-  return browserSessionId;
-}
-
 export type DebugStoreContextType = {
   isDebugMode: boolean;
-  getCurrentBrowserSessionId: () => string | null;
 };
 
 export const DebugStoreContext = createContext<
@@ -39,9 +23,7 @@ export const DebugStoreProvider: React.FC<{ children: React.ReactNode }> = ({
   const isDebugMode = useIsDebugMode();
 
   return (
-    <DebugStoreContext.Provider
-      value={{ isDebugMode, getCurrentBrowserSessionId }}
-    >
+    <DebugStoreContext.Provider value={{ isDebugMode }}>
       {children}
     </DebugStoreContext.Provider>
   );

--- a/skyvern-frontend/src/store/useOptimisticallyRequestBrowserSessionId.ts
+++ b/skyvern-frontend/src/store/useOptimisticallyRequestBrowserSessionId.ts
@@ -1,5 +1,7 @@
-import { create } from "zustand";
 import { AxiosInstance } from "axios";
+import { create as createStore } from "zustand";
+
+import { User } from "@/api/types";
 import { lsKeys } from "@/util/env";
 
 export interface BrowserSessionData {
@@ -7,59 +9,120 @@ export interface BrowserSessionData {
   expires_at: number | null; // seconds since epoch
 }
 
-interface OptimisticBrowserSessionIdState extends BrowserSessionData {
-  run: (client: AxiosInstance) => Promise<BrowserSessionData>;
+interface RunOpts {
+  client: AxiosInstance;
+  reason?: string;
+  user: User;
+  workflowPermanentId?: string;
+}
+
+export interface OptimisticBrowserSession {
+  get: (user: User, workflowPermanentId: string) => BrowserSessionData | null;
+  run: (runOpts: RunOpts) => Promise<BrowserSessionData>;
 }
 
 const SESSION_TIMEOUT_MINUTES = 60;
+const SPARE = "spare";
+
+const makeKey = (user: User, workflowPermanentId?: string | undefined) => {
+  return `${lsKeys.optimisticBrowserSession}:${user.id}:${workflowPermanentId ?? SPARE}`;
+};
+
+/**
+ * Read a `BrowserSessionData` from localStorage cache. If the entry is expired,
+ * return `null`. If the entry is invalid, return `null`. Otherwise return it.
+ */
+const read = (key: string): BrowserSessionData | null => {
+  const stored = localStorage.getItem(key);
+  if (stored) {
+    try {
+      const parsed = JSON.parse(stored);
+      const { browser_session_id, expires_at } = parsed;
+      const now = Math.floor(Date.now() / 1000); // seconds since epoch
+
+      if (
+        browser_session_id &&
+        typeof browser_session_id === "string" &&
+        expires_at &&
+        typeof expires_at === "number" &&
+        now < expires_at
+      ) {
+        return { browser_session_id, expires_at };
+      }
+    } catch (e) {
+      // pass
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Write a `BrowserSessionData` to localStorage cache.
+ */
+const write = (key: string, browserSessionData: BrowserSessionData) => {
+  localStorage.setItem(key, JSON.stringify(browserSessionData));
+};
+
+/**
+ * Delete a localStorage key.
+ */
+const del = (key: string) => {
+  localStorage.removeItem(key);
+};
+
+/**
+ * Create a new browser session and return the `BrowserSessionData`.
+ */
+const create = async (client: AxiosInstance): Promise<BrowserSessionData> => {
+  const resp = await client.post("/browser_sessions", {
+    timeout: SESSION_TIMEOUT_MINUTES,
+  });
+
+  const { browser_session_id: newBrowserSessionId, timeout } = resp.data;
+  const newExpiresAt = Math.floor(Date.now() / 1000) + timeout * 60 * 0.9;
+
+  return {
+    browser_session_id: newBrowserSessionId,
+    expires_at: newExpiresAt,
+  };
+};
 
 export const useOptimisticallyRequestBrowserSessionId =
-  create<OptimisticBrowserSessionIdState>((set) => ({
-    browser_session_id: null,
-    expires_at: null,
-    run: async (client) => {
-      const stored = localStorage.getItem(lsKeys.optimisticBrowserSession);
-      if (stored) {
-        try {
-          const parsed = JSON.parse(stored);
-          const { browser_session_id, expires_at } = parsed;
-          const now = Math.floor(Date.now() / 1000); // seconds since epoch
+  createStore<OptimisticBrowserSession>(() => ({
+    get: (user: User, workflowPermanentId: string) => {
+      return read(makeKey(user, workflowPermanentId));
+    },
+    run: async ({ client, user, workflowPermanentId }: RunOpts) => {
+      if (workflowPermanentId) {
+        const userKey = makeKey(user, workflowPermanentId);
+        const exists = read(userKey);
 
-          if (
-            browser_session_id &&
-            typeof browser_session_id === "string" &&
-            expires_at &&
-            typeof expires_at === "number" &&
-            now < expires_at
-          ) {
-            set({ browser_session_id, expires_at });
-            return { browser_session_id, expires_at };
-          }
-        } catch (e) {
-          // pass
+        if (exists) {
+          return exists;
+        }
+
+        const spareKey = makeKey(user, SPARE);
+        const spare = read(spareKey);
+
+        if (spare) {
+          del(spareKey);
+          write(userKey, spare);
+          create(client).then((newSpare) => write(spareKey, newSpare));
+          return spare;
         }
       }
 
-      const resp = await client.post("/browser_sessions", {
-        timeout: SESSION_TIMEOUT_MINUTES,
-      });
-      const { browser_session_id: newBrowserSessionId, timeout } = resp.data;
-      const newExpiresAt = Math.floor(Date.now() / 1000) + timeout * 60 * 0.9;
-      set({
-        browser_session_id: newBrowserSessionId,
-        expires_at: newExpiresAt,
-      });
-      localStorage.setItem(
-        lsKeys.optimisticBrowserSession,
-        JSON.stringify({
-          browser_session_id: newBrowserSessionId,
-          expires_at: newExpiresAt,
-        }),
-      );
+      const key = makeKey(user, workflowPermanentId);
+      const browserSessionData = read(key);
 
-      return {
-        browser_session_id: newBrowserSessionId,
-        expires_at: newExpiresAt,
-      };
+      if (browserSessionData) {
+        return browserSessionData;
+      }
+
+      const knew = await create(client);
+      write(key, knew);
+
+      return knew;
     },
   }));


### PR DESCRIPTION
Keys browser session ids to `(user_id, wpid_xxx)`. Maintains a spare browser session id when no `wpid_xxx` is in play. When a `wpid_xxx` comes into play, will use spare as first choice. If it takes it, the spare is also renewed.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Keys browser session IDs to `(user_id, workflowPermanentId)` and updates session management in `NodeHeader.tsx` and `useOptimisticallyRequestBrowserSessionId.ts`.
> 
>   - **Behavior**:
>     - Keys browser session IDs to `(user_id, workflowPermanentId)` in `useOptimisticallyRequestBrowserSessionId.ts`.
>     - Uses a spare session ID when no `workflowPermanentId` is available, renewing it when used.
>     - Updates `NodeHeader.tsx` to use the new session ID management, handling cases where no user or session ID is found.
>   - **Store Changes**:
>     - Removes `getCurrentBrowserSessionId` from `DebugStoreContext.tsx`.
>     - Adds `get` and `run` methods to `useOptimisticallyRequestBrowserSessionId.ts` for session ID retrieval and creation.
>   - **Misc**:
>     - Adds `User` type import to `NodeHeader.tsx` and `useOptimisticallyRequestBrowserSessionId.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 4924aa643d1b3c52406b17432f99b4753d402bf6. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->