### PR TITLE
remove onepassword token creation endpoint from api doc

### DIFF
--- a/skyvern/forge/sdk/routes/credentials.py
+++ b/skyvern/forge/sdk/routes/credentials.py
@@ -428,10 +428,6 @@ async def get_onepassword_token(
     response_model=CreateOnePasswordTokenResponse,
     summary="Create or update OnePassword service account token",
     description="Creates or updates a OnePassword service account token for the current organization. Only one valid token is allowed per organization.",
-    tags=["Auth Tokens"],
-    openapi_extra={
-        "x-fern-sdk-method-name": "update_onepassword_token",
-    },
 )
 @base_router.post(
     "/credentials/onepassword/create/",


### PR DESCRIPTION
---

📚 This PR removes API documentation metadata from the OnePassword token creation endpoint, specifically removing the endpoint from public API documentation while keeping the functionality intact.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **API Documentation**: Removed `tags=["Auth Tokens"]` from the OnePassword token creation endpoint decorator
- **SDK Integration**: Removed `openapi_extra` configuration that defined the Fern SDK method name `update_onepassword_token`
- **Endpoint Visibility**: The endpoint remains functional but is no longer exposed in the generated API documentation

### Technical Implementation
```mermaid
flowchart TD
    A[OnePassword Token Endpoint] --> B{Documentation Metadata}
    B --> C[tags: Auth Tokens - REMOVED]
    B --> D[openapi_extra: SDK method name - REMOVED]
    E[Endpoint Functionality] --> F[Still Available]
    E --> G[Still Accepts Requests]
    
    style C fill:#ffcccc
    style D fill:#ffcccc
    style F fill:#ccffcc
    style G fill:#ccffcc
```

### Impact
- **API Documentation**: The OnePassword token creation endpoint will no longer appear in generated API documentation or SDK clients
- **Functionality Preservation**: The actual endpoint remains fully functional and accessible programmatically
- **SDK Generation**: Fern SDK will no longer generate a `update_onepassword_token` method for this endpoint
- **Internal Use**: This change suggests the endpoint is intended for internal use only rather than public API consumption

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove OpenAPI documentation tags from `get_onepassword_token()` in `credentials.py`.
> 
>   - **API Documentation**:
>     - Removed `tags` and `openapi_extra` from `get_onepassword_token()` in `credentials.py`.
>     - This affects the OpenAPI documentation generation for the endpoint but not its functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 885bc41a3cdf851a021b099dd7cd4b9e1e797c74. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->