### PR TITLE
increase browser session timeout

### DIFF
--- a/skyvern-frontend/src/store/useOptimisticallyRequestBrowserSessionId.ts
+++ b/skyvern-frontend/src/store/useOptimisticallyRequestBrowserSessionId.ts
@@ -21,7 +21,7 @@ export interface OptimisticBrowserSession {
   run: (runOpts: RunOpts) => Promise<BrowserSessionData>;
 }
 
-const SESSION_TIMEOUT_MINUTES = 60;
+const SESSION_TIMEOUT_MINUTES = 60 * 4;
 const SPARE = "spare";
 
 const makeKey = (user: User, workflowPermanentId?: string | undefined) => {


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase browser session timeout from 60 minutes to ~~12~~ 4 hours in `useOptimisticallyRequestBrowserSessionId.ts`.
> 
>   - **Behavior**:
>     - Increase `SESSION_TIMEOUT_MINUTES` from 60 to ~~720~~ 240 in `useOptimisticallyRequestBrowserSessionId.ts`, extending browser session validity to 12 hours.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 4dcc7a7ce4dd42409a3e2c03010354d190673a60. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->