### PR TITLE
do not raise error when parsing totp secret

### DIFF
--- a/skyvern/forge/sdk/services/credentials.py
+++ b/skyvern/forge/sdk/services/credentials.py
@@ -5,8 +5,6 @@ from urllib.parse import unquote
 import pyotp
 import structlog
 
-from skyvern.exceptions import NoTOTPSecretFound
-
 LOG = structlog.get_logger()
 
 
@@ -36,7 +34,7 @@ def parse_totp_secret(totp_secret: str) -> str:
         LOG.warning("Failed to parse TOTP secret key from URI format, going to extract secret by regex", exc_info=True)
         m = re.search(r"(?i)(?:^|[?&])secret=([^&#]+)", unquote(totp_secret_no_whitespace))
         if m is None:
-            raise NoTOTPSecretFound()
+            return totp_secret_no_whitespace
         totp_secret = m.group(1)
         totp_secret_no_whitespace = "".join(totp_secret.split())
         return totp_secret_no_whitespace


### PR DESCRIPTION
---

🛡️ This PR changes the TOTP secret parsing behavior to return the original input instead of raising an exception when the secret cannot be extracted from URI format, making the system more resilient to malformed TOTP secrets.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Exception Handling**: Removed the `NoTOTPSecretFound` exception import and usage
- **Fallback Behavior**: Changed from raising an exception to returning the original `totp_secret_no_whitespace` when regex parsing fails
- **Error Resilience**: The function now gracefully handles cases where TOTP secrets don't match expected URI patterns

### Technical Implementation
```mermaid
flowchart TD
    A[TOTP Secret Input] --> B[Remove Whitespace]
    B --> C[Try Parse as URI]
    C --> D{URI Parse Success?}
    D -->|Yes| E[Extract Secret from URI]
    D -->|No| F[Log Warning & Try Regex]
    F --> G{Regex Match Found?}
    G -->|Yes| H[Extract Secret from Regex]
    G -->|No| I[Return Original Secret]
    E --> J[Return Processed Secret]
    H --> K[Remove Whitespace & Return]
    I --> L[Final Output]
    J --> L
    K --> L
```

### Impact
- **Improved Resilience**: The system no longer crashes when encountering malformed TOTP secrets
- **Better User Experience**: Users with non-standard TOTP secret formats can still proceed with their original input
- **Reduced Error Handling**: Eliminates the need for upstream code to catch and handle `NoTOTPSecretFound` exceptions

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `parse_totp_secret` in `credentials.py` now returns the input string instead of raising an error when TOTP secret parsing fails.
> 
>   - **Behavior**:
>     - `parse_totp_secret` in `credentials.py` no longer raises `NoTOTPSecretFound` when TOTP secret parsing fails.
>     - Returns `totp_secret_no_whitespace` if regex extraction fails.
>   - **Imports**:
>     - Removed unused import `NoTOTPSecretFound` from `credentials.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 4072cc3615ee399a520fc7f7a1fef3145ab58124. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->