### PR TITLE
code cache icon button instead of dropdown

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
@@ -2,6 +2,13 @@ import { getClient } from "@/api/AxiosClient";
 import { Handle, Node, NodeProps, Position, useReactFlow } from "@xyflow/react";
 import type { StartNode } from "./types";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Button } from "@/components/ui/button";
+import {
   Accordion,
   AccordionContent,
   AccordionItem,
@@ -25,7 +32,6 @@ import { MAX_SCREENSHOT_SCROLLS_DEFAULT } from "../Taskv2Node/types";
 import { KeyValueInput } from "@/components/KeyValueInput";
 import { OrgWalled } from "@/components/Orgwalled";
 import { placeholders } from "@/routes/workflows/editor/helpContent";
-import { NodeActionMenu } from "@/routes/workflows/editor/nodes/NodeActionMenu";
 import { useToggleScriptForNodeCallback } from "@/routes/workflows/hooks/useToggleScriptForNodeCallback";
 import { useWorkflowSettingsStore } from "@/store/WorkflowSettingsStore";
 import {
@@ -37,6 +43,7 @@ import { useRerender } from "@/hooks/useRerender";
 import { useBlockScriptStore } from "@/store/BlockScriptStore";
 import { BlockCodeEditor } from "@/routes/workflows/components/BlockCodeEditor";
 import { cn } from "@/util/utils";
+import { LightningBoltIcon } from "@radix-ui/react-icons";
 
 function StartNode({ id, data }: NodeProps<StartNode>) {
   const workflowSettingsStore = useWorkflowSettingsStore();
@@ -153,19 +160,23 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
             )}
           >
             <div className="relative">
-              <div className="absolute right-0 top-0">
+              <div className="absolute right-[-0.5rem] top-[-0.25rem]">
                 <div>
-                  <div className="rounded p-1 hover:bg-muted">
-                    <NodeActionMenu
-                      isDeletable={false}
-                      isScriptable={true}
-                      showScriptText="Show All Code"
-                      onShowScript={showAllScripts}
-                    />
-                  </div>
+                  <OrgWalled className="p-0">
+                    <Button variant="link" size="icon" onClick={showAllScripts}>
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <LightningBoltIcon className="h-4 w-4 text-[gold]" />
+                          </TooltipTrigger>
+                          <TooltipContent>Show all code</TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    </Button>
+                  </OrgWalled>
                 </div>
               </div>
-              <header className="mb-4">Start</header>
+              <header className="mb-6 mt-2">Start</header>
               <Separator />
               <Accordion
                 type="single"


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6053/make-caching-icon-more-prominent-instead-of-in-dropdown

<img width="511" height="732" alt="image" src="https://github.com/user-attachments/assets/2e86323f-9bda-4207-ae22-4c285dae9233" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replaces dropdown with a button in `StartNode.tsx` to show all scripts, using a `LightningBoltIcon` with tooltip, and removes `NodeActionMenu`.
> 
>   - **UI Changes**:
>     - Replaces dropdown menu with a button in `StartNode.tsx` to show all scripts.
>     - Uses `LightningBoltIcon` with a tooltip for the button.
>     - Removes `NodeActionMenu` and adds `OrgWalled` wrapper for the button.
>   - **Tooltip**:
>     - Adds `Tooltip`, `TooltipContent`, `TooltipProvider`, and `TooltipTrigger` for the button.
>   - **Layout Adjustments**:
>     - Adjusts header spacing in `StartNode.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 579571251d0329298350b574c9bef56f2cb7435a. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->