### PR TITLE
count block children in determining whether to enable debugging via b…

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -89,6 +89,7 @@ import {
   descendants,
   generateNodeLabel,
   getAdditionalParametersForEmailBlock,
+  getOrderedChildrenBlocks,
   getOutputParameterKey,
   getWorkflowBlocks,
   getWorkflowErrors,
@@ -397,10 +398,21 @@ function FlowRenderer({
   }, [nodesInitialized]);
 
   useEffect(() => {
-    const blocks = getWorkflowBlocks(nodes, edges);
-    const debuggable = blocks.filter((block) =>
+    const topLevelBlocks = getWorkflowBlocks(nodes, edges);
+    const debuggable = topLevelBlocks.filter((block) =>
       debuggableWorkflowBlockTypes.has(block.block_type),
     );
+
+    for (const node of nodes) {
+      const childBlocks = getOrderedChildrenBlocks(nodes, edges, node.id);
+
+      for (const child of childBlocks) {
+        if (debuggableWorkflowBlockTypes.has(child.block_type)) {
+          debuggable.push(child);
+        }
+      }
+    }
+
     setDebuggableBlockCount(debuggable.length);
   }, [nodes, edges]);
 

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -2242,6 +2242,7 @@ export {
   getLabelForWorkflowParameterType,
   maxNestingLevel,
   getWorkflowSettings,
+  getOrderedChildrenBlocks,
   getOutputParameterKey,
   getPreviousNodeIds,
   getUniqueLabelForExistingNode,


### PR DESCRIPTION
…utton

Currently cannot "Start Debugging" when a workflow contains no top-level debuggable blocks, but _does_ container child debuggable blocks. This fixes that.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Updates `FlowRenderer.tsx` to enable debugging if any child block is debuggable by using `getOrderedChildrenBlocks()` from `workflowEditorUtils.ts`.
> 
>   - **Behavior**:
>     - `FlowRenderer.tsx`: Updates `useEffect` to include child blocks in `debuggableBlockCount` by using `getOrderedChildrenBlocks()`.
>     - Enables "Start Debugging" if any child block is debuggable, not just top-level blocks.
>   - **Utilities**:
>     - Adds `getOrderedChildrenBlocks()` to `workflowEditorUtils.ts` to retrieve ordered child blocks for a given node.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 607f2549d75643738f27f6247642558901d1bc83. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🐛 This PR fixes a debugging functionality issue where the "Start Debugging" button was incorrectly disabled when workflows contained debuggable blocks only as children (nested within other blocks) rather than at the top level. The fix ensures all debuggable blocks are counted regardless of their nesting level.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **FlowRenderer.tsx**: Modified the `useEffect` hook that calculates debuggable block count to include child blocks in addition to top-level blocks
- **Import Addition**: Added `getOrderedChildrenBlocks` import from workflow editor utilities
- **Logic Enhancement**: Implemented nested loop to traverse all nodes and their children, checking each child block for debuggable types
- **Export Update**: Added `getOrderedChildrenBlocks` to the exports in `workflowEditorUtils.ts`

### Technical Implementation
```mermaid
flowchart TD
    A[useEffect Hook Triggered] --> B[Get Top-Level Blocks]
    B --> C[Filter Debuggable Top-Level Blocks]
    C --> D[Iterate Through All Nodes]
    D --> E[Get Child Blocks for Each Node]
    E --> F[Check if Child is Debuggable]
    F --> G{Is Debuggable?}
    G -->|Yes| H[Add to Debuggable Array]
    G -->|No| I[Continue to Next Child]
    H --> I
    I --> J[Set Debuggable Block Count]
    J --> K[Enable/Disable Debug Button]
```

### Impact
- **User Experience**: Users can now start debugging workflows that have debuggable blocks nested within parent blocks, eliminating a frustrating limitation
- **Functionality Completeness**: The debugging feature now works consistently regardless of workflow structure and block nesting
- **Code Robustness**: The solution properly traverses the entire workflow hierarchy to ensure no debuggable blocks are missed in the count

</details>

_Created with [Palmier](https://www.palmier.io)_