### PR TITLE
add endpoint and query for fetching script blocks for a wpid

### DIFF
--- a/skyvern/schemas/scripts.py
+++ b/skyvern/schemas/scripts.py
@@ -137,3 +137,12 @@ class ScriptBlock(BaseModel):
     created_at: datetime
     modified_at: datetime
     deleted_at: datetime | None = None
+
+
+class ScriptBlocksResponse(BaseModel):
+    blocks: dict[str, str]
+
+
+class ScriptBlocksRequest(BaseModel):
+    cache_key_value: str
+    cache_key: str | None = None


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-5805/create-script-endpoints
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `get_workflow_script_blocks` endpoint to fetch script blocks for a workflow, with database and schema updates.
> 
>   - **Behavior**:
>     - Adds `get_workflow_script_blocks` endpoint in `scripts.py` to fetch script blocks for a given `workflow_permanent_id`.
>     - Uses `get_workflow_scripts_by_cache_key_value` and `get_script_blocks_by_script_revision_id` to retrieve scripts and blocks.
>     - Handles missing workflows, scripts, script blocks, script files, and artifacts with appropriate logging and error responses.
>   - **Database**:
>     - Adds `get_script_file_by_id` in `client.py` to fetch script files by `file_id`.
>     - Updates `get_workflow_scripts_by_cache_key_value` in `client.py` to accept an optional `cache_key` parameter.
>   - **Schemas**:
>     - Adds `ScriptBlocksRequest` and `ScriptBlocksResponse` models in `scripts.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 15e8661a6284240809e06dbf8b92a0ca91b249c2. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->