### PR TITLE
defer flow updates to next tick

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -619,12 +619,13 @@ function FlowRenderer({
             ) {
               workflowChangesStore.setHasChanges(true);
             }
-            // throttle onNodesChange to prevent cascading React updates
+            // defer update to next tick to prevent max recursion errors;
+            // NOTE: deferring too long causes node updates to be skipped
             if (onNodesChangeTimeoutRef.current === null) {
               onNodesChange(changes);
               onNodesChangeTimeoutRef.current = setTimeout(() => {
                 onNodesChangeTimeoutRef.current = null;
-              }, 33); // ~30fps throttle
+              }, 0);
             }
           }}
           onEdgesChange={onEdgesChange}


### PR DESCRIPTION
---

⚡ This PR optimizes the flow update mechanism in the workflow editor by changing the throttling strategy from a 33ms delay to immediate deferral using setTimeout(0), preventing maximum recursion errors while maintaining responsive node updates.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Throttling Strategy**: Changed from 33ms (~30fps) throttle to 0ms defer using setTimeout(0)
- **Error Prevention**: Updated to specifically address maximum recursion errors in React updates
- **Comment Updates**: Clarified the purpose from general throttling to recursion prevention with timing considerations

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant FlowRenderer
    participant onNodesChange
    participant Timer
    
    User->>FlowRenderer: Triggers node change
    FlowRenderer->>FlowRenderer: Check if timeout is null
    alt No active timeout
        FlowRenderer->>onNodesChange: Execute immediately
        FlowRenderer->>Timer: setTimeout(callback, 0)
        Timer-->>FlowRenderer: Defer to next tick
        Timer->>FlowRenderer: Reset timeout to null
    else Active timeout exists
        FlowRenderer->>FlowRenderer: Skip update (throttled)
    end
```

### Impact
- **Performance**: Reduces delay from 33ms to next tick (~0ms), making updates more responsive
- **Stability**: Prevents maximum recursion errors that were occurring with cascading React updates
- **User Experience**: Maintains smooth node manipulation while avoiding update conflicts
- **Technical Debt**: Addresses a specific React update pattern issue with minimal code change

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Defers `onNodesChange` updates to the next tick in `FlowRenderer` to prevent recursion errors, changing timeout to `0ms`.
> 
>   - **Behavior**:
>     - Defers `onNodesChange` updates to the next tick in `FlowRenderer` to prevent max recursion errors.
>     - Changes timeout from `33ms` to `0ms` for immediate execution in `FlowRenderer`.
>   - **Comments**:
>     - Adds a note about potential skipped node updates if deferred too long in `FlowRenderer`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for fc7572c71eb79ac68b0c90a9f87883509e386509. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->