### PR TITLE
frontend support cdp for task and workflow

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -147,6 +147,7 @@ export type CreateTaskRequest = {
   application?: string | null;
   include_action_history_in_verification?: boolean | null;
   max_screenshot_scrolls?: number | null;
+  cdp_address?: string | null;
 };
 
 export type User = {

--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -147,7 +147,7 @@ export type CreateTaskRequest = {
   application?: string | null;
   include_action_history_in_verification?: boolean | null;
   max_screenshot_scrolls?: number | null;
-  cdp_address?: string | null;
+  browser_address?: string | null;
 };
 
 export type User = {

--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -90,7 +90,7 @@ function createTaskRequestObject(
     extracted_information_schema: extractedInformationSchema,
     extra_http_headers: extraHttpHeaders,
     totp_identifier: transform(formValues.totpIdentifier),
-    cdp_address: transform(formValues.cdpAddress),
+    browser_address: transform(formValues.cdpAddress),
     error_code_mapping: errorCodeMapping,
     max_screenshot_scrolls: formValues.maxScreenshotScrolls,
     include_action_history_in_verification:
@@ -705,9 +705,9 @@ function CreateNewTaskForm({ initialValues }: Props) {
                       <div className="flex gap-16">
                         <FormLabel>
                           <div className="w-72">
-                            <h1 className="text-lg">CDP Address</h1>
+                            <h1 className="text-lg">Browser Address</h1>
                             <h2 className="text-base text-slate-400">
-                              The address of the CDP server to use for the task
+                              The address of the Browser server to use for the task
                               run.
                             </h2>
                           </div>

--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -90,6 +90,7 @@ function createTaskRequestObject(
     extracted_information_schema: extractedInformationSchema,
     extra_http_headers: extraHttpHeaders,
     totp_identifier: transform(formValues.totpIdentifier),
+    cdp_address: transform(formValues.cdpAddress),
     error_code_mapping: errorCodeMapping,
     max_screenshot_scrolls: formValues.maxScreenshotScrolls,
     include_action_history_in_verification:
@@ -127,6 +128,7 @@ function CreateNewTaskForm({ initialValues }: Props) {
       maxStepsOverride: initialValues.maxStepsOverride ?? null,
       proxyLocation: initialValues.proxyLocation ?? ProxyLocation.Residential,
       maxScreenshotScrolls: initialValues.maxScreenshotScrolls ?? null,
+      cdpAddress: initialValues.cdpAddress ?? null,
     },
   });
   const { errors } = useFormState({ control: form.control });
@@ -686,6 +688,35 @@ function CreateNewTaskForm({ initialValues }: Props) {
                             <Input
                               {...field}
                               placeholder="Add an ID that links your TOTP to the task"
+                              value={field.value === null ? "" : field.value}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </div>
+                      </div>
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="cdpAddress"
+                  render={({ field }) => (
+                    <FormItem>
+                      <div className="flex gap-16">
+                        <FormLabel>
+                          <div className="w-72">
+                            <h1 className="text-lg">CDP Address</h1>
+                            <h2 className="text-base text-slate-400">
+                              The address of the CDP server to use for the task
+                              run.
+                            </h2>
+                          </div>
+                        </FormLabel>
+                        <div className="w-full">
+                          <FormControl>
+                            <Input
+                              {...field}
+                              placeholder="http://127.0.0.1:9222"
                               value={field.value === null ? "" : field.value}
                             />
                           </FormControl>

--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -707,8 +707,7 @@ function CreateNewTaskForm({ initialValues }: Props) {
                           <div className="w-72">
                             <h1 className="text-lg">Browser Address</h1>
                             <h2 className="text-base text-slate-400">
-                              The address of the Browser server to use for the task
-                              run.
+                              The address of the Browser server to use for the task run.
                             </h2>
                           </div>
                         </FormLabel>

--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -707,7 +707,8 @@ function CreateNewTaskForm({ initialValues }: Props) {
                           <div className="w-72">
                             <h1 className="text-lg">Browser Address</h1>
                             <h2 className="text-base text-slate-400">
-                              The address of the Browser server to use for the task run.
+                              The address of the Browser server to use for the
+                              task run.
                             </h2>
                           </div>
                         </FormLabel>

--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskFormPage.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskFormPage.tsx
@@ -64,6 +64,7 @@ function CreateNewTaskFormPage() {
             includeActionHistoryInVerification: null,
             maxScreenshotScrolls: null,
             extraHttpHeaders: null,
+            cdpAddress: null,
           }}
         />
       </div>
@@ -137,6 +138,7 @@ function CreateNewTaskFormPage() {
           extraHttpHeaders: data.extra_http_headers
             ? JSON.stringify(data.extra_http_headers)
             : null,
+          cdpAddress: null,
         }}
       />
     </div>

--- a/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
@@ -418,7 +418,8 @@ function PromptBox() {
                     <div className="w-48 shrink-0">
                       <div className="text-sm">Browser Address</div>
                       <div className="text-xs text-slate-400">
-                        The address of the Browser server to use for the task run.
+                        The address of the Browser server to use for the task
+                        run.
                       </div>
                     </div>
                     <Input

--- a/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
@@ -155,6 +155,7 @@ function PromptBox() {
     ProxyLocation.Residential,
   );
   const [browserSessionId, setBrowserSessionId] = useState<string | null>(null);
+  const [cdpAddress, setCdpAddress] = useState<string | null>(null);
   const [publishWorkflow, setPublishWorkflow] = useState(false);
   const [totpIdentifier, setTotpIdentifier] = useState("");
   const [maxStepsOverride, setMaxStepsOverride] = useState<string | null>(null);
@@ -175,6 +176,7 @@ function PromptBox() {
           webhook_callback_url: webhookCallbackUrl,
           proxy_location: proxyLocation,
           browser_session_id: browserSessionId,
+          cdp_address: cdpAddress,
           totp_identifier: totpIdentifier,
           publish_workflow: publishWorkflow,
           max_screenshot_scrolls: maxScreenshotScrolls,
@@ -409,6 +411,21 @@ function PromptBox() {
                       placeholder="pbs_xxx"
                       onChange={(event) => {
                         setBrowserSessionId(event.target.value);
+                      }}
+                    />
+                  </div>
+                  <div className="flex gap-16">
+                    <div className="w-48 shrink-0">
+                      <div className="text-sm">CDP Address</div>
+                      <div className="text-xs text-slate-400">
+                        The address of the CDP server to use for the task run.
+                      </div>
+                    </div>
+                    <Input
+                      value={cdpAddress ?? ""}
+                      placeholder="http://127.0.0.1:9222"
+                      onChange={(event) => {
+                        setCdpAddress(event.target.value);
                       }}
                     />
                   </div>

--- a/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
@@ -176,7 +176,7 @@ function PromptBox() {
           webhook_callback_url: webhookCallbackUrl,
           proxy_location: proxyLocation,
           browser_session_id: browserSessionId,
-          cdp_address: cdpAddress,
+          browser_address: cdpAddress,
           totp_identifier: totpIdentifier,
           publish_workflow: publishWorkflow,
           max_screenshot_scrolls: maxScreenshotScrolls,
@@ -416,9 +416,9 @@ function PromptBox() {
                   </div>
                   <div className="flex gap-16">
                     <div className="w-48 shrink-0">
-                      <div className="text-sm">CDP Address</div>
+                      <div className="text-sm">Browser Address</div>
                       <div className="text-xs text-slate-400">
-                        The address of the CDP server to use for the task run.
+                        The address of the Browser server to use for the task run.
                       </div>
                     </div>
                     <Input

--- a/skyvern-frontend/src/routes/tasks/create/retry/RetryTask.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/retry/RetryTask.tsx
@@ -48,7 +48,7 @@ function RetryTask() {
           extraHttpHeaders: task.request.extra_http_headers
             ? JSON.stringify(task.request.extra_http_headers)
             : null,
-          cdpAddress: task.request.cdp_address ?? null,
+          cdpAddress: task.request.browser_address ?? null,
         }}
       />
     </div>

--- a/skyvern-frontend/src/routes/tasks/create/retry/RetryTask.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/retry/RetryTask.tsx
@@ -48,6 +48,7 @@ function RetryTask() {
           extraHttpHeaders: task.request.extra_http_headers
             ? JSON.stringify(task.request.extra_http_headers)
             : null,
+          cdpAddress: task.request.cdp_address ?? null,
         }}
       />
     </div>

--- a/skyvern-frontend/src/routes/tasks/create/taskFormTypes.ts
+++ b/skyvern-frontend/src/routes/tasks/create/taskFormTypes.ts
@@ -13,6 +13,7 @@ const createNewTaskFormSchemaBase = z.object({
   extraHttpHeaders: z.string().or(z.null()),
   maxStepsOverride: z.number().or(z.null()).optional(),
   totpIdentifier: z.string().or(z.null()),
+  cdpAddress: z.string().or(z.null()),
   errorCodeMapping: z.string().or(z.null()),
   proxyLocation: z.nativeEnum(ProxyLocation).or(z.null()),
   includeActionHistoryInVerification: z.boolean().or(z.null()).default(false),

--- a/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
+++ b/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
@@ -38,6 +38,7 @@ type Props = {
   initialSettings: {
     proxyLocation: ProxyLocation;
     webhookCallbackUrl: string;
+    cdpAddress: string | null;
     maxScreenshotScrolls: number | null;
     extraHttpHeaders: Record<string, string> | null;
   };
@@ -81,6 +82,7 @@ type RunWorkflowRequestBody = {
   browser_session_id: string | null;
   max_screenshot_scrolls?: number | null;
   extra_http_headers?: Record<string, string> | null;
+  cdp_address?: string | null;
 };
 
 function getRunWorkflowRequestBody(
@@ -91,6 +93,7 @@ function getRunWorkflowRequestBody(
     webhookCallbackUrl,
     proxyLocation,
     browserSessionId,
+    cdpAddress,
     maxScreenshotScrolls,
     extraHttpHeaders,
     ...parameters
@@ -107,6 +110,7 @@ function getRunWorkflowRequestBody(
     data: parsedParameters,
     proxy_location: proxyLocation,
     browser_session_id: bsi,
+    cdp_address: cdpAddress,
   };
 
   if (maxScreenshotScrolls) {
@@ -133,6 +137,7 @@ type RunWorkflowFormType = Record<string, unknown> & {
   webhookCallbackUrl: string;
   proxyLocation: ProxyLocation;
   browserSessionId: string | null;
+  cdpAddress: string | null;
   maxScreenshotScrolls: number | null;
   extraHttpHeaders: string | null;
 };
@@ -156,6 +161,7 @@ function RunWorkflowForm({
       webhookCallbackUrl: initialSettings.webhookCallbackUrl,
       proxyLocation: initialSettings.proxyLocation,
       browserSessionId: browserSessionIdDefault,
+      cdpAddress: initialSettings.cdpAddress,
       maxScreenshotScrolls: initialSettings.maxScreenshotScrolls,
       extraHttpHeaders: initialSettings.extraHttpHeaders
         ? JSON.stringify(initialSettings.extraHttpHeaders)
@@ -208,6 +214,7 @@ function RunWorkflowForm({
       browserSessionId,
       maxScreenshotScrolls,
       extraHttpHeaders,
+      cdpAddress,
       ...parameters
     } = values;
 
@@ -222,6 +229,7 @@ function RunWorkflowForm({
       browserSessionId,
       maxScreenshotScrolls,
       extraHttpHeaders,
+      cdpAddress,
     });
   }
 
@@ -413,6 +421,42 @@ function RunWorkflowForm({
                         <Input
                           {...field}
                           placeholder="pbs_xxx"
+                          value={
+                            field.value === null ? "" : (field.value as string)
+                          }
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </div>
+                  </div>
+                </FormItem>
+              );
+            }}
+          />
+          <FormField
+            key="cdpAddress"
+            control={form.control}
+            name="cdpAddress"
+            render={({ field }) => {
+              return (
+                <FormItem>
+                  <div className="flex gap-16">
+                    <FormLabel>
+                      <div className="w-72">
+                        <div className="flex items-center gap-2 text-lg">
+                          CDP Address
+                        </div>
+                        <h2 className="text-sm text-slate-400">
+                          The address of the CDP server to use for the workflow
+                          run.
+                        </h2>
+                      </div>
+                    </FormLabel>
+                    <div className="w-full space-y-2">
+                      <FormControl>
+                        <Input
+                          {...field}
+                          placeholder="http://127.0.0.1:9222"
                           value={
                             field.value === null ? "" : (field.value as string)
                           }

--- a/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
+++ b/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
@@ -447,7 +447,8 @@ function RunWorkflowForm({
                           Browser Address
                         </div>
                         <h2 className="text-sm text-slate-400">
-                          The address of the Browser server to use for the workflow run.
+                          The address of the Browser server to use for the
+                          workflow run.
                         </h2>
                       </div>
                     </FormLabel>

--- a/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
+++ b/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
@@ -447,8 +447,7 @@ function RunWorkflowForm({
                           Browser Address
                         </div>
                         <h2 className="text-sm text-slate-400">
-                          The address of the Browser server to use for the workflow
-                          run.
+                          The address of the Browser server to use for the workflow run.
                         </h2>
                       </div>
                     </FormLabel>

--- a/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
+++ b/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
@@ -82,7 +82,7 @@ type RunWorkflowRequestBody = {
   browser_session_id: string | null;
   max_screenshot_scrolls?: number | null;
   extra_http_headers?: Record<string, string> | null;
-  cdp_address?: string | null;
+  browser_address?: string | null;
 };
 
 function getRunWorkflowRequestBody(
@@ -110,7 +110,7 @@ function getRunWorkflowRequestBody(
     data: parsedParameters,
     proxy_location: proxyLocation,
     browser_session_id: bsi,
-    cdp_address: cdpAddress,
+    browser_address: cdpAddress,
   };
 
   if (maxScreenshotScrolls) {
@@ -444,10 +444,10 @@ function RunWorkflowForm({
                     <FormLabel>
                       <div className="w-72">
                         <div className="flex items-center gap-2 text-lg">
-                          CDP Address
+                          Browser Address
                         </div>
                         <h2 className="text-sm text-slate-400">
-                          The address of the CDP server to use for the workflow
+                          The address of the Browser server to use for the workflow
                           run.
                         </h2>
                       </div>

--- a/skyvern-frontend/src/routes/workflows/WorkflowRunParameters.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRunParameters.tsx
@@ -84,6 +84,7 @@ function WorkflowRunParameters() {
             maxScreenshotScrolls ?? workflow.max_screenshot_scrolls ?? null,
           extraHttpHeaders:
             extraHttpHeaders ?? workflow.extra_http_headers ?? null,
+          cdpAddress: null,
         }}
       />
     </div>


### PR DESCRIPTION
---

🔧 This PR adds Chrome DevTools Protocol (CDP) address support to the Skyvern frontend, enabling users to specify custom CDP server endpoints for both task and workflow execution.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Type Definitions**: Added `cdp_address?: string | null` to `CreateTaskRequest` type and workflow request bodies
- **Form Components**: Integrated CDP address input fields in task creation forms, workflow run forms, and the prompt box interface
- **State Management**: Added CDP address state handling across all relevant components with proper form validation
- **UI Integration**: Implemented consistent input fields with placeholder `http://127.0.0.1:9222` and descriptive labels

### Technical Implementation
```mermaid
flowchart TD
    A[User Input] --> B[Form Validation]
    B --> C[Task/Workflow Creation]
    C --> D[CDP Address Parameter]
    D --> E[Backend API Call]
    E --> F[Chrome DevTools Protocol]
    F --> G[Browser Automation]
    
    H[CreateNewTaskForm] --> I[cdpAddress Field]
    J[RunWorkflowForm] --> K[cdpAddress Field]
    L[PromptBox] --> M[cdpAddress State]
    
    I --> C
    K --> C
    M --> C
```

### Impact
- **Enhanced Flexibility**: Users can now connect to custom CDP servers instead of relying on default browser instances
- **Development Workflow**: Enables debugging and testing with external Chrome instances running in CDP mode
- **Backward Compatibility**: All CDP address fields are optional (nullable), ensuring existing functionality remains unaffected
- **Consistent UX**: Uniform implementation across task creation, workflow execution, and retry scenarios

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds support for specifying a custom Chrome DevTools Protocol (CDP) address in Skyvern frontend task and workflow forms.
> 
>   - **Behavior**:
>     - Adds `cdpAddress` field to task and workflow forms, allowing users to specify a custom CDP server address.
>     - Ensures backward compatibility by making `cdpAddress` optional.
>   - **Form Components**:
>     - Updates `CreateNewTaskForm`, `RunWorkflowForm`, and `PromptBox` to include `cdpAddress` input field with placeholder `http://127.0.0.1:9222`.
>     - Adds `cdpAddress` handling in `RetryTask` and `CreateNewTaskFormPage`.
>   - **State Management**:
>     - Manages `cdpAddress` state in `PromptBox` and `RunWorkflowForm`.
>     - Validates `cdpAddress` in `taskFormTypes.ts`.
>   - **API Integration**:
>     - Modifies `CreateTaskRequest` and `RunWorkflowRequestBody` to include `browser_address` parameter.
>   - **Misc**:
>     - Updates `taskFormTypes.ts` to include `cdpAddress` in form schema.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9d6394de934537da118b88d70f88f8eff42dcc7f. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->