### PR TITLE
remove unused func from webeye persistent sessions manager

### DIFF
--- a/skyvern/webeye/persistent_sessions_manager.py
+++ b/skyvern/webeye/persistent_sessions_manager.py
@@ -141,13 +141,6 @@ class PersistentSessionsManager:
         """Release a specific browser session."""
         await self.database.release_persistent_browser_session(session_id, organization_id)
 
-    async def _clean_up_on_session_close(self, session_id: str, organization_id: str) -> None:
-        """Clean up session data when browser session is closed"""
-        browser_session = self._browser_sessions.get(session_id)
-        if browser_session:
-            await self.database.mark_persistent_browser_session_deleted(session_id, organization_id)
-            self._browser_sessions.pop(session_id, None)
-
     async def close_session(self, organization_id: str, browser_session_id: str) -> None:
         """Close a specific browser session."""
         browser_session = self._browser_sessions.get(browser_session_id)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove unused `_clean_up_on_session_close` function from `persistent_sessions_manager.py`, as its functionality is now handled in `close_session()`.
> 
>   - **Code Removal**:
>     - Remove unused function `_clean_up_on_session_close` from `persistent_sessions_manager.py`.
>     - Function was responsible for cleaning up session data on session close, now handled in `close_session()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0b3d2a4ef7003728d64522a9bfb097903223b1ba. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->