### PR TITLE
add support_empty_page and wait_seconds to the scrape_website interface

### DIFF
--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -405,6 +405,8 @@ async def scrape_website(
     draw_boxes: bool = True,
     max_screenshot_number: int = settings.MAX_NUM_SCREENSHOTS,
     scroll: bool = True,
+    support_empty_page: bool = False,
+    wait_seconds: float = 3,
 ) -> ScrapedPage:
     """
     ************************************************************************************************
@@ -439,6 +441,8 @@ async def scrape_website(
             draw_boxes=draw_boxes,
             max_screenshot_number=max_screenshot_number,
             scroll=scroll,
+            support_empty_page=support_empty_page,
+            wait_seconds=wait_seconds,
         )
     except ScrapingFailedBlankPage:
         raise
@@ -517,6 +521,8 @@ async def scrape_web_unsafe(
     draw_boxes: bool = True,
     max_screenshot_number: int = settings.MAX_NUM_SCREENSHOTS,
     scroll: bool = True,
+    support_empty_page: bool = False,
+    wait_seconds: float = 3,
 ) -> ScrapedPage:
     """
     Asynchronous function that performs web scraping without any built-in error handling. This function is intended
@@ -538,11 +544,11 @@ async def scrape_web_unsafe(
     # This also solves the issue where we can't scroll due to a popup.(e.g. geico first popup on the homepage after
     # clicking start my quote)
     url = page.url
-    if url == "about:blank":
+    if url == "about:blank" and not support_empty_page:
         raise ScrapingFailedBlankPage()
 
-    LOG.info("Waiting for 3 seconds before scraping the website.")
-    await asyncio.sleep(3)
+    LOG.info(f"Waiting for {wait_seconds} seconds before scraping the website.")
+    await asyncio.sleep(wait_seconds)
 
     elements, element_tree = await get_interactable_element_tree(page, scrape_exclude)
     element_tree = await cleanup_element_tree(page, url, copy.deepcopy(element_tree))
@@ -569,7 +575,7 @@ async def scrape_web_unsafe(
     )
 
     # if there are no elements, fail the scraping
-    if not elements:
+    if not elements and not support_empty_page:
         raise Exception("No elements found on the page")
 
     text_content = await get_frame_text(page.main_frame)


### PR DESCRIPTION
---

🔧 This PR enhances the web scraping interface by adding two new configurable parameters: `support_empty_page` to allow scraping of blank pages and `wait_seconds` to customize the delay before scraping begins.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Function Signatures**: Added `support_empty_page: bool = False` and `wait_seconds: float = 3` parameters to both `scrape_website()` and `scrape_web_unsafe()` functions
- **Blank Page Handling**: Modified the "about:blank" URL check to respect the `support_empty_page` flag, preventing automatic failure when this flag is enabled
- **Wait Time Configuration**: Replaced hardcoded 3-second wait with configurable `wait_seconds` parameter
- **Empty Elements Handling**: Updated the empty elements check to allow proceeding when `support_empty_page` is True

### Technical Implementation
```mermaid
flowchart TD
    A[scrape_website called] --> B[Check support_empty_page flag]
    B --> C{URL is about:blank?}
    C -->|Yes & support_empty_page=False| D[Raise ScrapingFailedBlankPage]
    C -->|Yes & support_empty_page=True| E[Continue scraping]
    C -->|No| E
    E --> F[Wait for wait_seconds duration]
    F --> G[Get interactable elements]
    G --> H{Elements found?}
    H -->|No & support_empty_page=False| I[Raise Exception]
    H -->|No & support_empty_page=True| J[Continue with empty page]
    H -->|Yes| J
    J --> K[Return ScrapedPage]
```

### Impact
- **Flexibility Enhancement**: Enables scraping of pages that may legitimately be blank or have no interactable elements
- **Performance Tuning**: Allows customization of wait times based on specific use cases, potentially improving scraping efficiency
- **Backward Compatibility**: Default parameter values maintain existing behavior, ensuring no breaking changes for current users

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `support_empty_page` and `wait_seconds` parameters to `scrape_website` and `scrape_web_unsafe` for flexible empty page handling and customizable wait times.
> 
>   - **Behavior**:
>     - Add `support_empty_page` and `wait_seconds` parameters to `scrape_website()` and `scrape_web_unsafe()`.
>     - `support_empty_page` allows scraping of pages with `about:blank` URL without raising `ScrapingFailedBlankPage`.
>     - `wait_seconds` allows customization of wait time before scraping, replacing the fixed 3-second wait.
>   - **Logging**:
>     - Update log message in `scrape_web_unsafe()` to reflect `wait_seconds` value.
>   - **Error Handling**:
>     - Modify condition in `scrape_web_unsafe()` to raise `ScrapingFailedBlankPage` only if `support_empty_page` is `False`.
>     - Modify condition to raise exception for no elements found only if `support_empty_page` is `False`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6b971a04fc21ad7ba63973b10141d7de7773230d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->