### PR TITLE
Update API specifications with fern api update

### DIFF
--- a/fern/openapi/skyvern_openapi.json
+++ b/fern/openapi/skyvern_openapi.json
@@ -1928,6 +1928,9 @@
                 "type": "array"
               },
               {
+                "type": "string"
+              },
+              {
                 "type": "null"
               }
             ],
@@ -3282,7 +3285,7 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 10080,
+                "maximum": 120,
                 "minimum": 5
               },
               {
@@ -3290,7 +3293,7 @@
               }
             ],
             "title": "Timeout",
-            "description": "Timeout in minutes for the session. Timeout is applied after the session is started. Must be between 5 and 10080. Defaults to 60.",
+            "description": "Timeout in minutes for the session. Timeout is applied after the session is started. Must be between 5 and 120. Defaults to 60.",
             "default": 60
           }
         },
@@ -3715,6 +3718,9 @@
                 "type": "array"
               },
               {
+                "type": "string"
+              },
+              {
                 "type": "null"
               }
             ],
@@ -3926,6 +3932,9 @@
                 "type": "array"
               },
               {
+                "type": "string"
+              },
+              {
                 "type": "null"
               }
             ],
@@ -4084,6 +4093,9 @@
               {
                 "items": {},
                 "type": "array"
+              },
+              {
+                "type": "string"
               },
               {
                 "type": "null"
@@ -5414,6 +5426,9 @@
                 "type": "array"
               },
               {
+                "type": "string"
+              },
+              {
                 "type": "null"
               }
             ],
@@ -5828,6 +5843,9 @@
               {
                 "items": {},
                 "type": "array"
+              },
+              {
+                "type": "string"
               },
               {
                 "type": "null"
@@ -7192,6 +7210,9 @@
                 "type": "array"
               },
               {
+                "type": "string"
+              },
+              {
                 "type": "null"
               }
             ],
@@ -7418,6 +7439,9 @@
               {
                 "items": {},
                 "type": "array"
+              },
+              {
+                "type": "string"
               },
               {
                 "type": "null"
@@ -8590,6 +8614,9 @@
                 "type": "array"
               },
               {
+                "type": "string"
+              },
+              {
                 "type": "null"
               }
             ],
@@ -8888,6 +8915,9 @@
               {
                 "items": {},
                 "type": "array"
+              },
+              {
+                "type": "string"
               },
               {
                 "type": "null"


### PR DESCRIPTION
Update API specifications by running fern api update.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `skyvern_openapi.json` to add `string` type to arrays and change `Timeout` maximum value to 120.
> 
>   - **API Specification Updates**:
>     - Add `string` type to arrays in `skyvern_openapi.json` at multiple locations.
>     - Change `maximum` value for `Timeout` integer from 10080 to 120 in `skyvern_openapi.json`.
>     - Update `description` for `Timeout` to reflect new maximum value in `skyvern_openapi.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f1ea4115b47a42cfca3b7b6dcc125b2f1ee65aaf. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->