### PR TITLE
elide duration from workflow blocks in timeline

### DIFF
--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineBlockItem.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineBlockItem.tsx
@@ -89,6 +89,9 @@ function WorkflowRunTimelineBlockItem({
   const duration =
     block.duration !== null ? formatDuration(toDuration(block.duration)) : null;
 
+  // NOTE(jdo): want to put this back; await for now
+  const showDuration = false as const;
+
   return (
     <div
       className={cn(
@@ -151,7 +154,7 @@ function WorkflowRunTimelineBlockItem({
                   </>
                 )}
               </div>
-              {duration && (
+              {duration && showDuration && (
                 <div className="pr-[5px] text-xs text-[#00ecff]">
                   {duration}
                 </div>


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-5798/elide-block-run-duration
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Elides duration display for workflow blocks in `WorkflowRunTimelineBlockItem` by setting `showDuration` to `false`.
> 
>   - **Behavior**:
>     - Elides duration display for workflow blocks in `WorkflowRunTimelineBlockItem` by setting `showDuration` to `false`.
>     - Duration is calculated but not displayed due to `showDuration` being `false`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b66a1e9c55032e615c116349a49aab6ad5e77626. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🚫 This PR temporarily hides the duration display from workflow timeline blocks by introducing a feature flag set to false, while preserving the underlying duration calculation logic for potential future restoration.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **UI Display Logic**: Added a `showDuration` constant set to `false` to conditionally hide duration information
- **Timeline Component**: Modified the render condition in `WorkflowRunTimelineBlockItem.tsx` to check both `duration` existence and `showDuration` flag
- **Code Preservation**: Duration calculation logic remains intact, suggesting this is a temporary UI change rather than a permanent removal

### Technical Implementation
```mermaid
flowchart TD
    A[WorkflowRunTimelineBlockItem] --> B[Calculate Duration]
    B --> C{showDuration = false}
    C -->|true| D[Display Duration]
    C -->|false| E[Hide Duration]
    B --> F[Duration Still Calculated]
    F --> G[Available for Future Use]
```

### Impact
- **User Experience**: Simplifies the timeline view by removing duration information that may have been cluttering the interface
- **Performance**: Minimal impact - duration calculation still occurs but display is suppressed
- **Maintainability**: The developer comment indicates this is intentionally temporary, making future restoration straightforward by simply changing the boolean flag

</details>

_Created with [Palmier](https://www.palmier.io)_