### PR TITLE
Win32 deployment compatibility fix

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -60,8 +60,8 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 # are written from script.py.mako
 # output_encoding = utf-8
 
-; sqlalchemy.url = driver://user:pass@localhost/dbname
-sqlalchemy.url = postgresql+psycopg://skyvern@localhost/skyvern
+; sqlalchemy.url = driver://user:pass@localhost/dbname, resolved by alembic\env.py using SettingsManager
+# sqlalchemy.url = postgresql+psycopg://skyvern@localhost/skyvern
 
 
 [post_write_hooks]

--- a/evaluation/core/utils.py
+++ b/evaluation/core/utils.py
@@ -21,7 +21,7 @@ class WorkflowRunResultRequest(BaseModel):
 
 
 def load_webvoyager_case_from_json(file_path: str, group_id: str = "") -> Iterator[WebVoyagerTestCase]:
-    with open("evaluation/datasets/webvoyager_reference_answer.json") as answer_file:
+    with open("evaluation/datasets/webvoyager_reference_answer.json", encoding="utf-8") as answer_file:
         webvoyager_answers: dict = json.load(answer_file)
 
     if not group_id:

--- a/skyvern/cli/commands.py
+++ b/skyvern/cli/commands.py
@@ -1,6 +1,8 @@
 import typer
 from dotenv import load_dotenv
 
+from skyvern.cli.utils import set_asyncio_event_loop_policy
+
 from .docs import docs_app
 from .init_command import init, init_browser
 from .quickstart import quickstart_app
@@ -55,4 +57,5 @@ def init_browser_command() -> None:
 
 if __name__ == "__main__":  # pragma: no cover - manual CLI invocation
     load_dotenv()
+    set_asyncio_event_loop_policy()
     cli_app()

--- a/skyvern/cli/llm_setup.py
+++ b/skyvern/cli/llm_setup.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import sys
 
 from dotenv import load_dotenv, set_key
 from rich.panel import Panel
@@ -12,6 +13,8 @@ def update_or_add_env_var(key: str, value: str) -> None:
     env_path = Path(".env")
     if not env_path.exists():
         env_path.touch()
