### PR TITLE
retry bitwarden failed requests

### DIFF
--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -715,14 +715,16 @@ class BitwardenService:
 
     @staticmethod
     async def _unlock_using_server(master_password: str) -> None:
-        status_response = await aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/status")
+        status_response = await aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/status", retry=3, retry_timeout=15)
         status = status_response["data"]["template"]["status"]
         if status != "unlocked":
             await aiohttp_post(f"{BITWARDEN_SERVER_BASE_URL}/unlock", data={"password": master_password})
 
     @staticmethod
     async def _get_login_item_by_id_using_server(item_id: str) -> PasswordCredential:
-        response = await aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}")
+        response = await aiohttp_get_json(
+            f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, retry_timeout=15
+        )
         if not response or response.get("success") is False:
             raise BitwardenGetItemError(f"Failed to get login item by ID: {item_id}")
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add retry logic to Bitwarden API requests in `bitwarden.py` to improve reliability.
> 
>   - **Behavior**:
>     - Add retry logic to `aiohttp_get_json` calls in `_unlock_using_server()` and `_get_login_item_by_id_using_server()` in `bitwarden.py` with `retry=3` and `retry_timeout=15`.
>   - **Misc**:
>     - No changes to existing logic or error handling, only added retry parameters to specific API calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f358202bb06bac79b2432ace0125dcf3b833348c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

---

🔄 This PR adds retry logic to Bitwarden server communication methods to improve reliability when interacting with the Bitwarden server for credential management operations.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Retry Logic Addition**: Added `retry=3` and `retry_timeout=15` parameters to `aiohttp_get_json()` calls in two critical Bitwarden methods
- **Status Check Enhancement**: Modified `_unlock_using_server()` method to retry status checks when communicating with the Bitwarden server
- **Item Retrieval Resilience**: Enhanced `_get_login_item_by_id_using_server()` method to retry failed requests when fetching login credentials

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client as Skyvern Client
    participant BW as Bitwarden Service
    participant Server as Bitwarden Server
    
    Client->>BW: Request unlock/get item
    BW->>Server: HTTP Request (attempt 1)
    alt Request fails
        Server-->>BW: Error/Timeout
        BW->>Server: HTTP Request (attempt 2)
        alt Still fails
            Server-->>BW: Error/Timeout
            BW->>Server: HTTP Request (attempt 3)
        end
    else Request succeeds
        Server-->>BW: Success response
    end
    BW-->>Client: Final result or error
```

### Impact
- **Reliability Improvement**: Reduces failures due to temporary network issues or server unavailability with up to 3 retry attempts
- **User Experience**: Minimizes authentication and credential retrieval failures that could interrupt automated workflows
- **Fault Tolerance**: Provides 15-second timeout windows between retries, allowing for transient issues to resolve naturally

</details>

_Created with [Palmier](https://www.palmier.io)_