### PR TITLE
start build tree from HTML element

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -835,6 +835,9 @@ function isInteractable(element, hoverStylesMap) {
   }
 
   const tagName = element.tagName.toLowerCase();
+  if (tagName === "html") {
+    return false;
+  }
 
   if (tagName === "iframe") {
     return false;
@@ -1530,13 +1533,16 @@ async function buildTreeFromBody(
   ) {
     window.GlobalSkyvernFrameIndex = frame_index;
   }
-  const elementsAndResultArray = await buildElementTree(document.body, frame);
+  const elementsAndResultArray = await buildElementTree(
+    document.documentElement,
+    frame,
+  );
   DomUtils.elementListCache = elementsAndResultArray[0];
   return elementsAndResultArray;
 }
 
 async function buildElementTree(
-  starter = document.body,
+  starter = document.documentElement,
   frame,
   full_tree = false,
   hoverStylesMap = undefined,
@@ -1570,13 +1576,17 @@ async function buildElementTree(
       return;
     }
 
+    if (tagName === "head") {
+      return;
+    }
+
     // skip processing option element as they are already added to the select.options
     if (tagName === "option") {
       return;
     }
 
     let current_xpath = null;
-    if (parent_xpath) {
+    if (parent_xpath !== null) {
       // ignore the namespace, otherwise the xpath sometimes won't find anything, specially for SVG elements
       current_xpath =
         parent_xpath +
@@ -1753,8 +1763,8 @@ async function buildElementTree(
   };
 
   let current_xpath = null;
-  if (starter === document.body) {
-    current_xpath = "/html[1]";
+  if (starter === document.documentElement) {
+    current_xpath = "";
   }
 
   // setup before parsing the dom


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change `buildTreeFromBody` and `buildElementTree` to start from `document.documentElement` and update `isInteractable` to exclude `html` elements.
> 
>   - **Behavior**:
>     - `buildTreeFromBody()` and `buildElementTree()` now start from `document.documentElement` instead of `document.body`.
>     - `isInteractable()` now returns `false` for `html` elements.
>   - **Functions**:
>     - Updated `buildTreeFromBody()` to use `document.documentElement`.
>     - Updated `buildElementTree()` to use `document.documentElement` and handle `head` elements.
>   - **Misc**:
>     - Adjusted XPath generation logic in `buildElementTree()` to accommodate changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 335a10c44ffd7a20f735afa589f4eefd1b7746ae. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🌳 This PR refactors the DOM tree building process to start from the HTML document element instead of the body, providing more complete DOM coverage and better XPath generation for web scraping operations.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Tree Building Origin**: Changed `buildTreeFromBody()` and `buildElementTree()` to start from `document.documentElement` instead of `document.body`
- **Element Filtering**: Added exclusion for `html` elements in `isInteractable()` and `head` elements in tree traversal
- **XPath Generation**: Updated XPath logic to use empty string as root path when starting from `document.documentElement`
- **Parameter Updates**: Modified default parameters and conditional checks to accommodate the new starting point

### Technical Implementation
```mermaid
flowchart TD
    A[document.documentElement] --> B{Element Type Check}
    B -->|html| C[Skip - Not Interactable]
    B -->|head| D[Skip - Not Processed]
    B -->|body| E[Process Element]
    B -->|other| F[Check Interactability]
    E --> G[Build Element Tree]
    F --> G
    G --> H[Generate XPath]
    H --> I[Add to Element Cache]
```

### Impact
- **Complete DOM Coverage**: Now captures elements that might exist outside the body tag, ensuring more comprehensive web page analysis
- **Improved XPath Accuracy**: Starting from document root provides more reliable element positioning and selection
- **Better Web Scraping**: Enhanced ability to interact with all page elements, not just those within the body tag
- **Backward Compatibility**: Maintains existing functionality while expanding scope to include previously missed elements

</details>

_Created with [Palmier](https://www.palmier.io)_