### PR TITLE
use single prompt to generate error code

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -2062,7 +2062,6 @@ class ForgeAgent:
             current_url=current_url,
             data_extraction_goal=task.data_extraction_goal,
             action_history=actions_and_results_str,
-            error_code_mapping_str=(json.dumps(task.error_code_mapping) if task.error_code_mapping else None),
             local_datetime=datetime.now(context.tz_info).isoformat(),
             verification_code_check=verification_code_check,
             complete_criterion=task.complete_criterion.strip() if task.complete_criterion else None,

--- a/skyvern/forge/prompts/skyvern/decisive-criterion-validate.j2
+++ b/skyvern/forge/prompts/skyvern/decisive-criterion-validate.j2
@@ -10,14 +10,6 @@ Reply in JSON format with the following keys:
         "reasoning": str, // The reasoning behind the action. This reasoning must be user information agnostic. Mention why you chose the action type, and why you chose the element id. Keep the reasoning short and to the point.
         "confidence_float": float, // The confidence of the action. Pick a number between 0.0 and 1.0. 0.0 means no confidence, 1.0 means full confidence
         "action_type": str, // It's a string enum: "COMPLETE", "TERMINATE". "COMPLETE" is used when the current page info has met the complete criterion. If there is no complete criterion, use "COMPLETE" as long as the page info hasn't met the terminate criterion. "TERMINATE" is used to terminate with a failure when the current page info has met the terminate criterion. It there is no terminate criterion, use "TERMINATE" as long as the page info hasn't met the complete criterion.
-{% if error_code_mapping_str %}
-        "errors": array // A list of errors. This is used to surface any errors that matches the current situation for COMPLETE and TERMINATE actions. For other actions or if no error description suits the current situation on the screenshots, return an empty list. You are allowed to return multiple errors if there are multiple errors on the page.
-        [{
-            "error_code": str, // The error code from the user's error code list
-            "reasoning": str, // The reasoning behind the error. Be specific, referencing any user information and their fields in your reasoning. Keep the reasoning short and to the point.
-            "confidence_float": float // The confidence of the error. Pick a number between 0.0 and 1.0. 0.0 means no confidence, 1.0 means full confidence
-        }]
-{% endif %}
     }]
 }
 
@@ -37,11 +29,6 @@ Complete Criterion:
 Terminate Criterion:
 ```
 {{ terminate_criterion }}
-```{% endif %}
-{% if error_code_mapping_str %}
-Use the error codes and their descriptions to surface user-defined errors. Do not return any error that's not defined by the user. User defined errors:
-```
-{{ error_code_mapping_str }}
 ```{% endif %}
 
 User details:

--- a/skyvern/forge/prompts/skyvern/extract-action.j2
+++ b/skyvern/forge/prompts/skyvern/extract-action.j2
@@ -27,15 +27,7 @@ Reply in JSON format with the following keys:
             "label": str, // the label of the option if any. MAKE SURE YOU USE THIS LABEL TO SELECT THE OPTION. DO NOT PUT ANYTHING OTHER THAN A VALID OPTION LABEL HERE
             "index": int, // the index corresponding to the option index under the select element.
             "value": str // the value of the option. MAKE SURE YOU USE THIS VALUE TO SELECT THE OPTION. DO NOT PUT ANYTHING OTHER THAN A VALID OPTION VALUE HERE
-        },
-{% if error_code_mapping_str %}
-        "errors": array // A list of errors. This is used to surface any errors that matches the current situation for COMPLETE and TERMINATE actions. For other actions or if no error description suits the current situation on the screenshots, return an empty list. You are allowed to return multiple errors if there are multiple errors on the page.
-        [{
-            "error_code": str, // The error code from the user's error code list
-            "reasoning": str, // The reasoning behind the error. Be specific, referencing any user information and their fields in your reasoning. Keep the reasoning short and to the point.
-            "confidence_float": float // The confidence of the error. Pick a number between 0.0 and 1.0. 0.0 means no confidence, 1.0 means full confidence
-        }]
-{% endif %}
+        }
     }],{% if verification_code_check %}
     "verification_code_reasoning": str, // Let's think step by step. Describe what you see and think if there is somewhere on the current page where you must enter the verification code now for login or any verification step. Explain why you believe a verification code needs to be entered somewhere or not. Do not imagine any place to enter the code if the code has not been sent yet.
     "place_to_enter_verification_code": bool, // Whether there is a place on the current page to enter the verification code now.
@@ -57,10 +49,6 @@ User goal:
 ```
 {{ navigation_goal }}
 ```
-{% if error_code_mapping_str %}
-Use the error codes and their descriptions to surface user-defined errors. Do not return any error that's not defined by the user. User defined errors:
-{{ error_code_mapping_str }}
-{% endif %}
 {% if data_extraction_goal %}
 User Data Extraction Goal:
 ```

--- a/skyvern/forge/prompts/skyvern/surface-user-defined-errors.j2
+++ b/skyvern/forge/prompts/skyvern/surface-user-defined-errors.j2
@@ -1,0 +1,39 @@
+You are here to help the user use the error codes and their descriptions to surface user-defined errors based on the screenshots, user goal, user details and the HTML elements.
+Do not return any error that's not defined by the user. 
+
+Reply in JSON format with the following keys:
+{
+    "errors": array // A list of errors. If no error description suits the current situation on the screenshots, return an empty list. You are allowed to return multiple errors if there are multiple errors on the page.
+    [{
+        "error_code": str, // The error code from the user's error code list
+        "reasoning": str, // The reasoning behind the error. Be specific, referencing any user information and their fields in your reasoning. Keep the reasoning short and to the point.
+        "confidence_float": float // The confidence of the error. Pick a number between 0.0 and 1.0. 0.0 means no confidence, 1.0 means full confidence
+    }]
+}
+
+User defined errors:
+```
+{{ error_code_mapping_str }}
+```
+
+User Goal:
+```
+{{ navigation_goal }}
+```
+
+User details:
+```
+{{ navigation_payload_str }}
+```
+
+Clickable elements from `{{ current_url }}`:
+```
+{{ elements }}
+```
+
+The URL of the page you're on right now is `{{ current_url }}`.
+
+Current datetime, ISO format:
+```
+{{ local_datetime }}
+```


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor error handling by introducing a new prompt for user-defined errors and updating handler logic to utilize it.
> 
>   - **Prompts**:
>     - Remove error code handling logic from `decisive-criterion-validate.j2` and `extract-action.j2`.
>     - Add new prompt `surface-user-defined-errors.j2` for handling user-defined errors.
>   - **Handler Logic**:
>     - Add `extract_user_defined_errors()` in `handler.py` to use the new prompt for error extraction.
>     - Update `handle_terminate_action()` and `handle_complete_action()` in `handler.py` to use `extract_user_defined_errors()` if `task.error_code_mapping` is present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 7912822e1a399687b40231abebc13ee1b1d709d0. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->