### PR TITLE
show all of the scripts via a button

### DIFF
--- a/skyvern-frontend/src/routes/workflows/components/BlockCodeEditor.tsx
+++ b/skyvern-frontend/src/routes/workflows/components/BlockCodeEditor.tsx
@@ -95,15 +95,13 @@ function BlockCodeEditor({
           <div className="absolute right-[-0.5rem] top-0 flex h-[2rem] w-[2rem] items-center justify-center rounded hover:bg-slate-800">
             <ExitIcon
               onClick={() => {
-                if (onExit) {
-                  const result = onExit();
+                const result = onExit ? onExit() : true;
 
-                  if (result !== false) {
-                    toggleScriptForNodeCallback({
-                      label: blockLabel,
-                      show: false,
-                    });
-                  }
+                if (result !== false) {
+                  toggleScriptForNodeCallback({
+                    label: blockLabel,
+                    show: false,
+                  });
                 }
               }}
               className="size-5 cursor-pointer"

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/NodeActionMenu.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/NodeActionMenu.tsx
@@ -10,7 +10,7 @@ import { DotsHorizontalIcon } from "@radix-ui/react-icons";
 import { OrgWalled } from "@/components/Orgwalled";
 
 type Props = {
-  isDeleteable?: boolean;
+  isDeletable?: boolean;
   isScriptable?: boolean;
   showScriptText?: string;
   onDelete?: () => void;
@@ -18,13 +18,13 @@ type Props = {
 };
 
 function NodeActionMenu({
-  isDeleteable = true,
+  isDeletable = true,
   isScriptable = false,
   showScriptText,
   onDelete,
   onShowScript,
 }: Props) {
-  if (!isDeleteable && !isScriptable) {
+  if (!isDeletable && !isScriptable) {
     return null;
   }
 
@@ -36,7 +36,7 @@ function NodeActionMenu({
       <DropdownMenuContent>
         <DropdownMenuLabel>Block Actions</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        {isDeleteable && (
+        {isDeletable && (
           <DropdownMenuItem
             onSelect={() => {
               onDelete?.();

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
@@ -26,12 +26,12 @@ import { KeyValueInput } from "@/components/KeyValueInput";
 import { OrgWalled } from "@/components/Orgwalled";
 import { placeholders } from "@/routes/workflows/editor/helpContent";
 import { NodeActionMenu } from "@/routes/workflows/editor/nodes/NodeActionMenu";
+import { useToggleScriptForNodeCallback } from "@/routes/workflows/hooks/useToggleScriptForNodeCallback";
 import { useWorkflowSettingsStore } from "@/store/WorkflowSettingsStore";
 import {
   scriptableWorkflowBlockTypes,
   type WorkflowBlockType,
 } from "@/routes/workflows/types/workflowTypes";
-// import { useToggleScriptForNodeCallback } from "@/routes/workflows/hooks/useToggleScriptForNodeCallback";
 
 import { Flippable } from "@/components/Flippable";
 import { useRerender } from "@/hooks/useRerender";
@@ -42,7 +42,6 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
   const workflowSettingsStore = useWorkflowSettingsStore();
   const credentialGetter = useCredentialGetter();
   const { updateNodeData } = useReactFlow();
-  // const toggleScriptForNodeCallback = useToggleScriptForNodeCallback();
   const reactFlowInstance = useReactFlow();
 
   const { data: availableModels } = useQuery<ModelsResponse>({
@@ -83,6 +82,7 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
   const blockScriptStore = useBlockScriptStore();
   const script = blockScriptStore.scripts.__start_block__;
   const rerender = useRerender({ prefix: "accordion" });
+  const toggleScriptForNodeCallback = useToggleScriptForNodeCallback();
 
   useEffect(() => {
     setFacing(data.showCode ? "back" : "front");
@@ -109,37 +109,31 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
   }
 
   function showAllScripts() {
-    reactFlowInstance.setNodes((nodes) => {
-      return nodes.map((node) => {
-        if (nodeIsFlippable(node)) {
-          return {
-            ...node,
-            data: {
-              ...node.data,
-              showCode: true,
-            },
-          };
-        }
-        return node;
-      });
-    });
+    for (const node of reactFlowInstance.getNodes()) {
+      const label = node.data.label;
+
+      label &&
+        nodeIsFlippable(node) &&
+        typeof label === "string" &&
+        toggleScriptForNodeCallback({
+          label,
+          show: true,
+        });
+    }
   }
 
   function hideAllScripts() {
-    reactFlowInstance.setNodes((nodes) => {
-      return nodes.map((node) => {
-        if (nodeIsFlippable(node)) {
-          return {
-            ...node,
-            data: {
-              ...node.data,
-              showCode: false,
-            },
-          };
-        }
-        return node;
-      });
-    });
+    for (const node of reactFlowInstance.getNodes()) {
+      const label = node.data.label;
+
+      label &&
+        nodeIsFlippable(node) &&
+        typeof label === "string" &&
+        toggleScriptForNodeCallback({
+          label,
+          show: false,
+        });
+    }
   }
 
   if (data.withWorkflowSettings) {
@@ -158,7 +152,7 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
                 <div>
                   <div className="rounded p-1 hover:bg-muted">
                     <NodeActionMenu
-                      isDeleteable={false}
+                      isDeletable={false}
                       isScriptable={true}
                       showScriptText="Show All Scripts"
                       onShowScript={showAllScripts}


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6007/show-all-code-for-entire-workflow
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds functionality to show all scripts in a workflow via a button in `StartNode.tsx` and updates `NodeActionMenu` to include this feature.
> 
>   - **Behavior**:
>     - Adds `showAllScripts()` and `hideAllScripts()` functions in `StartNode.tsx` to toggle script visibility for all nodes.
>     - Updates `NodeActionMenu` to include "Show All Scripts" button, triggering `showAllScripts()`.
>   - **Refactoring**:
>     - Fixes typo: `isDeleteable` to `isDeletable` in `NodeActionMenu.tsx` and `StartNode.tsx`.
>   - **Misc**:
>     - Updates `BlockCodeEditor.tsx` to simplify `onExit` logic by using a default return value.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 92f3ec792dd59690333ce7664d26e5190ed11be5. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->