### PR TITLE
fix task v2 cancel

### DIFF
--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -818,6 +818,7 @@ async def run_task_v2_helper(
             task_v2 = await update_task_v2_status_to_workflow_run_status(
                 task_v2_id=task_v2_id,
                 workflow_run_status=workflow_run.status,
+                organization_id=organization_id,
             )
             break
         if block_result.success is True:
@@ -1503,7 +1504,7 @@ async def mark_task_v2_as_timed_out(
 async def update_task_v2_status_to_workflow_run_status(
     task_v2_id: str,
     workflow_run_status: WorkflowRunStatus,
-    organization_id: str | None = None,
+    organization_id: str,
 ) -> TaskV2:
     task_v2 = await app.DATABASE.update_task_v2(
         task_v2_id,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Make `organization_id` a required parameter in `update_task_v2_status_to_workflow_run_status` and update its usage in `run_task_v2_helper`.
> 
>   - **Function Signature Change**:
>     - `update_task_v2_status_to_workflow_run_status` now requires `organization_id` as a non-optional parameter.
>   - **Function Call Update**:
>     - Updated call to `update_task_v2_status_to_workflow_run_status` in `run_task_v2_helper` to pass `organization_id` explicitly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a5dcec721c9ca3f647151edd1d960ea15951d749. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes a critical bug in task v2 cancellation by ensuring the `organization_id` parameter is properly passed to the status update function and making it a required parameter instead of optional.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Parameter Passing**: Added missing `organization_id` parameter to the `update_task_v2_status_to_workflow_run_status` function call in `run_task_v2_helper`
- **Function Signature**: Changed `organization_id` from optional (`str | None = None`) to required (`str`) in the `update_task_v2_status_to_workflow_run_status` function
- **Bug Fix**: Resolves task cancellation issues that were likely occurring due to missing organization context

### Technical Implementation
```mermaid
sequenceDiagram
    participant Helper as run_task_v2_helper
    participant UpdateFunc as update_task_v2_status_to_workflow_run_status
    participant DB as Database
    
    Helper->>UpdateFunc: Call with task_v2_id, workflow_run_status, organization_id
    Note over Helper,UpdateFunc: Previously organization_id was missing
    UpdateFunc->>DB: Update task with proper organization context
    DB-->>UpdateFunc: Return updated TaskV2
    UpdateFunc-->>Helper: Return TaskV2
```

### Impact
- **Bug Resolution**: Fixes task cancellation functionality that was broken due to missing organization context
- **Data Integrity**: Ensures proper organization scoping when updating task statuses
- **API Consistency**: Makes the function signature more explicit by requiring the organization_id parameter rather than allowing it to be optional

</details>

_Created with [Palmier](https://www.palmier.io)_