### PR TITLE
remove download to s3 block

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
@@ -186,17 +186,17 @@ const nodeLibraryItems: Array<{
     title: "Upload to S3 Block",
     description: "Upload files to AWS S3",
   },
-  {
-    nodeType: "download",
-    icon: (
-      <WorkflowBlockIcon
-        workflowBlockType={WorkflowBlockTypes.DownloadToS3}
-        className="size-6"
-      />
-    ),
-    title: "Download from S3 Block",
-    description: "Download files from AWS S3",
-  },
+  // {
+  //   nodeType: "download",
+  //   icon: (
+  //     <WorkflowBlockIcon
+  //       workflowBlockType={WorkflowBlockTypes.DownloadToS3}
+  //       className="size-6"
+  //     />
+  //   ),
+  //   title: "Download from S3 Block",
+  //   description: "Download files from AWS S3",
+  // },
   {
     nodeType: "fileUpload",
     icon: (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Commented out 'Download from S3 Block' in `WorkflowNodeLibraryPanel.tsx`, removing it from the UI.
> 
>   - **Behavior**:
>     - Commented out the 'Download from S3 Block' in `nodeLibraryItems` array in `WorkflowNodeLibraryPanel.tsx`, removing it from the UI.
>   - **Misc**:
>     - No other changes or impacts on functionality noted.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 73a131ee7385a89f281d4086fdff3b93a7810cd6. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->