### PR TITLE
add duration to workflow block timeline

### DIFF
--- a/skyvern-frontend/src/routes/workflows/types/workflowRunTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowRunTypes.ts
@@ -50,6 +50,7 @@ export type WorkflowRunBlock = {
   wait_sec?: number | null;
   created_at: string;
   modified_at: string;
+  duration: number | null;
 
   // for loop block itself
   loop_values: Array<unknown> | null;

--- a/skyvern-frontend/src/routes/workflows/utils.ts
+++ b/skyvern-frontend/src/routes/workflows/utils.ts
@@ -47,3 +47,33 @@ export const getInitialValues = (
 
   return iv as Record<string, unknown>;
 };
+
+export interface Duration {
+  hour: number;
+  minute: number;
+  second: number;
+}
+
+export const toDuration = (seconds: number): Duration => {
+  let minutes = Math.floor(seconds / 60);
+  let hours = Math.floor(minutes / 60);
+  seconds = seconds % 60;
+  minutes = minutes % 60;
+  hours = hours % 24;
+
+  return {
+    hour: Math.floor(hours),
+    minute: Math.floor(minutes),
+    second: Math.floor(seconds),
+  };
+};
+
+export const formatDuration = (duration: Duration): string => {
+  if (duration.hour) {
+    return `${duration.hour}h ${duration.minute}m ${duration.second}s`;
+  } else if (duration.minute) {
+    return `${duration.minute}m ${duration.second}s`;
+  } else {
+    return `${duration.second}s`;
+  }
+};

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineBlockItem.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineBlockItem.tsx
@@ -25,6 +25,7 @@ import { isTaskVariantBlock } from "../types/workflowTypes";
 import { Link } from "react-router-dom";
 import { useCallback } from "react";
 import { Status } from "@/api/types";
+import { formatDuration, toDuration } from "@/routes/workflows/utils";
 import { ThoughtCard } from "./ThoughtCard";
 import { ObserverThought } from "../types/workflowRunTypes";
 type Props = {
@@ -85,6 +86,9 @@ function WorkflowRunTimelineBlockItem({
       block.status === Status.TimedOut ||
       block.status === Status.Canceled);
 
+  const duration =
+    block.duration !== null ? formatDuration(toDuration(block.duration)) : null;
+
   return (
     <div
       className={cn(
@@ -115,7 +119,9 @@ function WorkflowRunTimelineBlockItem({
               <span className="text-sm">
                 {workflowBlockTitle[block.block_type]}
               </span>
-              <span className="text-xs text-slate-400">{block.label}</span>
+              <span className="flex gap-2 text-xs text-slate-400">
+                {block.label}
+              </span>
             </div>
           </div>
           <div className="flex gap-2">
@@ -129,19 +135,26 @@ function WorkflowRunTimelineBlockItem({
                 <CheckCircledIcon className="size-4 text-success" />
               </div>
             )}
-            <div className="flex gap-1 self-start rounded bg-slate-elevation5 px-2 py-1">
-              {showDiagnosticLink ? (
-                <Link to={`/tasks/${block.task_id}/diagnostics`}>
-                  <div className="flex gap-1">
-                    <ExternalLinkIcon className="size-4" />
-                    <span className="text-xs">Diagnostics</span>
-                  </div>
-                </Link>
-              ) : (
-                <>
-                  <CubeIcon className="size-4" />
-                  <span className="text-xs">Block</span>
-                </>
+            <div className="flex flex-col items-end gap-[1px]">
+              <div className="flex gap-1 self-start rounded bg-slate-elevation5 px-2 py-1">
+                {showDiagnosticLink ? (
+                  <Link to={`/tasks/${block.task_id}/diagnostics`}>
+                    <div className="flex gap-1">
+                      <ExternalLinkIcon className="size-4" />
+                      <span className="text-xs">Diagnostics</span>
+                    </div>
+                  </Link>
+                ) : (
+                  <>
+                    <CubeIcon className="size-4" />
+                    <span className="text-xs">Block</span>
+                  </>
+                )}
+              </div>
+              {duration && (
+                <div className="pr-[5px] text-xs text-[#00ecff]">
+                  {duration}
+                </div>
               )}
             </div>
           </div>


### PR DESCRIPTION
Follows https://github.com/Skyvern-AI/skyvern-cloud/pull/5741
Part of https://linear.app/skyvern/issue/SKY-5165/add-runtime-metrics-to-respective-database-tables-for-all-executions

<img width="374" height="288" alt="image" src="https://github.com/user-attachments/assets/4afce7ae-3939-4ab4-b7ec-41de40bc4e58" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds duration field to workflow block timeline, with utilities for formatting and UI updates for display.
> 
>   - **Behavior**:
>     - Adds `duration` field to `WorkflowRunBlock` in `workflowRunTypes.ts` to store block execution time.
>     - Displays formatted duration in `WorkflowRunTimelineBlockItem` if `duration` is not null.
>   - **Utilities**:
>     - Adds `toDuration(seconds: number): Duration` and `formatDuration(duration: Duration): string` in `utils.ts` to convert and format duration.
>   - **UI**:
>     - Updates `WorkflowRunTimelineBlockItem.tsx` to display duration in block items.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for eb85af4f6b0050bc2cfb056c5a06092da0ae400b. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->