### PR TITLE
do not remove target attr

### DIFF
--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -136,13 +136,6 @@ class SkyvernElement:
     def __repr__(self) -> str:
         return f"SkyvernElement({str(self.__static_element)})"
 
-    async def _trim_target_attr(self) -> None:
-        if "target" not in self.get_attributes():
-            return
-        LOG.debug("Removing target attribute from the element", element=self.get_id())
-        skyvern_frame = await SkyvernFrame.create_instance(self.get_frame())
-        await skyvern_frame.remove_target_attr(await self.get_element_handler())
-
     def build_HTML(self, need_trim_element: bool = True, need_skyvern_attrs: bool = True) -> str:
         element_dict = self.get_element_dict()
         if need_trim_element:
@@ -815,12 +808,10 @@ class SkyvernElement:
 
     async def navigate_to_a_href(self, page: Page) -> str | None:
         if self.get_tag_name() != InteractiveElement.A:
-            await self._trim_target_attr()
             return None
 
         href = await self.should_use_navigation_instead_click(page)
         if not href:
-            await self._trim_target_attr()
             return None
 
         LOG.info(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove `_trim_target_attr` method from `SkyvernElement` in `dom.py`, affecting `target` attribute handling in `navigate_to_a_href`.
> 
>   - **Behavior**:
>     - Removes `_trim_target_attr` method from `SkyvernElement` class in `dom.py`.
>     - `navigate_to_a_href` no longer calls `_trim_target_attr`, affecting how `target` attributes are handled.
>   - **Logging**:
>     - Removes debug log for removing `target` attribute in `_trim_target_attr`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 05acd80a5a7b3ce0a19e4fefae0812cadddff307. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->