### PR TITLE
fix back history

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -157,18 +157,24 @@ function Workspace({
   );
 
   useEffect(() => {
-    if (cacheKeyValue === "") {
-      setSearchParams((prev) => {
-        const newParams = new URLSearchParams(prev);
-        newParams.delete("cache-key-value");
-        return newParams;
-      });
-    } else {
-      setSearchParams({
-        "cache-key-value": `${cacheKeyValue}`,
-      });
+    const currentUrlValue = searchParams.get("cache-key-value");
+    const targetValue = cacheKeyValue === "" ? null : cacheKeyValue;
+
+    if (currentUrlValue !== targetValue) {
+      setSearchParams(
+        (prev) => {
+          const newParams = new URLSearchParams(prev);
+          if (cacheKeyValue === "") {
+            newParams.delete("cache-key-value");
+          } else {
+            newParams.set("cache-key-value", cacheKeyValue);
+          }
+          return newParams;
+        },
+        { replace: true },
+      );
     }
-  }, [cacheKeyValue, setSearchParams]);
+  }, [cacheKeyValue, searchParams, setSearchParams]);
 
   const { data: blockScripts } = useBlockScriptsQuery({
     cacheKey,


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6062/debugger-destroying-back-history-in-my-browser
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes browser back history issue in `Workspace.tsx` by updating `useEffect` to conditionally update search parameters with `{ replace: true }`.
> 
>   - **Behavior**:
>     - Fixes browser back history issue in `Workspace.tsx` by updating `useEffect` to check if `currentUrlValue` matches `targetValue` before calling `setSearchParams`.
>     - Uses `{ replace: true }` in `setSearchParams` to prevent adding new history entries when updating `cache-key-value`.
>   - **Dependencies**:
>     - Adds `searchParams` to the dependency array of the `useEffect` hook in `Workspace.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 2cd5ff02721defbf872378c9bba5045ba320d7e2. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->