### PR TITLE
handle exception when check date call failed

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -1190,13 +1190,22 @@ async def handle_input_text_action(
             return [ActionSuccess()]
 
         if tag_name == InteractiveElement.INPUT and await skyvern_element.get_attr("type") == "date":
-            text = await check_date_format(
-                value=text,
-                action=action,
-                skyvern_element=skyvern_element,
-                task=task,
-                step=step,
-            )
+            try:
+                text = await check_date_format(
+                    value=text,
+                    action=action,
+                    skyvern_element=skyvern_element,
+                    task=task,
+                    step=step,
+                )
+            except Exception:
+                LOG.warning(
+                    "Failed to check the date format, using the original text to fill in the date input",
+                    text=text,
+                    action=action,
+                    exc_info=True,
+                )
+
             await skyvern_element.input_fill(text=text)
             return [ActionSuccess()]
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds exception handling around `check_date_format()` in `handle_input_text_action()` to log errors and use original text if the call fails.
> 
>   - **Exception Handling**:
>     - Wraps `check_date_format()` call in `handle_input_text_action()` in a `try-except` block to handle exceptions.
>     - Logs a warning with `LOG.warning()` if `check_date_format()` fails, using the original text instead.
>   - **Logging**:
>     - Adds logging of the exception details with `exc_info=True` in `handle_input_text_action()` when `check_date_format()` fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for bcf76e4e13d8dd8c1c96f68d53b572d389eab55f. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->