### PR TITLE
debugger layout fixes 2

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -750,12 +750,12 @@ function Workspace({
 
         {/* divider if browser is in play */}
         {showBrowser && (
-          <div className="mt-[8rem] h-[calc(100%-8rem)] w-[1px] bg-slate-800" />
+          <div className="mt-[8rem] h-[calc(100%_-_8rem)] w-[1px] bg-slate-800" />
         )}
 
         {/* browser & timeline & sub-panels in debug mode */}
         {showBrowser && (
-          <div className="skyvern-split-right relative flex h-full w-[calc(100%-33rem)] items-end justify-center bg-[#020617] p-4 pl-6">
+          <div className="skyvern-split-right relative flex h-full w-[calc(100%_-_33rem)] items-end justify-center bg-[#020617] p-4 pl-6">
             {/* sub panels */}
             {workflowPanelState.active && (
               <div
@@ -803,9 +803,9 @@ function Workspace({
             )}
 
             {/* browser & timeline */}
-            <div className="flex h-[calc(100%-8rem)] w-full gap-6">
+            <div className="flex h-[calc(100%_-_8rem)] w-full gap-6">
               {/* browser */}
-              <div className="flex h-full w-full flex-1 flex-col items-center justify-center">
+              <div className="flex h-full w-[calc(100%_-_6rem)] flex-1 flex-col items-center justify-center">
                 <div key={reloadKey} className="w-full flex-1">
                   {activeDebugSession &&
                   activeDebugSession.browser_session_id &&


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix layout issues in `Workspace.tsx` by adjusting CSS for browser and timeline panels.
> 
>   - **Layout Fixes**:
>     - Adjusted CSS in `Workspace.tsx` for `showBrowser` condition:
>       - Changed `h-[calc(100%-8rem)]` to `h-[calc(100%_-_8rem)]` for divider and timeline.
>       - Changed `w-[calc(100%-33rem)]` to `w-[calc(100%_-_33rem)]` for browser & timeline container.
>       - Changed `w-full` to `w-[calc(100%_-_6rem)]` for browser container.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 7cd2c11f4faf4b6b8a87c152cafdd37a295a7358. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🎨 This PR fixes CSS calculation syntax issues in the debugger layout by correcting Tailwind CSS calc() expressions to use proper underscore spacing. The changes ensure proper rendering of height and width calculations in the workflow editor's workspace component.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **CSS Syntax Correction**: Fixed Tailwind CSS calc() expressions by replacing hyphens with underscores in spacing calculations
- **Height Calculations**: Updated `h-[calc(100%-8rem)]` to `h-[calc(100%_-_8rem)]` for proper vertical spacing
- **Width Calculations**: Changed `w-[calc(100%-33rem)]` to `w-[calc(100%_-_33rem)]` for correct horizontal layout
- **Browser Width Adjustment**: Modified browser container from `w-full` to `w-[calc(100%_-_6rem)]` for better spacing control

### Technical Implementation
```mermaid
flowchart TD
    A[Workspace Component] --> B[Browser Panel Check]
    B --> C{showBrowser?}
    C -->|Yes| D[Render Divider]
    C -->|Yes| E[Render Browser Container]
    D --> F[Fixed Height: calc(100% - 8rem)]
    E --> G[Fixed Width: calc(100% - 33rem)]
    E --> H[Browser Sub-container]
    H --> I[Fixed Width: calc(100% - 6rem)]
    
    style F fill:#e1f5fe
    style G fill:#e1f5fe
    style I fill:#e1f5fe
```

### Impact
- **Layout Stability**: Ensures CSS calculations render correctly across different browsers and Tailwind versions
- **Visual Consistency**: Maintains proper spacing and proportions in the debugger interface
- **Framework Compliance**: Follows Tailwind CSS best practices for calc() expressions with underscore syntax

</details>

_Created with [Palmier](https://www.palmier.io)_