### PR TITLE
make login workflow auto_generated so they don't show up in workflow history

### DIFF
--- a/skyvern/forge/sdk/routes/run_blocks.py
+++ b/skyvern/forge/sdk/routes/run_blocks.py
@@ -16,7 +16,7 @@ from skyvern.forge.sdk.routes.routers import base_router
 from skyvern.forge.sdk.schemas.organizations import Organization
 from skyvern.forge.sdk.services import org_auth_service
 from skyvern.forge.sdk.workflow.models.parameter import WorkflowParameterType
-from skyvern.forge.sdk.workflow.models.workflow import WorkflowRequestBody
+from skyvern.forge.sdk.workflow.models.workflow import WorkflowRequestBody, WorkflowStatus
 from skyvern.forge.sdk.workflow.models.yaml import (
     BitwardenLoginCredentialParameterYAML,
     LoginBlockYAML,
@@ -79,6 +79,7 @@ async def login(
         proxy_location=login_request.proxy_location,
         max_screenshot_scrolling_times=login_request.max_screenshot_scrolling_times,
         extra_http_headers=login_request.extra_http_headers,
+        status=WorkflowStatus.auto_generated,
     )
     # 2. add a login block to the workflow
     label = "login"


### PR DESCRIPTION
---

🔧 This PR marks login workflows as auto-generated to prevent them from cluttering the workflow history UI. The change adds a status parameter to automatically created login workflows, making them invisible in the standard workflow listing while maintaining their functionality.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Workflow Status Enhancement**: Added `WorkflowStatus` import to support the new auto-generated status classification
- **Login Workflow Marking**: Modified the login workflow creation to include `status=WorkflowStatus.auto_generated` parameter
- **UI/UX Improvement**: Prevents automatically generated login workflows from appearing in user-facing workflow history

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant API as Login API
    participant WF as Workflow Service
    participant UI as Workflow History UI
    
    User->>API: Request login workflow
    API->>WF: Create workflow with status=auto_generated
    WF->>WF: Process login workflow
    Note over UI: Auto-generated workflows filtered out
    UI->>User: Shows only user-created workflows
```

### Impact
- **Cleaner User Experience**: Users will no longer see system-generated login workflows in their workflow history
- **Improved Organization**: Separates user-initiated workflows from system-generated ones for better workflow management
- **Backward Compatibility**: Existing functionality remains unchanged, only adds metadata to distinguish workflow types

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets `status=WorkflowStatus.auto_generated` in `login()` in `run_blocks.py` to mark workflows as auto-generated.
> 
>   - **Behavior**:
>     - Sets `status=WorkflowStatus.auto_generated` in `login()` in `run_blocks.py` to mark workflows as auto-generated.
>   - **Imports**:
>     - Adds `WorkflowStatus` to imports in `run_blocks.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1ee9c15949a1f3649a33ab602426a2cec4904904. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->