### PR TITLE
bump max session timeout to 4 hours

### DIFF
--- a/skyvern/schemas/browser_sessions.py
+++ b/skyvern/schemas/browser_sessions.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, Field
 
 MIN_TIMEOUT = 5
-MAX_TIMEOUT = 120
+MAX_TIMEOUT = 60 * 4  # 4 hours
 DEFAULT_TIMEOUT = 60
 
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Increase `MAX_TIMEOUT` to 4 hours in `skyvern/schemas/browser_sessions.py`, affecting session duration validation.
> 
>   - **Behavior**:
>     - Increase `MAX_TIMEOUT` from 120 to 240 minutes (4 hours) in `skyvern/schemas/browser_sessions.py`.
>     - Affects `timeout` validation in `CreateBrowserSessionRequest` class, allowing longer session durations.
>   - **Misc**:
>     - Update comment to reflect new `MAX_TIMEOUT` value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 521dbdae14443480a376de6c58e8f4e1aabd2a7d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->