### PR TITLE
update project with project_revision_id

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -3537,7 +3537,7 @@ class AgentDB:
 
     async def update_project(
         self,
-        project_id: str,
+        project_revision_id: str,
         organization_id: str,
         artifact_id: str | None = None,
         workflow_permanent_id: str | None = None,
@@ -3548,9 +3548,8 @@ class AgentDB:
             async with self.Session() as session:
                 get_project_query = (
                     select(ProjectModel)
-                    .filter_by(project_id=project_id)
                     .filter_by(organization_id=organization_id)
-                    .filter(ProjectModel.deleted_at.is_(None))
+                    .filter_by(project_revision_id=project_revision_id)
                 )
                 if project := (await session.scalars(get_project_query)).first():
                     if artifact_id:
@@ -3570,7 +3569,7 @@ class AgentDB:
             LOG.error("SQLAlchemyError", exc_info=True)
             raise
         except NotFoundError:
-            LOG.error("No project found to update", project_id=project_id)
+            LOG.error("No project found to update", project_revision_id=project_revision_id)
             raise
         except Exception:
             LOG.error("UnexpectedError", exc_info=True)


### PR DESCRIPTION
---

🔄 This PR refactors the `update_project` method to use `project_revision_id` instead of `project_id` as the primary identifier, simplifying the database query logic and removing the deleted_at filter check.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Parameter Change**: Modified `update_project` method signature to accept `project_revision_id` instead of `project_id`
- **Query Simplification**: Updated database query to filter by `project_revision_id` and removed the `deleted_at` null check
- **Error Logging**: Updated error logging to reference the new `project_revision_id` parameter

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant update_project
    participant Database
    
    Client->>update_project: Call with project_revision_id
    update_project->>Database: Query ProjectModel by project_revision_id + organization_id
    Database-->>update_project: Return project or None
    alt Project found
        update_project->>Database: Update artifact_id/workflow_permanent_id
        update_project->>Database: Commit changes
        update_project-->>Client: Return updated project
    else Project not found
        update_project-->>Client: Raise NotFoundError
    end
```

### Impact
- **Query Efficiency**: Simplified database query with fewer filter conditions may improve performance
- **Data Model Alignment**: Better alignment with revision-based project management system
- **Breaking Change**: This is a breaking change as the method signature has changed from `project_id` to `project_revision_id`

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `update_project` in `client.py` now uses `project_revision_id` instead of `project_id` for project updates and logging.
> 
>   - **Behavior**:
>     - `update_project` in `client.py` now uses `project_revision_id` instead of `project_id` for filtering projects.
>     - Error logging updated to use `project_revision_id` in `client.py`.
>   - **Misc**:
>     - Removed filtering by `project_id` and `deleted_at` in `update_project` in `client.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6587f3fe834396738f4069ab068b64c378a54f77. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->