### PR TITLE
browser address schema update

### DIFF
--- a/scripts/test_persistent_browsers.py
+++ b/scripts/test_persistent_browsers.py
@@ -103,18 +103,6 @@ def close_all_sessions() -> None:
         print(f"Error closing sessions: {str(e)}")
 
 
-async def direct_get_network_info(session_id: str) -> None:
-    """Get network info directly from PersistentSessionsManager"""
-    try:
-        manager = app.PERSISTENT_SESSIONS_MANAGER
-        cdp_port, ip_address = await manager.get_network_info(session_id)
-        print("\nNetwork info:")
-        print(f"  CDP Port: {cdp_port}")
-        print(f"  IP Address: {ip_address}")
-    except Exception as e:
-        print(f"Error getting network info: {str(e)}")
-
-
 async def direct_list_sessions(organization_id: str) -> None:
     """List sessions directly from PersistentSessionsManager"""
     try:
@@ -143,11 +131,6 @@ async def handle_direct_command(cmd: str, args: list[str]) -> None:
     """Handle direct method calls"""
     if cmd == "help_direct":
         print_direct_help()
-    elif cmd == "direct_network":
-        if not args:
-            print("Error: session_id required")
-            return
-        await direct_get_network_info(args[0])
     elif cmd == "direct_list":
         if not args:
             print("Error: organization_id required")

--- a/skyvern/forge/sdk/routes/streaming_vnc.py
+++ b/skyvern/forge/sdk/routes/streaming_vnc.py
@@ -3,6 +3,7 @@ Streaming VNC WebSocket connections.
 """
 
 import asyncio
+from urllib.parse import urlparse
 
 import structlog
 import websockets
@@ -169,7 +170,9 @@ async def loop_stream_vnc(streaming: sc.Streaming) -> None:
         return
 
     browser_address = streaming.browser_session.browser_address
-    host, _ = browser_address.rsplit(":")
+
+    parsed_browser_address = urlparse(browser_address)
+    host = parsed_browser_address.hostname
     vnc_url = f"ws://{host}:{streaming.vnc_port}"
 
     LOG.info(

--- a/skyvern/webeye/persistent_sessions_manager.py
+++ b/skyvern/webeye/persistent_sessions_manager.py
@@ -16,8 +16,6 @@ LOG = structlog.get_logger()
 @dataclass
 class BrowserSession:
     browser_state: BrowserState
-    cdp_port: int
-    cdp_host: str = "localhost"
 
 
 class PersistentSessionsManager:
@@ -138,16 +136,6 @@ class PersistentSessionsManager:
             runnable_id=runnable_id,
             organization_id=organization_id,
         )
-
-    async def get_network_info(self, session_id: str) -> tuple[int | None, str | None]:
-        """Returns cdp port and ip address of the browser session"""
-        browser_session = self._browser_sessions.get(session_id)
-        if browser_session:
-            return (
-                browser_session.cdp_port,
-                browser_session.cdp_host,
-            )
-        return None, None
 
     async def release_browser_session(self, session_id: str, organization_id: str) -> None:
         """Release a specific browser session."""


### PR DESCRIPTION
Reverts Skyvern-AI/skyvern-cloud#5478
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reverts previous changes by removing network info retrieval, updating browser address parsing, and simplifying `BrowserSession` model.
> 
>   - **Behavior**:
>     - Removes `direct_get_network_info()` function and its command handling in `test_persistent_browsers.py`.
>     - Updates browser address parsing in `loop_stream_vnc()` in `streaming_vnc.py` to use `urlparse` instead of `rsplit`.
>   - **Models**:
>     - Removes `cdp_port` and `cdp_host` from `BrowserSession` in `persistent_sessions_manager.py`.
>   - **Misc**:
>     - Reverts changes from Skyvern-AI/skyvern-cloud#5478.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0b15043f9d49f485b6fd73e814cf3fca3fc82427. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->