### PR TITLE
script generation: regenerate click xpath from intention

### DIFF
--- a/skyvern/core/script_generations/run_initializer.py
+++ b/skyvern/core/script_generations/run_initializer.py
@@ -1,24 +1,9 @@
 from typing import Any
 
-from playwright.async_api import async_playwright
-
 from skyvern.core.script_generations.skyvern_page import RunContext, SkyvernPage
-from skyvern.forge.sdk.core import skyvern_context
-from skyvern.webeye.browser_factory import BrowserContextFactory
 
 
-# TODO: find a better name for this function
 async def setup(parameters: dict[str, Any], generate_response: bool = False) -> tuple[SkyvernPage, RunContext]:
-    # set up skyvern context
-    skyvern_context.set(skyvern_context.SkyvernContext())
-    # start playwright
-    pw = await async_playwright().start()
-    (
-        browser_context,
-        _,
-        _,
-    ) = await BrowserContextFactory.create_browser_context(playwright=pw)
-    new_page = await browser_context.new_page()
-    # skyvern_page = SkyvernPage(page=new_page, generate_response=generate_response)
-    skyvern_page = SkyvernPage(page=new_page)
-    return skyvern_page, RunContext(parameters=parameters, page=skyvern_page)
+    skyvern_page = await SkyvernPage.create()
+    run_context = RunContext(parameters=parameters, page=skyvern_page)
+    return skyvern_page, run_context

--- a/skyvern/forge/sdk/core/skyvern_context.py
+++ b/skyvern/forge/sdk/core/skyvern_context.py
@@ -26,6 +26,8 @@ class SkyvernContext:
     frame_index_map: dict[Frame, int] = field(default_factory=dict)
     dropped_css_svg_element_map: dict[str, bool] = field(default_factory=dict)
     max_screenshot_scrolls: int | None = None
+    script_id: str | None = None
+    script_revision_id: str | None = None
 
     def __repr__(self) -> str:
         return f"SkyvernContext(request_id={self.request_id}, organization_id={self.organization_id}, task_id={self.task_id}, workflow_id={self.workflow_id}, workflow_run_id={self.workflow_run_id}, task_v2_id={self.task_v2_id}, max_steps_override={self.max_steps_override}, run_id={self.run_id})"

--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -626,6 +626,7 @@ class BrowserState:
         proxy_location: ProxyLocation | None = None,
         task_id: str | None = None,
         workflow_run_id: str | None = None,
+        script_id: str | None = None,
         organization_id: str | None = None,
         extra_http_headers: dict[str, str] | None = None,
     ) -> None:
@@ -772,6 +773,7 @@ class BrowserState:
         proxy_location: ProxyLocation | None = None,
         task_id: str | None = None,
         workflow_run_id: str | None = None,
+        script_id: str | None = None,
         organization_id: str | None = None,
         extra_http_headers: dict[str, str] | None = None,
     ) -> Page:
@@ -785,6 +787,7 @@ class BrowserState:
                 proxy_location=proxy_location,
                 task_id=task_id,
                 workflow_run_id=workflow_run_id,
+                script_id=script_id,
                 organization_id=organization_id,
                 extra_http_headers=extra_http_headers,
             )
@@ -800,6 +803,7 @@ class BrowserState:
                 proxy_location=proxy_location,
                 task_id=task_id,
                 workflow_run_id=workflow_run_id,
+                script_id=script_id,
                 organization_id=organization_id,
                 extra_http_headers=extra_http_headers,
             )
@@ -814,6 +818,7 @@ class BrowserState:
                 proxy_location=proxy_location,
                 task_id=task_id,
                 workflow_run_id=workflow_run_id,
+                script_id=script_id,
                 organization_id=organization_id,
                 extra_http_headers=extra_http_headers,
             )


### PR DESCRIPTION
## Summary
- allow SkyvernPage.click to regenerate target xpath using the `single-click-action` prompt
- fall back to the original xpath if the prompt fails

## Testing
- `pre-commit run --files skyvern/core/script_generations/skyvern_page.py` *(fails: pre-commit: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest tests/prompt/phone_format/test_phone_format.py` *(fails: No module named 'ddtrace')*
- `pip install ddtrace` *(fails: Could not find a version that satisfies the requirement ddtrace)*

------
https://chatgpt.com/codex/tasks/task_b_689acbfcdd0c832d8a5183b222c4ef1e
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance `SkyvernPage.click` to regenerate xpath using a prompt and add browser state management for scripts.
> 
>   - **Behavior**:
>     - `SkyvernPage.click` now regenerates target xpath using `single-click-action` prompt, falling back to original xpath if prompt fails.
>     - `SkyvernPage.create` initializes browser state and returns a `SkyvernPage` instance.
>   - **Context**:
>     - Adds `script_id` and `script_revision_id` to `SkyvernContext`.
>   - **Browser Management**:
>     - Adds `get_or_create_for_script` method to `BrowserManager` to manage browser state for scripts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for e87cef19c753bd57bc9653e4f8c965fe00bfe11c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->