### PR TITLE
attempt to allow nested blocks in the debugger

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -2989,6 +2989,26 @@ class HttpRequestBlock(Block):
             )
 
 
+def get_all_blocks(blocks: list[BlockTypeVar]) -> list[BlockTypeVar]:
+    """
+    Recursively get "all blocks" in a workflow definition.
+
+    At time of writing, blocks can be nested via the ForLoop block. This function
+    returns all blocks, flattened.
+    """
+
+    all_blocks: list[BlockTypeVar] = []
+
+    for block in blocks:
+        all_blocks.append(block)
+
+        if block.block_type == BlockType.FOR_LOOP:
+            nested_blocks = get_all_blocks(block.loop_blocks)
+            all_blocks.extend(nested_blocks)
+
+    return all_blocks
+
+
 BlockSubclasses = Union[
     ForLoopBlock,
     TaskBlock,

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -63,6 +63,7 @@ from skyvern.forge.sdk.workflow.models.block import (
     UrlBlock,
     ValidationBlock,
     WaitBlock,
+    get_all_blocks,
 )
 from skyvern.forge.sdk.workflow.models.parameter import (
     PARAMETER_TYPE,
@@ -330,12 +331,12 @@ class WorkflowService:
             )
             return workflow_run
 
-        all_blocks = workflow.workflow_definition.blocks
+        top_level_blocks = workflow.workflow_definition.blocks
+        all_blocks = get_all_blocks(top_level_blocks)
 
         if block_labels and len(block_labels):
             blocks: list[BlockTypeVar] = []
             all_labels = {block.label: block for block in all_blocks}
-
             for label in block_labels:
                 if label not in all_labels:
                     raise BlockNotFound(block_label=label)
@@ -350,7 +351,7 @@ class WorkflowService:
             )
 
         else:
-            blocks = all_blocks
+            blocks = top_level_blocks
 
         if not blocks:
             raise SkyvernException(f"No blocks found for the given block labels: {block_labels}")


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-5685/w3-invesitgate-debugger-not-working-inside-for-loop-block

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `get_all_blocks()` to handle nested `ForLoopBlock` types, integrating it into `execute_workflow()` for executing all blocks, including nested ones.
> 
>   - **Behavior**:
>     - Adds `get_all_blocks()` in `block.py` to recursively flatten nested blocks, specifically handling `ForLoopBlock` types.
>     - Integrates `get_all_blocks()` into `execute_workflow()` in `service.py` to execute all blocks, including nested ones.
>   - **Misc**:
>     - Adjusts block execution logic in `execute_workflow()` to use flattened block list for execution.
>     - No changes to block execution order or logic outside of handling nested blocks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 18cf1f4a6df21953827cfa866f89ee7c7702dc8b. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR enhances the workflow debugger by adding support for nested blocks, specifically enabling the debugger to access and execute blocks that are nested within ForLoop structures through a new recursive flattening function.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **New Utility Function**: Added `get_all_blocks()` in `block.py` that recursively traverses workflow definitions to flatten nested block structures, specifically handling `ForLoopBlock` types
- **Workflow Service Integration**: Modified `execute_workflow()` in `service.py` to use the new flattening function when processing block labels for debugging
- **Block Discovery Enhancement**: The debugger can now find and execute blocks that are nested within ForLoop blocks, which was previously not possible

### Technical Implementation
```mermaid
flowchart TD
    A[execute_workflow called] --> B[Get top_level_blocks]
    B --> C[Call get_all_blocks()]
    C --> D{Block is ForLoopBlock?}
    D -->|Yes| E[Recursively get nested blocks]
    D -->|No| F[Add block to list]
    E --> G[Extend all_blocks list]
    F --> H[Continue to next block]
    G --> H
    H --> I[Return flattened block list]
    I --> J[Use flattened list for label matching]
    J --> K[Execute selected blocks]
```

### Impact
- **Debugger Functionality**: Developers can now debug nested blocks within ForLoop structures, significantly improving the debugging experience for complex workflows
- **Backward Compatibility**: The changes maintain existing behavior for non-nested scenarios while extending functionality for nested cases
- **Code Organization**: The recursive approach provides a clean, maintainable solution that can be extended for other nested block types in the future

</details>

_Created with [Palmier](https://www.palmier.io)_