### PR TITLE
Login endpoint Part 2 - support 3 types of credentials and fix bugs

### DIFF
--- a/skyvern/schemas/run_blocks.py
+++ b/skyvern/schemas/run_blocks.py
@@ -1,10 +1,18 @@
-from pydantic import BaseModel
+from enum import StrEnum
+from typing import Annotated, Literal, Union
+
+from pydantic import BaseModel, Field
 
 from skyvern.schemas.runs import ProxyLocation
 
 
-class LoginRequest(BaseModel):
-    credential_id: str
+class CredentialType(StrEnum):
+    skyvern = "skyvern"
+    bitwarden = "bitwarden"
+    onepassword = "1password"
+
+
+class LoginRequestBase(BaseModel):
     url: str | None = None
     prompt: str | None = None
     webhook_url: str | None = None
@@ -14,3 +22,27 @@ class LoginRequest(BaseModel):
     browser_session_id: str | None = None
     extra_http_headers: dict[str, str] | None = None
     max_screenshot_scrolling_times: int | None = None
+
+
+class SkyvernCredentialLoginRequest(LoginRequestBase):
+    credential_type: Literal[CredentialType.skyvern] = CredentialType.skyvern
+    credential_id: str
+
+
+class BitwardenLoginRequest(LoginRequestBase):
+    credential_type: Literal[CredentialType.bitwarden] = CredentialType.bitwarden
+    collection_id: str | None = None
+    item_id: str | None = None
+    url: str | None = None
+
+
+class OnePasswordLoginRequest(LoginRequestBase):
+    credential_type: Literal[CredentialType.onepassword] = CredentialType.onepassword
+    vault_id: str
+    item_id: str
+
+
+LoginRequest = Annotated[
+    Union[SkyvernCredentialLoginRequest, BitwardenLoginRequest, OnePasswordLoginRequest],
+    Field(discriminator="credential_type"),
+]


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `login()` to support `skyvern`, `bitwarden`, and `onepassword` credentials, with schema updates and bug fixes.
> 
>   - **Behavior**:
>     - `login()` in `run_blocks.py` now supports `skyvern`, `bitwarden`, and `onepassword` credential types.
>     - Validates credentials based on type and raises `HTTPException` if not found.
>   - **Schemas**:
>     - Introduces `CredentialType` enum in `run_blocks.py` for credential type differentiation.
>     - Adds `SkyvernCredentialLoginRequest`, `BitwardenLoginRequest`, and `OnePasswordLoginRequest` classes in `run_blocks.py`.
>     - `LoginRequest` is now a union of the three credential-specific request classes.
>   - **Misc**:
>     - Removes redundant credential validation in `login()` in `run_blocks.py`.
>     - Updates `WorkflowParameterYAML` handling to accommodate new credential types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f9f1702cfa9aebd010783416be7932fd1c1b2926. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->