### PR TITLE
Jon/sky 5868 max recursion error in app

### DIFF
--- a/skyvern-frontend/src/components/AutoResizingTextarea/AutoResizingTextarea.tsx
+++ b/skyvern-frontend/src/components/AutoResizingTextarea/AutoResizingTextarea.tsx
@@ -1,12 +1,6 @@
 import { Textarea } from "@/components/ui/textarea";
 import type { ChangeEventHandler, HTMLAttributes } from "react";
-import {
-  forwardRef,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useCallback,
-} from "react";
+import { forwardRef, useEffect, useRef, useCallback } from "react";
 import { cn } from "@/util/utils";
 
 type Props = {
@@ -48,14 +42,6 @@ const AutoResizingTextarea = forwardRef<HTMLTextAreaElement, Props>(
         forwardedRef.current = element;
       }
     };
-
-    useLayoutEffect(() => {
-      const textareaElement = getTextarea();
-      if (!textareaElement) {
-        return;
-      }
-      textareaElement.style.height = `${textareaElement.scrollHeight + 2}px`;
-    }, [getTextarea]);
 
     useEffect(() => {
       const textareaElement = getTextarea();

--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -271,6 +271,7 @@ function FlowRenderer({
   const [debuggableBlockCount, setDebuggableBlockCount] = useState(0);
   const nodesInitialized = useNodesInitialized();
   const [shouldConstrainPan, setShouldConstrainPan] = useState(false);
+  const onNodesChangeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     if (nodesInitialized) {
@@ -713,7 +714,15 @@ function FlowRenderer({
               ) {
                 workflowChangesStore.setHasChanges(true);
               }
-              onNodesChange(changes);
+
+              // prevent cascading React updates
+              if (onNodesChangeTimeoutRef.current) {
+                clearTimeout(onNodesChangeTimeoutRef.current);
+              }
+
+              onNodesChangeTimeoutRef.current = setTimeout(() => {
+                onNodesChange(changes);
+              }, 0); // defer to next tick
             }}
             onEdgesChange={onEdgesChange}
             nodeTypes={nodeTypes}


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-5868/max-recursion-error-in-app
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix max recursion error by removing `useLayoutEffect` in `AutoResizingTextarea.tsx` and deferring `onNodesChange` execution in `FlowRenderer.tsx`.
> 
>   - **Behavior**:
>     - Remove `useLayoutEffect` in `AutoResizingTextarea.tsx` to prevent max recursion error.
>     - Defer `onNodesChange` execution using `setTimeout` in `FlowRenderer.tsx` to prevent cascading React updates.
>   - **Misc**:
>     - Remove unused `useLayoutEffect` import in `AutoResizingTextarea.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for adcfedf9c40f1d08220d45e9e1028f8cdbe1c1f8. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->