### PR TITLE
add more rule to parse filename when downloading

### DIFF
--- a/skyvern/forge/sdk/api/files.py
+++ b/skyvern/forge/sdk/api/files.py
@@ -113,15 +113,14 @@ async def download_file(url: str, max_size_mb: int | None = None) -> str:
                 except Exception:
                     LOG.exception("Failed to retrieve the file extension from HTTP headers")
 
+                # parse the query params to get the file name
+                query_params = dict(parse_qsl(a.query))
+                if "download" in query_params:
+                    file_name = query_params["download"]
+
                 if not file_name:
                     LOG.info("No file name retrieved from HTTP headers, using the file name from the URL")
                     file_name = os.path.basename(a.path)
-
-                # Check for download parameter in Supabase URLs
-                if "supabase.co" in a.netloc.lower():
-                    query_params = dict(parse_qsl(a.query))
-                    if "download" in query_params:
-                        file_name = query_params["download"]
 
                 if not Path(file_name).suffix and file_suffix:
                     LOG.info("No file extension detected, adding the extension from HTTP headers")


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Generalizes filename extraction from query parameters in `download_file` function in `files.py`.
> 
>   - **Behavior**:
>     - In `download_file` function, filename extraction from query parameters is now generalized to all URLs, not just Supabase URLs.
>     - Removes specific check for `supabase.co` in URL netloc.
>   - **Logging**:
>     - Logs a message if no filename is retrieved from HTTP headers, using the URL path instead.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 951ba9ca94a93cd35badb7a0360469fb4a77a5d7. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR generalizes filename parsing logic in the file download functionality by extracting filenames from the 'download' query parameter for any URL, removing the previous Supabase-specific restriction. The change makes the filename detection more robust and applicable across different file hosting services.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Filename Parsing Logic**: Moved the query parameter parsing logic outside the Supabase-specific condition, making it apply to all URLs
- **Code Simplification**: Removed the hardcoded check for "supabase.co" in the netloc, making the code more generic
- **Parsing Order**: The query parameter check now happens before falling back to extracting filename from the URL path

### Technical Implementation
```mermaid
flowchart TD
    A[Start download_file] --> B[Parse URL]
    B --> C[Try to get filename from HTTP headers]
    C --> D{Filename found in headers?}
    D -->|No| E[Parse query parameters]
    E --> F{download param exists?}
    F -->|Yes| G[Use download param as filename]
    F -->|No| H[Use basename from URL path]
    D -->|Yes| I[Use header filename]
    G --> J[Check file extension]
    H --> J
    I --> J
    J --> K[Add extension if missing]
    K --> L[Continue download process]
```

### Impact
- **Broader Compatibility**: The filename parsing now works with any service that uses the 'download' query parameter, not just Supabase
- **Code Maintainability**: Removes service-specific hardcoded logic, making the code more maintainable and extensible
- **Backward Compatibility**: Maintains existing functionality while expanding support to additional URL formats

</details>

_Created with [Palmier](https://www.palmier.io)_