### PR TITLE
fix login schema

### DIFF
--- a/skyvern/forge/sdk/routes/run_blocks.py
+++ b/skyvern/forge/sdk/routes/run_blocks.py
@@ -85,6 +85,8 @@ async def login(
     yaml_parameters = []
     parameter_key = "credential"
     if login_request.credential_type == CredentialType.skyvern:
+        if not login_request.credential_id:
+            raise HTTPException(status_code=400, detail="credential_id is required to login with Skyvern credential")
         credential = await app.DATABASE.get_credential(login_request.credential_id, organization.organization_id)
         if not credential:
             raise HTTPException(status_code=404, detail=f"Credential {login_request.credential_id} not found")
@@ -111,6 +113,14 @@ async def login(
             )
         ]
     elif login_request.credential_type == CredentialType.onepassword:
+        if not login_request.onepassword_vault_id:
+            raise HTTPException(
+                status_code=400, detail="onepassword_vault_id is required to login with 1Password credential"
+            )
+        if not login_request.onepassword_item_id:
+            raise HTTPException(
+                status_code=400, detail="onepassword_item_id is required to login with 1Password credential"
+            )
         yaml_parameters = [
             OnePasswordCredentialParameterYAML(
                 key=parameter_key,

--- a/skyvern/schemas/run_blocks.py
+++ b/skyvern/schemas/run_blocks.py
@@ -1,5 +1,4 @@
 from enum import StrEnum
-from typing import Annotated, Literal, Union
 
 from pydantic import BaseModel, Field
 
@@ -12,7 +11,8 @@ class CredentialType(StrEnum):
     onepassword = "1password"
 
 
-class LoginRequestBase(BaseModel):
+class LoginRequest(BaseModel):
+    credential_type: CredentialType = Field(..., description="Where to get the credential from")
     url: str | None = Field(default=None, description="Website url")
     prompt: str | None = Field(
         default=None,
@@ -25,7 +25,9 @@ class LoginRequestBase(BaseModel):
     )
     totp_url: str | None = Field(default=None, description="TOTP URL to fetch one-time passwords")
     browser_session_id: str | None = Field(
-        default=None, description="ID of the browser session to use, which is prefixed by `pbs_` e.g. `pbs_123456`"
+        default=None,
+        description="ID of the browser session to use, which is prefixed by `pbs_` e.g. `pbs_123456`",
+        examples=["pbs_123456"],
     )
     extra_http_headers: dict[str, str] | None = Field(
         default=None, description="Additional HTTP headers to include in requests"
@@ -34,37 +36,18 @@ class LoginRequestBase(BaseModel):
         default=None, description="Maximum number of times to scroll for screenshots"
     )
 
+    # Skyvern credential
+    credential_id: str | None = Field(
+        default=None, description="ID of the Skyvern credential to use for login.", examples=["cred_123"]
+    )
 
-class SkyvernLoginRequest(LoginRequestBase):
-    """
-    Login with password saved in Skyvern
-    """
-
-    credential_type: Literal[CredentialType.skyvern] = CredentialType.skyvern
-    credential_id: str = Field(..., description="ID of the Skyvern credential to use for login.")
-
-
-class BitwardenLoginRequest(LoginRequestBase):
-    """
-    Login with password saved in Bitwarden
-    """
-
-    credential_type: Literal[CredentialType.bitwarden] = CredentialType.bitwarden
-    bitwarden_collection_id: str | None = Field(default=None, description="Bitwarden collection ID")
+    # Bitwarden credential
+    bitwarden_collection_id: str | None = Field(
+        default=None,
+        description="Bitwarden collection ID. You can find it in the Bitwarden collection URL. e.g. `https://vault.bitwarden.com/vaults/collection_id/items`",
+    )
     bitwarden_item_id: str | None = Field(default=None, description="Bitwarden item ID")
 
-
-class OnePasswordLoginRequest(LoginRequestBase):
-    """
-    Login with password saved in 1Password
-    """
-
-    credential_type: Literal[CredentialType.onepassword] = CredentialType.onepassword
-    onepassword_vault_id: str = Field(..., description="1Password vault ID.")
-    onepassword_item_id: str = Field(..., description="1Password item ID.")
-
-
-LoginRequest = Annotated[
-    Union[SkyvernLoginRequest, BitwardenLoginRequest, OnePasswordLoginRequest],
-    Field(discriminator="credential_type"),
-]
+    # 1Password credential
+    onepassword_vault_id: str | None = Field(default=None, description="1Password vault ID")
+    onepassword_item_id: str | None = Field(default=None, description="1Password item ID")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix login schema by consolidating `LoginRequest` and adding validation for required credential fields.
> 
>   - **Behavior**:
>     - Adds validation in `login()` in `run_blocks.py` to check for `credential_id` for Skyvern and `onepassword_vault_id`, `onepassword_item_id` for 1Password.
>   - **Schema**:
>     - Consolidates `LoginRequest` class in `run_blocks.py` by removing `SkyvernLoginRequest`, `BitwardenLoginRequest`, and `OnePasswordLoginRequest`.
>     - Adds `credential_id`, `bitwarden_collection_id`, `bitwarden_item_id`, `onepassword_vault_id`, and `onepassword_item_id` fields to `LoginRequest` in `run_blocks.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 3bd9a2a86f2304cda92d1612a3d6a3260e84d5d4. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->