### PR TITLE
Debugger: Increase left-side width

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -731,7 +731,7 @@ function Workspace({
       <div className="relative flex h-full w-full overflow-hidden overflow-x-hidden">
         {/* infinite canvas */}
         <div
-          className={cn("skyvern-split-left h-full w-[33rem] min-w-[33rem]", {
+          className={cn("skyvern-split-left h-full w-[39rem] min-w-[39rem]", {
             "w-full": !showBrowser,
           })}
         >
@@ -755,7 +755,7 @@ function Workspace({
 
         {/* browser & timeline & sub-panels in debug mode */}
         {showBrowser && (
-          <div className="skyvern-split-right relative flex h-full w-[calc(100%_-_33rem)] items-end justify-center bg-[#020617] p-4 pl-6">
+          <div className="skyvern-split-right relative flex h-full w-[calc(100%_-_39rem)] items-end justify-center bg-[#020617] p-4 pl-6">
             {/* sub panels */}
             {workflowPanelState.active && (
               <div

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -149,7 +149,7 @@ export function descendants(nodes: Array<AppNode>, id: string): Array<AppNode> {
 export function getLoopNodeWidth(node: AppNode, nodes: Array<AppNode>): number {
   const maxNesting = maxNestingLevel(nodes);
   const nestingLevel = getNestingLevel(node, nodes);
-  return 600 + (maxNesting - nestingLevel) * 50;
+  return 450 + (maxNesting - nestingLevel) * 50;
 }
 
 function maxNestingLevel(nodes: Array<AppNode>): number {


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6191/fix-issue-with-loop-blocks-being-cut-off-in-debugger-view
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase left-side panel width in debugger view to prevent loop blocks from being cut off.
> 
>   - **Behavior**:
>     - Increase left-side panel width from `33rem` to `39rem` in `Workspace.tsx`.
>     - Adjust right-side panel width calculation to `calc(100% - 39rem)` in `Workspace.tsx`.
>   - **Utils**:
>     - Change loop node width calculation from `600 + (maxNesting - nestingLevel) * 50` to `450 + (maxNesting - nestingLevel) * 50` in `getLoopNodeWidth()` in `workflowEditorUtils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 80de1ef0add52784767db4a874ea298429090dd6. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->