### PR TITLE
Adding 2fa type tracking to Credentials

### DIFF
--- a/alembic/versions/2025_07_31_1452-7b97b51ddd0e_add_totp_type_to_credentials.py
+++ b/alembic/versions/2025_07_31_1452-7b97b51ddd0e_add_totp_type_to_credentials.py
@@ -1,0 +1,33 @@
+"""add_totp_type_to_credentials
+
+Revision ID: 7b97b51ddd0e
+Revises: 0ecb03206fc6
+Create Date: 2025-07-31 14:52:46.804631+00:00
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7b97b51ddd0e"
+down_revision: Union[str, None] = "0ecb03206fc6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add totp_type column to credentials table
+    op.add_column("credentials", sa.Column("totp_type", sa.String(), nullable=True))
+    # Set default value for existing records
+    op.execute("UPDATE credentials SET totp_type = 'none' WHERE totp_type IS NULL")
+    # Make column non-nullable after setting defaults
+    op.alter_column("credentials", "totp_type", nullable=False, server_default="none")
+
+
+def downgrade() -> None:
+    # Remove totp_type column from credentials table
+    op.drop_column("credentials", "totp_type")

--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -363,6 +363,7 @@ export type Createv2TaskRequest = {
 
 export type PasswordCredentialApiResponse = {
   username: string;
+  totp_type: "authenticator" | "email" | "text" | "none";
 };
 
 export type CreditCardCredentialApiResponse = {
@@ -399,6 +400,7 @@ export type PasswordCredential = {
   username: string;
   password: string;
   totp: string | null;
+  totp_type: "authenticator" | "email" | "text" | "none";
 };
 
 export type CreditCardCredential = {

--- a/skyvern-frontend/src/routes/credentials/CredentialItem.tsx
+++ b/skyvern-frontend/src/routes/credentials/CredentialItem.tsx
@@ -1,12 +1,25 @@
-import { isPasswordCredential } from "@/api/types";
+import { CredentialApiResponse, isPasswordCredential } from "@/api/types";
 import { DeleteCredentialButton } from "./DeleteCredentialButton";
-import { CredentialApiResponse } from "@/api/types";
 
 type Props = {
   credential: CredentialApiResponse;
 };
 
 function CredentialItem({ credential }: Props) {
+  const getTotpTypeDisplay = (totpType: string) => {
+    switch (totpType) {
+      case "authenticator":
+        return "2FA: Authenticator App";
+      case "email":
+        return "2FA: Email";
+      case "text":
+        return "2FA: Text Message";
+      case "none":
+      default:
+        return "";
+    }
+  };
+
   return (
     <div className="flex gap-5 rounded-lg bg-slate-elevation2 p-4">
       <div className="w-48 space-y-2">
@@ -21,10 +34,18 @@ function CredentialItem({ credential }: Props) {
             <div className="shrink-0 space-y-2">
               <p className="text-sm text-slate-400">Username/Email</p>
               <p className="text-sm text-slate-400">Password</p>
+              {credential.credential.totp_type !== "none" && (
+                <p className="text-sm text-slate-400">2FA</p>
+              )}
             </div>
             <div className="space-y-2">
               <p className="text-sm">{credential.credential.username}</p>
               <p className="text-sm">{"********"}</p>
+              {credential.credential.totp_type !== "none" && (
+                <p className="text-sm text-blue-400">
+                  {getTotpTypeDisplay(credential.credential.totp_type)}
+                </p>
+              )}
             </div>
           </div>
         </div>

--- a/skyvern-frontend/src/routes/credentials/CredentialsModal.tsx
+++ b/skyvern-frontend/src/routes/credentials/CredentialsModal.tsx
@@ -27,6 +27,7 @@ const PASSWORD_CREDENTIAL_INITIAL_VALUES = {
   username: "",
   password: "",
   totp: "",
+  totp_type: "none" as "none" | "authenticator" | "email" | "text",
 };
 
 const CREDIT_CARD_CREDENTIAL_INITIAL_VALUES = {
@@ -156,6 +157,7 @@ function CredentialsModal({ onCredentialCreated }: Props) {
           username,
           password,
           totp: totp === "" ? null : totp,
+          totp_type: passwordCredentialValues.totp_type,
         },
       });
     } else if (type === CredentialModalTypes.CREDIT_CARD) {

--- a/skyvern-frontend/src/routes/credentials/PasswordCredentialContent.tsx
+++ b/skyvern-frontend/src/routes/credentials/PasswordCredentialContent.tsx
@@ -24,23 +24,39 @@ type Props = {
     username: string;
     password: string;
     totp: string;
+    totp_type: "authenticator" | "email" | "text" | "none";
   };
   onChange: (values: {
     name: string;
     username: string;
     password: string;
     totp: string;
+    totp_type: "authenticator" | "email" | "text" | "none";
   }) => void;
 };
 
 function PasswordCredentialContent({
-  values: { name, username, password, totp },
+  values: { name, username, password, totp, totp_type },
   onChange,
 }: Props) {
   const [totpMethod, setTotpMethod] = useState<
-    "text" | "email" | "authenticator"
+    "authenticator" | "email" | "text"
   >("authenticator");
   const [showPassword, setShowPassword] = useState(false);
+
+  // Update totp_type when totpMethod changes
+  const handleTotpMethodChange = (
+    method: "authenticator" | "email" | "text",
+  ) => {
+    setTotpMethod(method);
+    onChange({
+      name,
+      username,
+      password,
+      totp: method === "authenticator" ? totp : "",
+      totp_type: method,
+    });
+  };
 
   return (
     <div className="space-y-5">
@@ -59,6 +75,7 @@ function PasswordCredentialContent({
               username,
               password,
               totp,
+              totp_type,
             })
           }
         />
@@ -76,6 +93,7 @@ function PasswordCredentialContent({
               username: e.target.value,
               password,
               totp,
+              totp_type,
             })
           }
         />
@@ -95,6 +113,7 @@ function PasswordCredentialContent({
                 username,
                 totp,
                 password: e.target.value,
+                totp_type,
               })
             }
           />
@@ -133,7 +152,7 @@ function PasswordCredentialContent({
                       "bg-slate-elevation3": totpMethod === "authenticator",
                     },
                   )}
-                  onClick={() => setTotpMethod("authenticator")}
+                  onClick={() => handleTotpMethodChange("authenticator")}
                 >
                   <QRCodeIcon className="h-6 w-6" />
                   <Label>Authenticator App</Label>
@@ -145,7 +164,7 @@ function PasswordCredentialContent({
                       "bg-slate-elevation3": totpMethod === "email",
                     },
                   )}
-                  onClick={() => setTotpMethod("email")}
+                  onClick={() => handleTotpMethodChange("email")}
                 >
                   <EnvelopeClosedIcon className="h-6 w-6" />
                   <Label>Email</Label>
@@ -157,7 +176,7 @@ function PasswordCredentialContent({
                       "bg-slate-elevation3": totpMethod === "text",
                     },
                   )}
-                  onClick={() => setTotpMethod("text")}
+                  onClick={() => handleTotpMethodChange("text")}
                 >
                   <MobileIcon className="h-6 w-6" />
                   <Label>Text Message</Label>
@@ -202,6 +221,7 @@ function PasswordCredentialContent({
                           username,
                           password,
                           totp: e.target.value,
+                          totp_type,
                         })
                       }
                     />

--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -3256,6 +3256,7 @@ class AgentDB:
         credential_type: CredentialType,
         organization_id: str,
         item_id: str,
+        totp_type: str = "none",
     ) -> Credential:
         async with self.Session() as session:
             credential = CredentialModel(
@@ -3263,6 +3264,7 @@ class AgentDB:
                 name=name,
                 credential_type=credential_type,
                 item_id=item_id,
+                totp_type=totp_type,
             )
             session.add(credential)
             await session.commit()

--- a/skyvern/forge/sdk/db/models.py
+++ b/skyvern/forge/sdk/db/models.py
@@ -753,6 +753,7 @@ class CredentialModel(Base):
 
     name = Column(String, nullable=False)
     credential_type = Column(String, nullable=False)
+    totp_type = Column(String, nullable=False, default="none")
 
     created_at = Column(DateTime, default=datetime.datetime.utcnow, nullable=False)
     modified_at = Column(DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow, nullable=False)

--- a/skyvern/forge/sdk/routes/credentials.py
+++ b/skyvern/forge/sdk/routes/credentials.py
@@ -157,11 +157,13 @@ async def create_credential(
         item_id=item_id,
         name=data.name,
         credential_type=data.credential_type,
+        totp_type=data.credential.totp_type if hasattr(data.credential, "totp_type") else "none",
     )
 
     if data.credential_type == CredentialType.PASSWORD:
         credential_response = PasswordCredentialResponse(
             username=data.credential.username,
+            totp_type=data.credential.totp_type if hasattr(data.credential, "totp_type") else "none",
         )
         return CredentialResponse(
             credential=credential_response,
@@ -273,6 +275,7 @@ async def get_credential(
     if credential_item.credential_type == CredentialType.PASSWORD:
         credential_response = PasswordCredentialResponse(
             username=credential_item.credential.username,
+            totp_type=credential.totp_type,
         )
         return CredentialResponse(
             credential=credential_response,
@@ -344,7 +347,10 @@ async def get_credentials(
         if not item:
             continue
         if item.credential_type == CredentialType.PASSWORD:
-            credential_response = PasswordCredentialResponse(username=item.credential.username)
+            credential_response = PasswordCredentialResponse(
+                username=item.credential.username,
+                totp_type=credential.totp_type,
+            )
             response_items.append(
                 CredentialResponse(
                     credential=credential_response,

--- a/skyvern/forge/sdk/schemas/credentials.py
+++ b/skyvern/forge/sdk/schemas/credentials.py
@@ -11,10 +11,24 @@ class CredentialType(StrEnum):
     CREDIT_CARD = "credit_card"
 
 
+class TotpType(StrEnum):
+    """Type of 2FA/TOTP method used."""
+
+    AUTHENTICATOR = "authenticator"
+    EMAIL = "email"
+    TEXT = "text"
+    NONE = "none"
+
+
 class PasswordCredentialResponse(BaseModel):
     """Response model for password credentials, containing only the username."""
 
     username: str = Field(..., description="The username associated with the credential", examples=["user@example.com"])
+    totp_type: TotpType = Field(
+        TotpType.NONE,
+        description="Type of 2FA method used for this credential",
+        examples=[TotpType.AUTHENTICATOR],
+    )
 
 
 class CreditCardCredentialResponse(BaseModel):
@@ -33,6 +47,11 @@ class PasswordCredential(BaseModel):
         None,
         description="Optional TOTP (Time-based One-Time Password) string used to generate 2FA codes",
         examples=["JBSWY3DPEHPK3PXP"],
+    )
+    totp_type: TotpType = Field(
+        TotpType.NONE,
+        description="Type of 2FA method used for this credential",
+        examples=[TotpType.AUTHENTICATOR],
     )
 
 
@@ -124,6 +143,11 @@ class Credential(BaseModel):
     name: str = Field(..., description="Name of the credential", examples=["Skyvern Login"])
     credential_type: CredentialType = Field(..., description="Type of the credential. Eg password, credit card, etc.")
     item_id: str = Field(..., description="ID of the associated credential item", examples=["item_1234567890"])
+    totp_type: TotpType = Field(
+        TotpType.NONE,
+        description="Type of 2FA method used for this credential",
+        examples=[TotpType.AUTHENTICATOR],
+    )
 
     created_at: datetime = Field(..., description="Timestamp when the credential was created")
     modified_at: datetime = Field(..., description="Timestamp when the credential was last modified")


### PR DESCRIPTION
# Add 2FA Type Tracking to Credentials

## Summary
This PR adds support for tracking the 2FA method type in saved credentials, allowing users to see which authentication method is configured for each credential.

## Changes Made

### Backend Changes
- **Database Schema**: Added `totp_type` column to the `credentials` table with values: `authenticator`, `email`, `text`, `none`
- **API Schemas**: Updated `PasswordCredential`, `PasswordCredentialResponse`, and `Credential` schemas to include `totp_type` field
- **Database Service**: Modified `create_credential` method to accept and store `totp_type` parameter
- **API Routes**: Updated credential endpoints (create, get, list) to handle `totp_type` in requests and responses
- **Migration**: Added Alembic migration to safely add the column to existing data

### Frontend Changes
- **Type Definitions**: Added `totp_type` field to TypeScript types for credential API responses and creation
- **Credential Display**: Enhanced credential list to show 2FA type with visual indicators (blue text showing "2FA: Authenticator App", "2FA: Email", or "2FA: Text Message")
- **Form Integration**: Updated credential creation form to properly track and pass the selected 2FA method

## Key Features
- ✅ **Backward Compatible**: Existing credentials default to `totp_type = "none"`
- ✅ **Visual Indicators**: Clear display of 2FA method in credential list
- ✅ **Safe Migration**: Handles existing data gracefully by setting defaults before making column non-nullable
- ✅ **Consistent Terminology**: Uses "text" instead of "sms" for SMS-based 2FA

## Testing
- Database migration runs successfully
- New credentials properly store 2FA method selection
- API responses include `totp_type` field
- Frontend displays 2FA type information for password credentials

## Migration Details
The migration safely adds the `totp_type` column by:
1. Adding column as nullable initially
2. Setting existing records to `totp_type = 'none'`
3. Making column non-nullable with default value

This ensures no data loss and maintains database integrity during the upgrade process.

---

🔐 This PR adds comprehensive 2FA type tracking to the credentials system, allowing users to specify and view which two-factor authentication method (authenticator app, email, or text message) is configured for each saved credential.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Database Schema**: Added `totp_type` column to credentials table with enum values (`authenticator`, `email`, `text`, `none`) and safe migration handling existing data
- **Backend API**: Updated credential schemas, database client, and API routes to support TOTP type creation, storage, and retrieval across all credential endpoints
- **Frontend UI**: Enhanced credential display with visual 2FA indicators and integrated TOTP type selection into the credential creation form
- **Type Safety**: Added comprehensive TypeScript definitions and Pydantic schemas with proper validation and documentation

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant Frontend
    participant API
    participant Database
    
    User->>Frontend: Create credential with 2FA method
    Frontend->>API: POST /credentials with totp_type
    API->>Database: Store credential with totp_type
    Database-->>API: Return saved credential
    API-->>Frontend: Return credential response with totp_type
    Frontend-->>User: Display credential with 2FA indicator
    
    User->>Frontend: View credentials list
    Frontend->>API: GET /credentials
    API->>Database: Fetch credentials with totp_type
    Database-->>API: Return credentials data
    API-->>Frontend: Return credentials with totp_type
    Frontend-->>User: Show 2FA method for each credential
```

### Impact
- **User Experience**: Users can now easily identify which 2FA method is configured for each credential through clear visual indicators in the UI
- **Data Integrity**: Safe migration ensures existing credentials are preserved with appropriate defaults, maintaining backward compatibility
- **System Extensibility**: Well-structured enum-based approach allows for easy addition of new 2FA methods in the future without breaking changes
- **Security Awareness**: Enhanced visibility into 2FA configuration helps users better manage their authentication security posture

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `totp_type` tracking to credentials, updating database, API, and frontend to support 2FA method types.
> 
>   - **Database**:
>     - Add `totp_type` column to `credentials` table with default `none` in `models.py`.
>     - Alembic migration script `add_totp_type_to_credentials.py` to add and set default for `totp_type`.
>   - **API**:
>     - Update `create_credential` in `client.py` to accept `totp_type`.
>     - Modify `create_credential`, `get_credential`, and `get_credentials` in `credentials.py` to handle `totp_type`.
>     - Update `PasswordCredential`, `PasswordCredentialResponse`, and `Credential` schemas in `schemas/credentials.py` to include `totp_type`.
>   - **Frontend**:
>     - Add `totp_type` to TypeScript types in `types.ts`.
>     - Update `CredentialItem.tsx` and `CredentialsModal.tsx` to display and handle `totp_type`.
>     - Modify `PasswordCredentialContent.tsx` to manage `totp_type` selection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for dab1870837b516124d651f24c848a70cfc61261f. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->