### PR TITLE
throttle instead of debounce

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -715,14 +715,13 @@ function FlowRenderer({
                 workflowChangesStore.setHasChanges(true);
               }
 
-              // prevent cascading React updates
-              if (onNodesChangeTimeoutRef.current) {
-                clearTimeout(onNodesChangeTimeoutRef.current);
-              }
-
-              onNodesChangeTimeoutRef.current = setTimeout(() => {
+              // throttle onNodesChange to prevent cascading React updates
+              if (onNodesChangeTimeoutRef.current === null) {
                 onNodesChange(changes);
-              }, 0); // defer to next tick
+                onNodesChangeTimeoutRef.current = setTimeout(() => {
+                  onNodesChangeTimeoutRef.current = null;
+                }, 33); // ~30fps throttle
+              }
             }}
             onEdgesChange={onEdgesChange}
             nodeTypes={nodeTypes}


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace debounce with throttle for `onNodesChange` in `FlowRenderer.tsx` to limit updates to ~30fps and prevent cascading React updates.
> 
>   - **Behavior**:
>     - Replace debounce with throttle for `onNodesChange` in `FlowRenderer.tsx` to limit updates to ~30fps.
>     - Prevents cascading React updates by ensuring `onNodesChange` is called at most once every 33ms.
>   - **Implementation**:
>     - Uses `setTimeout` to reset `onNodesChangeTimeoutRef` to `null` after 33ms, allowing the next update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for b8eca81a89bf2d7af24da3eaec74e82fb1fa0629. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->