### PR TITLE
extend chain click to add coordinate click

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -2055,6 +2055,22 @@ async def chain_click(
                 )
                 return action_results
 
+            try:
+                LOG.info(
+                    "Chain click: element is blocked by an non-interactable element, try to click by the coordinates",
+                    task_id=task.task_id,
+                    action=action,
+                    element=str(skyvern_element),
+                    locator=locator,
+                )
+                await skyvern_element.coordinate_click(page=page)
+                action_results.append(ActionSuccess())
+                return action_results
+            except Exception as e:
+                action_results.append(
+                    ActionFailure(FailToClick(action.element_id, anchor="coordinate_click", msg=str(e)))
+                )
+
             LOG.info(
                 "Chain click: element is blocked by an non-interactable element, going to use javascript click instead of playwright click",
                 task_id=task.task_id,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds coordinate-based click attempt in `chain_click` in `handler.py` when element is blocked by non-interactable element.
> 
>   - **Behavior**:
>     - In `chain_click` in `handler.py`, adds a coordinate-based click attempt if an element is blocked by a non-interactable element.
>     - Logs an info message before attempting the coordinate click.
>     - If coordinate click fails, logs an error and appends `ActionFailure` with `FailToClick` exception.
>   - **Logging**:
>     - Adds logging for coordinate click attempt and failure in `chain_click`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 08a78923d520365374cd9bb359c70d28abf4329c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->