### PR TITLE
release session in main cancel routine

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1059,6 +1059,9 @@ async def _cancel_workflow_run(workflow_run_id: str, organization_id: str, x_api
             detail=f"Workflow run not found {workflow_run_id}",
         )
 
+    if workflow_run.browser_session_id:
+        await app.PERSISTENT_SESSIONS_MANAGER.release_browser_session(workflow_run.browser_session_id, organization_id)
+
     # get all the child workflow runs and cancel them
     child_workflow_runs = await app.DATABASE.get_workflow_runs_by_parent_workflow_run_id(
         parent_workflow_run_id=workflow_run_id,
@@ -1108,8 +1111,6 @@ async def cancel_persistent_browser_session_workflow_run(
     current_org: Organization = Depends(org_auth_service.get_current_org),
     x_api_key: Annotated[str | None, Header()] = None,
 ) -> None:
-    await app.PERSISTENT_SESSIONS_MANAGER.release_browser_session(browser_session_id, current_org.organization_id)
-
     await _cancel_workflow_run(workflow_run_id, current_org.organization_id, x_api_key)
 
 


### PR DESCRIPTION
This is so I can call the workflow cancel endpoint without a browser session id on the frontend. The backend has that info in the workflow_runs table. 

After which I'll:

- update the frontend to remove the optimistic fetch of browser session ids. 
- remove the redundant cancel endpoint in in agent_protocol.py
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `_cancel_workflow_run()` in `agent_protocol.py` to release browser sessions and remove redundant code, allowing frontend cancel calls without session IDs.
> 
>   - **Behavior**:
>     - `_cancel_workflow_run()` in `agent_protocol.py` now releases the browser session if `workflow_run.browser_session_id` exists.
>     - Removes redundant `release_browser_session` call in `cancel_persistent_browser_session_workflow_run()`.
>   - **Frontend**:
>     - Allows calling the workflow cancel endpoint without a browser session ID.
>   - **Backend**:
>     - Utilizes `workflow_runs` table to retrieve browser session ID.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6457880146e743e5ce5822480a2990edb7c9740a. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->