### PR TITLE
ensure browser session id for GET workflow run

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1533,7 +1533,7 @@ async def get_workflow_run_with_workflow_id(
 
     browser_session_id = browser_session.persistent_browser_session_id if browser_session else None
 
-    return_dict["browser_session_id"] = browser_session_id
+    return_dict["browser_session_id"] = browser_session_id or return_dict.get("browser_session_id")
 
     task_v2 = await app.DATABASE.get_task_v2_by_workflow_run_id(
         workflow_run_id=workflow_run_id,

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -1243,6 +1243,7 @@ class WorkflowService:
             total_steps=total_steps,
             total_cost=total_cost,
             workflow_title=workflow.title,
+            browser_session_id=workflow_run.browser_session_id,
             max_screenshot_scrolls=workflow_run.max_screenshot_scrolls,
         )
 


### PR DESCRIPTION
## What 

I want to use browser_session_id in frontend when connecting to a browser for the debugger. Currently, when a workflow ends, it no longer has a browser_session_id, as it was only being eagerly read from the persistent_browser_sessions table. With this PR, we also return it from the workflow_runs table.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure `browser_session_id` is retained for workflow runs by checking both `persistent_browser_sessions` and `workflow_runs` tables.
> 
>   - **Behavior**:
>     - Ensure `browser_session_id` is retained for workflow runs by checking both `persistent_browser_sessions` and `workflow_runs` tables in `get_workflow_run_with_workflow_id()` in `agent_protocol.py`.
>     - Include `browser_session_id` in the response of `build_workflow_run_status_response()` in `service.py`.
>   - **Misc**:
>     - Minor logic adjustment in `agent_protocol.py` to prioritize `persistent_browser_sessions` over `workflow_runs` for `browser_session_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5faa0f6b4dde6a48f9b16d16c146ef73ca6fbeff. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->