### PR TITLE
expand start block when code is flipped

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
@@ -32,11 +32,11 @@ import {
   scriptableWorkflowBlockTypes,
   type WorkflowBlockType,
 } from "@/routes/workflows/types/workflowTypes";
-
 import { Flippable } from "@/components/Flippable";
 import { useRerender } from "@/hooks/useRerender";
 import { useBlockScriptStore } from "@/store/BlockScriptStore";
 import { BlockCodeEditor } from "@/routes/workflows/components/BlockCodeEditor";
+import { cn } from "@/util/utils";
 
 function StartNode({ id, data }: NodeProps<StartNode>) {
   const workflowSettingsStore = useWorkflowSettingsStore();
@@ -146,7 +146,12 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
             id="a"
             className="opacity-0"
           />
-          <div className="w-[30rem] rounded-lg bg-slate-elevation3 px-6 py-4 text-center">
+          <div
+            className={cn(
+              "w-[30rem] rounded-lg bg-slate-elevation3 px-6 py-4 text-center",
+              { "h-[20rem] overflow-hidden": facing === "back" },
+            )}
+          >
             <div className="relative">
               <div className="absolute right-0 top-0">
                 <div>


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6036/expand-start-block-when-code-is-flipped

<img width="514" height="177" alt="image" src="https://github.com/user-attachments/assets/c5fbbb9d-b270-47e6-9b76-6c3c27ce80ef" />


<img width="508" height="360" alt="image" src="https://github.com/user-attachments/assets/79e4e35d-7877-4d76-9a0c-3bc50a098be6" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Expand start block in `StartNode.tsx` when code is flipped to the back by conditionally adjusting height and overflow.
> 
>   - **Behavior**:
>     - In `StartNode.tsx`, expand the start block when `facing` is "back" by adding `h-[20rem] overflow-hidden` class conditionally.
>     - This change affects the visual representation when the code is flipped to the back side.
>   - **Misc**:
>     - Import `cn` from `@/util/utils` to handle conditional class names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c7b2e85cf8fc2e1cf449afa15d461ba1d51f1f57. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

---

🔄 This PR enhances the UI behavior of the StartNode component by expanding the start block when the code view is flipped to show the back side. The change improves the user experience by providing more space for code editing when users flip the node to view/edit code.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **UI Enhancement**: Added conditional styling to expand the start block height when `facing === "back"`
- **Class Management**: Imported and utilized the `cn` utility function for conditional class application
- **Layout Adjustment**: Applied `h-[20rem] overflow-hidden` classes when the node is flipped to provide adequate space for code editing

### Technical Implementation
```mermaid
flowchart TD
    A[StartNode Component] --> B{facing === "back"?}
    B -->|Yes| C[Apply expanded classes<br/>h-[20rem] overflow-hidden]
    B -->|No| D[Use default styling<br/>w-[30rem] only]
    C --> E[Render expanded node for code editing]
    D --> F[Render normal node view]
```

### Impact
- **User Experience**: Provides better visibility and space for code editing when the node is flipped
- **Visual Consistency**: Maintains clean UI by using overflow-hidden to prevent layout issues
- **Code Quality**: Leverages the `cn` utility for maintainable conditional class application
- **Backward Compatibility**: No breaking changes - only enhances existing functionality when code view is active

</details>

_Created with [Palmier](https://www.palmier.io)_