### PR TITLE
Remove frontend hack for requesting persistent browser sessions, part ii (backend)

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -294,6 +294,21 @@ class Settings(BaseSettings):
     TRACE_PROVIDER_HOST: str | None = None
     TRACE_PROVIDER_API_KEY: str = "fillmein"
 
+    # Debug Session Settings
+    DEBUG_SESSION_TIMEOUT_MINUTES: int = 60 * 4
+    """
+    The timeout for a persistent browser session backing a debug session,
+    in minutes.
+    """
+
+    DEBUG_SESSION_TIMEOUT_THRESHOLD_MINUTES: int = 5
+    """
+    If there are `DEBUG_SESSION_TIMEOUT_THRESHOLD_MINUTES` or more minutes left
+    in the persistent browser session (`started_at` + `timeout_minutes`), then
+    the `timeout_minutes` of the persistent browser session can be extended.
+    Otherwise we'll consider the persistent browser session to be expired.
+    """
+
     def get_model_name_to_llm_key(self) -> dict[str, dict[str, str]]:
         """
         Keys are model names available to blocks in the frontend. These map to key names

--- a/skyvern/forge/app.py
+++ b/skyvern/forge/app.py
@@ -75,6 +75,7 @@ AGENT_FUNCTION = AgentFunction()
 PERSISTENT_SESSIONS_MANAGER = PersistentSessionsManager(database=DATABASE)
 scrape_exclude: ScrapeExcludeFunc | None = None
 authentication_function: Callable[[str], Awaitable[Organization]] | None = None
+authenticate_user_function: Callable[[str], Awaitable[str | None]] | None = None
 setup_api_app: Callable[[FastAPI], None] | None = None
 
 agent = ForgeAgent()

--- a/skyvern/forge/sdk/schemas/debug_sessions.py
+++ b/skyvern/forge/sdk/schemas/debug_sessions.py
@@ -1,13 +1,13 @@
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class DebugSession(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     debug_session_id: str
-    organization_id: str
     browser_session_id: str
-    workflow_permanent_id: str
-    user_id: str
+    workflow_permanent_id: str | None = None
     created_at: datetime
     modified_at: datetime

--- a/skyvern/forge/sdk/services/org_auth_service.py
+++ b/skyvern/forge/sdk/services/org_auth_service.py
@@ -86,6 +86,44 @@ async def _authenticate_helper(authorization: str) -> Organization:
     return organization
 
 
+async def get_current_user_id(
+    authorization: Annotated[str | None, Header(include_in_schema=False)] = None,
+) -> str:
+    if not authorization:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid credentials",
+        )
+    return await _authenticate_user_helper(authorization)
+
+
+async def get_current_user_id_with_authentication(
+    authorization: Annotated[str | None, Header()] = None,
+) -> str:
+    if not authorization:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid credentials",
+        )
+    return await _authenticate_user_helper(authorization)
+
+
+async def _authenticate_user_helper(authorization: str) -> str:
+    token = authorization.split(" ")[1]
+    if not app.authenticate_user_function:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid user authentication method",
+        )
+    user_id = await app.authenticate_user_function(token)
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid credentials",
+        )
+    return user_id
+
+
 @cached(cache=TTLCache(maxsize=CACHE_SIZE, ttl=AUTHENTICATION_TTL))
 async def _get_current_org_cached(x_api_key: str, db: AgentDB) -> Organization:
     """


### PR DESCRIPTION
- add api for requesting debug sessions
- extend pbs timeout_seconds as necessary
- threshold up to 5 minutes
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces API for managing debug sessions with persistent browser sessions, including session creation and extension, and updates database and configuration for session management.
> 
>   - **API Changes**:
>     - Added `get_or_create_debug_session_by_user_and_workflow_permanent_id()` in `agent_protocol.py` to manage debug sessions.
>     - Extends or creates a new debug session with a persistent browser session.
>   - **Database**:
>     - Added `update_persistent_browser_session()` and `update_debug_session()` in `client.py` to handle session updates.
>   - **Configuration**:
>     - Added `DEBUG_SESSION_TIMEOUT_MINUTES` and `DEBUG_SESSION_TIMEOUT_THRESHOLD_MINUTES` in `config.py` for session management.
>   - **Authentication**:
>     - Added `get_current_user_id()` and `get_current_user_id_with_authentication()` in `org_auth_service.py` for user identification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 26eeadac3e41bbbf7352b32c025ef010d5cb5bb6. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR implements a backend API for managing persistent browser debug sessions, removing the need for frontend hacks by providing proper session lifecycle management with automatic timeout extension and user authentication.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **API Endpoint**: Added `GET /debug-session/{workflow_permanent_id}` that creates or retrieves debug sessions with intelligent timeout management
- **Database Operations**: Implemented `update_persistent_browser_session()` and `update_debug_session()` methods for session lifecycle management
- **Configuration**: Added `DEBUG_SESSION_TIMEOUT_MINUTES` (4 hours) and `DEBUG_SESSION_TIMEOUT_THRESHOLD_MINUTES` (5 minutes) settings
- **Authentication**: Introduced user authentication functions to support per-user debug sessions
- **Session Logic**: Refactored debug session creation/retrieval to handle timeout extensions automatically

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant API
    participant DB
    participant SessionManager
    
    Client->>API: GET /debug-session/{workflow_id}
    API->>DB: get_debug_session()
    
    alt Debug session exists
        DB-->>API: Return existing session
        API->>DB: get_persistent_browser_session()
        
        alt Session active & time remaining >= 5min
            API->>DB: update_persistent_browser_session()
            Note over API: Extend timeout to 4 hours
        else Session expired/inactive
            API->>SessionManager: create_session()
            API->>DB: update_debug_session()
        end
    else No debug session
        API->>SessionManager: create_session()
        API->>DB: create_debug_session()
    end
    
    API-->>Client: Return debug session
```

### Impact
- **User Experience**: Eliminates frontend workarounds by providing a clean backend API for debug session management
- **Session Management**: Automatic timeout extension prevents premature session expiration during active debugging
- **Resource Optimization**: Intelligent session reuse reduces unnecessary browser session creation
- **Security**: Proper user authentication ensures debug sessions are isolated per user
- **Maintainability**: Centralizes session logic in the backend, making it easier to modify timeout policies

</details>

_Created with [Palmier](https://www.palmier.io)_