### PR TITLE
fix useRerender

### DIFF
--- a/skyvern-frontend/src/hooks/useRerender.ts
+++ b/skyvern-frontend/src/hooks/useRerender.ts
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 /**
  * ```tsx
- * const { bump, key } = useRerender({ delay: 40,prefix: "my-prefix" });
+ * const { bump, key } = useRerender({ delay: 40, prefix: "my-prefix" });
  *
  * <div key={key}>...</div>
  *
@@ -17,17 +17,17 @@ const useRerender = ({
   delay?: number;
   prefix: string;
 }) => {
-  const [forceRenderKey, setForceRenderKey] = useState(`${prefix}-0`);
+  const [forceRenderKey, setForceRenderKey] = useState(0);
 
   const bump = () => {
     setTimeout(() => {
-      setForceRenderKey((prev) => `${prefix}-${prev + 1}`);
+      setForceRenderKey((prev) => prev + 1);
     }, delay);
   };
 
   return {
     bump,
-    key: forceRenderKey,
+    key: `${prefix}-${forceRenderKey}`,
   };
 };
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `useRerender` hook to initialize `forceRenderKey` as a number and update key generation logic.
> 
>   - **Behavior**:
>     - `useRerender` hook in `useRerender.ts` now initializes `forceRenderKey` as a number instead of a string.
>     - `bump` function increments `forceRenderKey` numerically, appending the prefix during return.
>   - **Misc**:
>     - Fix spacing in example comment in `useRerender.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for ffee904ab10d61e27d7647073b2fab1ea5027d01. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->