### PR TITLE
fix task v2 download issue

### DIFF
--- a/skyvern/forge/sdk/api/files.py
+++ b/skyvern/forge/sdk/api/files.py
@@ -173,12 +173,12 @@ def unzip_files(zip_file_path: str, output_dir: str) -> None:
         zip_ref.extractall(output_dir)
 
 
-def get_path_for_workflow_download_directory(workflow_run_id: str) -> Path:
-    return Path(get_download_dir(workflow_run_id=workflow_run_id, task_id=None))
+def get_path_for_workflow_download_directory(run_id: str | None) -> Path:
+    return Path(get_download_dir(run_id=run_id))
 
 
-def get_download_dir(workflow_run_id: str | None, task_id: str | None) -> str:
-    download_dir = f"{REPO_ROOT_DIR}/downloads/{workflow_run_id or task_id}"
+def get_download_dir(run_id: str | None) -> str:
+    download_dir = f"{REPO_ROOT_DIR}/downloads/{run_id}"
     os.makedirs(download_dir, exist_ok=True)
     return download_dir
 

--- a/skyvern/forge/sdk/artifact/storage/base.py
+++ b/skyvern/forge/sdk/artifact/storage/base.py
@@ -124,15 +124,11 @@ class BaseStorage(ABC):
         pass
 
     @abstractmethod
-    async def save_downloaded_files(
-        self, organization_id: str, task_id: str | None, workflow_run_id: str | None
-    ) -> None:
+    async def save_downloaded_files(self, organization_id: str, run_id: str | None) -> None:
         pass
 
     @abstractmethod
-    async def get_downloaded_files(
-        self, organization_id: str, task_id: str | None, workflow_run_id: str | None
-    ) -> list[FileInfo]:
+    async def get_downloaded_files(self, organization_id: str, run_id: str | None) -> list[FileInfo]:
         pass
 
     @abstractmethod

--- a/skyvern/forge/sdk/artifact/storage/local.py
+++ b/skyvern/forge/sdk/artifact/storage/local.py
@@ -171,15 +171,11 @@ class LocalStorage(BaseStorage):
             return None
         return str(stored_folder_path)
 
-    async def save_downloaded_files(
-        self, organization_id: str, task_id: str | None, workflow_run_id: str | None
-    ) -> None:
+    async def save_downloaded_files(self, organization_id: str, run_id: str | None) -> None:
         pass
 
-    async def get_downloaded_files(
-        self, organization_id: str, task_id: str | None, workflow_run_id: str | None
-    ) -> list[FileInfo]:
-        download_dir = get_download_dir(workflow_run_id=workflow_run_id, task_id=task_id)
+    async def get_downloaded_files(self, organization_id: str, run_id: str | None) -> list[FileInfo]:
+        download_dir = get_download_dir(run_id=run_id)
         file_infos: list[FileInfo] = []
         files_and_folders = os.listdir(download_dir)
         for file_or_folder in files_and_folders:

--- a/skyvern/forge/sdk/artifact/storage/s3.py
+++ b/skyvern/forge/sdk/artifact/storage/s3.py
@@ -195,14 +195,14 @@ class S3Storage(BaseStorage):
         temp_zip_file.close()
         return temp_dir
 
-    async def save_downloaded_files(
-        self, organization_id: str, task_id: str | None, workflow_run_id: str | None
-    ) -> None:
-        download_dir = get_download_dir(workflow_run_id=workflow_run_id, task_id=task_id)
+    async def save_downloaded_files(self, organization_id: str, run_id: str | None) -> None:
+        download_dir = get_download_dir(run_id=run_id)
         files = os.listdir(download_dir)
         sc = await self._get_storage_class_for_org(organization_id)
         tags = await self._get_tags_for_org(organization_id)
-        base_uri = f"s3://{settings.AWS_S3_BUCKET_UPLOADS}/{DOWNLOAD_FILE_PREFIX}/{settings.ENV}/{organization_id}/{workflow_run_id or task_id}"
+        base_uri = (
+            f"s3://{settings.AWS_S3_BUCKET_UPLOADS}/{DOWNLOAD_FILE_PREFIX}/{settings.ENV}/{organization_id}/{run_id}"
+        )
         for file in files:
             fpath = os.path.join(download_dir, file)
             if not os.path.isfile(fpath):
@@ -225,10 +225,8 @@ class S3Storage(BaseStorage):
                 tags=tags,
             )
 
-    async def get_downloaded_files(
-        self, organization_id: str, task_id: str | None, workflow_run_id: str | None
-    ) -> list[FileInfo]:
-        uri = f"s3://{settings.AWS_S3_BUCKET_UPLOADS}/{DOWNLOAD_FILE_PREFIX}/{settings.ENV}/{organization_id}/{workflow_run_id or task_id}"
+    async def get_downloaded_files(self, organization_id: str, run_id: str | None) -> list[FileInfo]:
+        uri = f"s3://{settings.AWS_S3_BUCKET_UPLOADS}/{DOWNLOAD_FILE_PREFIX}/{settings.ENV}/{organization_id}/{run_id}"
         object_keys = await self.async_client.list_files(uri=uri)
         if len(object_keys) == 0:
             return []

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1530,7 +1530,7 @@ async def get_workflow_run_with_workflow_id(
         organization_id=current_org.organization_id,
         include_cost=True,
     )
