### PR TITLE
fix browser session bug

### DIFF
--- a/skyvern/webeye/browser_manager.py
+++ b/skyvern/webeye/browser_manager.py
@@ -92,7 +92,6 @@ class BrowserManager:
                     "Browser state not found in persistent sessions manager",
                     browser_session_id=browser_session_id,
                 )
-                raise MissingBrowserState(task_id=task.task_id)
             else:
                 if task.organization_id:
                     LOG.info("User to occupy browser session here", browser_session_id=browser_session_id)
@@ -113,6 +112,12 @@ class BrowserManager:
                 organization_id=task.organization_id,
                 extra_http_headers=task.extra_http_headers,
             )
+
+            if browser_session_id:
+                await app.PERSISTENT_SESSIONS_MANAGER.set_browser_state(
+                    browser_session_id,
+                    browser_state,
+                )
 
         self.pages[task.task_id] = browser_state
         if task.workflow_run_id:
@@ -160,7 +165,6 @@ class BrowserManager:
                 LOG.warning(
                     "Browser state not found in persistent sessions manager", browser_session_id=browser_session_id
                 )
-                raise MissingBrowserState(workflow_run_id=workflow_run.workflow_run_id)
             else:
                 LOG.info("Used to occupy browser session here", browser_session_id=browser_session_id)
                 page = await browser_state.get_working_page()
@@ -182,6 +186,12 @@ class BrowserManager:
                 organization_id=workflow_run.organization_id,
                 extra_http_headers=workflow_run.extra_http_headers,
             )
+
+            if browser_session_id:
+                await app.PERSISTENT_SESSIONS_MANAGER.set_browser_state(
+                    browser_session_id,
+                    browser_state,
+                )
 
         self.pages[workflow_run_id] = browser_state
         if parent_workflow_run_id:

--- a/skyvern/webeye/persistent_sessions_manager.py
+++ b/skyvern/webeye/persistent_sessions_manager.py
@@ -223,6 +223,10 @@ class PersistentSessionsManager:
         browser_session = self._browser_sessions.get(session_id)
         return browser_session.browser_state if browser_session else None
 
+    async def set_browser_state(self, session_id: str, browser_state: BrowserState) -> None:
+        browser_session = BrowserSession(browser_state=browser_state)
+        self._browser_sessions[session_id] = browser_session
+
     async def get_session(self, session_id: str, organization_id: str) -> PersistentBrowserSession | None:
         """Get a specific browser session by session ID."""
         return await self.database.get_persistent_browser_session(session_id, organization_id)


### PR DESCRIPTION
---

🔧 This PR fixes a browser session management bug by removing premature exception throwing and ensuring browser states are properly stored in the persistent sessions manager when browser session IDs are provided.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Exception Handling**: Removed `MissingBrowserState` exceptions that were being raised when browser states weren't found in persistent sessions, allowing the code to continue and create new browser states instead
- **State Persistence**: Added calls to `set_browser_state()` in both task and workflow run creation flows to ensure newly created browser states are stored in the persistent sessions manager
- **New Method**: Introduced `set_browser_state()` method in `PersistentSessionsManager` to enable storing browser states with their session IDs

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant BrowserManager
    participant PersistentSessionsManager
    participant BrowserState

    Client->>BrowserManager: get_or_create_for_task()
    BrowserManager->>PersistentSessionsManager: get_browser_state()
    alt Browser state not found
        PersistentSessionsManager-->>BrowserManager: None
        Note over BrowserManager: Previously threw MissingBrowserState
        BrowserManager->>BrowserState: create_browser_state()
        BrowserState-->>BrowserManager: new browser_state
        BrowserManager->>PersistentSessionsManager: set_browser_state()
    else Browser state found
        PersistentSessionsManager-->>BrowserManager: existing browser_state
    end
    BrowserManager-->>Client: browser_state
```

### Impact
- **Bug Resolution**: Fixes crashes that occurred when browser sessions weren't found in the persistent manager by gracefully creating new ones instead
- **Session Continuity**: Ensures browser states are properly persisted, enabling session reuse across multiple requests
- **Improved Reliability**: Both task and workflow run flows now handle missing browser sessions consistently without throwing exceptions

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix browser session bug by removing exceptions for missing states and ensuring states are set in persistent sessions.
> 
>   - **Behavior**:
>     - Removed `raise MissingBrowserState` in `get_or_create_for_task()` and `get_or_create_for_workflow_run()` in `browser_manager.py` to prevent exceptions when browser state is missing.
>     - Added `set_browser_state()` calls in `get_or_create_for_task()` and `get_or_create_for_workflow_run()` in `browser_manager.py` to ensure browser state is saved in persistent sessions.
>   - **PersistentSessionsManager**:
>     - Added `set_browser_state()` method in `persistent_sessions_manager.py` to store browser state in `_browser_sessions` dictionary.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1575891cacad75904be7215921c87020711adc4b. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->