### PR TITLE
allow deletion of blocks within the debugger

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -576,7 +576,13 @@ function FlowRenderer({
       </Dialog>
       <BlockActionContext.Provider
         value={{
-          deleteNodeCallback: deleteNode,
+          /**
+           * NOTE: defer deletion to next tick to allow React Flow's internal
+           * event handlers to complete; removes a console warning from the
+           * React Flow library
+           */
+          deleteNodeCallback: (id: string) =>
+            setTimeout(() => deleteNode(id), 0),
           toggleScriptForNodeCallback: toggleScript,
         }}
       >

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
@@ -408,7 +408,7 @@ function NodeHeader({
               )}
             </button>
           )}
-          {disabled || debugStore.isDebugMode ? null : (
+          {disabled ? null : (
             <div>
               <div
                 className={cn("rounded p-1 hover:bg-muted", {


### PR DESCRIPTION
SKY-5848/debugger-feature-allow-deletion-of-blocks-within-the-debugger
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Allow block deletion within the debugger by deferring deletion to avoid console warnings and removing debug mode restriction.
> 
>   - **Behavior**:
>     - Defer block deletion to next tick in `FlowRenderer.tsx` to avoid React Flow console warnings.
>     - Allow block deletion in debug mode by removing `debugStore.isDebugMode` check in `NodeHeader.tsx`.
>   - **Misc**:
>     - Add comment in `FlowRenderer.tsx` explaining the reason for deferring deletion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 8e85f9bf329da394f93bdc65619da2b66d5d175c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🐛 This PR enables block deletion within the debugger mode by removing the debug mode restriction and implementing a deferred deletion mechanism to prevent React Flow console warnings.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **FlowRenderer.tsx**: Modified `deleteNodeCallback` to defer deletion using `setTimeout(() => deleteNode(id), 0)` to avoid React Flow internal event handler conflicts
- **NodeHeader.tsx**: Removed `debugStore.isDebugMode` condition from the delete button visibility logic, allowing deletion in debug mode
- **Code Quality**: Added comprehensive comment explaining the technical reasoning behind the deferred deletion approach

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant NodeHeader
    participant FlowRenderer
    participant ReactFlow
    participant Browser

    User->>NodeHeader: Click delete button
    NodeHeader->>FlowRenderer: Call deleteNodeCallback(id)
    FlowRenderer->>Browser: setTimeout(() => deleteNode(id), 0)
    Note over FlowRenderer,Browser: Defer to next tick
    ReactFlow->>ReactFlow: Complete internal event handlers
    Browser->>FlowRenderer: Execute deleteNode(id)
    FlowRenderer->>ReactFlow: Remove node from flow
```

### Impact
- **User Experience**: Debugger users can now delete blocks during debugging sessions, improving workflow flexibility
- **Technical Stability**: Eliminates React Flow console warnings by properly sequencing deletion operations after internal event handling
- **Code Maintainability**: Clear documentation of the setTimeout workaround helps future developers understand the implementation choice

</details>

_Created with [Palmier](https://www.palmier.io)_