### PR TITLE
use medium as the default reasoning effort

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -141,7 +141,7 @@ class Settings(BaseSettings):
     ENABLE_OPENAI_COMPATIBLE: bool = False
     # OPENAI
     OPENAI_API_KEY: str | None = None
-    GPT5_REASONING_EFFORT: str | None = "minimal"
+    GPT5_REASONING_EFFORT: str | None = "medium"
     # ANTHROPIC
     ANTHROPIC_API_KEY: str | None = None
     ANTHROPIC_CUA_LLM_KEY: str = "ANTHROPIC_CLAUDE3.7_SONNET"


### PR DESCRIPTION
---

⚙️ This PR changes the default GPT-5 reasoning effort level from "minimal" to "medium" in the application configuration. This adjustment aims to improve the quality of AI reasoning outputs by using a more balanced effort level as the default setting.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Configuration Update**: Modified `GPT5_REASONING_EFFORT` default value from "minimal" to "medium" in `skyvern/config.py`
- **Single Line Change**: This is a focused configuration adjustment affecting only one parameter
- **Default Behavior**: Changes the out-of-the-box experience for new installations and deployments

### Technical Implementation
```mermaid
flowchart TD
    A[Application Start] --> B[Load Settings from config.py]
    B --> C{GPT5_REASONING_EFFORT set?}
    C -->|No| D[Use Default: 'medium']
    C -->|Yes| E[Use Custom Value]
    D --> F[Initialize GPT-5 with Medium Effort]
    E --> F
    F --> G[AI Processing with Configured Effort Level]
```

### Impact
- **Quality Improvement**: Medium effort level should provide better reasoning quality compared to minimal effort
- **Performance Trade-off**: May result in slightly longer processing times but with improved output quality
- **User Experience**: New users will get better default AI performance without needing to configure reasoning effort manually
- **Backward Compatibility**: Existing deployments with explicit configuration will remain unaffected

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change default `GPT5_REASONING_EFFORT` to "medium" in `skyvern/config.py`.
> 
>   - **Behavior**:
>     - Change default `GPT5_REASONING_EFFORT` from "minimal" to "medium" in `Settings` class in `skyvern/config.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c27a684bbc58a893f03d225124e86b718ef5c692. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->