### PR TITLE
add gpt5 model option

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -353,6 +353,7 @@ class Settings(BaseSettings):
                     "label": "Gemini 2.5 Flash",
                 },
                 "azure/gpt-4.1": {"llm_key": "AZURE_OPENAI_GPT4_1", "label": "GPT 4.1"},
+                "azure/gpt-5": {"llm_key": "AZURE_OPENAI_GPT5", "label": "GPT 5"},
                 "azure/o3": {"llm_key": "AZURE_OPENAI_O3", "label": "GPT O3"},
                 "us.anthropic.claude-opus-4-20250514-v1:0": {
                     "llm_key": "BEDROCK_ANTHROPIC_CLAUDE4_OPUS_INFERENCE_PROFILE",
@@ -380,6 +381,7 @@ class Settings(BaseSettings):
                     "label": "Gemini 2.5 Flash",
                 },
                 "azure/gpt-4.1": {"llm_key": "AZURE_OPENAI_GPT4_1", "label": "GPT 4.1"},
+                "azure/gpt-5": {"llm_key": "AZURE_OPENAI_GPT5", "label": "GPT 5"},
                 "azure/o3": {"llm_key": "AZURE_OPENAI_O3", "label": "GPT O3"},
                 "us.anthropic.claude-opus-4-20250514-v1:0": {
                     "llm_key": "BEDROCK_ANTHROPIC_CLAUDE4_OPUS_INFERENCE_PROFILE",


### PR DESCRIPTION
## Summary
- add gpt-5 to model mapping so it can be selected in workflow blocks

## Testing
- `ruff check skyvern/config.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_689ee87d7230832daea5e9c994351559
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add GPT-5 model option to `skyvern/config.py` for selection in workflow blocks.
> 
>   - **Behavior**:
>     - Add `azure/gpt-5` to model mapping in `get_model_name_to_llm_key()` in `skyvern/config.py`.
>     - New model can be selected in workflow blocks.
>   - **Testing**:
>     - `ruff check skyvern/config.py` executed.
>     - `pytest` fails due to missing `fastapi` module.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 446afec28cd8b59a20781c2324dfc838ba5dafc0. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->