### PR TITLE
store workflow start block code

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -347,6 +347,9 @@ class Settings(BaseSettings):
     ENCRYPTOR_AES_SALT: str | None = None
     ENCRYPTOR_AES_IV: str | None = None
 
+    # script generation settings
+    WORKFLOW_START_BLOCK_LABEL: str = "__start_block__"
+
     def get_model_name_to_llm_key(self) -> dict[str, dict[str, str]]:
         """
         Keys are model names available to blocks in the frontend. These map to key names


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Store workflow start block code in Skyvern by creating and saving a `__start_block__` in `generate_script.py` and adding a configuration label in `config.py`.
> 
>   - **Behavior**:
>     - Store workflow start block code in `generate_script.py` by creating a `__start_block__` containing imports, model classes, and run function.
>     - If script context is available, save `__start_block__` to the database with label `WORKFLOW_START_BLOCK_LABEL`.
>   - **Configuration**:
>     - Add `WORKFLOW_START_BLOCK_LABEL` to `Settings` in `config.py` with default value `"__start_block__"`.
>   - **Functions**:
>     - Modify `create_script_block()` in `generate_script.py` to accept `block_code` instead of `block_fn_def`.
>     - Adjust `generate_workflow_script()` to handle `__start_block__` creation and storage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e549747c708090a93776fb9d54f292856cfea770. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR refactors workflow script generation to store workflow start block code by creating a dedicated `__start_block__` containing imports, model classes, and run functions, while updating the script block creation interface to accept raw code instead of function definitions.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Configuration**: Added `WORKFLOW_START_BLOCK_LABEL` setting with default value `"__start_block__"` for consistent labeling
- **Script Generation**: Refactored `generate_workflow_script()` to create a dedicated start block containing imports, model classes, and run function
- **Block Creation Interface**: Updated `create_script_block()` to accept `block_code` string parameter instead of `block_fn_def` LibCST object
- **Block Naming**: Changed priority order for block names to prioritize `label` over `title` and `task_id`

### Technical Implementation
```mermaid
flowchart TD
    A[generate_workflow_script] --> B[Create individual task blocks]
    A --> C[Build start_block_body with imports/models/run_fn]
    C --> D[Create __start_block__ via create_script_block]
    B --> E[Convert block_fn_def to block_code]
    E --> F[Create task blocks via create_script_block]
    D --> G[Combine all blocks in final module]
    F --> G
    G --> H[Write complete script to file]
```

### Impact
- **Code Organization**: Better separation of concerns by isolating workflow initialization code into a dedicated start block
- **Database Storage**: Improved script block storage by standardizing on string-based code representation instead of AST objects
- **Error Handling**: Enhanced robustness with try-catch blocks around script block creation to prevent workflow generation failures
- **Maintainability**: Simplified interface for `create_script_block()` function reduces complexity and improves reusability

</details>

_Created with [Palmier](https://www.palmier.io)_