### PR TITLE
add duration to WorkflowRunBlock

### DIFF
--- a/skyvern/forge/sdk/db/utils.py
+++ b/skyvern/forge/sdk/db/utils.py
@@ -489,6 +489,9 @@ def convert_to_workflow_run_block(
         modified_at=workflow_run_block_model.modified_at,
     )
     if task:
+        if task.finished_at and task.started_at:
+            duration = task.finished_at - task.started_at
+            block.duration = duration.total_seconds()
         block.url = task.url
         block.navigation_goal = task.navigation_goal
         block.navigation_payload = task.navigation_payload

--- a/skyvern/forge/sdk/schemas/workflow_runs.py
+++ b/skyvern/forge/sdk/schemas/workflow_runs.py
@@ -38,6 +38,7 @@ class WorkflowRunBlock(BaseModel):
     created_at: datetime
     modified_at: datetime
     include_action_history_in_verification: bool | None = False
+    duration: float | None = None
 
     # for loop block
     loop_values: list[Any] | None = None


### PR DESCRIPTION
Part of [SKY-5165](https://linear.app/skyvern/issue/SKY-5165/add-runtime-metrics-to-respective-database-tables-for-all-executions)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add task duration calculation and storage to `WorkflowRunBlock` in `utils.py` and `workflow_runs.py`.
> 
>   - **Behavior**:
>     - Calculate task duration in `convert_to_workflow_run_block()` in `utils.py` if `task.finished_at` and `task.started_at` are present.
>     - Store duration in `WorkflowRunBlock` in `workflow_runs.py`.
>   - **Schema**:
>     - Add `duration: float | None = None` to `WorkflowRunBlock` in `workflow_runs.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 7992eec86bb163549e440f7439d35fd187925f50. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

⏱️ This PR adds duration tracking to WorkflowRunBlock by introducing a new `duration` field and calculating it from task execution timestamps. The change is part of a larger initiative (SKY-5165) to add runtime metrics to database tables for better execution monitoring and analytics.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Schema Enhancement**: Added optional `duration` field (float | None) to the `WorkflowRunBlock` model in `workflow_runs.py`
- **Duration Calculation**: Implemented duration computation in `convert_to_workflow_run_block` function using task start and finish timestamps
- **Conditional Logic**: Duration is only calculated when both `task.finished_at` and `task.started_at` are available, ensuring robustness

### Technical Implementation
```mermaid
flowchart TD
    A[convert_to_workflow_run_block] --> B{Task exists?}
    B -->|Yes| C{Both timestamps available?}
    B -->|No| D[Skip duration calculation]
    C -->|Yes| E[Calculate duration = finished_at - started_at]
    C -->|No| F[Leave duration as None]
    E --> G[Set block.duration = total_seconds()]
    F --> H[Continue with other task properties]
    G --> H
    D --> I[Return WorkflowRunBlock]
    H --> I
```

### Impact
- **Runtime Metrics**: Enables tracking of workflow execution performance and identifying bottlenecks
- **Backward Compatibility**: The optional field ensures existing code continues to work without modifications
- **Data Analytics**: Provides foundation for performance analysis and optimization of workflow executions
- **Monitoring Enhancement**: Supports better observability of workflow run durations across the system

</details>

_Created with [Palmier](https://www.palmier.io)_