### PR TITLE
fix stop waiting bug

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -576,13 +576,7 @@ function FlowRenderer({
       </Dialog>
       <BlockActionContext.Provider
         value={{
-          /**
-           * NOTE: defer deletion to next tick to allow React Flow's internal
-           * event handlers to complete; removes a console warning from the
-           * React Flow library
-           */
-          deleteNodeCallback: (id: string) =>
-            setTimeout(() => deleteNode(id), 0),
+          deleteNodeCallback: deleteNode,
           toggleScriptForNodeCallback: toggleScript,
         }}
       >

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
@@ -408,7 +408,7 @@ function NodeHeader({
               )}
             </button>
           )}
-          {disabled ? null : (
+          {disabled || debugStore.isDebugMode ? null : (
             <div>
               <div
                 className={cn("rounded p-1 hover:bg-muted", {

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -414,7 +414,7 @@ async def scrape_website(
     max_screenshot_number: int = settings.MAX_NUM_SCREENSHOTS,
     scroll: bool = True,
     support_empty_page: bool = False,
-    wait_seconds: float = 3,
+    wait_seconds: float = 0,
 ) -> ScrapedPage:
     """
     ************************************************************************************************


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes stop waiting bug by removing deferred deletion in `FlowRenderer.tsx`, adjusting UI logic in `NodeHeader.tsx`, and setting `wait_seconds` to 0 in `scraper.py`.
> 
>   - **Behavior**:
>     - Remove deferred deletion in `FlowRenderer.tsx` by directly using `deleteNode` instead of `setTimeout`.
>     - In `NodeHeader.tsx`, hide certain UI elements when `debugStore.isDebugMode` is active.
>     - Set `wait_seconds` to 0 in `scrape_website()` in `scraper.py`, eliminating wait time before scraping.
>   - **Misc**:
>     - Minor UI logic adjustment in `NodeHeader.tsx` to account for debug mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6eb8f4d08987d553e3e9ccedd7847a31b8596f79. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🚀 This PR fixes a "stop waiting bug" by eliminating unnecessary wait times and improving the workflow editor's user experience through three targeted optimizations: removing the default 3-second wait in web scraping, simplifying node deletion logic, and hiding delete buttons during debug mode.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Web Scraping Performance**: Changed default `wait_seconds` parameter from `3` to `0` in `scrape_website()` function to eliminate initial wait time before scraping begins
- **Node Deletion Logic**: Simplified the `deleteNodeCallback` by removing the `setTimeout` wrapper that was previously used to defer deletion to the next tick
- **Debug Mode UX**: Enhanced NodeHeader component to hide delete buttons when in debug mode (`debugStore.isDebugMode`) in addition to the existing disabled state check

### Technical Implementation
```mermaid
flowchart TD
    A[Web Scraping Request] --> B{wait_seconds parameter}
    B -->|Before: 3 seconds| C[Wait 3s then scrape]
    B -->|After: 0 seconds| D[Scrape immediately]
    
    E[Node Deletion Request] --> F{Delete callback}
    F -->|Before: setTimeout| G[Defer to next tick]
    F -->|After: Direct call| H[Delete immediately]
    
    I[NodeHeader Render] --> J{Show delete button?}
    J -->|Before: !disabled| K[Show if enabled]
    J -->|After: !disabled && !debugMode| L[Show if enabled and not debugging]
```

### Impact
- **Performance Improvement**: Eliminates 3-second delay in web scraping operations, significantly speeding up the scraping process
- **Code Simplification**: Removes unnecessary complexity in node deletion logic while maintaining functionality
- **Enhanced Debug Experience**: Prevents accidental node deletion during debug sessions by hiding delete controls when in debug mode
- **Reduced Wait Times**: The "stop waiting bug" referenced in the title appears to be resolved by removing artificial delays that were causing unnecessary waiting periods

</details>

_Created with [Palmier](https://www.palmier.io)_