### PR TITLE
Add O3 as a model option

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -308,7 +308,7 @@ class Settings(BaseSettings):
                     "label": "Gemini 2.5 Flash",
                 },
                 "azure/gpt-4.1": {"llm_key": "AZURE_OPENAI_GPT4_1", "label": "GPT 4.1"},
-                "azure/o4-mini": {"llm_key": "AZURE_OPENAI_O4_MINI", "label": "GPT O4 Mini"},
+                "azure/o3": {"llm_key": "AZURE_OPENAI_O3", "label": "GPT O3"},
                 # "us.anthropic.claude-opus-4-20250514-v1:0": {
                 #     "llm_key": "BEDROCK_ANTHROPIC_CLAUDE4_OPUS_INFERENCE_PROFILE",
                 #     "label": "Anthropic Claude 4 Opus",
@@ -335,7 +335,7 @@ class Settings(BaseSettings):
                     "label": "Gemini 2.5 Flash",
                 },
                 "azure/gpt-4.1": {"llm_key": "AZURE_OPENAI_GPT4_1", "label": "GPT 4.1"},
-                "azure/o4-mini": {"llm_key": "AZURE_OPENAI_O4_MINI", "label": "GPT O4 Mini"},
+                "azure/o3": {"llm_key": "AZURE_OPENAI_O3", "label": "GPT O3"},
                 "us.anthropic.claude-opus-4-20250514-v1:0": {
                     "llm_key": "BEDROCK_ANTHROPIC_CLAUDE4_OPUS_INFERENCE_PROFILE",
                     "label": "Anthropic Claude 4 Opus",

--- a/skyvern/forge/sdk/db/polls.py
+++ b/skyvern/forge/sdk/db/polls.py
@@ -13,7 +13,7 @@ async def wait_on_persistent_browser_address(
     session_id: str,
     organization_id: str,
     timeout: int = 600,
-    poll_interval: float = 2,
+    poll_interval: int = 2,
 ) -> str | None:
     persistent_browser_session = await await_browser_session(db, session_id, organization_id, timeout, poll_interval)
     return persistent_browser_session.browser_address if persistent_browser_session else None
@@ -24,7 +24,7 @@ async def await_browser_session(
     session_id: str,
     organization_id: str,
     timeout: int = 600,
-    poll_interval: float = 2,
+    poll_interval: int = 2,
 ) -> PersistentBrowserSession | None:
     try:
         async with asyncio.timeout(timeout):


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `azure/o3` as a model option in `get_model_name_to_llm_key()` in `config.py`.
> 
>   - **Behavior**:
>     - Adds `azure/o3` as a model option in `get_model_name_to_llm_key()` in `config.py` for both cloud and non-cloud environments.
>     - Maps `azure/o3` to `AZURE_OPENAI_O3` with label `GPT O3`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 4c3906d7b196977e3eb298e771375979c2c811a7. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->