### PR TITLE
improve dynamic wait when multiple frames

### DIFF
--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -689,6 +689,16 @@ async def add_frame_interactable_elements(
         return elements, element_tree
 
     skyvern_frame = await SkyvernFrame.create_instance(frame)
+    try:
+        await skyvern_frame.get_frame().wait_for_load_state("load", timeout=3000)
+        await skyvern_frame.safe_wait_for_animation_end()
+    except Exception:
+        LOG.warning(
+            "Failed to wait for load state or animation end for the frame, will continue scraping",
+            frame_id=unique_id,
+            exc_info=True,
+        )
+
     frame_elements, frame_element_tree = await skyvern_frame.build_tree_from_body(
         frame_name=unique_id, frame_index=frame_index
     )


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves dynamic wait handling in `add_frame_interactable_elements` by logging and continuing on exceptions during frame load state and animation end waits.
> 
>   - **Behavior**:
>     - In `add_frame_interactable_elements` in `scraper.py`, added a try-except block to handle exceptions during `wait_for_load_state` and `safe_wait_for_animation_end`.
>     - Logs a warning and continues scraping if waiting for load state or animation end fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 69d7633ef55577cc86c8d55f2b27b4f96d93a61e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->