+
+        dbstr = "postgresql+asyncpg://skyvern@localhost/skyvern" if sys.platform == "win32" else "postgresql+psycopg://skyvern@localhost/skyvern"
         defaults = {
             "ENV": "local",
             "ENABLE_OPENAI": "false",
@@ -41,7 +44,7 @@ def update_or_add_env_var(key: str, value: str) -> None:
             "MAX_STEPS_PER_RUN": "50",
             "LOG_LEVEL": "INFO",
             "LITELLM_LOG": "CRITICAL",
-            "DATABASE_STRING": "postgresql+psycopg://skyvern@localhost/skyvern",
+            "DATABASE_STRING": dbstr,
             "PORT": "8000",
             "ANALYTICS_ID": "anonymous",
             "ENABLE_LOG_ARTIFACTS": "false",

--- a/skyvern/cli/mcp.py
+++ b/skyvern/cli/mcp.py
@@ -144,7 +144,7 @@ def setup_claude_desktop_config(host_system: str, path_to_env: str) -> bool:
         claude_config: dict = {"mcpServers": {}}
         if os.path.exists(path_claude_config):
             try:
-                with open(path_claude_config) as f:
+                with open(path_claude_config, encoding="utf-8") as f:
                     claude_config = json.load(f)
                     claude_config["mcpServers"].pop("Skyvern", None)
                     claude_config["mcpServers"]["Skyvern"] = {
@@ -196,7 +196,7 @@ def setup_cursor_config(host_system: str, path_to_env: str) -> bool:
         cursor_config: dict = {"mcpServers": {}}
         if os.path.exists(path_cursor_config):
             try:
-                with open(path_cursor_config) as f:
+                with open(path_cursor_config, encoding="utf-8") as f:
                     cursor_config = json.load(f)
                     cursor_config["mcpServers"].pop("Skyvern", None)
                     cursor_config["mcpServers"]["Skyvern"] = {
@@ -245,7 +245,7 @@ def setup_windsurf_config(host_system: str, path_to_env: str) -> bool:
         windsurf_config: dict = {"mcpServers": {}}
         if os.path.exists(path_windsurf_config):
             try:
-                with open(path_windsurf_config) as f:
+                with open(path_windsurf_config, encoding="utf-8") as f:
                     windsurf_config = json.load(f)
                     windsurf_config["mcpServers"].pop("Skyvern", None)
                     windsurf_config["mcpServers"]["Skyvern"] = {

--- a/skyvern/cli/quickstart.py
+++ b/skyvern/cli/quickstart.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import subprocess
+import sys
+import traceback
 
 import typer
 from rich.panel import Panel
@@ -10,7 +12,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 # Import console after skyvern.cli to ensure proper initialization
 from skyvern.cli.console import console
 from skyvern.cli.init_command import init  # init is used directly
-from skyvern.cli.utils import start_services
+from skyvern.cli.utils import start_services, start_services_sync
 
 quickstart_app = typer.Typer(help="Quickstart command to set up and run Skyvern with one command.")
 
@@ -77,11 +79,15 @@ def quickstart(
 
         # Start services
         console.print("\n[bold blue]Starting Skyvern services...[/bold blue]")
-        asyncio.run(start_services(server_only=server_only))
+        if sys.platform == "win32":
+            start_services_sync(server_only=server_only)
+        else:
+            asyncio.run(start_services(server_only=server_only))
 
     except KeyboardInterrupt:
         console.print("\n[bold yellow]Quickstart process interrupted by user.[/bold yellow]")
         raise typer.Exit(0)
     except Exception as e:
         console.print(f"[bold red]Error during quickstart: {str(e)}[/bold red]")
+        console.print(traceback.format_exc())
         raise typer.Exit(1)

--- a/skyvern/cli/run_commands.py
+++ b/skyvern/cli/run_commands.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import sys
 import shutil
 import subprocess
 from pathlib import Path
@@ -13,7 +14,7 @@ from mcp.server.fastmcp import FastMCP
 from rich.panel import Panel
 from rich.prompt import Confirm
 
-from skyvern.cli.utils import start_services
+from skyvern.cli.utils import start_services, start_services_sync, set_asyncio_event_loop_policy
 from skyvern.config import settings
 from skyvern.library.skyvern import Skyvern
 from skyvern.utils import detect_os
@@ -82,6 +83,7 @@ def kill_pids(pids: List[int]) -> None:
 
 @run_app.command(name="server")
 def run_server() -> None:
+    set_asyncio_event_loop_policy()
     """Run the Skyvern API server."""
     load_dotenv()
     load_dotenv(".env")
@@ -99,6 +101,7 @@ def run_server() -> None:
 
 @run_app.command(name="ui")
 def run_ui() -> None:
+    set_asyncio_event_loop_policy()
     """Run the Skyvern UI server."""
     console.print(Panel("[bold blue]Starting Skyvern UI Server...[/bold blue]", border_style="blue"))
     try:
@@ -196,11 +199,15 @@ def run_ui() -> None:
 @run_app.command(name="all")
 def run_all() -> None:
     """Run the Skyvern API server and UI server in parallel."""
-    asyncio.run(start_services())
+    if sys.platform == "win32":
+        start_services_sync()
+    else:
+        asyncio.run(start_services())
 
 
 @run_app.command(name="mcp")
 def run_mcp() -> None:
+    set_asyncio_event_loop_policy()
     """Run the MCP server."""
     # This breaks the MCP processing because it expects json output only
     # console.print(Panel("[bold green]Starting MCP Server...[/bold green]", border_style="green"))

--- a/skyvern/cli/utils.py
+++ b/skyvern/cli/utils.py
@@ -1,10 +1,9 @@
 import asyncio
 import sys
-
+import subprocess
 import typer
 
 from skyvern.cli.console import console
-
 
 async def start_services(server_only: bool = False) -> None:
     """Start Skyvern services in the background.
@@ -38,3 +37,45 @@ async def start_services(server_only: bool = False) -> None:
     except Exception as e:
         console.print(f"[bold red]Error starting services: {str(e)}[/bold red]")
         raise typer.Exit(1)
+
+
+def start_services_sync(server_only: bool = False) -> None:
+    """
+    Start Skyvern services (server and optionally UI) using synchronous subprocesses.
+    This does not require any event loop policy changes and is fully compatible with psycopg.
+    """
+
+    try:
+        # Start server
+        server_proc = subprocess.Popen([sys.executable, "-m", "skyvern.cli.commands", "run", "server"])
+        console.print("[green]Skyvern API server started.[/green]")
+
+        if not server_only:
+            # Start UI
+            ui_proc = subprocess.Popen([sys.executable, "-m", "skyvern.cli.commands", "run", "ui"])
+            console.print("[green]Skyvern UI started.[/green]")
+
+        console.print("\n🎉 [bold green]Skyvern is now running![/bold green]")
+        console.print("🌐 [bold]Access the UI at:[/bold] [cyan]http://localhost:8080[/cyan]")
+        console.print("🔑 [bold]Your API key is in your .env file as SKYVERN_API_KEY[/bold]")
+
+        # Wait for processes to complete (they won't unless killed)
+        if not server_only:
+            server_proc.wait()
+            ui_proc.wait()
+        else:
+            server_proc.wait()
+
+    except Exception as e:
+        console.print(f"[bold red]Error starting services: {str(e)}[/bold red]")
+        raise
+
+
+def set_asyncio_event_loop_policy():
+    """
+    Set the event loop policy to WindowsSelectorEventLoopPolicy if running on Windows.
+    This should be called at the top of any entry point that needs psycopg compatibility.
+    """
+    if sys.platform == "win32" and asyncio.get_event_loop_policy() != asyncio.WindowsProactorEventLoopPolicy():
+        print("Updating event loop policy for Windows")
+        asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())

--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -1,3 +1,4 @@
+import sys
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from skyvern import constants
@@ -34,7 +35,7 @@ class Settings(BaseSettings):
     LONG_RUNNING_TASK_WARNING_RATIO: float = 0.95
     MAX_RETRIES_PER_STEP: int = 5
     DEBUG_MODE: bool = False
-    DATABASE_STRING: str = "postgresql+psycopg://skyvern@localhost/skyvern"
+    DATABASE_STRING: str = "postgresql+asyncpg://skyvern@localhost/skyvern" if sys.platform == "win32" else "postgresql+psycopg://skyvern@localhost/skyvern"
     DATABASE_STATEMENT_TIMEOUT_MS: int = 60000
     DISABLE_CONNECTION_POOL: bool = False
     PROMPT_ACTION_HISTORY_WINDOW: int = 1

--- a/skyvern/forge/sdk/artifact/storage/s3.py
+++ b/skyvern/forge/sdk/artifact/storage/s3.py
@@ -28,6 +28,11 @@ from skyvern.forge.sdk.schemas.workflow_runs import WorkflowRunBlock
 LOG = structlog.get_logger()
 
 
+def get_timestamp_part() -> str:
+    """Generate a timestamp string for use in artifact URIs."""
+    return datetime.utcnow().isoformat().replace(":", "-")
+
+
 class S3Storage(BaseStorage):
     _PATH_VERSION = "v1"
 
@@ -37,7 +42,7 @@ class S3Storage(BaseStorage):
 
     def build_uri(self, *, organization_id: str, artifact_id: str, step: Step, artifact_type: ArtifactType) -> str:
         file_ext = FILE_EXTENTSION_MAP[artifact_type]
-        return f"{self._build_base_uri(organization_id)}/{step.task_id}/{step.order:02d}_{step.retry_index}_{step.step_id}/{datetime.utcnow().isoformat()}_{artifact_id}_{artifact_type}.{file_ext}"
+        return f"{self._build_base_uri(organization_id)}/{step.task_id}/{step.order:02d}_{step.retry_index}_{step.step_id}/{get_timestamp_part()}_{artifact_id}_{artifact_type}.{file_ext}"
 
     async def retrieve_global_workflows(self) -> list[str]:
         uri = f"s3://{self.bucket}/{settings.ENV}/global_workflows.txt"
@@ -53,19 +58,19 @@ class S3Storage(BaseStorage):
         self, *, organization_id: str, log_entity_type: LogEntityType, log_entity_id: str, artifact_type: ArtifactType
     ) -> str:
         file_ext = FILE_EXTENTSION_MAP[artifact_type]
-        return f"{self._build_base_uri(organization_id)}/logs/{log_entity_type}/{log_entity_id}/{datetime.utcnow().isoformat()}_{artifact_type}.{file_ext}"
+        return f"{self._build_base_uri(organization_id)}/logs/{log_entity_type}/{log_entity_id}/{get_timestamp_part()}_{artifact_type}.{file_ext}"
 
     def build_thought_uri(
         self, *, organization_id: str, artifact_id: str, thought: Thought, artifact_type: ArtifactType
     ) -> str:
         file_ext = FILE_EXTENTSION_MAP[artifact_type]
-        return f"{self._build_base_uri(organization_id)}/observers/{thought.observer_cruise_id}/{thought.observer_thought_id}/{datetime.utcnow().isoformat()}_{artifact_id}_{artifact_type}.{file_ext}"
+        return f"{self._build_base_uri(organization_id)}/observers/{thought.observer_cruise_id}/{thought.observer_thought_id}/{get_timestamp_part()}_{artifact_id}_{artifact_type}.{file_ext}"
 
     def build_task_v2_uri(
         self, *, organization_id: str, artifact_id: str, task_v2: TaskV2, artifact_type: ArtifactType
     ) -> str:
         file_ext = FILE_EXTENTSION_MAP[artifact_type]
-        return f"{self._build_base_uri(organization_id)}/observers/{task_v2.observer_cruise_id}/{datetime.utcnow().isoformat()}_{artifact_id}_{artifact_type}.{file_ext}"
+        return f"{self._build_base_uri(organization_id)}/observers/{task_v2.observer_cruise_id}/{get_timestamp_part()}_{artifact_id}_{artifact_type}.{file_ext}"
 
     def build_workflow_run_block_uri(
         self,
@@ -76,13 +81,13 @@ class S3Storage(BaseStorage):
         artifact_type: ArtifactType,
     ) -> str:
         file_ext = FILE_EXTENTSION_MAP[artifact_type]
-        return f"{self._build_base_uri(organization_id)}/workflow_runs/{workflow_run_block.workflow_run_id}/{workflow_run_block.workflow_run_block_id}/{datetime.utcnow().isoformat()}_{artifact_id}_{artifact_type}.{file_ext}"
+        return f"{self._build_base_uri(organization_id)}/workflow_runs/{workflow_run_block.workflow_run_id}/{workflow_run_block.workflow_run_block_id}/{get_timestamp_part()}_{artifact_id}_{artifact_type}.{file_ext}"
 
     def build_ai_suggestion_uri(
         self, *, organization_id: str, artifact_id: str, ai_suggestion: AISuggestion, artifact_type: ArtifactType
     ) -> str:
         file_ext = FILE_EXTENTSION_MAP[artifact_type]
-        return f"{self._build_base_uri(organization_id)}/ai_suggestions/{ai_suggestion.ai_suggestion_id}/{datetime.utcnow().isoformat()}_{artifact_id}_{artifact_type}.{file_ext}"
+        return f"{self._build_base_uri(organization_id)}/ai_suggestions/{ai_suggestion.ai_suggestion_id}/{get_timestamp_part()}_{artifact_id}_{artifact_type}.{file_ext}"
 
     async def store_artifact(self, artifact: Artifact, data: bytes) -> None:
         sc = await self._get_storage_class_for_org(artifact.organization_id)

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -2160,7 +2160,7 @@ class FileParserBlock(Block):
     def validate_file_type(self, file_url_used: str, file_path: str) -> None:
         if self.file_type == FileType.CSV:
             try:
-                with open(file_path) as file:
+                with open(file_path, encoding="utf-8") as file:
                     csv.Sniffer().sniff(file.read(1024))
             except csv.Error as e:
                 raise InvalidFileType(file_url=file_url_used, file_type=self.file_type, error=str(e))
@@ -2209,7 +2209,7 @@ class FileParserBlock(Block):
         self.validate_file_type(self.file_url, file_path)
         # Parse the file into a list of dictionaries where each dictionary represents a row in the file
         parsed_data = []
-        with open(file_path) as file:
+        with open(file_path, encoding="utf-8") as file:
             if self.file_type == FileType.CSV:
                 reader = csv.DictReader(file)
                 for row in reader:

--- a/skyvern/utils/__init__.py
+++ b/skyvern/utils/__init__.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 from alembic import command
 from alembic.config import Config
+
+from skyvern.config import settings
 from skyvern.constants import REPO_ROOT_DIR
 
 
@@ -12,6 +14,7 @@ def migrate_db() -> None:
     alembic_cfg = Config()
     path = f"{REPO_ROOT_DIR}/alembic"
     alembic_cfg.set_main_option("script_location", path)
+    alembic_cfg.set_main_option("sqlalchemy.url", settings.DATABASE_STRING)
     command.upgrade(alembic_cfg, "head")
 
 
@@ -28,7 +31,7 @@ def detect_os() -> str:
     system = platform.system()
     if system == "Linux":
         try:
-            with open("/proc/version") as f:
+            with open("/proc/version", encoding="utf-8") as f:
                 version_info = f.read().lower()
                 if "microsoft" in version_info:
                     return "wsl"

--- a/skyvern/utils/files.py
+++ b/skyvern/utils/files.py
@@ -25,5 +25,5 @@ def get_json_from_file(file_path: str) -> dict[str, str]:
     if not os.path.exists(file_path):
         return {}
 
-    with open(file_path) as json_file:
+    with open(file_path, encoding="utf-8") as json_file:
         return json.load(json_file)

--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -162,7 +162,7 @@ class BrowserContextFactory:
         preference_template = f"{SKYVERN_DIR}/webeye/chromium_preferences.json"
 
         preference_file_content = ""
-        with open(preference_template) as f:
+        with open(preference_template, encoding="utf-8") as f:
             preference_file_content = f.read()
             preference_file_content = preference_file_content.replace("MASK_SAVEFILE_DEFAULT_DIRECTORY", download_dir)
             preference_file_content = preference_file_content.replace("MASK_DOWNLOAD_DEFAULT_DIRECTORY", download_dir)

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -78,7 +78,7 @@ def load_js_script() -> str:
     try:
         # TODO: Implement TS of domUtils.js and use the complied JS file instead of the raw JS file.
         # This will allow our code to be type safe.
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             return f.read()
     except FileNotFoundError as e:
         LOG.exception("Failed to load the JS script", path=path)

--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -25,7 +25,7 @@ def load_js_script() -> str:
     try:
         # TODO: Implement TS of domUtils.js and use the complied JS file instead of the raw JS file.
         # This will allow our code to be type safe.
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             return f.read()
     except FileNotFoundError as e:
         LOG.exception("Failed to load the JS script", path=path)


### PR DESCRIPTION
Use explicit UTF-8 encoding in file open() calls, as otherwise Windows retrieves locale aware decoder.
Set asyncio event loop policy to WindowsSelectorEventLoopPolicy required by PostgreSQL Psycopg. Created a separate start_services path to run commands without create_subprocess_exec which requires a conflicting WindowsProactorEventLoopPolicy. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Windows compatibility by setting UTF-8 encoding for file operations and adjusting asyncio event loop policy.
> 
>   - **File Encoding**:
>     - Set UTF-8 encoding in `open()` calls in `utils.py`, `mcp.py`, `local.py`, `block.py`, `files.py`, `browser_factory.py`, `scraper.py`, and `page.py`.
>   - **Asyncio Event Loop Policy**:
>     - Introduce `set_selector_event_loop_policy_win32()` in `utils.py` to set `WindowsSelectorEventLoopPolicy` on Windows.
>     - Modify `quickstart.py` and `run_commands.py` to use `start_services_sync()` on Windows, avoiding `create_subprocess_exec`.
>   - **Misc**:
>     - Add `start_services_sync()` in `utils.py` for synchronous service start on Windows.
>     - Adjust `quickstart()` in `quickstart.py` to handle Windows-specific service start.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 49070a59b6bdb236dd3b9b0e99ea0c0fa6cbe860. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->