### PR TITLE
allow empty urls

### DIFF
--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, PrivateAttr
 
 from skyvern.config import settings
 from skyvern.constants import BUILDING_ELEMENT_TREE_TIMEOUT_MS, DEFAULT_MAX_TOKENS, SKYVERN_DIR, SKYVERN_ID_ATTR
-from skyvern.exceptions import FailedToTakeScreenshot, ScrapingFailed, ScrapingFailedNoUrl, UnknownElementTreeFormat
+from skyvern.exceptions import FailedToTakeScreenshot, ScrapingFailed, UnknownElementTreeFormat
 from skyvern.forge.sdk.api.crypto import calculate_sha256
 from skyvern.forge.sdk.core import skyvern_context
 from skyvern.forge.sdk.trace import TraceManager
@@ -427,8 +427,10 @@ async def scrape_website(
     :raises Exception: When scraping fails after maximum retries.
     """
 
-    if not url.strip():
-        raise ScrapingFailedNoUrl()
+    # TODO(jdo) why is this a problem?
+    # ref: https://skyvern.slack.com/archives/C074UNDSRJM/p1752771256298149
+    # if not url.strip():
+    #     raise ScrapingFailedNoUrl()
 
     try:
         num_retry += 1


### PR DESCRIPTION
ref: https://skyvern.slack.com/archives/C074UNDSRJM/p1752771256298149
ref: https://linear.app/skyvern/issue/SKY-5654/enpal-skyvern-fails-to-load-website-consistently-for-installation
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Removed empty URL check in `scrape_website()` in `scraper.py`, allowing function to proceed with empty URLs.
> 
>   - **Behavior**:
>     - Removed check for empty `url` in `scrape_website()` in `scraper.py`, allowing function to proceed with empty URLs.
>     - Removed import of `ScrapingFailedNoUrl` from `scraper.py` as it is no longer used.
>   - **Comments**:
>     - Added TODO comment questioning the necessity of the empty URL check, with a reference to a Slack discussion for context.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0bd02d5a1e1dd68ca31da853841f03322cd02871. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->