### PR TITLE
componentize window; add buttons

### DIFF
--- a/skyvern-frontend/src/components/FloatingWindow.tsx
+++ b/skyvern-frontend/src/components/FloatingWindow.tsx
@@ -1,5 +1,9 @@
 /**
  * A draggable, resizable, floating window.
+ *
+ * NOTE: there is copious use of flushSync; see TODOs. We will need to remove
+ * this. (We can build our own windowing from scratch, sans `react-draggable`
+ * and `re-resizable`; but I don't want to do that until it's worth the effort.)
  */
 
 import { Resizable } from "re-resizable";
@@ -13,7 +17,6 @@ import {
 import { flushSync } from "react-dom";
 import Draggable from "react-draggable";
 
-import { useDebugStore } from "@/store/useDebugStore";
 import { cn } from "@/util/utils";
 
 type OS = "Windows" | "macOS" | "Linux" | "Unknown";
@@ -95,8 +98,6 @@ function FloatingWindow({
   children: React.ReactNode;
   title: string;
 }) {
-  const debugStore = useDebugStore();
-  const isDebugMode = debugStore.isDebugMode;
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const [size, setSize] = useState({
     left: 0,
@@ -333,7 +334,7 @@ function FloatingWindow({
     };
   }, [isMaximized]);
 
-  return !isDebugMode ? null : (
+  return (
     <div
       ref={parentRef}
       style={{


### PR DESCRIPTION
	Part of improving debugger.

- componentize window component, so it can be reused: `FloatingWindow`
- stub in min/max/restore/close buttons
- both macOS and Windows style
- only enable max/restore

<img width="3420" height="2214" alt="image" src="https://github.com/user-attachments/assets/c9e58447-a91e-4116-9f85-4522471d0017" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `FloatingWindow` to be reusable and add UI buttons with macOS and Windows styles, enabling only maximize/restore functionality.
> 
>   - **Componentization**:
>     - Refactor `FloatingWindow` in `FloatingWindow.tsx` to be reusable.
>   - **UI Enhancements**:
>     - Add stub buttons for min/max/restore/close in `FloatingWindow`.
>     - Implement macOS and Windows styles for buttons.
>     - Enable only maximize/restore functionality.
>   - **Code Changes**:
>     - Remove `useDebugStore` and `isDebugMode` check from `FloatingWindow`.
>     - Always render `FloatingWindow`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5388fd76cee6f2c6f6478b80987dc37a3a9af88f. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->