### PR TITLE
add endpoint for making a new debug session (with a new browser session) SKY-5666

### DIFF
--- a/skyvern/forge/sdk/schemas/debug_sessions.py
+++ b/skyvern/forge/sdk/schemas/debug_sessions.py
@@ -1,6 +1,9 @@
+import typing as t
 from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict
+
+DebugSessionStatus = t.Literal["created", "completed"]
 
 
 class DebugSession(BaseModel):
@@ -11,3 +14,5 @@ class DebugSession(BaseModel):
     workflow_permanent_id: str | None = None
     created_at: datetime
     modified_at: datetime
+    deleted_at: datetime | None = None
+    status: DebugSessionStatus


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds an endpoint to create a new debug session with a new browser session, updating the database client and schema to manage session statuses.
> 
>   - **New Endpoint**:
>     - Adds `new_browser_session_for_debug_session` in `agent_protocol.py` to create a new debug session with a new browser session.
>     - Completes existing debug sessions before creating a new one.
>   - **Database Client**:
>     - Updates `get_debug_session` in `client.py` to filter by `deleted_at=None` and `status="created"`.
>     - Adds `complete_debug_sessions` in `client.py` to mark sessions as completed.
>     - Sets `status="created"` in `create_debug_session` in `client.py`.
>   - **Schema Changes**:
>     - Adds `DebugSessionStatus` type in `debug_sessions.py`.
>     - Adds `status` field to `DebugSession` in `debug_sessions.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e9dd90361ea75c68fa196e6bbcac85440ac36a18. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->