### PR TITLE
add app_url for browser session

### DIFF
--- a/skyvern/webeye/schemas.py
+++ b/skyvern/webeye/schemas.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+from skyvern.config import settings
 from skyvern.forge.sdk.schemas.persistent_browser_sessions import PersistentBrowserSession
 
 
@@ -33,6 +34,11 @@ class BrowserSessionResponse(BaseModel):
         description="Url for connecting to the browser",
         examples=["http://localhost:9222", "https://3.12.10.11/browser/123456"],
     )
+    app_url: str | None = Field(
+        None,
+        description="Url for the browser session page",
+        examples=["https://app.skyvern.com/browser-session/pbs_123456"],
+    )
     started_at: datetime | None = Field(None, description="Timestamp when the session was started")
     completed_at: datetime | None = Field(None, description="Timestamp when the session was completed")
     created_at: datetime = Field(
@@ -52,6 +58,9 @@ class BrowserSessionResponse(BaseModel):
         Returns:
             BrowserSessionResponse: The converted response object
         """
+        app_url = (
+            f"{settings.SKYVERN_APP_URL.rstrip('/')}/browser-session/{browser_session.persistent_browser_session_id}"
+        )
         return cls(
             browser_session_id=browser_session.persistent_browser_session_id,
             organization_id=browser_session.organization_id,
@@ -59,6 +68,7 @@ class BrowserSessionResponse(BaseModel):
             runnable_id=browser_session.runnable_id,
             timeout=browser_session.timeout_minutes,
             browser_address=browser_session.browser_address,
+            app_url=app_url,
             started_at=browser_session.started_at,
             completed_at=browser_session.completed_at,
             created_at=browser_session.created_at,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `app_url` to `BrowserSessionResponse` in `schemas.py` for browser session page URL.
> 
>   - **Behavior**:
>     - Adds `app_url` field to `BrowserSessionResponse` in `schemas.py` for the browser session page URL.
>     - Constructs `app_url` in `from_browser_session()` using `settings.SKYVERN_APP_URL` and `persistent_browser_session_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a4d765124382b807af31ccc28bc70c6bbc8e795b. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->