### PR TITLE
use type instead of press

### DIFF
--- a/skyvern/webeye/actions/handler_utils.py
+++ b/skyvern/webeye/actions/handler_utils.py
@@ -32,7 +32,7 @@ async def input_sequentially(locator: Locator, text: str, timeout: float = setti
         text = text[length - TEXT_PRESS_MAX_LENGTH :]
 
     for char in text:
-        await locator.press(char, delay=TEXT_INPUT_DELAY, timeout=timeout)
+        await locator.type(char, delay=TEXT_INPUT_DELAY, timeout=timeout)
 
 
 async def keypress(page: Page, keys: list[str], hold: bool = False, duration: float = 0) -> None:

--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -573,7 +573,7 @@ class SkyvernElement:
 
     async def press_fill(self, text: str, timeout: float = settings.BROWSER_ACTION_TIMEOUT_MS) -> None:
         for char in text:
-            await self.get_locator().press(char, delay=TEXT_INPUT_DELAY, timeout=timeout)
+            await self.get_locator().type(char, delay=TEXT_INPUT_DELAY, timeout=timeout)
 
     async def input(self, text: str, timeout: float = settings.BROWSER_ACTION_TIMEOUT_MS) -> None:
         if self.get_tag_name().lower() not in COMMON_INPUT_TAGS:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change text input method from `press` to `type` in `input_sequentially()` and `press_fill()` functions.
> 
>   - **Behavior**:
>     - Change `press` to `type` for character input in `input_sequentially()` in `handler_utils.py`.
>     - Change `press` to `type` for character input in `press_fill()` in `dom.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 9bfb66f0fada7bf3160d0ce645f4c74e974c77e3. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->