### PR TITLE
allow ai_fallback to save

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -674,6 +674,7 @@ class WorkflowService:
         extra_http_headers: dict[str, str] | None = None,
         generate_script: bool = False,
         cache_key: str | None = None,
+        ai_fallback: bool | None = None,
     ) -> Workflow:
         return await app.DATABASE.create_workflow(
             title=title,
@@ -694,6 +695,7 @@ class WorkflowService:
             extra_http_headers=extra_http_headers,
             generate_script=generate_script,
             cache_key=cache_key,
+            ai_fallback=False if ai_fallback is None else ai_fallback,
         )
 
     async def get_workflow(self, workflow_id: str, organization_id: str | None = None) -> Workflow:
@@ -1647,6 +1649,7 @@ class WorkflowService:
                     status=request.status,
                     generate_script=request.generate_script,
                     cache_key=request.cache_key,
+                    ai_fallback=request.ai_fallback,
                 )
             else:
                 workflow = await self.create_workflow(


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6110/allow-ai-fallback-to-save
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `ai_fallback` parameter to `create_workflow` and `create_workflow_from_request` in `service.py`, defaulting to `False`.
> 
>   - **Behavior**:
>     - Add `ai_fallback` parameter to `create_workflow` and `create_workflow_from_request` in `service.py`.
>     - Default `ai_fallback` to `False` if not provided.
>   - **Functions**:
>     - Update `create_workflow` to include `ai_fallback` in workflow creation.
>     - Update `create_workflow_from_request` to pass `ai_fallback` from request to `create_workflow`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 8ade9fcdae16c3e77fe152d87a10851e299b23ff. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR adds support for persisting the `ai_fallback` parameter when creating workflows, ensuring this configuration option is properly saved to the database with a default value of `False`.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Parameter Addition**: Added `ai_fallback` parameter to the `create_workflow` function signature with optional typing
- **Default Value Handling**: Implemented logic to default `ai_fallback` to `False` when not explicitly provided
- **Request Processing**: Updated `create_workflow_from_request` to pass through the `ai_fallback` value from incoming requests
- **Database Integration**: Ensured the `ai_fallback` parameter is passed to the database layer for persistence

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant Service
    participant Database
    
    Client->>Service: create_workflow_from_request(ai_fallback=true)
    Service->>Service: create_workflow(ai_fallback=true)
    Note over Service: ai_fallback = False if None else ai_fallback
    Service->>Database: create_workflow(..., ai_fallback=true)
    Database-->>Service: Workflow created
    Service-->>Client: Workflow response
```

### Impact
- **Configuration Persistence**: The `ai_fallback` setting will now be properly stored and maintained across workflow operations
- **Backward Compatibility**: Existing code continues to work as the parameter is optional with a sensible default
- **API Consistency**: Aligns the service layer with the expected database schema and request handling patterns

</details>

_Created with [Palmier](https://www.palmier.io)_