### PR TITLE
Launch login sdk after fix for skyvern.login local mode not supported message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "skyvern"
-version = "0.2.5"
+version = "0.2.6"
 description = ""
 authors = ["Skyvern AI <info@skyvern.com>"]
 readme = "README.md"

--- a/skyvern/library/skyvern.py
+++ b/skyvern/library/skyvern.py
@@ -474,7 +474,7 @@ class Skyvern(AsyncSkyvern):
     ) -> None:
         if not self._api_key:
             raise ValueError(
-                "Local mode is not supported for run_workflow. Please instantiate Skyvern with an API key like this: Skyvern(api_key='your-api-key')"
+                "Local mode is not supported for login. Please instantiate Skyvern with an API key like this: Skyvern(api_key='your-api-key')"
             )
         workflow_run = await super().login(
             credential_type=credential_type,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes error message in `login()` in `skyvern.py` to correctly state local mode is not supported for login, and updates version to `0.2.6`.
> 
>   - **Behavior**:
>     - Fixes error message in `login()` in `skyvern.py` to correctly state "Local mode is not supported for login" instead of "run_workflow".
>   - **Versioning**:
>     - Updates version in `pyproject.toml` from `0.2.5` to `0.2.6`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e9eed210c103eaa3ef0cced30d42ce3aa4ae193c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->