### PR TITLE
Add created_by for script actions

### DIFF
--- a/skyvern/core/script_generations/skyvern_page.py
+++ b/skyvern/core/script_generations/skyvern_page.py
@@ -222,6 +222,7 @@ class SkyvernPage:
                 text=text,
                 option=select_option,
                 response=response,
+                created_by="script",
             )
 
             created_action = await app.DATABASE.create_action(action)

--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -2476,6 +2476,7 @@ class AgentDB:
                 skyvern_element_data=action.skyvern_element_data,
                 action_json=action.model_dump(),
                 confidence_float=action.confidence_float,
+                created_by=action.created_by,
             )
             session.add(new_action)
             await session.commit()


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `created_by` field to actions created by scripts, setting it to "script" in `skyvern_page.py` and `client.py`.
> 
>   - **Behavior**:
>     - Add `created_by="script"` to actions in `_create_action_before_execution()` in `skyvern_page.py`.
>     - Add `created_by=action.created_by` in `create_action()` in `client.py` to store the creator of the action.
>   - **Misc**:
>     - No changes to existing functionality, only additional metadata for actions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for aae6c86939727f7f5a28136365fc899348764534. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->