### PR TITLE
fix block screenshot bug

### DIFF
--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -310,7 +310,7 @@ class SkyvernFrame:
             )
         finally:
             if x is not None and y is not None:
-                await skyvern_frame.scroll_to_x_y(x, y)
+                await skyvern_frame.safe_scroll_to_x_y(x, y)
 
     @staticmethod
     @TraceManager.traced_async(ignore_inputs=["page"])
@@ -365,6 +365,12 @@ class SkyvernFrame:
     async def scroll_to_x_y(self, x: int, y: int) -> None:
         js_script = "([x, y]) => scrollToXY(x, y)"
         return await self.evaluate(frame=self.frame, expression=js_script, arg=[x, y])
+
+    async def safe_scroll_to_x_y(self, x: int, y: int) -> None:
+        try:
+            await self.scroll_to_x_y(x, y)
+        except Exception:
+            LOG.warning("Failed to scroll to x, y, ignore it", x=x, y=y, exc_info=True)
 
     async def scroll_to_element_bottom(self, element: ElementHandle, page_by_page: bool = False) -> None:
         js_script = "([element, page_by_page]) => scrollToElementBottom(element, page_by_page)"


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Improved error handling and logging for browser state and screenshot operations in `block.py` and `page.py`, including marking tasks as failed on exceptions and adding `safe_scroll_to_x_y()` for safer scrolling.
> 
>   - **Behavior**:
>     - In `block.py`, improved error handling for browser state retrieval and screenshot operations in `execute()`.
>     - Tasks are marked as failed in the database if exceptions occur during browser state retrieval or screenshot operations.
>     - Improved logging for exceptions during screenshot operations.
>   - **Functions**:
>     - Added `safe_scroll_to_x_y()` in `SkyvernFrame` in `page.py` to handle exceptions during scrolling.
>     - Replaced `scroll_to_x_y()` with `safe_scroll_to_x_y()` in `take_scrolling_screenshot()` in `page.py`.
>   - **Logging**:
>     - Changed exception logging to warning for screenshot failures in `block.py` and `page.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 641c5ed52aa9e35a98f144e49e643ac6ee8c6122. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🐛 This PR fixes a critical bug in block screenshot functionality by improving error handling and preventing workflow failures when screenshots cannot be taken during task execution.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Error Handling Separation**: Split browser state creation and screenshot taking into separate try-catch blocks in `block.py` to handle failures independently
- **Safe Scrolling**: Added `safe_scroll_to_x_y()` method in `SkyvernFrame` to gracefully handle scroll failures during screenshot operations
- **Logging Improvements**: Changed screenshot failure logging from `LOG.exception` to `LOG.warning` to reduce noise while maintaining visibility

### Technical Implementation
```mermaid
sequenceDiagram
    participant Block as BaseTaskBlock
    participant Browser as BrowserManager
    participant Frame as SkyvernFrame
    participant DB as Database
    
    Block->>Browser: get_or_create_for_workflow_run()
    alt Browser Creation Fails
        Browser-->>Block: Exception
        Block->>DB: update_task(status=failed)
        Block->>Block: raise exception
    else Browser Creation Success
        Block->>Browser: take_fullpage_screenshot()
        alt Screenshot Fails
            Browser-->>Block: Exception
            Block->>Block: LOG.warning (continue execution)
        else Screenshot Success
            Block->>DB: create_artifact()
        end
    end
    
    Note over Frame: During screenshot cleanup
    Frame->>Frame: safe_scroll_to_x_y()
    alt Scroll Fails
        Frame->>Frame: LOG.warning (ignore failure)
    end
```

### Impact
- **Improved Reliability**: Workflow execution no longer fails when screenshots cannot be taken, allowing tasks to continue
- **Better Error Isolation**: Browser creation failures are still treated as critical errors, while screenshot failures are non-blocking
- **Enhanced Debugging**: Maintains error visibility through warning logs without causing unnecessary workflow terminations

</details>

_Created with [Palmier](https://www.palmier.io)_