### PR TITLE
make missing script key value 'default'

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
@@ -181,7 +181,7 @@ function WorkflowHeader({
                   }
                   onCacheKeyValuesKeydown(e);
                 }}
-                placeholder="Script Key"
+                placeholder="Script Key Value"
                 value={chosenCacheKeyValue ?? undefined}
                 onBlur={(e) => {
                   onCacheKeyValuesBlurred(e.target.value);

--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -681,7 +681,7 @@ function Workspace({
             <WorkflowCacheKeyValuesPanel
               cacheKeyValues={cacheKeyValues}
               pending={cacheKeyValuesLoading}
-              scriptKey={workflow.cache_key ?? "<none>"}
+              scriptKey={workflow.cache_key ?? "default"}
               onDelete={(cacheKeyValue) => {
                 setToDeleteCacheKeyValue(cacheKeyValue);
                 setOpenConfirmCacheKeyValueDeleteDialogue(true);

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
@@ -151,16 +151,21 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
                         </div>
                       </div>
                       {inputs.useScriptCache && (
-                        <WorkflowBlockInputTextarea
-                          nodeId={id}
-                          onChange={(value) => {
-                            const v = value.length ? value : null;
-                            handleChange("scriptCacheKey", v);
-                          }}
-                          value={inputs.scriptCacheKey ?? ""}
-                          placeholder={placeholders["scripts"]["scriptKey"]}
-                          className="nopan text-xs"
-                        />
+                        <div className="space-y-2">
+                          <div className="flex gap-2">
+                            <Label>Script Key (optional)</Label>
+                          </div>
+                          <WorkflowBlockInputTextarea
+                            nodeId={id}
+                            onChange={(value) => {
+                              const v = value.length ? value : null;
+                              handleChange("scriptCacheKey", v);
+                            }}
+                            value={inputs.scriptCacheKey ?? ""}
+                            placeholder={placeholders["scripts"]["scriptKey"]}
+                            className="nopan text-xs"
+                          />
+                        </div>
                       )}
                     </OrgWalled>
                     <div className="space-y-2">

--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowCacheKeyValuesPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowCacheKeyValuesPanel.tsx
@@ -50,10 +50,10 @@ function WorkflowCacheKeyValuesPanel({
             <code className="font-mono text-xs text-slate-200">
               {scriptKey}
             </code>
-            , search for a cached value to see scripts for. For this script key
+            , search for scripts using a script key value. For this script key
             there {totalCount === 1 ? "is" : "are"}{" "}
             <span className="font-bold text-slate-200">{totalCount}</span>{" "}
-            cached {totalCount === 1 ? "value" : "values"}
+            script key {totalCount === 1 ? "value" : "values"}
             {filteredCount !== totalCount && (
               <>
                 {" "}
@@ -140,7 +140,7 @@ function WorkflowCacheKeyValuesPanel({
               </PaginationItem>
               <PaginationItem>
                 <div className="text-sm font-bold">
-                  {displayPage} of {totalPages}
+                  {displayPage} of {isNaN(totalPages) ? 0 : totalPages}
                 </div>
               </PaginationItem>
               <PaginationItem>

--- a/skyvern-frontend/src/store/WorkflowHasChangesStore.ts
+++ b/skyvern-frontend/src/store/WorkflowHasChangesStore.ts
@@ -100,6 +100,10 @@ const useWorkflowSave = () => {
         }
       }
 
+      const scriptCacheKey = saveData.settings.scriptCacheKey ?? "";
+      const normalizedKey =
+        scriptCacheKey === "" ? "default" : saveData.settings.scriptCacheKey;
+
       const requestBody: WorkflowCreateYAMLRequest = {
         title: saveData.title,
         description: saveData.workflow.description,
@@ -111,7 +115,7 @@ const useWorkflowSave = () => {
         totp_verification_url: saveData.workflow.totp_verification_url,
         extra_http_headers: extraHttpHeaders,
         generate_script: saveData.settings.useScriptCache,
-        cache_key: saveData.settings.scriptCacheKey,
+        cache_key: normalizedKey,
         workflow_definition: {
           parameters: saveData.parameters,
           blocks: saveData.blocks,


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6017/make-empty-script-key-value-default-instead-of-null-or

- make missing script key value 'default'
- show 'default' instead of '<…none>'
- fix a NaN
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set default script key value to 'default' and fix NaN issue in pagination.
> 
>   - **Behavior**:
>     - Default script key value set to 'default' when missing in `Workspace.tsx` and `WorkflowHasChangesStore.ts`.
>     - UI now shows 'default' instead of '<none>' in `Workspace.tsx`.
>     - Fixes NaN issue in pagination in `WorkflowCacheKeyValuesPanel.tsx`.
>   - **UI Changes**:
>     - Placeholder text changed from 'Script Key' to 'Script Key Value' in `WorkflowHeader.tsx`.
>     - Added label for 'Script Key (optional)' in `StartNode.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 3058f52878d82a30e0367995f732fed41a779672. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->