### PR TITLE
Jon/debugger layout fixes 3

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -203,6 +203,14 @@ function Workspace({
   const showBreakoutButton =
     activeDebugSession && activeDebugSession.browser_session_id;
 
+  const hasLoopBlock = nodes.some((node) => node.type === "loop");
+  const hasHttpBlock = nodes.some((node) => node.type === "http_request");
+  const workflowWidth = hasHttpBlock
+    ? "39rem"
+    : hasLoopBlock
+      ? "34.25rem"
+      : "33rem";
+
   /**
    * Open a new tab (not window) with the browser session URL.
    */
@@ -731,9 +739,13 @@ function Workspace({
       <div className="relative flex h-full w-full overflow-hidden overflow-x-hidden">
         {/* infinite canvas */}
         <div
-          className={cn("skyvern-split-left h-full w-[39rem] min-w-[39rem]", {
+          className={cn("skyvern-split-left h-full", {
             "w-full": !showBrowser,
           })}
+          style={{
+            width: workflowWidth,
+            maxWidth: workflowWidth,
+          }}
         >
           <FlowRenderer
             hideBackground={showBrowser}
@@ -755,7 +767,12 @@ function Workspace({
 
         {/* browser & timeline & sub-panels in debug mode */}
         {showBrowser && (
-          <div className="skyvern-split-right relative flex h-full w-[calc(100%_-_39rem)] items-end justify-center bg-[#020617] p-4 pl-6">
+          <div
+            className="skyvern-split-right relative flex h-full items-end justify-center bg-[#020617] p-4 pl-6"
+            style={{
+              width: `calc(100% - ${workflowWidth})`,
+            }}
+          >
             {/* sub panels */}
             {workflowPanelState.active && (
               <div
@@ -830,7 +847,11 @@ function Workspace({
                   {showBreakoutButton && (
                     <BreakoutButton onClick={() => breakout()} />
                   )}
-                  <div className="ml-auto flex items-center gap-2">
+                  <div
+                    className={cn("ml-auto flex items-center gap-2", {
+                      "mr-16": !blockLabel,
+                    })}
+                  >
                     {showPowerButton && <PowerButton onClick={() => cycle()} />}
                     <ReloadButton
                       isReloading={isReloading}


### PR DESCRIPTION
- browser: nudge cycle and refresh buttons when no timeline exists yet
- otherwise they're blocked by Pylon bubble
- map workflow width to workflow block types
- different width depending if there is an http block, a loop block, or neither of those    
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adjust `Workspace.tsx` layout to vary workflow width based on block types and reposition cycle/refresh buttons when timeline is absent.
> 
>   - **Layout Adjustments**:
>     - Adjust `workflowWidth` in `Workspace.tsx` based on presence of `loop` or `http_request` blocks: `39rem` for `http_request`, `34.25rem` for `loop`, `33rem` otherwise.
>     - Update styles for `skyvern-split-left` and `skyvern-split-right` divs to use `workflowWidth` for width and max-width.
>   - **UI Positioning**:
>     - Add margin-right (`mr-16`) to cycle and refresh buttons when `blockLabel` is not present in `Workspace.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 95c8ade06d493eee4b4b13cb603eb3a3ebf8d586. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🎨 This PR fixes debugger layout issues in the workflow editor by implementing dynamic width adjustments based on workflow block types and repositioning UI elements to prevent overlap with the Pylon bubble.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Dynamic Width Calculation**: Introduces logic to calculate `workflowWidth` based on the presence of specific block types (`http_request`, `loop`, or default)
- **Layout Responsiveness**: Updates the split-panel layout to use calculated widths instead of hardcoded values
- **Button Positioning**: Adds conditional margin to cycle and refresh buttons to prevent overlap with UI elements when no timeline exists

### Technical Implementation
```mermaid
flowchart TD
    A[Analyze Workflow Nodes] --> B{Has HTTP Block?}
    B -->|Yes| C[Set Width: 39rem]
    B -->|No| D{Has Loop Block?}
    D -->|Yes| E[Set Width: 34.25rem]
    D -->|No| F[Set Width: 33rem]
    
    C --> G[Apply Dynamic Width to Split Panels]
    E --> G
    F --> G
    
    G --> H[Check Block Label Presence]
    H -->|No Label| I[Add mr-16 Margin to Buttons]
    H -->|Has Label| J[Keep Default Button Position]
    
    I --> K[Prevent Pylon Bubble Overlap]
    J --> K
```

### Impact
- **Improved UX**: Eliminates UI overlap issues where buttons were blocked by the Pylon bubble
- **Adaptive Layout**: Workflow editor now dynamically adjusts its width based on the complexity of workflow blocks
- **Better Space Utilization**: Different block types get appropriately sized workspace areas (HTTP blocks need more space at 39rem, loop blocks at 34.25rem, basic workflows at 33rem)

</details>

_Created with [Palmier](https://www.palmier.io)_