### PR TITLE
add generate_script to v2 task settings

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
@@ -48,6 +48,7 @@ import {
   MAX_SCREENSHOT_SCROLLS_DEFAULT,
   MAX_STEPS_DEFAULT,
 } from "@/routes/workflows/editor/nodes/Taskv2Node/types";
+import { OrgWalled } from "@/components/Orgwalled";
 
 function createTemplateTaskFromTaskGenerationParameters(
   values: TaskGenerationApiResponse,
@@ -156,6 +157,7 @@ function PromptBox() {
   );
   const [browserSessionId, setBrowserSessionId] = useState<string | null>(null);
   const [cdpAddress, setCdpAddress] = useState<string | null>(null);
+  const [generateScript, setGenerateScript] = useState(false);
   const [publishWorkflow, setPublishWorkflow] = useState(false);
   const [totpIdentifier, setTotpIdentifier] = useState("");
   const [maxStepsOverride, setMaxStepsOverride] = useState<string | null>(null);
@@ -178,7 +180,8 @@ function PromptBox() {
           browser_session_id: browserSessionId,
           browser_address: cdpAddress,
           totp_identifier: totpIdentifier,
-          publish_workflow: publishWorkflow,
+          generate_script: generateScript,
+          publish_workflow: publishWorkflow || generateScript,
           max_screenshot_scrolls: maxScreenshotScrolls,
           extracted_information_schema: dataSchema
             ? (() => {
@@ -468,11 +471,29 @@ function PromptBox() {
                       />
                     </div>
                   </div>
+                  <OrgWalled className="p-0">
+                    <div className="flex gap-16">
+                      <div className="w-48 shrink-0">
+                        <div className="text-sm">Generate Script</div>
+                        <div className="text-xs text-slate-400">
+                          Whether to generate scripts for this task run (on
+                          success).
+                        </div>
+                      </div>
+                      <Switch
+                        checked={generateScript}
+                        onCheckedChange={(checked) => {
+                          setGenerateScript(Boolean(checked));
+                        }}
+                      />
+                    </div>
+                  </OrgWalled>
                   <div className="flex gap-16">
                     <div className="w-48 shrink-0">
                       <div className="text-sm">Publish Workflow</div>
                       <div className="text-xs text-slate-400">
                         Whether to create a workflow alongside this task run.
+                        Will also be created if "Generate Scripts" is true.
                       </div>
                     </div>
                     <Switch


### PR DESCRIPTION
Follows https://github.com/Skyvern-AI/skyvern/pull/3332
https://linear.app/skyvern/issue/SKY-6052/can-i-cache-skyvern-20-runs-should-i
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `generateScript` feature to `PromptBox` for script generation in task runs, with UI and logic updates.
> 
>   - **Behavior**:
>     - Adds `generateScript` state to `PromptBox` in `PromptBox.tsx` to control script generation for task runs.
>     - Updates task creation logic to include `generate_script` in the request payload.
>     - Ensures `publishWorkflow` is true if `generateScript` is true.
>   - **UI**:
>     - Adds a switch for `Generate Script` in the advanced settings of `PromptBox`.
>     - Updates `Publish Workflow` description to reflect dependency on `Generate Script`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 3723209d7b2210447aab036bf46459f30676885e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->