### PR TITLE
fix style map parsing

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -2275,13 +2275,13 @@ async function getHoverStylesMap() {
 
           let newLink = null;
           try {
+            const oldLink = sheet.ownerNode;
+            const url = new URL(sheet.href);
             _jsConsoleLog("recreating the link element: ", sheet.href);
-            const oldLink = document.querySelector(
-              `link[href="${sheet.href}"]`,
-            );
             newLink = document.createElement("link");
             newLink.rel = "stylesheet";
-            newLink.href = oldLink.href + "?v=" + Date.now(); // to void cache
+            url.searchParams.set("v", Date.now());
+            newLink.href = url.toString();
             newLink.crossOrigin = "anonymous";
             // until the new link loaded, removing the old one
             document.head.append(newLink);


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `getHoverStylesMap()` in `domUtils.js` to use `URL` for managing query parameters, improving cache-busting logic.
> 
>   - **Behavior**:
>     - In `getHoverStylesMap()`, change the method of appending a timestamp to the `href` of a new link element to avoid caching issues.
>     - Use `URL` object to manage query parameters instead of string concatenation.
>   - **Misc**:
>     - Minor refactoring in `getHoverStylesMap()` for better readability and maintainability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b1e3702e4e3c35215925a0d4dbb492db3a0d4143. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

*Created with [Palmier](https://www.palmier.io)*