### PR TITLE
Remove "Contributor Setup" from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,20 +389,6 @@ We love to see how Skyvern is being used in the wild. Here are some examples of 
   <img src="fern/images/geico_shu_recording_cropped.gif"/>
 </p>
 
-# Contributor Setup
-For a complete local environment CLI Installation
-```bash
-pip install -e .
-```
-The following command sets up your development environment to use pre-commit (our commit hook handler)
-```
-skyvern quickstart contributors
-```
-
-
-1. Navigate to `http://localhost:8080` in your browser to start using the UI
-   *The Skyvern CLI supports Windows, WSL, macOS, and Linux environments.*
-
 # Documentation
 
 More extensive documentation can be found on our [📕 docs page](https://docs.skyvern.com). Please let us know if something is unclear or missing by opening an issue or reaching out to us [via email](mailto:founders@skyvern.com) or [discord](https://discord.gg/fG2XXEuQX3).


### PR DESCRIPTION
The `skyvern quickstart contributors` don't work anyway, just deleting the section as it would not make sense without it. 