### PR TITLE
update 'Scripts' -> 'Code'; update some other verbiage

### DIFF
--- a/skyvern-frontend/src/routes/tasks/detail/ScrollableActionList.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/ScrollableActionList.tsx
@@ -96,7 +96,7 @@ function ScrollableActionList({
                         </div>
                       </TooltipTrigger>
                       <TooltipContent className="max-w-[250px]">
-                        Scripted Execution
+                        Code Execution
                       </TooltipContent>
                     </Tooltip>
                   </TooltipProvider>

--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
@@ -181,7 +181,7 @@ function WorkflowHeader({
                   }
                   onCacheKeyValuesKeydown(e);
                 }}
-                placeholder="Script Key Value"
+                placeholder="Code Key Value"
                 value={chosenCacheKeyValue ?? undefined}
                 onBlur={(e) => {
                   onCacheKeyValuesBlurred(e.target.value);

--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -324,7 +324,7 @@ function Workspace({
     onError: (error: AxiosError) => {
       toast({
         variant: "destructive",
-        title: "Failed to delete cache key value",
+        title: "Failed to delete code key value",
         description: error.message,
       });
       setToDeleteCacheKeyValue(null);
@@ -534,15 +534,15 @@ function Workspace({
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Delete A Script Key Value</DialogTitle>
+            <DialogTitle>Delete A Code Key Value</DialogTitle>
             <DialogDescription>
               <div className="w-full pb-2 pt-4 text-sm text-slate-400">
                 {deleteCacheKeyValue.isPending ? (
-                  "Deleting script key value..."
+                  "Deleting code key value..."
                 ) : (
                   <div className="flex w-full flex-col gap-2">
                     <div className="w-full">
-                      Are you sure you want to delete this script key value?
+                      Are you sure you want to delete this code key value?
                     </div>
                     <div
                       className="max-w-[29rem] overflow-hidden text-ellipsis whitespace-nowrap text-sm font-bold text-slate-400"

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/NodeActionMenu.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/NodeActionMenu.tsx
@@ -53,7 +53,7 @@ function NodeActionMenu({
                   onShowScript();
                 }}
               >
-                {showScriptText ?? "Show Script"}
+                {showScriptText ?? "Show Code"}
               </DropdownMenuItem>
             )}
           </OrgWalled>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
@@ -159,7 +159,7 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
                     <NodeActionMenu
                       isDeletable={false}
                       isScriptable={true}
-                      showScriptText="Show All Scripts"
+                      showScriptText="Show All Code"
                       onShowScript={showAllScripts}
                     />
                   </div>
@@ -218,8 +218,8 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
                       <OrgWalled className="flex flex-col gap-4">
                         <div className="space-y-2">
                           <div className="flex items-center gap-2">
-                            <Label>Generate Script</Label>
-                            <HelpTooltip content="Generate & use cached scripts for faster execution." />
+                            <Label>Generate Code</Label>
+                            <HelpTooltip content="Generate & use cached code for faster execution." />
                             <Switch
                               className="ml-auto"
                               checked={inputs.useScriptCache}
@@ -232,7 +232,8 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
                         {inputs.useScriptCache && (
                           <div className="space-y-2">
                             <div className="flex gap-2">
-                              <Label>Script Key (optional)</Label>
+                              <Label>Code Key (optional)</Label>
+                              <HelpTooltip content="A static or dynamic key for directing code generation." />
                             </div>
                             <WorkflowBlockInputTextarea
                               nodeId={id}

--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowCacheKeyValuesPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowCacheKeyValuesPanel.tsx
@@ -44,16 +44,16 @@ function WorkflowCacheKeyValuesPanel({
     >
       <div className="space-y-4">
         <header>
-          <h1 className="text-lg">Cached Scripts</h1>
+          <h1 className="text-lg">Code Cache</h1>
           <span className="text-sm text-slate-400">
-            Given your script key,{" "}
+            Given your code key,{" "}
             <code className="font-mono text-xs text-slate-200">
               {scriptKey}
             </code>
-            , search for scripts using a script key value. For this script key
+            , search for saved code using a code key value. For this code key
             there {totalCount === 1 ? "is" : "are"}{" "}
-            <span className="font-bold text-slate-200">{totalCount}</span>{" "}
-            script key {totalCount === 1 ? "value" : "values"}
+            <span className="font-bold text-slate-200">{totalCount}</span> code
+            key {totalCount === 1 ? "value" : "values"}
             {filteredCount !== totalCount && (
               <>
                 {" "}

--- a/skyvern-frontend/src/routes/workflows/editor/utils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/utils.ts
@@ -98,10 +98,10 @@ const getInitialParameters = (workflow: WorkflowApiResponse) => {
 };
 
 /**
- * Attempt to construct a valid cache key value from the workflow parameters.
+ * Attempt to construct a valid code key value from the workflow parameters.
  */
 const constructCacheKeyValue = (
-  cacheKey: string,
+  codeKey: string,
   workflow: WorkflowApiResponse,
 ) => {
   const workflowParameters = getInitialParameters(workflow)
@@ -119,14 +119,14 @@ const constructCacheKeyValue = (
       continue;
     }
 
-    cacheKey = cacheKey.replace(`{{${name}}}`, value.toString());
+    codeKey = codeKey.replace(`{{${name}}}`, value.toString());
   }
 
-  if (cacheKey.includes("{") || cacheKey.includes("}")) {
+  if (codeKey.includes("{") || codeKey.includes("}")) {
     return "";
   }
 
-  return cacheKey;
+  return codeKey;
 };
 
 export { constructCacheKeyValue, getInitialParameters };

--- a/skyvern-frontend/src/routes/workflows/workflowRun/ActionCard.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/ActionCard.tsx
@@ -66,7 +66,7 @@ function ActionCard({ action, onClick, active, index }: Props) {
                     </div>
                   </TooltipTrigger>
                   <TooltipContent className="max-w-[250px]">
-                    Scripted Execution
+                    Code Execution
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6042/change-button-text-from-show-scripts-to-show-code
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update text references from 'Script' to 'Code' across multiple files for consistent terminology in the `skyvern-frontend` project.
> 
>   - **Text Updates**:
>     - Change 'Scripted Execution' to 'Code Execution' in `ScrollableActionList.tsx` and `ActionCard.tsx`.
>     - Update placeholder from 'Script Key Value' to 'Code Key Value' in `WorkflowHeader.tsx`.
>     - Change dialog titles and descriptions from 'Script Key Value' to 'Code Key Value' in `Workspace.tsx`.
>     - Update 'Show Script' to 'Show Code' in `NodeActionMenu.tsx`.
>     - Change 'Generate Script' to 'Generate Code' and related labels in `StartNode.tsx`.
>     - Update 'Cached Scripts' to 'Code Cache' in `WorkflowCacheKeyValuesPanel.tsx`.
>   - **Function Renames**:
>     - Rename `constructCacheKeyValue` parameter from `cacheKey` to `codeKey` in `utils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 80f82d5df7e4724ff692072e3ae78df4544e6127. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->