### PR TITLE
Add run timeline endpoint

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -31,6 +31,7 @@ from skyvern.forge.sdk.routes.code_samples import (
     CREATE_WORKFLOW_CODE_SAMPLE_PYTHON,
     DELETE_WORKFLOW_CODE_SAMPLE,
     GET_RUN_CODE_SAMPLE,
+    GET_RUN_TIMELINE_CODE_SAMPLE,
     GET_WORKFLOWS_CODE_SAMPLE,
     RETRY_RUN_WEBHOOK_CODE_SAMPLE,
     RUN_TASK_CODE_SAMPLE,
@@ -842,6 +843,71 @@ async def retry_run_webhook(
 ) -> None:
     analytics.capture("skyvern-oss-agent-run-retry-webhook")
     await run_service.retry_run_webhook(run_id, organization_id=current_org.organization_id, api_key=x_api_key)
+
+
+@base_router.get(
+    "/runs/{run_id}/timeline",
+    tags=["Agent", "Workflows"],
+    response_model=list[WorkflowRunTimeline],
+    openapi_extra={
+        "x-fern-sdk-method-name": "get_run_timeline",
+        "x-fern-examples": [{"code-samples": [{"sdk": "python", "code": GET_RUN_TIMELINE_CODE_SAMPLE}]}],
+    },
+    description="Get timeline for a run (workflow run or task_v2 run)",
+    summary="Get run timeline",
+    responses={
+        200: {"description": "Successfully retrieved run timeline"},
+        404: {"description": "Run not found"},
+        400: {"description": "Timeline not available for this run type"},
+    },
+)
+@base_router.get(
+    "/runs/{run_id}/timeline/",
+    response_model=list[WorkflowRunTimeline],
+    include_in_schema=False,
+)
+async def get_run_timeline(
+    run_id: str = Path(
+        ..., description="The id of the workflow run or task_v2 run.", examples=["wr_123", "tsk_v2_123"]
+    ),
+    current_org: Organization = Depends(org_auth_service.get_current_org),
+) -> list[WorkflowRunTimeline]:
+    analytics.capture("skyvern-oss-run-timeline-get")
+
+    # Check if the run exists
+    run_response = await run_service.get_run_response(run_id, organization_id=current_org.organization_id)
+    if not run_response:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Run not found {run_id}",
+        )
+
+    # Handle workflow runs directly
+    if run_response.run_type == RunType.workflow_run:
+        return await _flatten_workflow_run_timeline(current_org.organization_id, run_id)
+
+    # Handle task_v2 runs by getting their associated workflow_run_id
+    if run_response.run_type == RunType.task_v2:
+        task_v2 = await app.DATABASE.get_task_v2(task_v2_id=run_id, organization_id=current_org.organization_id)
+        if not task_v2:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Task v2 not found {run_id}",
+            )
+
+        if not task_v2.workflow_run_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Task v2 {run_id} has no associated workflow run",
+            )
+
+        return await _flatten_workflow_run_timeline(current_org.organization_id, task_v2.workflow_run_id)
+
+    # Timeline not available for other run types
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=f"Timeline not available for run type {run_response.run_type}",
+    )
 
 
 @base_router.post(

--- a/skyvern/forge/sdk/routes/code_samples.py
+++ b/skyvern/forge/sdk/routes/code_samples.py
@@ -25,6 +25,17 @@ RETRY_RUN_WEBHOOK_CODE_SAMPLE = """from skyvern import Skyvern
 skyvern = Skyvern(api_key="YOUR_API_KEY")
 await skyvern.retry_run_webhook(run_id="tsk_v2_123")
 """
+GET_RUN_TIMELINE_CODE_SAMPLE = """from skyvern import Skyvern
+
+skyvern = Skyvern(api_key="YOUR_API_KEY")
+# Get timeline for a workflow run
+timeline = await skyvern.get_run_timeline(run_id="wr_123")
+print(timeline)
+
+# Get timeline for a task_v2 run
+timeline = await skyvern.get_run_timeline(run_id="tsk_v2_123")
+print(timeline)
+"""
 LOGIN_CODE_SAMPLE_SKYVERN = """# Login with password saved in Skyvern
 from skyvern import Skyvern
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `get_run_timeline` endpoint to retrieve run timelines and a corresponding code sample for usage.
> 
>   - **New Endpoint**:
>     - Adds `get_run_timeline` endpoint in `agent_protocol.py` to retrieve timeline for a run (workflow or task_v2).
>     - Handles `workflow_run` and `task_v2` types, returning a flattened timeline.
>     - Returns 404 if run not found, 400 if timeline not available for run type.
>   - **Code Samples**:
>     - Adds `GET_RUN_TIMELINE_CODE_SAMPLE` in `code_samples.py` for Python SDK usage example.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a2f8473666580bf4844ba7346a09b247cf21e204. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🕒 This PR adds a new `/runs/{run_id}/timeline` endpoint that allows users to retrieve timeline information for both workflow runs and task_v2 runs. The endpoint intelligently handles different run types and provides comprehensive error handling for missing runs or unsupported run types.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **New API Endpoint**: Added `GET /runs/{run_id}/timeline` endpoint in `agent_protocol.py` that returns `WorkflowRunTimeline` data
- **Multi-Run Type Support**: Handles both workflow runs directly and task_v2 runs by resolving their associated workflow_run_id
- **Code Documentation**: Added `GET_RUN_TIMELINE_CODE_SAMPLE` in `code_samples.py` with Python SDK usage examples
- **Error Handling**: Comprehensive HTTP error responses (404 for not found, 400 for unsupported run types)

### Technical Implementation
```mermaid
flowchart TD
    A[GET /runs/{run_id}/timeline] --> B{Check run exists}
    B -->|Not found| C[Return 404 Error]
    B -->|Found| D{Check run type}
    D -->|workflow_run| E[Return timeline directly]
    D -->|task_v2| F{Has workflow_run_id?}
    F -->|No| G[Return 400 Error]
    F -->|Yes| H[Return associated workflow timeline]
    D -->|Other types| I[Return 400 Error - Timeline not available]
```

### Impact
- **Enhanced API Coverage**: Provides timeline visibility for both workflow and task execution flows
- **Developer Experience**: Includes comprehensive OpenAPI documentation and SDK code samples for easy integration
- **Robust Error Handling**: Clear error messages help developers understand when timeline data is unavailable or runs don't exist
- **Unified Interface**: Single endpoint handles multiple run types transparently, simplifying client implementation

</details>

_Created with [Palmier](https://www.palmier.io)_