-    return_dict = workflow_run_status_response.model_dump()
+    return_dict = workflow_run_status_response.model_dump(by_alias=True)
 
     browser_session = await app.DATABASE.get_persistent_browser_session_by_runnable_id(
         runnable_id=workflow_run_id,
@@ -1540,14 +1540,6 @@ async def get_workflow_run_with_workflow_id(
     browser_session_id = browser_session.persistent_browser_session_id if browser_session else None
 
     return_dict["browser_session_id"] = browser_session_id or return_dict.get("browser_session_id")
-
-    task_v2 = await app.DATABASE.get_task_v2_by_workflow_run_id(
-        workflow_run_id=workflow_run_id,
-        organization_id=current_org.organization_id,
-    )
-
-    if task_v2:
-        return_dict["task_v2"] = task_v2.model_dump(by_alias=True)
 
     return return_dict
 

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -790,7 +790,10 @@ async def handle_click_to_download_file_action(
     skyvern_element = await dom.get_skyvern_element_by_id(action.element_id)
     locator = skyvern_element.locator
 
-    download_dir = Path(get_download_dir(workflow_run_id=task.workflow_run_id, task_id=task.task_id))
+    context = skyvern_context.current()
+    download_dir = Path(
+        get_download_dir(run_id=context.run_id if context and context.run_id else task.workflow_run_id or task.task_id)
+    )
     list_files_before = list_files_in_directory(download_dir)
     LOG.info(
         "Number of files in download directory before click",

--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -131,7 +131,9 @@ def set_download_file_listener(browser_context: BrowserContext, **kwargs: Any) -
 
 def initialize_download_dir() -> str:
     context = ensure_context()
-    return get_download_dir(context.workflow_run_id, context.task_id)
+    return get_download_dir(
+        context.run_id if context and context.run_id else context.workflow_run_id or context.task_id
+    )
 
 
 class BrowserContextCreator(Protocol):


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix task v2 download issue by using `run_id` for download directories and file operations across the codebase.
> 
>   - **Behavior**:
>     - Update `execute_step()` in `agent.py` to use `context.run_id` for download directory paths if available, otherwise fallback to `workflow_run_id`.
>     - Modify `clean_up_task()` and `build_task_response()` in `agent.py` to use `context.run_id` for saving and retrieving downloaded files.
>     - Adjust `handle_click_to_download_file_action()` in `handler.py` to use `context.run_id` for download directory.
>   - **Functions**:
>     - Change `get_path_for_workflow_download_directory()` and `get_download_dir()` in `files.py` to use `run_id` instead of `workflow_run_id` and `task_id`.
>     - Update `save_downloaded_files()` and `get_downloaded_files()` in `base.py`, `local.py`, and `s3.py` to use `run_id`.
>   - **Misc**:
>     - Remove `task_v2` handling from `get_workflow_run_with_workflow_id()` in `agent_protocol.py`.
>     - Add `task_v2` to `build_workflow_run_status_response()` in `service.py` for additional context in responses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 23fbe84554aeb7bb3dc2871cfac8e731c844f0a8. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes task v2 download issues by standardizing download directory logic to use `context.run_id` as the primary identifier, with fallbacks to `workflow_run_id` or `task_id`. The changes ensure consistent file handling across workflow runs and task executions while simplifying the storage interface.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Download Directory Logic**: Replaced dual parameter system (`workflow_run_id`, `task_id`) with single `run_id` parameter that prioritizes `context.run_id`
- **Storage Interface Simplification**: Updated `save_downloaded_files()` and `get_downloaded_files()` methods across all storage implementations to use unified `run_id` parameter
- **Context-Aware File Handling**: Modified multiple functions to check for `context.run_id` first, then fallback to `workflow_run_id` or `task_id`
- **Code Organization**: Moved `task_v2` retrieval from `agent_protocol.py` to `workflow/service.py` for better separation of concerns

### Technical Implementation
```mermaid
flowchart TD
    A[Context Available?] --> B{context.run_id exists?}
    B -->|Yes| C[Use context.run_id]
    B -->|No| D{workflow_run_id exists?}
    D -->|Yes| E[Use workflow_run_id]
    D -->|No| F[Use task_id]
    C --> G[Generate Download Directory]
    E --> G
    F --> G
    G --> H[Save/Retrieve Files]
```

### Impact
- **Consistency**: Eliminates confusion between different ID types for download directory management
- **Task v2 Support**: Properly handles download files for both regular workflows and task v2 executions
- **Simplified API**: Storage methods now have cleaner signatures with single `run_id` parameter instead of multiple optional parameters
- **Better Context Handling**: Leverages Skyvern's context system to determine the appropriate run identifier automatically

</details>

_Created with [Palmier](https://www.palmier.io)_