### PR TITLE
reuse parameter-patching input

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/helpContent.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/helpContent.ts
@@ -180,4 +180,7 @@ export const placeholders = {
       '{\n  "Content-Type": "application/json",\n  "Authorization": "Bearer {{ token }}"\n}',
     body: '{\n  "key": "value",\n  "parameter": "{{ parameter_name }}"\n}',
   },
+  scripts: {
+    scriptKey: "my-{{param1}}-{{param2}}-key",
+  },
 };

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
@@ -12,6 +12,7 @@ import { ProxyLocation } from "@/api/types";
 import { useQuery } from "@tanstack/react-query";
 import { Label } from "@/components/ui/label";
 import { HelpTooltip } from "@/components/HelpTooltip";
+import { WorkflowBlockInputTextarea } from "@/components/WorkflowBlockInputTextarea";
 import { Input } from "@/components/ui/input";
 import { ProxySelector } from "@/components/ProxySelector";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
@@ -23,6 +24,7 @@ import { WorkflowModel } from "@/routes/workflows/types/workflowTypes";
 import { MAX_SCREENSHOT_SCROLLS_DEFAULT } from "../Taskv2Node/types";
 import { KeyValueInput } from "@/components/KeyValueInput";
 import { OrgWalled } from "@/components/Orgwalled";
+import { placeholders } from "@/routes/workflows/editor/helpContent";
 import { useWorkflowSettingsStore } from "@/store/WorkflowSettingsStore";
 
 function StartNode({ id, data }: NodeProps<StartNode>) {
@@ -149,21 +151,16 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
                         </div>
                       </div>
                       {inputs.useScriptCache && (
-                        <div className="space-y-2">
-                          <div className="flex gap-2">
-                            <Label>Script Key</Label>
-                            <HelpTooltip content="A constant string or templated name, comprised of one or more of your parameters. It's the unique key for a workflow script." />
-                          </div>
-                          <Input
-                            value={inputs.scriptCacheKey ?? ""}
-                            placeholder="my-{{param1}}-{{param2}}-key"
-                            onChange={(event) => {
-                              const value = (event.target.value ?? "").trim();
-                              const v = value.length ? value : null;
-                              handleChange("scriptCacheKey", v);
-                            }}
-                          />
-                        </div>
+                        <WorkflowBlockInputTextarea
+                          nodeId={id}
+                          onChange={(value) => {
+                            const v = value.length ? value : null;
+                            handleChange("scriptCacheKey", v);
+                          }}
+                          value={inputs.scriptCacheKey ?? ""}
+                          placeholder={placeholders["scripts"]["scriptKey"]}
+                          className="nopan text-xs"
+                        />
                       )}
                     </OrgWalled>
                     <div className="space-y-2">


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-5983/script-textbox-should-have-the-icon-for-parameters-there-jon

<img width="420" height="81" alt="image" src="https://github.com/user-attachments/assets/5fa04a02-0d05-400e-80e0-739c737ba05d" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replaces `Input` with `WorkflowBlockInputTextarea` for `scriptCacheKey` in `StartNode.tsx` and updates placeholders in `helpContent.ts`.
> 
>   - **Components**:
>     - Replaces `Input` with `WorkflowBlockInputTextarea` for `scriptCacheKey` in `StartNode.tsx`.
>     - Imports `WorkflowBlockInputTextarea` in `StartNode.tsx`.
>   - **Placeholders**:
>     - Adds `scripts` placeholder with `scriptKey` in `helpContent.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for de3596544ceee03092c4cb083cffd2bd364be778. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->