### PR TITLE
fix input value bug for script run

### DIFF
--- a/skyvern/core/script_generations/skyvern_page.py
+++ b/skyvern/core/script_generations/skyvern_page.py
@@ -380,9 +380,6 @@ class SkyvernPage:
         # format the text with the actual value of the parameter if it's a secret when running a workflow
         context = skyvern_context.current()
         value = value or ""
-        if context and context.workflow_run_id:
-            value = await _get_actual_value_of_parameter_if_secret(context.workflow_run_id, value)
-
         if ai_infer and intention:
             try:
                 prompt = context.prompt if context else None
@@ -403,6 +400,9 @@ class SkyvernPage:
                 value = json_response.get("answer", value)
             except Exception:
                 LOG.exception(f"Failed to adapt value for input text action on xpath={xpath}, value={value}")
+
+        if context and context.workflow_run_id:
+            value = await _get_actual_value_of_parameter_if_secret(context.workflow_run_id, value)
 
         locator = self.page.locator(f"xpath={xpath}")
         await handler_utils.input_sequentially(locator, value, timeout=timeout)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Reorders secret parameter value retrieval in `_input_text()` in `skyvern_page.py` to occur after AI inference logic.
> 
>   - **Behavior**:
>     - Moved retrieval of actual parameter value if secret in `_input_text()` in `skyvern_page.py` to occur after AI inference logic.
>     - Ensures that AI-inferred values are checked for secrets before inputting text.
>   - **Misc**:
>     - No changes to function signatures or external interfaces.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 42558a79a5f72bc3c9fbcb3b48b4e7fcc799f9ec. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes a critical bug in the input value handling for script runs by reordering when secret parameter values are retrieved, ensuring they are processed after AI inference modifications rather than before.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Secret Value Retrieval Timing**: Moved the `_get_actual_value_of_parameter_if_secret()` call from before AI inference processing to after it in the `_input_text()` method
- **Processing Order Fix**: The secret value resolution now occurs after potential AI inference modifications to the input value
- **Code Structure**: No changes to function signatures or external interfaces, maintaining backward compatibility

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client as Script Runner
    participant InputText as _input_text()
    participant AI as AI Inference
    participant Secret as Secret Resolver
    participant Page as Web Page

    Client->>InputText: Call with value parameter
    Note over InputText: OLD: Secret resolution happened here
    InputText->>AI: Process with ai_infer (if enabled)
    AI-->>InputText: Return modified value
    Note over InputText: NEW: Secret resolution happens here
    InputText->>Secret: _get_actual_value_of_parameter_if_secret()
    Secret-->>InputText: Return actual secret value
    InputText->>Page: Input final value to page element
```

### Impact
- **Bug Resolution**: Fixes scenarios where AI inference modifications to input values were being overwritten by secret parameter resolution
- **Workflow Reliability**: Ensures that secret values are properly resolved after all text processing is complete
- **Processing Logic**: Maintains the correct order of operations: initial value → AI inference → secret resolution → page input

</details>

_Created with [Palmier](https://www.palmier.io)_