### PR TITLE
restore run button in debug view

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
@@ -145,17 +145,15 @@ function WorkflowHeader({
                 <ChevronDownIcon className="h-6 w-6" />
               )}
             </Button>
-            {!debugStore.isDebugMode && (
-              <Button
-                size="lg"
-                onClick={() => {
-                  navigate(`/workflows/${workflowPermanentId}/run`);
-                }}
-              >
-                <PlayIcon className="mr-2 h-6 w-6" />
-                Run
-              </Button>
-            )}
+            <Button
+              size="lg"
+              onClick={() => {
+                navigate(`/workflows/${workflowPermanentId}/run`);
+              }}
+            >
+              <PlayIcon className="mr-2 h-6 w-6" />
+              Run
+            </Button>
           </>
         )}
       </div>


### PR DESCRIPTION
/SKY-5837/restore-run-button-in-debug-view
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restores the 'Run' button in `WorkflowHeader.tsx` to be always visible, regardless of debug mode status.
> 
>   - **UI Change**:
>     - Restores the 'Run' button in `WorkflowHeader.tsx` by removing the condition that hides it when `debugStore.isDebugMode` is true.
>     - The 'Run' button is now always visible, regardless of debug mode status.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 616cbe08fb0457d3156d37e2daa8db7137557128. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->