### PR TITLE
Update API specifications with fern api update

### DIFF
--- a/fern/openapi/skyvern_openapi.json
+++ b/fern/openapi/skyvern_openapi.json
@@ -9004,6 +9004,22 @@
             ],
             "title": "Max Screenshot Scrolls",
             "description": "The maximum number of scrolls for the post action screenshot. When it's None or 0, it takes the current viewpoint screenshot."
+          },
+          "browser_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Browser Address",
+            "description": "The CDP address for the task.",
+            "examples": [
+              "http://127.0.0.1:9222",
+              "ws://127.0.0.1:9222/devtools/browser/1234567890"
+            ]
           }
         },
         "type": "object",
@@ -11485,6 +11501,22 @@
             ],
             "title": "Extra Http Headers",
             "description": "The extra HTTP headers for the requests in browser."
+          },
+          "browser_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Browser Address",
+            "description": "The CDP address for the workflow run.",
+            "examples": [
+              "http://127.0.0.1:9222",
+              "ws://127.0.0.1:9222/devtools/browser/1234567890"
+            ]
           }
         },
         "type": "object",


### PR DESCRIPTION
Update API specifications by running fern api update.

---

📋 This PR updates the OpenAPI specification to add a new `browser_address` field to both task and workflow run configurations, enabling users to specify custom Chrome DevTools Protocol (CDP) addresses for browser automation.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **API Schema Enhancement**: Added `browser_address` field to two main configuration objects in the OpenAPI specification
- **Task Configuration**: New optional field allows specifying CDP address for individual tasks
- **Workflow Configuration**: Same field added to workflow run configurations for broader automation scenarios
- **Field Specification**: Defined as optional string with null support, including example values for HTTP and WebSocket CDP endpoints

### Technical Implementation
```mermaid
flowchart TD
    A[API Specification Update] --> B[Task Configuration]
    A --> C[Workflow Run Configuration]
    B --> D[browser_address Field]
    C --> E[browser_address Field]
    D --> F[CDP Address Examples]
    E --> G[CDP Address Examples]
    F --> H[http://127.0.0.1:9222]
    F --> I[ws://127.0.0.1:9222/devtools/browser/1234567890]
    G --> H
    G --> I
```

### Impact
- **Enhanced Flexibility**: Users can now connect to custom browser instances or remote CDP endpoints
- **Remote Automation Support**: Enables distributed browser automation scenarios where browsers run on different machines
- **Backward Compatibility**: Field is optional and nullable, ensuring existing integrations continue to work
- **Developer Experience**: Clear examples provided for both HTTP and WebSocket CDP connection formats

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `browser_address` field to `skyvern_openapi.json` for task and workflow CDP addresses.
> 
>   - **API Specification Update**:
>     - Adds `browser_address` field to two objects in `skyvern_openapi.json`.
>     - `browser_address` can be a `string` or `null`, representing the CDP address.
>     - Includes examples for `browser_address` such as `http://127.0.0.1:9222` and `ws://127.0.0.1:9222/devtools/browser/1234567890`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b59a391705a7dd31f8198250d8519604226843ed. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->