### PR TITLE
Jon/construct cache key and show

### DIFF
--- a/skyvern-frontend/src/routes/workflows/components/BlockCodeEditor.tsx
+++ b/skyvern-frontend/src/routes/workflows/components/BlockCodeEditor.tsx
@@ -1,14 +1,18 @@
 import { ExitIcon } from "@radix-ui/react-icons";
+import { useParams } from "react-router-dom";
 import { Handle } from "@xyflow/react";
 import { Position } from "@xyflow/react";
 
+import { KeyIcon } from "@/components/icons/KeyIcon";
 import { WorkflowBlockType } from "@/routes/workflows/types/workflowTypes";
 import { useToggleScriptForNodeCallback } from "@/routes/workflows/hooks/useToggleScriptForNodeCallback";
+import { useWorkflowQuery } from "@/routes/workflows/hooks/useWorkflowQuery";
 import { cn } from "@/util/utils";
 
 import { CodeEditor } from "./CodeEditor";
 import { workflowBlockTitle } from "../editor/nodes/types";
 import { WorkflowBlockIcon } from "../editor/nodes/WorkflowBlockIcon";
+import { constructCacheKeyValue } from "../editor/utils";
 
 function BlockCodeEditor({
   blockLabel,
@@ -21,8 +25,19 @@ function BlockCodeEditor({
   script: string | undefined;
   onClick?: (e: React.MouseEvent) => void;
 }) {
+  const { workflowPermanentId } = useParams();
   const blockTitle = workflowBlockTitle[blockType];
   const toggleScriptForNodeCallback = useToggleScriptForNodeCallback();
+
+  const { data: workflow } = useWorkflowQuery({
+    workflowPermanentId,
+  });
+  const cacheKey = workflow?.cache_key ?? "";
+  const cacheKeyValue = workflow
+    ? cacheKey === ""
+      ? ""
+      : constructCacheKeyValue(cacheKey, workflow)
+    : "";
 
   return (
     <div className="h-full">
@@ -47,7 +62,7 @@ function BlockCodeEditor({
           onClick?.(e);
         }}
       >
-        <header className="!mt-0 flex h-[2.75rem] justify-between gap-2">
+        <header className="relative !mt-0 flex h-[2.75rem] justify-between gap-2">
           <div className="flex w-full gap-2">
             <div className="relative flex h-[2.75rem] w-[2.75rem] items-center justify-center overflow-hidden rounded border border-slate-600">
               <WorkflowBlockIcon
@@ -58,21 +73,29 @@ function BlockCodeEditor({
                 <span className="text-xs font-bold text-black">code</span>
               </div>
             </div>
-            <div className="flex flex-col gap-1">
+            <div className="flex w-full flex-col gap-1">
               {blockLabel}
-              <span className="text-xs text-slate-400">{blockTitle}</span>
+              <div className="flex w-full items-center justify-center gap-1">
+                <span className="text-xs text-slate-400">{blockTitle}</span>
+                <div className="ml-auto scale-[60%] opacity-50">
+                  <KeyIcon />
+                </div>
+                <span className="text-xs text-slate-400">
+                  {cacheKeyValue === "" ? "(none)" : cacheKeyValue}
+                </span>
+              </div>
             </div>
-            <div className="ml-auto flex w-[2.75rem] items-center justify-center rounded hover:bg-slate-800">
-              <ExitIcon
-                onClick={() => {
-                  toggleScriptForNodeCallback({
-                    label: blockLabel,
-                    show: false,
-                  });
-                }}
-                className="size-5 cursor-pointer"
-              />
-            </div>
+          </div>
+          <div className="absolute right-[-0.5rem] top-0 flex h-[2rem] w-[2rem] items-center justify-center rounded hover:bg-slate-800">
+            <ExitIcon
+              onClick={() => {
+                toggleScriptForNodeCallback({
+                  label: blockLabel,
+                  show: false,
+                });
+              }}
+              className="size-5 cursor-pointer"
+            />
           </div>
         </header>
         {script ? (

--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -57,6 +57,7 @@ import {
   layout,
   startNode,
 } from "./workflowEditorUtils";
+import { constructCacheKeyValue } from "./utils";
 
 const Constants = {
   NewBrowserCooldown: 30000,
@@ -130,7 +131,13 @@ function Workspace({
   const initialHeight = (initialWidth / 16) * 9;
   // ---end fya
 
+  const cacheKey = workflow?.cache_key ?? "";
+  const cacheKeyValue =
+    cacheKey === "" ? "" : constructCacheKeyValue(cacheKey, workflow);
+
   const { data: blockScripts } = useBlockScriptsQuery({
+    cacheKey,
+    cacheKeyValue,
     workflowPermanentId,
   });
 

--- a/skyvern-frontend/src/routes/workflows/editor/utils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/utils.ts
@@ -97,4 +97,36 @@ const getInitialParameters = (workflow: WorkflowApiResponse) => {
     .filter(Boolean) as ParametersState;
 };
 
-export { getInitialParameters };
+/**
+ * Attempt to construct a valid cache key value from the workflow parameters.
+ */
+const constructCacheKeyValue = (
+  cacheKey: string,
+  workflow: WorkflowApiResponse,
+) => {
+  const workflowParameters = getInitialParameters(workflow)
+    .filter((p) => p.parameterType === "workflow")
+    .reduce(
+      (acc, parameter) => {
+        acc[parameter.key] = parameter.defaultValue;
+        return acc;
+      },
+      {} as Record<string, unknown>,
+    );
+
+  for (const [name, value] of Object.entries(workflowParameters)) {
+    if (value === null || value === undefined || value === "") {
+      continue;
+    }
+
+    cacheKey = cacheKey.replace(`{{${name}}}`, value.toString());
+  }
+
+  if (cacheKey.includes("{") || cacheKey.includes("}")) {
+    return "";
+  }
+
+  return cacheKey;
+};
+
+export { constructCacheKeyValue, getInitialParameters };

--- a/skyvern-frontend/src/store/WorkflowHasChangesStore.ts
+++ b/skyvern-frontend/src/store/WorkflowHasChangesStore.ts
@@ -152,6 +152,10 @@ const useWorkflowSave = () => {
         queryKey: ["workflows"],
       });
 
+      queryClient.invalidateQueries({
+        queryKey: ["block-scripts", saveData.workflow.workflow_permanent_id],
+      });
+
       setHasChanges(false);
     },
     onError: (error: AxiosError) => {


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-5973/construct-cache-key-value-and-show-it

<img width="546" height="459" alt="image" src="https://github.com/user-attachments/assets/0c5fbf55-b929-47d6-8e40-1c18bed345c5" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add cache key value construction and display in workflow editor with UI and data fetching updates.
> 
>   - **Feature**:
>     - Add `constructCacheKeyValue` function in `utils.ts` to generate cache key values from workflow parameters.
>     - Display cache key value in `BlockCodeEditor.tsx` using `KeyIcon` and show "(none)" if empty.
>   - **UI Changes**:
>     - Update `BlockCodeEditor.tsx` to show cache key value next to block title.
>     - Adjust `header` layout in `BlockCodeEditor.tsx` to accommodate new cache key display.
>   - **Data Fetching**:
>     - Use `cacheKey` and `cacheKeyValue` in `Workspace.tsx` to fetch block scripts.
>   - **Cache Invalidation**:
>     - Invalidate `block-scripts` query in `WorkflowHasChangesStore.ts` on workflow save.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 16d25bb26fcf2a62e82d17f65ad1520fadd7f66d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->