### PR TITLE
fix bug introduced by #5941

### DIFF
--- a/skyvern-frontend/src/components/WorkflowBlockInputTextarea.tsx
+++ b/skyvern-frontend/src/components/WorkflowBlockInputTextarea.tsx
@@ -31,9 +31,9 @@ function WorkflowBlockInputTextarea(props: Props) {
 
   const doOnChange = (value: string) => {
     onChange(value);
-    maybeWriteTitle(value);
 
     if (canWriteTitle) {
+      maybeWriteTitle(value);
       maybeAcceptTitle();
     }
   };


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes bug in `WorkflowBlockInputTextarea.tsx` by ensuring `maybeWriteTitle` is called only when `canWriteTitle` is true.
> 
>   - **Behavior**:
>     - Fixes bug in `WorkflowBlockInputTextarea.tsx` by moving `maybeWriteTitle(value)` inside `if (canWriteTitle)` block in `doOnChange()` function.
>     - Ensures `maybeWriteTitle` is only called when `canWriteTitle` is true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 1e416b5e83ab37250c3ec819957252af60109574. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->