### PR TITLE
make ai fallback true by default

### DIFF
--- a/skyvern-frontend/src/routes/workflows/Workflows.tsx
+++ b/skyvern-frontend/src/routes/workflows/Workflows.tsx
@@ -49,7 +49,11 @@ import { WorkflowTemplates } from "../discover/WorkflowTemplates";
 const emptyWorkflowRequest: WorkflowCreateYAMLRequest = {
   title: "New Workflow",
   description: "",
-  workflow_definition: { blocks: [], parameters: [] },
+  ai_fallback: true,
+  workflow_definition: {
+    blocks: [],
+    parameters: [],
+  },
 };
 
 function Workflows() {

--- a/skyvern-frontend/src/routes/workflows/debugger/Debugger.tsx
+++ b/skyvern-frontend/src/routes/workflows/debugger/Debugger.tsx
@@ -63,7 +63,7 @@ function Debugger() {
       : null,
     useScriptCache: workflow.generate_script,
     scriptCacheKey: workflow.cache_key,
-    aiFallback: workflow.ai_fallback,
+    aiFallback: workflow.ai_fallback ?? true,
   };
 
   const elements = getElements(

--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowEditor.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowEditor.tsx
@@ -64,7 +64,7 @@ function WorkflowEditor() {
       : null,
     useScriptCache: workflow.generate_script,
     scriptCacheKey: workflow.cache_key,
-    aiFallback: workflow.ai_fallback,
+    aiFallback: workflow.ai_fallback ?? true,
   };
 
   const elements = getElements(

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
@@ -82,7 +82,7 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
     extraHttpHeaders: data.withWorkflowSettings ? data.extraHttpHeaders : null,
     useScriptCache: data.withWorkflowSettings ? data.useScriptCache : false,
     scriptCacheKey: data.withWorkflowSettings ? data.scriptCacheKey : null,
-    aiFallback: data.withWorkflowSettings ? data.aiFallback : false,
+    aiFallback: data.withWorkflowSettings ? data.aiFallback : true,
   });
 
   const [facing, setFacing] = useState<"front" | "back">("front");

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -705,7 +705,7 @@ function getElements(
       editable,
       useScriptCache: settings.useScriptCache,
       scriptCacheKey: settings.scriptCacheKey,
-      aiFallback: settings.aiFallback ?? false,
+      aiFallback: settings.aiFallback ?? true,
       label: "__start_block__",
       showCode: false,
     }),
@@ -1417,7 +1417,7 @@ function getWorkflowSettings(nodes: Array<AppNode>): WorkflowSettings {
     extraHttpHeaders: null,
     useScriptCache: false,
     scriptCacheKey: null,
-    aiFallback: false,
+    aiFallback: true,
   };
   const startNodes = nodes.filter(isStartNode);
   const startNodeWithWorkflowSettings = startNodes.find(

--- a/skyvern-frontend/src/store/WorkflowHasChangesStore.ts
+++ b/skyvern-frontend/src/store/WorkflowHasChangesStore.ts
@@ -116,7 +116,7 @@ const useWorkflowSave = () => {
         extra_http_headers: extraHttpHeaders,
         generate_script: saveData.settings.useScriptCache,
         cache_key: normalizedKey,
-        ai_fallback: saveData.settings.aiFallback ?? undefined,
+        ai_fallback: saveData.settings.aiFallback ?? true,
         workflow_definition: {
           parameters: saveData.parameters,
           blocks: saveData.blocks,


### PR DESCRIPTION
Frontend part for https://linear.app/skyvern/issue/SKY-6199/fallback-to-ai-on-failure-should-be-on-by-default-for-new-workflows

Backend part is https://github.com/Skyvern-AI/skyvern-cloud/pull/6134
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Set `ai_fallback` to `true` by default for new and existing workflows in the frontend.
> 
>   - **Behavior**:
>     - Default `ai_fallback` set to `true` in `Workflows.tsx` for new workflows.
>     - In `Debugger.tsx` and `WorkflowEditor.tsx`, `aiFallback` defaults to `true` if not specified.
>     - In `StartNode.tsx`, `aiFallback` defaults to `true` when `withWorkflowSettings` is true.
>   - **Utils**:
>     - In `workflowEditorUtils.ts`, `aiFallback` defaults to `true` in `getElements()` and `getWorkflowSettings()`.
>   - **Store**:
>     - In `WorkflowHasChangesStore.ts`, `ai_fallback` defaults to `true` in `useWorkflowSave()` when saving workflows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 3603cffd35827bee6a52f64a1e9d01f333dfffdd. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🤖 This PR changes the default value of AI fallback functionality from `false` to `true` across the Skyvern frontend workflow system, ensuring that new workflows automatically enable AI assistance when primary automation fails.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Default Configuration**: Updated `emptyWorkflowRequest` in `Workflows.tsx` to include `ai_fallback: true` for new workflows
- **Null Coalescing Updates**: Modified multiple components (`Debugger.tsx`, `WorkflowEditor.tsx`, `StartNode.tsx`) to use `workflow.ai_fallback ?? true` instead of relying on falsy values
- **Utility Functions**: Updated `workflowEditorUtils.ts` to default `aiFallback` to `true` in both `getElements()` and `getWorkflowSettings()` functions
- **Save Operations**: Modified `WorkflowHasChangesStore.ts` to ensure `ai_fallback` defaults to `true` when saving workflows

### Technical Implementation
```mermaid
flowchart TD
    A[New Workflow Creation] --> B[emptyWorkflowRequest with ai_fallback: true]
    C[Existing Workflow Loading] --> D{ai_fallback exists?}
    D -->|No| E[Default to true]
    D -->|Yes| F[Use existing value]
    E --> G[Workflow Components]
    F --> G
    G --> H[Debugger/Editor/StartNode]
    H --> I[Save Operation]
    I --> J[Backend with ai_fallback: true default]
```

### Impact
- **User Experience**: New workflows will automatically have AI fallback enabled, reducing manual configuration and improving automation reliability
- **Backward Compatibility**: Existing workflows maintain their current settings while benefiting from the improved default for undefined values
- **System Reliability**: Enhanced fault tolerance as workflows can now fall back to AI assistance when scripted automation encounters issues

</details>

_Created with [Palmier](https://www.palmier.io)_