### PR TITLE
Jon/sky 5981 turn off debugger for oss and self host

### DIFF
--- a/skyvern-frontend/src/router.tsx
+++ b/skyvern-frontend/src/router.tsx
@@ -18,7 +18,6 @@ import { WorkflowRun } from "./routes/workflows/WorkflowRun";
 import { WorkflowRunParameters } from "./routes/workflows/WorkflowRunParameters";
 import { Workflows } from "./routes/workflows/Workflows";
 import { WorkflowsPageLayout } from "./routes/workflows/WorkflowsPageLayout";
-import { Debugger } from "./routes/workflows/debugger/Debugger";
 import { WorkflowEditor } from "./routes/workflows/editor/WorkflowEditor";
 import { WorkflowPostRunParameters } from "./routes/workflows/workflowRun/WorkflowPostRunParameters";
 import { WorkflowRunOutput } from "./routes/workflows/workflowRun/WorkflowRunOutput";
@@ -111,11 +110,11 @@ const router = createBrowserRouter([
               },
               {
                 path: "debug",
-                element: <Debugger />,
+                element: <WorkflowEditor />,
               },
               {
                 path: ":workflowRunId/:blockLabel/debug",
-                element: <Debugger />,
+                element: <WorkflowEditor />,
               },
               {
                 path: "edit",

--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
@@ -15,6 +15,7 @@ import {
   ReloadIcon,
 } from "@radix-ui/react-icons";
 import { useNavigate, useParams } from "react-router-dom";
+import { useUser } from "@/hooks/useUser";
 import { statusIsRunningOrQueued } from "@/routes/tasks/types";
 import { useGlobalWorkflowsQuery } from "../hooks/useGlobalWorkflowsQuery";
 import { EditableNodeTitle } from "./nodes/components/EditableNodeTitle";
@@ -51,6 +52,7 @@ function WorkflowHeader({
   const debugStore = useDebugStore();
   const workflowRunIsRunningOrQueued =
     workflowRun && statusIsRunningOrQueued(workflowRun);
+  const user = useUser().get();
 
   if (!globalWorkflows) {
     return null; // this should be loaded already by some other components
@@ -103,36 +105,38 @@ function WorkflowHeader({
           </Button>
         ) : (
           <>
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    size="icon"
-                    variant={debugStore.isDebugMode ? "default" : "tertiary"}
-                    className="size-10"
-                    disabled={workflowRunIsRunningOrQueued}
-                    onClick={() => {
-                      if (debugStore.isDebugMode) {
-                        navigate(`/workflows/${workflowPermanentId}/edit`);
-                      } else {
-                        navigate(`/workflows/${workflowPermanentId}/debug`);
-                      }
-                    }}
-                  >
-                    {debugStore.isDebugMode ? (
-                      <BrowserIcon className="h-6 w-6" />
-                    ) : (
-                      <BrowserIcon className="h-6 w-6" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {debugStore.isDebugMode
-                    ? "Turn off Browser"
-                    : "Turn on Browser"}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            {user && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      size="icon"
+                      variant={debugStore.isDebugMode ? "default" : "tertiary"}
+                      className="size-10"
+                      disabled={workflowRunIsRunningOrQueued}
+                      onClick={() => {
+                        if (debugStore.isDebugMode) {
+                          navigate(`/workflows/${workflowPermanentId}/edit`);
+                        } else {
+                          navigate(`/workflows/${workflowPermanentId}/debug`);
+                        }
+                      }}
+                    >
+                      {debugStore.isDebugMode ? (
+                        <BrowserIcon className="h-6 w-6" />
+                      ) : (
+                        <BrowserIcon className="h-6 w-6" />
+                      )}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {debugStore.isDebugMode
+                      ? "Turn off Browser"
+                      : "Turn on Browser"}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -36,7 +36,6 @@ import { DebuggerRun } from "@/routes/workflows/debugger/DebuggerRun";
 import { useWorkflowRunQuery } from "@/routes/workflows/hooks/useWorkflowRunQuery";
 import { DebuggerRunOutput } from "@/routes/workflows/debugger/DebuggerRunOutput";
 import { DebuggerPostRunParameters } from "@/routes/workflows/debugger/DebuggerPostRunParameters";
-import { useDebugStore } from "@/store/useDebugStore";
 import { useWorkflowPanelStore } from "@/store/WorkflowPanelStore";
 import {
   useWorkflowHasChangesStore,
@@ -88,7 +87,6 @@ function Workspace({
   const [content, setContent] = useState("actions");
   const { workflowPanelState, setWorkflowPanelState, closeWorkflowPanel } =
     useWorkflowPanelStore();
-  const debugStore = useDebugStore();
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
   const saveWorkflow = useWorkflowSave();
@@ -488,7 +486,7 @@ function Workspace({
         </div>
       )}
 
-      {debugStore.isDebugMode && (
+      {showBrowser && (
         <div
           className="absolute right-6 top-[8.5rem] h-[calc(100vh-9.5rem)]"
           style={{ zIndex: rankedItems.history ?? 1 }}


### PR DESCRIPTION
---

🔒 This PR disables the debugger feature for OSS and self-hosted deployments by removing the dedicated Debugger component and conditionally hiding the browser toggle button based on user authentication status.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Router Configuration**: Removed import of `Debugger` component and redirected debug routes to use `WorkflowEditor` instead
- **UI Conditional Rendering**: Added user authentication check to conditionally show/hide the browser toggle button in the workflow header
- **Component Cleanup**: Removed unused `useDebugStore` import and replaced debug mode check with `showBrowser` prop in the Workspace component

### Technical Implementation
```mermaid
flowchart TD
    A[User Access] --> B{User Authenticated?}
    B -->|Yes| C[Show Browser Toggle]
    B -->|No| D[Hide Browser Toggle]
    C --> E[Debug Routes → WorkflowEditor]
    D --> E
    E --> F[Standard Workflow Editor Experience]
```

### Impact
- **Access Control**: Debugger functionality is now restricted to authenticated users only, preventing access in OSS/self-hosted environments
- **UI Simplification**: Non-authenticated users see a cleaner interface without debug-related controls
- **Code Maintenance**: Simplified routing by consolidating debug paths to use the existing WorkflowEditor component

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `Debugger` with `WorkflowEditor` in routes and UI, and conditionally render debug button based on user authentication.
> 
>   - **Routing Changes**:
>     - Replace `Debugger` with `WorkflowEditor` for `debug` paths in `router.tsx`.
>   - **UI Changes**:
>     - In `WorkflowHeader.tsx`, wrap debug button in a conditional rendering block to check for `user`.
>     - In `Workspace.tsx`, replace `debugStore.isDebugMode` with `showBrowser` for rendering logic.
>   - **Misc**:
>     - Remove unused `Debugger` imports in `router.tsx` and `Workspace.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 294a441dd73a2613aa457ad32699f6d686f86669. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->