### PR TITLE
debugger layout fixes 4

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -743,8 +743,8 @@ function Workspace({
             "w-full": !showBrowser,
           })}
           style={{
-            width: workflowWidth,
-            maxWidth: workflowWidth,
+            width: showBrowser ? workflowWidth : "100%",
+            maxWidth: showBrowser ? workflowWidth : "100%",
           }}
         >
           <FlowRenderer


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6252/bug-unable-to-turn-off-debugger
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes layout issue in `Workspace.tsx` by setting `width` and `maxWidth` to `100%` when `showBrowser` is false, ensuring proper rendering of the workflow editor.
> 
>   - **Behavior**:
>     - Fixes layout issue in `Workspace.tsx` by setting `width` and `maxWidth` to `100%` when `showBrowser` is false.
>     - Ensures proper rendering of the workflow editor when the browser is not displayed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for cfd43dddcec8ee87f0e44fd70adee4a36efbcb72. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🐛 This PR fixes a UI layout bug in the workflow editor where the debugger browser panel couldn't be properly turned off, ensuring the workspace takes full width when the browser is hidden.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Layout Logic**: Modified the `Workspace.tsx` component to conditionally set width and maxWidth styles based on the `showBrowser` prop
- **Style Properties**: Changed from static `workflowWidth` to dynamic width calculation that uses "100%" when browser is hidden
- **UI Responsiveness**: Fixed the workspace to properly expand to full width when the debugger browser panel is toggled off

### Technical Implementation
```mermaid
flowchart TD
    A[showBrowser prop] --> B{showBrowser === true?}
    B -->|Yes| C[width: workflowWidth<br/>maxWidth: workflowWidth]
    B -->|No| D[width: 100%<br/>maxWidth: 100%]
    C --> E[Workspace renders with browser panel]
    D --> F[Workspace renders full width]
```

### Impact
- **User Experience**: Users can now properly toggle off the debugger browser panel and have the workflow editor expand to use the full available space
- **Layout Consistency**: Ensures the workspace component responds correctly to the showBrowser state changes
- **Bug Resolution**: Directly addresses the Linear issue SKY-6252 where users were unable to turn off the debugger

</details>

_Created with [Palmier](https://www.palmier.io)_