### PR TITLE
add Use Script Cache toggle; align toggles to right-hand side

### DIFF
--- a/skyvern-frontend/src/components/FloatingWindow.tsx
+++ b/skyvern-frontend/src/components/FloatingWindow.tsx
@@ -18,6 +18,7 @@ import {
 import { flushSync } from "react-dom";
 import Draggable from "react-draggable";
 
+import { OrgWalled } from "./Orgwalled";
 import {
   Tooltip,
   TooltipContent,
@@ -627,7 +628,11 @@ function FloatingWindow({
                         onClick={toggleMaximized}
                       />
                     )}
-                    {showPowerButton && <PowerButton onClick={() => cycle()} />}
+                    {showPowerButton && (
+                      <OrgWalled className="flex items-center justify-center">
+                        <PowerButton onClick={() => cycle()} />
+                      </OrgWalled>
+                    )}
                   </div>
                   <div className="ml-auto">{title}</div>
                   {showReloadButton && (

--- a/skyvern-frontend/src/components/Orgwalled.tsx
+++ b/skyvern-frontend/src/components/Orgwalled.tsx
@@ -1,0 +1,46 @@
+import { useIsSkyvernUser } from "@/hooks/useIsSkyvernUser";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+import { cn } from "@/util/utils";
+
+function OrgWalled({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  const isSkyvernUser = useIsSkyvernUser();
+
+  if (!isSkyvernUser) {
+    return null;
+  }
+
+  // Wrap children with visual indication for org-walled features
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className={cn(
+              "relative rounded-md border-2 border-dashed border-yellow-400 p-2",
+              className,
+            )}
+          >
+            {children}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>This feature is only available to Skyvern organization members</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export { OrgWalled };

--- a/skyvern-frontend/src/hooks/useIsSkyvernUser.ts
+++ b/skyvern-frontend/src/hooks/useIsSkyvernUser.ts
@@ -1,0 +1,11 @@
+import { useUser } from "./useUser";
+
+function useIsSkyvernUser() {
+  const user = useUser().get();
+  const email = user?.email;
+  const isSkyvernUser = email?.toLowerCase().endsWith("@skyvern.com") ?? false;
+
+  return isSkyvernUser;
+}
+
+export { useIsSkyvernUser };

--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -349,6 +349,7 @@ function FlowRenderer({
         max_screenshot_scrolls: data.settings.maxScreenshotScrolls,
         totp_verification_url: workflow.totp_verification_url,
         extra_http_headers: extraHttpHeaders,
+        use_cache: data.settings.useScriptCache,
         workflow_definition: {
           parameters: data.parameters,
           blocks: data.blocks,

--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowDebugger.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowDebugger.tsx
@@ -24,7 +24,6 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "@/components/ui/use-toast";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
 import { useMountEffect } from "@/hooks/useMountEffect";
-import { useUser } from "@/hooks/useUser";
 import { statusIsFinalized } from "@/routes/tasks/types.ts";
 import { useSidebarStore } from "@/store/SidebarStore";
 import { useWorkflowHasChangesStore } from "@/store/WorkflowHasChangesStore";
@@ -44,9 +43,6 @@ function WorkflowDebugger() {
   const credentialGetter = useCredentialGetter();
   const queryClient = useQueryClient();
   const [shouldFetchDebugSession, setShouldFetchDebugSession] = useState(false);
-  const user = useUser().get();
-  const email = user?.email;
-  const isSkyvernUser = email?.toLowerCase().endsWith("@skyvern.com") ?? false;
 
   const { data: workflowRun } = useWorkflowRunQuery();
   const { data: workflow } = useWorkflowQuery({
@@ -157,6 +153,7 @@ function WorkflowDebugger() {
     extraHttpHeaders: workflow.extra_http_headers
       ? JSON.stringify(workflow.extra_http_headers)
       : null,
+    useScriptCache: workflow.use_cache,
   };
 
   const elements = getElements(
@@ -235,7 +232,7 @@ function WorkflowDebugger() {
           initialHeight={360}
           showMaximizeButton={true}
           showMinimizeButton={true}
-          showPowerButton={blockLabel === undefined && isSkyvernUser}
+          showPowerButton={blockLabel === undefined}
           showReloadButton={true}
           // --
           onCycle={handleOnCycle}

--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowEditor.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowEditor.tsx
@@ -58,6 +58,7 @@ function WorkflowEditor() {
     extraHttpHeaders: workflow.extra_http_headers
       ? JSON.stringify(workflow.extra_http_headers)
       : null,
+    useScriptCache: workflow.use_cache,
   };
 
   const elements = getElements(

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
@@ -22,6 +22,7 @@ import { ModelSelector } from "@/components/ModelSelector";
 import { WorkflowModel } from "@/routes/workflows/types/workflowTypes";
 import { MAX_SCREENSHOT_SCROLLS_DEFAULT } from "../Taskv2Node/types";
 import { KeyValueInput } from "@/components/KeyValueInput";
+import { OrgWalled } from "@/components/Orgwalled";
 import { useWorkflowSettingsStore } from "@/store/WorkflowSettingsStore";
 
 function StartNode({ id, data }: NodeProps<StartNode>) {
@@ -59,6 +60,7 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
       ? data.maxScreenshotScrolls
       : null,
     extraHttpHeaders: data.withWorkflowSettings ? data.extraHttpHeaders : null,
+    useScriptCache: data.withWorkflowSettings ? data.useScriptCache : false,
   });
 
   useEffect(() => {
@@ -131,11 +133,27 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
                         }}
                       />
                     </div>
+                    <OrgWalled>
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-2">
+                          <Label>Use Script Cache</Label>
+                          <HelpTooltip content="Generate & use cached scripts for faster execution" />
+                          <Switch
+                            className="ml-auto"
+                            checked={inputs.useScriptCache}
+                            onCheckedChange={(value) => {
+                              handleChange("useScriptCache", value);
+                            }}
+                          />
+                        </div>
+                      </div>
+                    </OrgWalled>
                     <div className="space-y-2">
                       <div className="flex items-center gap-2">
                         <Label>Save &amp; Reuse Session</Label>
                         <HelpTooltip content="Persist session information across workflow runs" />
                         <Switch
+                          className="ml-auto"
                           checked={inputs.persistBrowserSession}
                           onCheckedChange={(value) => {
                             handleChange("persistBrowserSession", value);

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/types.ts
@@ -12,6 +12,7 @@ export type WorkflowStartNodeData = {
   maxScreenshotScrolls: number | null;
   extraHttpHeaders: string | null;
   editable: boolean;
+  useScriptCache: boolean;
 };
 
 export type OtherStartNodeData = {

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -698,6 +698,7 @@ function getElements(
       maxScreenshotScrolls: settings.maxScreenshotScrolls,
       extraHttpHeaders: settings.extraHttpHeaders,
       editable,
+      useScriptCache: settings.useScriptCache,
     }),
   );
 
@@ -1400,6 +1401,7 @@ function getWorkflowSettings(nodes: Array<AppNode>): WorkflowSettings {
     model: null,
     maxScreenshotScrolls: null,
     extraHttpHeaders: null,
+    useScriptCache: false,
   };
   const startNodes = nodes.filter(isStartNode);
   const startNodeWithWorkflowSettings = startNodes.find(
@@ -1417,6 +1419,7 @@ function getWorkflowSettings(nodes: Array<AppNode>): WorkflowSettings {
       model: data.model,
       maxScreenshotScrolls: data.maxScreenshotScrolls,
       extraHttpHeaders: data.extraHttpHeaders,
+      useScriptCache: data.useScriptCache,
     };
   }
   return defaultSettings;

--- a/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
@@ -501,6 +501,7 @@ export type WorkflowApiResponse = {
   created_at: string;
   modified_at: string;
   deleted_at: string | null;
+  use_cache: boolean;
 };
 
 export type WorkflowSettings = {
@@ -510,6 +511,7 @@ export type WorkflowSettings = {
   model: WorkflowModel | null;
   maxScreenshotScrolls: number | null;
   extraHttpHeaders: string | null;
+  useScriptCache: boolean;
 };
 
 export type WorkflowModel = JsonObjectExtendable<{ model_name: string }>;

--- a/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
@@ -14,6 +14,7 @@ export type WorkflowCreateYAMLRequest = {
   is_saved_task?: boolean;
   max_screenshot_scrolls?: number | null;
   extra_http_headers?: Record<string, string> | null;
+  use_cache?: boolean;
 };
 
 export type WorkflowDefinitionYAML = {


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-5793/caching-ui-add-workflow-level-config-caching-toggle

<img width="528" height="596" alt="image" src="https://github.com/user-attachments/assets/d138bda4-b082-419b-bff2-746b58a1cf25" />

In addition:
- adds `OrgWalled` component for org-walling features that are not ready for consumption by the outside world; only users with skyvern.com email addresses can see such things; here, we've org-walled the "Use Script Cache" toggle; I also added this to the power button for recycling interactive browsers sessions in the debugger.

e.g. we see this:

<img width="674" height="720" alt="image" src="https://github.com/user-attachments/assets/5693d545-c089-4f74-bca4-55dbe118018d" />

<img width="720" height="407" alt="image" src="https://github.com/user-attachments/assets/2ca32ecc-f2ab-4125-a29d-b53c18ca56dc" />

outside world sees this:

<img width="683" height="720" alt="image" src="https://github.com/user-attachments/assets/06d1b8c6-8632-4ae6-8e51-472a8dcc8379" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `useScriptCache` toggle and `OrgWalled` component for org-specific feature visibility, aligning UI elements.
> 
>   - **Features**:
>     - Add `useScriptCache` toggle in `StartNode.tsx` and `WorkflowEditor.tsx` for workflow-level script caching.
>     - Introduce `OrgWalled` component in `Orgwalled.tsx` to restrict features to Skyvern organization members.
>   - **UI Changes**:
>     - Align toggle switches to the right in `StartNode.tsx`.
>     - Wrap `PowerButton` in `FloatingWindow.tsx` with `OrgWalled` for org-specific visibility.
>   - **Data Handling**:
>     - Add `use_cache` field to `WorkflowApiResponse` and `WorkflowCreateYAMLRequest` in `workflowTypes.ts` and `workflowYamlTypes.ts`.
>     - Update `getElements()` and `getWorkflowSettings()` in `workflowEditorUtils.ts` to handle `useScriptCache`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 81e5b5352e1a617a90e7f55243b8f81d89f9c3ae. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

⚙️ This PR adds a "Use Script Cache" toggle for workflows that is restricted to Skyvern organization members, while also introducing an organization-walling system and aligning UI toggles to the right-hand side for better visual consistency.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Organization Access Control**: Introduces `OrgWalled` component and `useIsSkyvernUser` hook to restrict features to users with @skyvern.com email addresses
- **Script Caching Feature**: Adds `useScriptCache` toggle in workflow settings to enable cached script generation for faster execution
- **UI Alignment**: Moves toggles to the right-hand side using `ml-auto` class for consistent visual layout
- **Type System Updates**: Extends workflow types to include `use_cache` field across API responses, settings, and YAML requests

### Technical Implementation
```mermaid
flowchart TD
    A[User Login] --> B{Check Email Domain}
    B -->|@skyvern.com| C[Show OrgWalled Features]
    B -->|Other Domain| D[Hide OrgWalled Features]
    C --> E[Use Script Cache Toggle Visible]
    C --> F[Power Button Visible]
    D --> G[Standard UI Only]
    E --> H[Workflow Settings Updated]
    H --> I[Backend API Call with use_cache]
```

### Impact
- **Access Control**: Provides a clean way to gate experimental features for internal users while maintaining a polished external experience
- **Performance Enhancement**: Script caching capability can significantly improve workflow execution speed by reusing generated scripts
- **UI Consistency**: Right-aligned toggles create a more professional and consistent interface design
- **Developer Experience**: The OrgWalled component pattern can be reused for future internal-only features

</details>

_Created with [Palmier](https://www.palmier.io)_