### PR TITLE
make the default page size 10 for the run history

### DIFF
--- a/skyvern-frontend/src/routes/history/RunHistory.tsx
+++ b/skyvern-frontend/src/routes/history/RunHistory.tsx
@@ -37,7 +37,7 @@ function RunHistory() {
   const page = searchParams.get("page") ? Number(searchParams.get("page")) : 1;
   const itemsPerPage = searchParams.get("page_size")
     ? Number(searchParams.get("page_size"))
-    : 5;
+    : 10;
   const [statusFilters, setStatusFilters] = useState<Array<Status>>([]);
   const { data: runs, isFetching } = useRunsQuery({
     page,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default page size to 10 in `RunHistory` component for run history view.
> 
>   - **Behavior**:
>     - Change default `itemsPerPage` from 5 to 10 in `RunHistory` component in `RunHistory.tsx`. This affects the number of items displayed per page in the run history view.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 20c6946698978515bd04a3f6a8bd8e6b16a3e1bd. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->