### PR TITLE
fix logo centering

### DIFF
--- a/skyvern-frontend/src/routes/root/SidebarContent.tsx
+++ b/skyvern-frontend/src/routes/root/SidebarContent.tsx
@@ -18,7 +18,7 @@ function SidebarContent({ useCollapsedState }: Props) {
   return (
     <div className="flex h-full flex-col overflow-y-auto px-6">
       <Link to={window.location.origin}>
-        <div className="flex h-24 items-center">
+        <div className="flex h-24 items-center justify-center">
           {collapsed ? <LogoMinimized /> : <Logo />}
         </div>
       </Link>


### PR DESCRIPTION
Before:

<img width="109" height="125" alt="image" src="https://github.com/user-attachments/assets/b415fd7f-9b04-4157-b18f-709cd67807d8" />

After:

<img width="109" height="125" alt="image" src="https://github.com/user-attachments/assets/6b1cdf88-760c-49f2-ab6b-92445bf1a830" />
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `justify-center` to center logo in `SidebarContent.tsx` in two locations.
> 
>   - **UI Fix**:
>     - Add `justify-center` to logo container `div` in `SidebarContent.tsx` in both `cloud/routes/root` and `src/routes/root` to center the logo.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 7cddf086de25f5732f2d67e0ca00b3e01e59379a. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->