### PR TITLE
Jon/sky 5741 enable take control via buttons in browser stream component

### DIFF
--- a/skyvern-frontend/src/components/BrowserStream.tsx
+++ b/skyvern-frontend/src/components/BrowserStream.tsx
@@ -75,7 +75,7 @@ function BrowserStream({
   } else {
     throw new Error("No browser session, task or workflow provided");
   }
-  const [userIsControlling, setUserIsControlling] = useState(false);
+  const [userIsControlling, setUserIsControlling] = useState(interactive);
   const [commandSocket, setCommandSocket] = useState<WebSocket | null>(null);
   const [vncDisconnectedTrigger, setVncDisconnectedTrigger] = useState(0);
   const prevVncConnectedRef = useRef<boolean>(false);
@@ -282,13 +282,13 @@ function BrowserStream({
       commandSocket.send(JSON.stringify(command));
     };
 
-    if (interactive) {
+    if (interactive || userIsControlling) {
       sendCommand({ kind: "take-control" });
     } else {
       sendCommand({ kind: "cede-control" });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [interactive, isCommandConnected]);
+  }, [interactive, isCommandConnected, userIsControlling]);
 
   // Effect to show toast when task or workflow reaches a final state based on hook updates
   useEffect(() => {


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Initialize `userIsControlling` state with `interactive` prop and update command sending logic in `BrowserStream.tsx`.
> 
>   - **Behavior**:
>     - Initialize `userIsControlling` state with `interactive` prop in `BrowserStream.tsx`.
>     - Modify effect to send `take-control` or `cede-control` command based on `userIsControlling` state.
>     - Add `userIsControlling` to effect dependencies to ensure commands are sent when state changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a55888292a8778b6f978b309e0bc19e2edbf691c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🎮 This PR enables dynamic user control in the browser stream component by allowing users to take or cede control through UI buttons, rather than relying solely on the initial `interactive` prop. The changes modify the state management and command logic to support real-time control switching during browser streaming sessions.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **State Initialization**: Changed `userIsControlling` state to initialize with the `interactive` prop value instead of hardcoded `false`
- **Command Logic**: Updated the useEffect to send control commands based on `userIsControlling` state in addition to the `interactive` prop
- **Dependency Management**: Added `userIsControlling` to the useEffect dependency array to trigger command updates when control state changes
- **UI Enhancement**: According to the description, buttons are added to allow users to dynamically take or cede control (though not visible in the provided patch)

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant BrowserStream
    participant WebSocket
    participant Backend
    
    User->>BrowserStream: Clicks take/cede control button
    BrowserStream->>BrowserStream: Updates userIsControlling state
    BrowserStream->>WebSocket: Sends take-control/cede-control command
    WebSocket->>Backend: Forwards control command
    Backend->>WebSocket: Acknowledges control change
    WebSocket->>BrowserStream: Control state updated
```

### Impact
- **User Experience**: Users can now dynamically switch between controlling and observing the browser stream without needing to restart the session
- **Flexibility**: The component becomes more interactive by supporting real-time control state changes through UI interactions
- **State Consistency**: Proper initialization ensures the control state aligns with the interactive prop from the start, preventing initial state mismatches

</details>

_Created with [Palmier](https://www.palmier.io)_