### PR TITLE
set-initial-window-debugger-position-size-as-specified-in-the

### DIFF
--- a/skyvern-frontend/src/components/FloatingWindow.tsx
+++ b/skyvern-frontend/src/components/FloatingWindow.tsx
@@ -145,6 +145,7 @@ function getOs(): OS {
 function FloatingWindow({
   bounded,
   children,
+  initialPosition,
   initialWidth,
   initialHeight,
   maximized,
@@ -162,6 +163,7 @@ function FloatingWindow({
   bounded?: boolean;
   children: React.ReactNode;
   initialHeight?: number;
+  initialPosition?: { x: number; y: number };
   initialWidth?: number;
   maximized?: boolean;
   showCloseButton?: boolean;
@@ -177,22 +179,22 @@ function FloatingWindow({
 }) {
   const [reloadKey, setReloadKey] = useState(0);
   const [isReloading, setIsReloading] = useState(false);
-  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [position, setPosition] = useState(initialPosition ?? { x: 0, y: 0 });
   const [size, setSize] = useState({
-    left: 0,
-    top: 0,
+    left: initialPosition?.x ?? 0,
+    top: initialPosition?.y ?? 0,
     height: initialHeight ?? Constants.MinHeight,
     width: initialWidth ?? Constants.MinWidth,
   });
   const [lastSize, setLastSize] = useState({
-    left: 0,
-    top: 0,
+    left: initialPosition?.x ?? 0,
+    top: initialPosition?.y ?? 0,
     height: initialHeight ?? Constants.MinHeight,
     width: initialWidth ?? Constants.MinWidth,
   });
   const [restoreSize, setRestoreSize] = useState({
-    left: 0,
-    top: 0,
+    left: initialPosition?.x ?? 0,
+    top: initialPosition?.y ?? 0,
     height: initialHeight ?? Constants.MinHeight,
     width: initialWidth ?? Constants.MinWidth,
   });
@@ -286,13 +288,13 @@ function FloatingWindow({
       return;
     }
     setSize({
-      left: 0,
-      top: 0,
+      left: initialPosition?.x ?? 0,
+      top: initialPosition?.y ?? 0,
       width: initialWidth,
       height: initialHeight,
     });
-    setPosition({ x: 0, y: 0 });
-  }, [initialWidth, initialHeight]);
+    setPosition({ x: initialPosition?.x ?? 0, y: initialPosition?.y ?? 0 });
+  }, [initialWidth, initialHeight, initialPosition]);
 
   /**
    * Forces the sizing to take place after the resize is complete.

--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowDebugger.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowDebugger.tsx
@@ -186,6 +186,21 @@ function WorkflowDebugger() {
   const interactor = workflowRun && isFinalized === false ? "agent" : "human";
   const browserTitle = interactor === "agent" ? `Browser [🤖]` : `Browser [👤]`;
 
+  // ---start fya: https://github.com/frontyardart
+  const initialBrowserPosition = {
+    x: 600,
+    y: 132,
+  };
+
+  const windowWidth = window.innerWidth;
+  const rightPadding = 567;
+  const initialWidth = Math.max(
+    512,
+    windowWidth - initialBrowserPosition.x - rightPadding,
+  );
+  const initialHeight = (initialWidth / 16) * 9;
+  // ---end fya
+
   return (
     <div className="relative flex h-screen w-full">
       <Dialog
@@ -247,8 +262,9 @@ function WorkflowDebugger() {
       <FloatingWindow
         title={browserTitle}
         bounded={false}
-        initialWidth={512}
-        initialHeight={360}
+        initialPosition={initialBrowserPosition}
+        initialWidth={initialWidth}
+        initialHeight={initialHeight}
         showMaximizeButton={true}
         showMinimizeButton={true}
         showPowerButton={blockLabel === undefined && showPowerButton}


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-5839/set-initial-window-debugger-position-size-as-specified-in-the
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add initial position and size configuration to `FloatingWindow` in `FloatingWindow.tsx` and `WorkflowDebugger.tsx`.
> 
>   - **Behavior**:
>     - `FloatingWindow` now accepts `initialPosition` prop to set initial x and y coordinates.
>     - Updates `position`, `size`, `lastSize`, and `restoreSize` states in `FloatingWindow` to use `initialPosition`.
>     - `WorkflowDebugger` calculates `initialWidth` and `initialHeight` based on `window.innerWidth` and `initialBrowserPosition`.
>   - **Components**:
>     - `FloatingWindow` in `FloatingWindow.tsx` updated to handle `initialPosition`.
>     - `WorkflowDebugger` in `WorkflowDebugger.tsx` sets `initialPosition`, `initialWidth`, and `initialHeight` for `FloatingWindow`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6ece1356180867f449d51c939b8655a5362cd436. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🪟 This PR enhances the FloatingWindow component by adding support for custom initial positioning, allowing the workflow debugger to specify exactly where and how large the browser window should appear on screen.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **FloatingWindow Component**: Added `initialPosition` prop with `{ x: number; y: number }` type to control window placement
- **State Management**: Updated all position-related state variables (`position`, `size`, `lastSize`, `restoreSize`) to use the initial position values
- **WorkflowDebugger Integration**: Implemented smart positioning logic that places the browser window at x:600, y:132 with dynamic sizing based on screen width

### Technical Implementation
```mermaid
flowchart TD
    A[WorkflowDebugger] --> B[Calculate Initial Position]
    B --> C[Set x: 600, y: 132]
    B --> D[Calculate Dynamic Width]
    D --> E[windowWidth - x - rightPadding]
    E --> F[Calculate 16:9 Aspect Ratio Height]
    F --> G[Pass to FloatingWindow]
    G --> H[Initialize All Position States]
    H --> I[Render Window at Specified Position]
```

### Impact
- **User Experience**: Browser window now appears in a predictable, well-positioned location instead of defaulting to (0,0)
- **Responsive Design**: Dynamic width calculation ensures the window adapts to different screen sizes while maintaining proper spacing
- **Component Reusability**: The `initialPosition` prop makes FloatingWindow more flexible for other use cases requiring custom positioning

</details>

_Created with [Palmier](https://www.palmier.io)_