### PR TITLE
Rework Workflow Save

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowDebugger.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowDebugger.tsx
@@ -62,9 +62,7 @@ function WorkflowDebugger() {
     return state.setCollapsed;
   });
 
-  const setHasChanges = useWorkflowHasChangesStore(
-    (state) => state.setHasChanges,
-  );
+  const workflowChangesStore = useWorkflowHasChangesStore();
 
   const handleOnCycle = () => {
     setOpenDialogue(true);
@@ -72,7 +70,7 @@ function WorkflowDebugger() {
 
   useMountEffect(() => {
     setCollapsed(true);
-    setHasChanges(false);
+    workflowChangesStore.setHasChanges(false);
 
     if (workflowPermanentId) {
       queryClient.removeQueries({

--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowEditor.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowEditor.tsx
@@ -16,9 +16,7 @@ function WorkflowEditor() {
   const setCollapsed = useSidebarStore((state) => {
     return state.setCollapsed;
   });
-  const setHasChanges = useWorkflowHasChangesStore(
-    (state) => state.setHasChanges,
-  );
+  const workflowChangesStore = useWorkflowHasChangesStore();
 
   const { data: workflow, isLoading } = useWorkflowQuery({
     workflowPermanentId,
@@ -29,7 +27,7 @@ function WorkflowEditor() {
 
   useMountEffect(() => {
     setCollapsed(true);
-    setHasChanges(false);
+    workflowChangesStore.setHasChanges(false);
   });
 
   if (isLoading || isGlobalWorkflowsLoading) {

--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
@@ -40,7 +40,7 @@ function WorkflowHeader({
   saving,
 }: Props) {
   const { title, setTitle } = useWorkflowTitleStore();
-  const { setHasChanges } = useWorkflowHasChangesStore();
+  const workflowChangesStore = useWorkflowHasChangesStore();
   const { blockLabel: urlBlockLabel, workflowPermanentId } = useParams();
   const { data: globalWorkflows } = useGlobalWorkflowsQuery();
   const navigate = useNavigate();
@@ -68,7 +68,7 @@ function WorkflowHeader({
           editable={true}
           onChange={(newTitle) => {
             setTitle(newTitle);
-            setHasChanges(true);
+            workflowChangesStore.setHasChanges(true);
           }}
           value={title}
           titleClassName="text-3xl"

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/routes/workflows/types/workflowTypes";
 import { getInitialValues } from "@/routes/workflows/utils";
 import { useDebugStore } from "@/store/useDebugStore";
+import { useWorkflowSave } from "@/store/WorkflowHasChangesStore";
 import {
   useWorkflowSettingsStore,
   type WorkflowSettingsState,
@@ -155,6 +156,7 @@ function NodeHeader({
   const { data: debugSession } = useDebugSessionQuery({
     workflowPermanentId,
   });
+  const saveWorkflow = useWorkflowSave();
 
   useEffect(() => {
     if (!workflowRun || !workflowPermanentId || !workflowRunId) {
@@ -190,6 +192,8 @@ function NodeHeader({
 
   const runBlock = useMutation({
     mutationFn: async () => {
+      await saveWorkflow.mutateAsync();
+
       if (!workflowPermanentId) {
         console.error("There is no workflowPermanentId");
         toast({

--- a/skyvern-frontend/src/store/WorkflowHasChangesStore.ts
+++ b/skyvern-frontend/src/store/WorkflowHasChangesStore.ts
@@ -1,13 +1,179 @@
+import { AxiosError } from "axios";
+import { useEffect } from "react";
 import { create } from "zustand";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { stringify as convertToYAML } from "yaml";
 
-type WorkflowHasChangesStore = {
-  hasChanges: boolean;
-  setHasChanges: (hasChanges: boolean) => void;
+import { getClient } from "@/api/AxiosClient";
+import { toast } from "@/components/ui/use-toast";
+import { useCredentialGetter } from "@/hooks/useCredentialGetter";
+import type {
+  BlockYAML,
+  ParameterYAML,
+} from "@/routes/workflows/types/workflowYamlTypes";
+import type {
+  WorkflowApiResponse,
+  WorkflowSettings,
+} from "@/routes/workflows/types/workflowTypes";
+import { WorkflowCreateYAMLRequest } from "@/routes/workflows/types/workflowYamlTypes";
+type SaveData = {
+  parameters: Array<ParameterYAML>;
+  blocks: Array<BlockYAML>;
+  title: string;
+  settings: WorkflowSettings;
+  workflow: WorkflowApiResponse;
 };
 
-const useWorkflowHasChangesStore = create<WorkflowHasChangesStore>((set) => ({
-  hasChanges: false,
-  setHasChanges: (hasChanges) => set({ hasChanges }),
-}));
+type WorkflowHasChangesStore = {
+  getSaveData: () => SaveData | null;
+  hasChanges: boolean;
+  saveIsPending: boolean;
+  setGetSaveData: (getSaveData: () => SaveData) => void;
+  setHasChanges: (hasChanges: boolean) => void;
+  setSaveIsPending: (isPending: boolean) => void;
+};
 
-export { useWorkflowHasChangesStore };
+const useWorkflowHasChangesStore = create<WorkflowHasChangesStore>((set) => {
+  return {
+    hasChanges: false,
+    saveIsPending: false,
+    getSaveData: () => null,
+    setGetSaveData: (getSaveData: () => SaveData) => {
+      set({ getSaveData });
+    },
+    setHasChanges: (hasChanges: boolean) => {
+      set({ hasChanges });
+    },
+    setSaveIsPending: (isPending: boolean) => {
+      set({ saveIsPending: isPending });
+    },
+  };
+});
+
+const useWorkflowSave = () => {
+  const credentialGetter = useCredentialGetter();
+  const queryClient = useQueryClient();
+  const { getSaveData, setHasChanges, setSaveIsPending } =
+    useWorkflowHasChangesStore();
+
+  const saveWorkflowMutation = useMutation({
+    mutationFn: async () => {
+      const saveData = getSaveData();
+
+      if (!saveData) {
+        setHasChanges(false);
+        return;
+      }
+
+      const client = await getClient(credentialGetter);
+      const extraHttpHeaders: Record<string, string> = {};
+
+      if (saveData.settings.extraHttpHeaders) {
+        try {
+          const parsedHeaders = JSON.parse(saveData.settings.extraHttpHeaders);
+          if (
+            parsedHeaders &&
+            typeof parsedHeaders === "object" &&
+            !Array.isArray(parsedHeaders)
+          ) {
+            for (const [key, value] of Object.entries(parsedHeaders)) {
+              if (key && typeof key === "string") {
+                if (key in extraHttpHeaders) {
+                  toast({
+                    title: "Error",
+                    description: `Duplicate key '${key}' in extra http headers`,
+                    variant: "destructive",
+                  });
+                  continue;
+                }
+                extraHttpHeaders[key] = String(value);
+              }
+            }
+          }
+        } catch (error) {
+          toast({
+            title: "Error",
+            description: "Invalid JSON format in extra http headers",
+            variant: "destructive",
+          });
+          return;
+        }
+      }
+
+      const requestBody: WorkflowCreateYAMLRequest = {
+        title: saveData.title,
+        description: saveData.workflow.description,
+        proxy_location: saveData.settings.proxyLocation,
+        webhook_callback_url: saveData.settings.webhookCallbackUrl,
+        persist_browser_session: saveData.settings.persistBrowserSession,
+        model: saveData.settings.model,
+        max_screenshot_scrolls: saveData.settings.maxScreenshotScrolls,
+        totp_verification_url: saveData.workflow.totp_verification_url,
+        extra_http_headers: extraHttpHeaders,
+        use_cache: saveData.settings.useScriptCache,
+        cache_key: saveData.settings.scriptCacheKey,
+        workflow_definition: {
+          parameters: saveData.parameters,
+          blocks: saveData.blocks,
+        },
+        is_saved_task: saveData.workflow.is_saved_task,
+      };
+
+      const yaml = convertToYAML(requestBody);
+
+      return client.put<string, WorkflowApiResponse>(
+        `/workflows/${saveData.workflow.workflow_permanent_id}`,
+        yaml,
+        {
+          headers: {
+            "Content-Type": "text/plain",
+          },
+        },
+      );
+    },
+    onSuccess: () => {
+      const saveData = getSaveData();
+
+      if (!saveData) {
+        return;
+      }
+
+      toast({
+        title: "Changes saved",
+        description: "Your changes have been saved",
+        variant: "success",
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: ["workflow", saveData.workflow.workflow_permanent_id],
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: ["workflows"],
+      });
+
+      setHasChanges(false);
+    },
+    onError: (error: AxiosError) => {
+      const detail = (error.response?.data as { detail?: string })?.detail;
+
+      toast({
+        title: "Error",
+        description: detail ? detail : error.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  useEffect(() => {
+    setSaveIsPending(saveWorkflowMutation.isPending);
+  }, [saveWorkflowMutation.isPending, setSaveIsPending]);
+
+  return saveWorkflowMutation;
+};
+
+export {
+  useWorkflowSave,
+  useWorkflowHasChangesStore,
+  type SaveData as WorkflowSaveData,
+};


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-5842/debugger-not-saving-changes-before-running

- constructed a surgery to make workflow save functionality (from the `FlowRenderer` component) available to other components
- in this case, available to blocks via `NodeHeader`
- save the workflow right before a block is run

I'll need someone to test this more. 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor workflow save functionality to be reusable across components, introducing `useWorkflowSave` hook and updating components to save workflows before block execution.
> 
>   - **Behavior**:
>     - Refactor workflow save functionality in `FlowRenderer` to be reusable by other components.
>     - Introduce `useWorkflowSave` hook in `WorkflowHasChangesStore.ts` to handle workflow saving logic.
>     - Save workflow before running a block in `NodeHeader`.
>   - **State Management**:
>     - Add `getSaveData`, `setGetSaveData`, and `setSaveIsPending` to `useWorkflowHasChangesStore`.
>     - Use `useWorkflowSave` in `FlowRenderer`, `NodeHeader`, and `WorkflowHeader` to manage save state.
>   - **UI Changes**:
>     - Update save button states in `FlowRenderer` and `WorkflowHeader` to reflect pending save operations.
>     - Display toast notifications for save success and errors in `WorkflowHasChangesStore.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2008eec474f40fc828a18ea075b10f6685aee04d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔄 This PR refactors the workflow save functionality by extracting it from the FlowRenderer component into a reusable hook, enabling other components to save workflows before critical operations. The main improvement ensures that workflows are automatically saved before running individual blocks in the debugger, addressing the issue where unsaved changes could be lost during block execution.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Store Refactoring**: Moved workflow save logic from `FlowRenderer` to `WorkflowHasChangesStore` as a reusable `useWorkflowSave` hook
- **Save Data Management**: Added `getSaveData` function to the store that can be dynamically set by components to provide save data
- **Block Execution Safety**: Modified `NodeHeader` to automatically save workflows before running individual blocks
- **State Management**: Added `saveIsPending` state to track save operations across components
- **Code Cleanup**: Removed unused imports and dependencies from `FlowRenderer` after extracting save functionality

### Technical Implementation
```mermaid
sequenceDiagram
    participant NH as NodeHeader
    participant WS as useWorkflowSave
    participant FR as FlowRenderer
    participant Store as WorkflowHasChangesStore
    
    FR->>Store: setGetSaveData(constructSaveData)
    NH->>WS: saveWorkflow.mutateAsync()
    WS->>Store: getSaveData()
    Store->>WS: return SaveData
    WS->>API: PUT /workflows/{id}
    API->>WS: Success/Error
    WS->>Store: setHasChanges(false)
    WS->>Store: setSaveIsPending(false)
```

### Impact
- **Improved Data Safety**: Workflows are now automatically saved before block execution, preventing loss of unsaved changes
- **Better Code Organization**: Save functionality is centralized and reusable across multiple components
- **Enhanced User Experience**: Users no longer need to manually save before testing individual blocks
- **Consistent State Management**: All components now use the same save mechanism and pending state tracking

</details>

_Created with [Palmier](https://www.palmier.io)_