### PR TITLE
allow ai_fallback to save

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -674,6 +674,7 @@ class WorkflowService:
         extra_http_headers: dict[str, str] | None = None,
         generate_script: bool = False,
         cache_key: str | None = None,
+        ai_fallback: bool | None = None,
     ) -> Workflow:
         return await app.DATABASE.create_workflow(
             title=title,
@@ -694,6 +695,7 @@ class WorkflowService:
             extra_http_headers=extra_http_headers,
             generate_script=generate_script,
             cache_key=cache_key,
+            ai_fallback=False if ai_fallback is None else ai_fallback,
         )
 
     async def get_workflow(self, workflow_id: str, organization_id: str | None = None) -> Workflow:
@@ -1647,6 +1649,7 @@ class WorkflowService:
                     status=request.status,
                     generate_script=request.generate_script,
                     cache_key=request.cache_key,
+                    ai_fallback=request.ai_fallback,
                 )
             else:
                 workflow = await self.create_workflow(

--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -523,7 +523,7 @@ class SkyvernFrame:
             await self.frame.wait_for_load_state("load", timeout=timeout_ms)
             await self.wait_for_animation_end(timeout_ms=timeout_ms)
         except Exception:
-            LOG.debug("Failed to wait for animation end, but ignore it", exc_info=True)
+            LOG.info("Failed to wait for animation end, but ignore it", exc_info=True)
             return
 
     async def wait_for_animation_end(self, timeout_ms: float = 3000) -> None:


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6110/allow-ai-fallback-to-save
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `ai_fallback` parameter to workflow creation functions and update logging level in `page.py`.
> 
>   - **Behavior**:
>     - Add `ai_fallback` parameter to `create_workflow` and `create_workflow_from_request` in `service.py`.
>     - Default `ai_fallback` to `False` if not provided.
>   - **Logging**:
>     - Change log level from `debug` to `info` in `safe_wait_for_animation_end` in `page.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2482157da834357fb49f61709fb6d53c6db63873. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR adds support for persisting the `ai_fallback` parameter in workflow creation, allowing workflows to save their AI fallback configuration instead of losing it during the creation process.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Workflow Service**: Added `ai_fallback` parameter to `create_workflow()` function with a default value of `False` when not provided
- **Request Handling**: Updated `create_workflow_from_request()` to pass through the `ai_fallback` parameter from incoming requests
- **Logging Enhancement**: Changed log level from `DEBUG` to `INFO` for animation wait failures in page utilities for better visibility

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant WorkflowService
    participant Database
    
    Client->>WorkflowService: create_workflow_from_request(ai_fallback=true)
    WorkflowService->>WorkflowService: create_workflow(ai_fallback=true)
    WorkflowService->>Database: create_workflow(ai_fallback=true)
    Database-->>WorkflowService: Workflow created
    WorkflowService-->>Client: Workflow with ai_fallback saved
```

### Impact
- **Data Persistence**: AI fallback settings are now properly saved and maintained across workflow creation operations
- **API Consistency**: The workflow creation API now fully supports the ai_fallback parameter end-to-end
- **Backward Compatibility**: Changes are non-breaking as the parameter defaults to `False` when not specified
- **Debugging Improvement**: Enhanced logging visibility for animation-related issues during page interactions

</details>

_Created with [Palmier](https://www.palmier.io)_