### PR TITLE
dns for browser session（part 2)

### DIFF
--- a/skyvern/forge/sdk/routes/streaming_vnc.py
+++ b/skyvern/forge/sdk/routes/streaming_vnc.py
@@ -169,11 +169,19 @@ async def loop_stream_vnc(streaming: sc.Streaming) -> None:
         LOG.info("No browser session found for task.", task=streaming.task, organization_id=streaming.organization_id)
         return
 
-    browser_address = streaming.browser_session.browser_address
+    vnc_url: str = ""
+    if streaming.browser_session.ip_address:
+        if ":" in streaming.browser_session.ip_address:
+            ip, _ = streaming.browser_session.ip_address.split(":")
+            vnc_url = f"ws://{ip}:{streaming.vnc_port}"
+        else:
+            vnc_url = f"ws://{streaming.browser_session.ip_address}:{streaming.vnc_port}"
+    else:
+        browser_address = streaming.browser_session.browser_address
 
-    parsed_browser_address = urlparse(browser_address)
-    host = parsed_browser_address.hostname
-    vnc_url = f"ws://{host}:{streaming.vnc_port}"
+        parsed_browser_address = urlparse(browser_address)
+        host = parsed_browser_address.hostname
+        vnc_url = f"ws://{host}:{streaming.vnc_port}"
 
     LOG.info(
         "Connecting to VNC URL.",

--- a/skyvern/forge/sdk/schemas/persistent_browser_sessions.py
+++ b/skyvern/forge/sdk/schemas/persistent_browser_sessions.py
@@ -11,6 +11,7 @@ class PersistentBrowserSession(BaseModel):
     runnable_type: str | None = None
     runnable_id: str | None = None
     browser_address: str | None = None
+    ip_address: str | None = None
     status: str | None = None
     timeout_minutes: int | None = None
     started_at: datetime | None = None


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for using `ip_address` in VNC connections in `loop_stream_vnc()` and update `PersistentBrowserSession` model.
> 
>   - **Behavior**:
>     - Update `loop_stream_vnc()` in `streaming_vnc.py` to use `ip_address` for VNC URL if available, otherwise fallback to `browser_address`.
>     - Handles both IPv4 and IPv6 addresses by checking for a colon in the `ip_address`.
>   - **Models**:
>     - Add `ip_address` field to `PersistentBrowserSession` in `persistent_browser_sessions.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 3d1a8d63af2e904478faa45ed2adfa0b2fe05a20. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->