### PR TITLE
Switch from Poetry to uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,45 +40,19 @@ jobs:
       # number in the cache key, and the "-0" suffix: this allows you to invalidate the cache
       # manually if/when you want to upgrade Poetry, or if something goes wrong. This could be
       # mildly cleaner by using an environment variable, but I don't really care.
-      - name: cache poetry install
-        uses: actions/cache@v3
-        with:
-          path: ~/.local
-          key: poetry-1.7.1
-      # Install Poetry. You could do this manually, or there are several actions that do this.
-      # `snok/install-poetry` seems to be minimal yet complete, and really just calls out to
-      # Poetry's default install script, which feels correct. I pin the Poetry version here
-      # because Poetry does occasionally change APIs between versions and I don't want my
-      # actions to break if it does.
-      #
-      # The key configuration value here is `virtualenvs-in-project: true`: this creates the
-      # venv as a `.venv` in your testing directory, which allows the next step to easily
-      # cache it.
-      - uses: snok/install-poetry@v1
-        with:
-          version: 1.7.1
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-      # Cache your dependencies (i.e. all the stuff in your `pyproject.toml`). Note the cache
-      # key: if you're using multiple Python versions, or multiple OSes, you'd need to include
-      # them in the cache key. I'm not, so it can be simple and just depend on the poetry.lock.
       - name: cache deps
         id: cache-deps
         uses: actions/cache@v3
         with:
           path: .venv
-          key: pydeps-${{ hashFiles('**/poetry.lock') }}
-      # Install dependencies. `--no-root` means "install all dependencies but not the project
-      # itself", which is what you want to avoid caching _your_ code. The `if` statement
-      # ensures this only runs on a cache miss.
-      - run: poetry install --no-interaction --no-root
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-      # Now install _your_ project. This isn't necessary for many types of projects -- particularly
-      # things like Django apps don't need this. But it's a good idea since it fully-exercises the
-      # pyproject.toml and makes that if you add things like console-scripts at some point that
-      # they'll be installed and working.
-      - run: poetry install --no-interaction
-      # Finally, run pre-commit.
+          key: pydeps-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
+      - name: Install uv
+        run: pip install uv
+      - run: |
+          uv venv
+          uv pip install -e ".[dev]"
+        if: steps.cache-deps.outputs.cache-hit != "true"
+      - run: uv pip install -e ".[dev]"
       - name: Run all pre-commit hooks
         uses: pre-commit/action@v3.0.0
         env:
@@ -102,14 +76,18 @@ jobs:
           AZURE_GPT4O_MINI_API_VERSION: "dummy"
           AWS_REGION: "us-east-1"
           ENABLE_BEDROCK: "true"
-        run: poetry run ./run_alembic_check.sh
+        run: |
+          source .venv/bin/activate
+          ./run_alembic_check.sh
       - name: trigger tests
         env:
           ENABLE_OPENAI: "true"
           OPENAI_API_KEY: "sk-dummy"
           AWS_ACCESS_KEY_ID: "dummy"
           AWS_SECRET_ACCESS_KEY: "dummy"
-        run: poetry run pytest
+        run: |
+          source .venv/bin/activate
+          pytest
   fe-lint-build:
     name: Frontend Lint and Build
     runs-on: ubuntu-latest

--- a/.github/workflows/codeflash.yaml
+++ b/.github/workflows/codeflash.yaml
@@ -28,16 +28,17 @@ jobs:
       - name: Install Project Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install poetry
-          poetry install --all-extras
-          poetry add codeflash
+          pip install uv
+          uv venv
+          uv pip install -e '.[all]'
+          uv pip install codeflash
       - name: create test dir
         run: |
           mkdir -p codeflash-tests
       - name: Run Codeflash to optimize code
         run: |
-          poetry env use python
-          poetry run codeflash
+          source .venv/bin/activate
+          codeflash
       - name: remove test dir
         run: |-
           rm -rf codeflash-tests

--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -48,55 +48,25 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      # Cache the installation of Poetry itself, e.g. the next step. This prevents the workflow
-      # from installing Poetry every time, which can be slow. Note the use of the Poetry version
-      # number in the cache key, and the "-0" suffix: this allows you to invalidate the cache
-      # manually if/when you want to upgrade Poetry, or if something goes wrong. This could be
-      # mildly cleaner by using an environment variable, but I don't really care.
-      - name: cache poetry install
-        uses: actions/cache@v3
-        with:
-          path: ~/.local
-          key: poetry-1.7.1
-      # Install Poetry. You could do this manually, or there are several actions that do this.
-      # `snok/install-poetry` seems to be minimal yet complete, and really just calls out to
-      # Poetry's default install script, which feels correct. I pin the Poetry version here
-      # because Poetry does occasionally change APIs between versions and I don't want my
-      # actions to break if it does.
-      #
-      # The key configuration value here is `virtualenvs-in-project: true`: this creates the
-      # venv as a `.venv` in your testing directory, which allows the next step to easily
-      # cache it.
-      - uses: snok/install-poetry@v1
-        with:
-          version: 1.7.1
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-      # Cache your dependencies (i.e. all the stuff in your `pyproject.toml`). Note the cache
-      # key: if you're using multiple Python versions, or multiple OSes, you'd need to include
-      # them in the cache key. I'm not, so it can be simple and just depend on the poetry.lock.
+      - name: Install uv
+        run: pip install uv build
       - name: cache deps
         id: cache-deps
         uses: actions/cache@v3
         with:
           path: .venv
