### PR TITLE
log updates for run block (error objects are filtered our in Sentry)

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
@@ -333,6 +333,7 @@ function NodeHeader({
         debugSessionId: debugSession?.debug_session_id,
         browserSessionId: debugSession?.browser_session_id,
         error,
+        detail,
       });
       toast({
         variant: "destructive",
@@ -376,18 +377,20 @@ function NodeHeader({
         description: "The workflow has been successfully canceled.",
       });
     },
-    onError: (error) => {
+    onError: (error: AxiosError) => {
+      const detail = (error.response?.data as { detail?: string })?.detail;
       log.error("Cancel block: error", {
         workflowPermanentId,
         blockLabel,
         debugSessionId: debugSession?.debug_session_id,
         browserSessionId: debugSession?.browser_session_id,
         error,
+        detail,
       });
       toast({
         variant: "destructive",
         title: "Error",
-        description: error.message,
+        description: detail ?? error.message,
       });
     },
   });


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance error handling and logging in `NodeHeader.tsx` by adding a `detail` field to error logs and toast notifications for `runBlock` and `cancelBlock` mutations.
> 
>   - **Error Handling**:
>     - Add `detail` field to error logging in `onError` for `runBlock` and `cancelBlock` mutations in `NodeHeader.tsx`.
>     - Update toast descriptions to use `detail` if available, otherwise fallback to `error.message`.
>   - **Logging**:
>     - Log `detail` field in error logs for `runBlock` and `cancelBlock` mutations in `NodeHeader.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 71bce09f694c76bf411871fe1a5e28cd35b1d0af. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->