### PR TITLE
remove get 1password token from doc

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -193,6 +193,7 @@ navigation:
           - section: Scripts
             contents:
               - POST /v1/scripts
+              - POST /v1/scripts/{script_id}/run
               - POST /v1/scripts/{script_id}/deploy
               - GET /v1/scripts/{script_id}
               - GET /v1/scripts

--- a/skyvern/forge/sdk/routes/credentials.py
+++ b/skyvern/forge/sdk/routes/credentials.py
@@ -379,10 +379,6 @@ async def get_credentials(
     response_model=CreateOnePasswordTokenResponse,
     summary="Get OnePassword service account token",
     description="Retrieves the current OnePassword service account token for the organization.",
-    tags=["Auth Tokens"],
-    openapi_extra={
-        "x-fern-sdk-method-name": "get_onepassword_token",
-    },
 )
 @base_router.get(
     "/credentials/onepassword/get/",
@@ -435,11 +431,7 @@ async def get_onepassword_token(
     include_in_schema=False,
 )
 async def update_onepassword_token(
-    data: CreateOnePasswordTokenRequest = Body(
-        ...,
-        description="The OnePassword token data",
-        openapi_extra={"x-fern-sdk-parameter-name": "data"},
-    ),
+    data: CreateOnePasswordTokenRequest,
     current_org: Organization = Depends(org_auth_service.get_current_org),
 ) -> CreateOnePasswordTokenResponse:
     """


### PR DESCRIPTION
---

📚 This PR removes OnePassword token endpoint from API documentation by removing OpenAPI metadata and simplifying parameter definitions, effectively hiding the endpoint from generated documentation while keeping the functionality intact.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **API Documentation**: Removed `tags=["Auth Tokens"]` and `openapi_extra` metadata from the get OnePassword token endpoint
- **Parameter Simplification**: Simplified the `update_onepassword_token` function parameter by removing Body wrapper and OpenAPI extras
- **Schema Visibility**: Added `include_in_schema=False` to hide the update endpoint from API documentation

### Technical Implementation
```mermaid
flowchart TD
    A[OnePassword Token Endpoints] --> B[Get Token Endpoint]
    A --> C[Update Token Endpoint]
    B --> D[Remove from API docs<br/>Keep functionality]
    C --> E[Already hidden<br/>Simplify parameters]
    D --> F[No tags, no OpenAPI extras]
    E --> G[Plain parameter definition]
    F --> H[Hidden from generated docs]
    G --> H
```

### Impact
- **Documentation Cleanup**: OnePassword token endpoints are now hidden from public API documentation, suggesting these are internal-only operations
- **Code Simplification**: Removed unnecessary OpenAPI metadata and parameter decorators, making the code cleaner and more maintainable
- **Backward Compatibility**: No breaking changes to actual functionality - endpoints still work but are not exposed in documentation

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove OnePassword token endpoint from API documentation by altering OpenAPI metadata in `credentials.py`.
> 
>   - **API Documentation**:
>     - Removed `tags=["Auth Tokens"]` and `openapi_extra` metadata from `get_onepassword_token` in `credentials.py`.
>     - Added `include_in_schema=False` to `update_onepassword_token` to hide it from API documentation.
>   - **Parameter Simplification**:
>     - Simplified `update_onepassword_token` parameters by removing `Body` wrapper and OpenAPI extras.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for bea0e7d72ebe84876eeb77ebaa137d633e281e6d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->