-          key: pydeps-${{ hashFiles('**/poetry.lock') }}
-      # Install dependencies. `--no-root` means "install all dependencies but not the project
-      # itself", which is what you want to avoid caching _your_ code. The `if` statement
-      # ensures this only runs on a cache miss.
-      - run: poetry install --no-interaction --no-root
+          key: pydeps-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
+      - run: |
+          uv venv
+          uv pip install -e '.[dev]'
         if: steps.cache-deps.outputs.cache-hit != 'true'
-      # Now install _your_ project. This isn't necessary for many types of projects -- particularly
-      # things like Django apps don't need this. But it's a good idea since it fully-exercises the
-      # pyproject.toml and makes that if you add things like console-scripts at some point that
-      # they'll be installed and working.
-      - run: poetry install --no-interaction
+      - run: uv pip install -e '.[dev]'
       - name: Clean dist directory
         run: rm -rf dist
       - name: Build Package
-        run: poetry build
+        run: python -m build
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: poetry run twine upload --repository pypi dist/*
+        run: uv pip install twine && twine upload --repository pypi dist/*

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ We love to see how Skyvern is being used in the wild. Here are some examples of 
 # Contributor Setup
 For a complete local environment CLI Installation
 ```bash
-pip install -e .
+uv pip install -e .
 ```
 The following command sets up your development environment to use pre-commit (our commit hook handler)
 ```

--- a/run_skyvern.sh
+++ b/run_skyvern.sh
@@ -10,7 +10,11 @@ if [ ! -f .env ]; then
   echo "Please add your api keys to the .env file."
 fi
 # shellcheck source=/dev/null
-source "$(poetry env info --path)/bin/activate"
-poetry install
+if [ ! -d .venv ]; then
+  uv venv
+fi
+# shellcheck source=/dev/null
+source .venv/bin/activate
+uv pip install -e ".[dev]"
 ./run_alembic_check.sh
-poetry run python -m skyvern.forge
+python -m skyvern.forge

--- a/skyvern/webeye/README.md
+++ b/skyvern/webeye/README.md
@@ -20,7 +20,7 @@ These instructions will get you a copy of the project up and running on your loc
 
 Before you begin, ensure you have the following installed:
 - [Python 3.11](https://www.python.org/downloads/)
-- [Poetry](https://python-poetry.org/docs/#installation)
+- [uv](https://github.com/astral-sh/uv)
 
 ### Installation
 
@@ -33,8 +33,8 @@ Before you begin, ensure you have the following installed:
 2. **Install dependencies**
 
    ```sh
-    poetry install
-    ```
+   uv pip install -e .
+   ```
 
 3. *Define the following environment variables*
 


### PR DESCRIPTION
## Summary
- use `uv` for local scripts
- replace Poetry with uv in Dockerfile
- document uv in README files
- migrate CI/CD workflows to uv

## Description

This pull request migrates the project's Python package management from Poetry to uv across all environments and workflows. The change affects CI/CD pipelines, Docker builds, local development scripts, and documentation. Key modifications include:

- **CI/CD Workflows**: Updated `.github/workflows/ci.yml`, `.github/workflows/codeflash.yaml`, and `.github/workflows/sdk-release.yml` to use `uv` instead of Poetry for dependency management and virtual environment creation
- **Docker Build**: Simplified `Dockerfile` by removing the multi-stage Poetry-based requirements generation and directly using `uv pip install`
- **Local Development**: Updated `run_skyvern.sh` to create and activate virtual environments using `uv venv` and install dependencies with `uv pip install`
- **Documentation**: Updated README files to reference `uv` instead of Poetry for installation instructions

The migration maintains the same dependency caching strategy but updates cache keys to include both `pyproject.toml` and `poetry.lock` files. All workflow steps that previously used `poetry run` commands now activate the virtual environment manually and run commands directly.

## Testing
- `pre-commit run --all-files` *(fails: pre-commit not installed)*
- `pytest` *(fails: missing dependencies)*

## Changes that Break Backward Compatibility

This change may break backward compatibility for developers who have existing Poetry-based local development setups. Developers will need to:
- Install `uv` instead of Poetry
- Use `uv pip install -e .` instead of `poetry install`
- Activate virtual environments manually with `source .venv/bin/activate` instead of using `poetry run`

## Documentation

Updated documentation includes:
- `README.md`: Changed installation command from `pip install -e .` to `uv pip install -e .`
- `skyvern/webeye/README.md`: Updated prerequisites to mention `uv` instead of Poetry and changed installation instructions

------
https://chatgpt.com/codex/tasks/task_b_6881b0bcd644832d9b7d03ba7191469f

*Created with [Palmier](https://www.palmier.io)*
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch from Poetry to uv for dependency management and virtual environment setup across the project.
> 
>   - **CI/CD Workflows**:
>     - Replace Poetry with `uv` in `.github/workflows/ci.yml`, `.github/workflows/codeflash.yaml`, and `.github/workflows/sdk-release.yml`.
>     - Update dependency installation and virtual environment setup to use `uv`.
>   - **Dockerfile**:
>     - Remove Poetry setup and use `uv` for installing dependencies.
>     - Simplify Dockerfile by directly installing `uv` and dependencies.
>   - **Scripts and Documentation**:
>     - Update `run_skyvern.sh` to use `uv` for virtual environment and dependency management.
>     - Modify `README.md` and `skyvern/webeye/README.md` to document `uv` usage for installation and setup.
>   - **Testing**:
>     - `pre-commit` and `pytest` fail due to missing dependencies and pre-commit not being installed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0a79ed1f5165797f6a0a148296dbcecc84f45098. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->