### PR TITLE
set status to failed when browser session fails to initially connect

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -3040,7 +3040,9 @@ class AgentDB:
     async def update_persistent_browser_session(
         self,
         browser_session_id: str,
-        timeout_minutes: int,
+        *,
+        status: str | None = None,
+        timeout_minutes: int | None = None,
         organization_id: str | None = None,
     ) -> PersistentBrowserSession:
         try:
@@ -3055,7 +3057,12 @@ class AgentDB:
                 ).first()
                 if not persistent_browser_session:
                     raise NotFoundError(f"PersistentBrowserSession {browser_session_id} not found")
-                persistent_browser_session.timeout_minutes = timeout_minutes
+
+                if status:
+                    persistent_browser_session.status = status
+                if timeout_minutes:
+                    persistent_browser_session.timeout_minutes = timeout_minutes
+
                 await session.commit()
                 await session.refresh(persistent_browser_session)
                 return PersistentBrowserSession.model_validate(persistent_browser_session)

--- a/skyvern/forge/sdk/schemas/persistent_browser_sessions.py
+++ b/skyvern/forge/sdk/schemas/persistent_browser_sessions.py
@@ -2,6 +2,12 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict
 
+FINAL_STATUSES = ("completed", "failed")
+
+
+def is_final_status(status: str | None) -> bool:
+    return status in FINAL_STATUSES
+
 
 class PersistentBrowserSession(BaseModel):
     model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Set browser session status to 'failed' if initial connection fails, with updates to error handling and status management.
> 
>   - **Behavior**:
>     - In `claim_browser_activity()` in `browser_activity.py`, set status to 'failed' if `set_browser_address()` fails.
>     - Add `update_status()` to `PersistentSessionsManager` in `persistent_sessions_manager.py` to update session status.
>   - **Database**:
>     - Modify `update_persistent_browser_session()` in `client.py` to allow updating session status.
>   - **Utilities**:
>     - Add `is_final_status()` in `persistent_browser_sessions.py` to check if a status is final.
>   - **Misc**:
>     - Import `update_status` in `persistent_sessions_manager.py` and `browser_activity.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 2046f5aa5ba1ff64327ba16bea2a53624b5667ff. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->