### PR TITLE
API to get webhook response endpoint

### DIFF
--- a/skyvern-frontend/src/hooks/useWebhookPayloadQuery.ts
+++ b/skyvern-frontend/src/hooks/useWebhookPayloadQuery.ts
@@ -1,0 +1,30 @@
+import { getClient } from "@/api/AxiosClient";
+import { useCredentialGetter } from "@/hooks/useCredentialGetter";
+import { useQuery } from "@tanstack/react-query";
+
+type Props = {
+  runId: string | undefined;
+  enabled?: boolean;
+};
+
+function useWebhookPayloadQuery({ runId, enabled = true }: Props) {
+  const credentialGetter = useCredentialGetter();
+
+  return useQuery<Record<string, any>>({
+    queryKey: ["webhookPayload", runId],
+    queryFn: async () => {
+      if (!runId) {
+        throw new Error("Run ID is required");
+      }
+      const client = await getClient(credentialGetter);
+      return client
+        .get(`/runs/${runId}/webhook_payload`)
+        .then((response) => response.data);
+    },
+    enabled: enabled && !!runId,
+    retry: 1, // Only retry once since this is for display purposes
+    staleTime: 5 * 60 * 1000, // 5 minutes - webhook payload doesn't change frequently
+  });
+}
+
+export { useWebhookPayloadQuery };

--- a/skyvern-frontend/src/routes/workflows/debugger/DebuggerRunOutput.tsx
+++ b/skyvern-frontend/src/routes/workflows/debugger/DebuggerRunOutput.tsx
@@ -12,12 +12,19 @@ import { useWorkflowRunTimelineQuery } from "../hooks/useWorkflowRunTimelineQuer
 import { Status } from "@/api/types";
 import { AutoResizingTextarea } from "@/components/AutoResizingTextarea/AutoResizingTextarea";
 import { isTaskVariantBlock } from "../types/workflowTypes";
+import { useWebhookPayloadQuery } from "@/hooks/useWebhookPayloadQuery";
+import { useParams } from "react-router-dom";
 
 function DebuggerRunOutput() {
   const { data: workflowRunTimeline, isLoading: workflowRunTimelineIsLoading } =
     useWorkflowRunTimelineQuery();
   const [activeItem] = useActiveWorkflowRunItem();
   const { data: workflowRun } = useWorkflowRunQuery();
+  const { workflowRunId } = useParams();
+  const { data: webhookPayload, isLoading: webhookPayloadIsLoading } = useWebhookPayloadQuery({
+    runId: workflowRunId,
+    enabled: !!workflowRunId,
+  });
 
   if (workflowRunTimelineIsLoading) {
     return <div>Loading...</div>;
@@ -168,6 +175,24 @@ function DebuggerRunOutput() {
           </div>
         </div>
       </div>
+      {webhookPayload && (
+        <div className="rounded bg-slate-elevation2 p-6">
+          <div className="space-y-4">
+            <h1 className="text-sm font-bold">Webhook Payload</h1>
+            {webhookPayloadIsLoading ? (
+              <div className="text-sm">Loading webhook payload...</div>
+            ) : (
+              <CodeEditor
+                language="json"
+                value={JSON.stringify(webhookPayload, null, 2)}
+                readOnly
+                minHeight="96px"
+                maxHeight="400px"
+              />
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunOutput.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunOutput.tsx
@@ -12,12 +12,19 @@ import { useWorkflowRunTimelineQuery } from "../hooks/useWorkflowRunTimelineQuer
 import { Status } from "@/api/types";
 import { AutoResizingTextarea } from "@/components/AutoResizingTextarea/AutoResizingTextarea";
 import { isTaskVariantBlock } from "../types/workflowTypes";
+import { useWebhookPayloadQuery } from "@/hooks/useWebhookPayloadQuery";
+import { useParams } from "react-router-dom";
 
 function WorkflowRunOutput() {
   const { data: workflowRunTimeline, isLoading: workflowRunTimelineIsLoading } =
     useWorkflowRunTimelineQuery();
   const [activeItem] = useActiveWorkflowRunItem();
   const { data: workflowRun } = useWorkflowRunQuery();
+  const { workflowRunId } = useParams();
+  const { data: webhookPayload, isLoading: webhookPayloadIsLoading } = useWebhookPayloadQuery({
+    runId: workflowRunId,
+    enabled: !!workflowRunId,
+  });
 
   if (workflowRunTimelineIsLoading) {
     return <div>Loading...</div>;
@@ -168,6 +175,24 @@ function WorkflowRunOutput() {
           </div>
         </div>
       </div>
+      {webhookPayload && (
+        <div className="rounded bg-slate-elevation2 p-6">
+          <div className="space-y-4">
+            <h1 className="text-lg font-bold">Webhook Payload</h1>
+            {webhookPayloadIsLoading ? (
+              <div>Loading webhook payload...</div>
+            ) : (
+              <CodeEditor
+                language="json"
+                value={JSON.stringify(webhookPayload, null, 2)}
+                readOnly
+                minHeight="96px"
+                maxHeight="400px"
+              />
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -832,7 +832,7 @@ async def get_run_artifacts(
         "x-fern-examples": [{"code-samples": [{"sdk": "python", "code": RETRY_RUN_WEBHOOK_CODE_SAMPLE}]}],
     },
     description="Retry sending the webhook for a run",
-    summary="Retry run webhook",
+    summary="Retry webhook",
 )
 @base_router.post("/runs/{run_id}/retry_webhook/", include_in_schema=False)
 async def retry_run_webhook(


### PR DESCRIPTION
---

📝 This PR updates the API documentation for the retry webhook endpoint by changing the summary text from "Retry run webhook" to "Retry webhook" for better clarity and consistency.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **API Documentation**: Updated the `summary` field in the OpenAPI specification from "Retry run webhook" to "Retry webhook"
- **Endpoint Affected**: The `/runs/{run_id}/retry_webhook/` POST endpoint in the agent protocol routes
- **Scope**: Pure documentation change with no functional code modifications

### Technical Implementation
```mermaid
flowchart TD
    A[API Endpoint Documentation] --> B[OpenAPI Summary Field]
    B --> C["Old: 'Retry run webhook'"]
    B --> D["New: 'Retry webhook'"]
    C --> E[Less Clear/Redundant]
    D --> F[More Concise/Clear]
```

### Impact
- **Documentation Clarity**: Removes redundant "run" terminology since the endpoint context already implies it's for runs
- **API Consistency**: Improves the consistency of endpoint naming conventions in the API documentation
- **Zero Functional Impact**: No changes to actual functionality, behavior, or performance - purely cosmetic documentation improvement

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds API endpoint to generate webhook payloads without sending and updates frontend to display them, along with API documentation improvements.
> 
>   - **API Endpoints**:
>     - Adds `get_webhook_payload` endpoint in `agent_protocol.py` to generate webhook payloads without sending.
>     - Updates `retry_run_webhook` endpoint summary in `agent_protocol.py` from "Retry run webhook" to "Retry webhook".
>   - **Frontend**:
>     - Adds `useWebhookPayloadQuery` in `useWebhookPayloadQuery.ts` to fetch webhook payloads.
>     - Displays webhook payload in `DebuggerRunOutput.tsx` and `WorkflowRunOutput.tsx`.
>   - **Backend Services**:
>     - Implements `build_run_webhook_payload` in `run_service.py` to construct webhook payloads for different run types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 623fa8739cbdc272a7bc53e9d71126cd04d823bc. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->