### PR TITLE
always return debug sessions that are <30s fresh

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -3492,6 +3492,28 @@ class AgentDB:
 
             return DebugSession.model_validate(debug_session)
 
+    async def get_latest_debug_session_for_user(
+        self,
+        *,
+        organization_id: str,
+        user_id: str,
+        workflow_permanent_id: str,
+    ) -> DebugSession | None:
+        async with self.Session() as session:
+            query = (
+                select(DebugSessionModel)
+                .filter_by(organization_id=organization_id)
+                .filter_by(deleted_at=None)
+                .filter_by(status="created")
+                .filter_by(user_id=user_id)
+                .filter_by(workflow_permanent_id=workflow_permanent_id)
+                .order_by(DebugSessionModel.created_at.desc())
+            )
+
+            model = (await session.scalars(query)).first()
+
+            return DebugSession.model_validate(model) if model else None
+
     async def complete_debug_sessions(
         self,
         *,

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from functools import partial
 from typing import Annotated, Any
@@ -2100,7 +2101,31 @@ async def new_debug_session(
     sessions associated with those completed debug sessions.
 
     Return the new debug session.
+
+    CAVEAT: if an existing debug session for this user is <30s old, then we
+    return that instead. This is to curtail damage from browser session
+    spamming.
     """
+
+    if current_user_id:
+        debug_session = await app.DATABASE.get_latest_debug_session_for_user(
+            organization_id=current_org.organization_id,
+            user_id=current_user_id,
+            workflow_permanent_id=workflow_permanent_id,
+        )
+
+        if debug_session:
+            now = datetime.now(timezone.utc)
+            if now - debug_session.created_at < timedelta(seconds=30):
+                LOG.info(
+                    "Existing debug session is less than 30s old, returning it",
+                    debug_session_id=debug_session.debug_session_id,
+                    browser_session_id=debug_session.browser_session_id,
+                    organization_id=current_org.organization_id,
+                    user_id=current_user_id,
+                    workflow_permanent_id=workflow_permanent_id,
+                )
+                return debug_session
 
     completed_debug_sessions = await app.DATABASE.complete_debug_sessions(
         organization_id=current_org.organization_id,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> This PR modifies `new_debug_session` in `agent_protocol.py` to return an existing debug session if it is less than 30 seconds old, using a new database query function `get_latest_debug_session_for_user` in `client.py`.
> 
>   - **Behavior**:
>     - In `new_debug_session` in `agent_protocol.py`, return existing debug session if <30s old to prevent session spamming.
>     - Uses `get_latest_debug_session_for_user` in `client.py` to fetch the latest debug session.
>   - **Database**:
>     - Adds `get_latest_debug_session_for_user` in `client.py` to query the latest debug session for a user by `organization_id`, `user_id`, and `workflow_permanent_id`.
>   - **Logging**:
>     - Logs when an existing debug session is returned in `new_debug_session` in `agent_protocol.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 30c85d2cdb372b3c32d9f4979a33a8f7df2a0861. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🛡️ This PR implements session spam protection by preventing the creation of new debug sessions when a user already has an active session less than 30 seconds old. Instead of creating a duplicate session, it returns the existing fresh session to reduce resource waste and prevent abuse.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Database Layer**: Added `get_latest_debug_session_for_user()` method in `client.py` to query the most recent debug session for a specific user, organization, and workflow
- **API Layer**: Enhanced `new_debug_session()` endpoint in `agent_protocol.py` to check for existing sessions before creating new ones
- **Session Management**: Implemented 30-second freshness check to prevent rapid session creation spam

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant API as new_debug_session()
    participant DB as Database
    participant Session as Debug Session

    Client->>API: Request new debug session
    API->>DB: get_latest_debug_session_for_user()
    DB-->>API: Return latest session (if exists)
    
    alt Session exists and < 30s old
        API->>API: Check timestamp difference
        API-->>Client: Return existing session
    else No recent session
        API->>DB: complete_debug_sessions()
        API->>Session: Create new debug session
        Session-->>Client: Return new session
    end
```

### Impact
- **Resource Optimization**: Prevents unnecessary creation of duplicate debug sessions when users rapidly click or refresh
- **System Stability**: Reduces database load and browser session overhead by reusing recent sessions
- **User Experience**: Maintains consistent behavior while protecting against accidental session spam without impacting normal usage patterns

</details>

_Created with [Palmier](https://www.palmier.io)_