### PR TITLE
no user-select when splitter is dragging

### DIFF
--- a/skyvern-frontend/src/components/Splitter.tsx
+++ b/skyvern-frontend/src/components/Splitter.tsx
@@ -173,22 +173,18 @@ const normalizeUnitsToPercent = (
   if (storageKey) {
     const stored = getStoredSizing(firstSizingTarget, storageKey);
 
-    if (!stored) {
-      const normalized = normalize(sizing, containerSize);
-
-      if (firstSizingTarget === "right" || firstSizingTarget === "bottom") {
-        return 100 - normalized;
-      }
-
-      return normalized;
-    } else {
+    if (stored) {
       return parseFloat(stored);
     }
-  } else {
-    const normalized = normalize(sizing, containerSize);
-
-    return normalized;
   }
+
+  const normalized = normalize(sizing, containerSize);
+
+  if (firstSizingTarget === "right" || firstSizingTarget === "bottom") {
+    return 100 - normalized;
+  }
+
+  return normalized;
 };
 
 const setStoredSizing = (
@@ -217,6 +213,7 @@ function Splitter({ children, direction, split, storageKey }: Props) {
 
   const onMouseDown = (e: React.MouseEvent) => {
     setIsDragging(true);
+    document.body.classList.add("no-select-global");
     const startCoord = direction === "vertical" ? e.clientX : e.clientY;
     const container = e.currentTarget.closest(".splitter") as HTMLDivElement;
     const containerSize =
@@ -248,6 +245,7 @@ function Splitter({ children, direction, split, storageKey }: Props) {
 
     const onMouseUp = () => {
       setIsDragging(false);
+      document.body.classList.remove("no-select-global");
       document.removeEventListener("mousemove", onMouseMove);
       document.removeEventListener("mouseup", onMouseUp);
     };
@@ -292,7 +290,7 @@ function Splitter({ children, direction, split, storageKey }: Props) {
   return (
     <div
       className={cn(
-        "splitter flex h-full w-full",
+        "splitter flex h-full w-full overflow-hidden",
         direction === "vertical" ? "flex-row" : "flex-col",
       )}
       ref={containerRef}
@@ -312,7 +310,7 @@ function Splitter({ children, direction, split, storageKey }: Props) {
           </div>
           <div
             className={cn(
-              "splitter-bar z-[100] h-full w-[5px] cursor-col-resize bg-[#ccc] opacity-10 hover:opacity-90",
+              "splitter-bar z-[0] h-full w-[5px] cursor-col-resize bg-[#ccc] opacity-10 hover:opacity-90",
               { "opacity-90": isDragging },
             )}
             onMouseDown={onMouseDown}

--- a/skyvern-frontend/src/index.css
+++ b/skyvern-frontend/src/index.css
@@ -109,3 +109,10 @@ body,
 .cm-search.cm-panel {
   @apply text-sm;
 }
+
+.no-select-global * {
+  user-select: none !important;
+  -webkit-user-select: none !important;
+  -moz-user-select: none !important;
+  -ms-user-select: none !important;
+}


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Prevent text selection during splitter dragging by adding a global `no-select-global` class in `Splitter.tsx`.
> 
>   - **Behavior**:
>     - Add `no-select-global` class to `document.body` in `onMouseDown` and remove it in `onMouseUp` in `Splitter` component to prevent text selection during dragging.
>   - **CSS**:
>     - Add `.no-select-global` class to `index.css` to disable `user-select` globally.
>     - Change `z-index` of `splitter-bar` to `0` in `Splitter.tsx`.
>     - Add `overflow-hidden` to `splitter` class in `Splitter.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6668a30cac736b89833a7a5af5197df694e6b27d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->