### PR TITLE
show input value before the value is interpretated into a real secret

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -304,7 +304,7 @@ class Settings(BaseSettings):
     SVG_MAX_LENGTH: int = 100000
 
     ENABLE_LOG_ARTIFACTS: bool = False
-    ENABLE_CODE_BLOCK: bool = True
+    ENABLE_CODE_BLOCK: bool = False
 
     TASK_BLOCKED_SITE_FALLBACK_URL: str = "https://www.google.com"
 


### PR DESCRIPTION
---

🔍 This PR modifies the input text functionality to show the original input value before it gets transformed into a secret, improving debugging and logging capabilities for workflow executions.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Input Text Methods**: Modified `fill()` and `type()` methods to return the original input value as a string instead of void
- **Action Creation**: Enhanced `_create_action_before_execution()` to accept and use `call_result` parameter for better action logging
- **Secret Handling**: Separated original value from transformed value in `_input_text()` method to preserve the pre-transformation state
- **Configuration**: Disabled `ENABLE_CODE_BLOCK` feature flag by default

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client as Client Code
    participant Page as SkyvernPage
    participant Action as Action Creator
    participant Workflow as Workflow Context
    
    Client->>Page: fill(xpath, value)
    Page->>Page: Store original value
    Page->>Workflow: Transform value if secret
    Page->>Page: Input transformed value
    Page->>Action: Create action with original value
    Page->>Client: Return original value
```

### Impact
- **Debugging Enhancement**: Developers can now see the original input values before secret transformation, making workflow debugging easier
- **Action Logging**: Action records now contain the original input values rather than transformed secrets, improving audit trails
- **API Consistency**: Input methods now return meaningful values that can be used for validation or further processing
- **Backward Compatibility**: Changes maintain existing functionality while adding new return values and logging capabilities

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `SkyvernPage` to return original input values before secret transformation and update `config.py` to disable code blocks.
> 
>   - **Behavior**:
>     - `SkyvernPage._input_text()` now returns the original input value before secret transformation.
>     - `SkyvernPage.fill()` and `SkyvernPage.type()` return the result of `_input_text()`.
>     - Adds `call_result` parameter to `_create_action_before_execution()` to store action call results.
>   - **Settings**:
>     - Change `ENABLE_CODE_BLOCK` in `config.py` from `True` to `False`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 06a762e641450694bd7f06a9f7dce29de2f90fd0. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->