### PR TITLE
Fix incorrect model reference in .env.sample for GEMINI_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,7 @@ AZURE_GPT4O_MINI_API_VERSION=""
 
 # ENABLE_GEMINI: Set to true to enable Gemini as a language model provider.
 ENABLE_GEMINI=false
-# GEMINI_API_KEY: Your Gemini API key for accessing models like GPT-4.
+# GEMINI_API_KEY: Your Gemini API key for accessing models like Gemini 2.5 Pro.
 GEMINI_API_KEY=""
 
 # ENABLE_NOVITA: Set to true to enable Novita AI as a language model provider.


### PR DESCRIPTION
This PR updates the `.env.sample` file to correct the description for `GEMINI_API_KEY`.

Before:
# GEMINI_API_KEY: Your Gemini API key for accessing models like GPT-4.

After:
# GEMINI_API_KEY: Your Gemini API key for accessing models like Gemini 2.5 Pro.