### PR TITLE
fix open source streaming in a container

### DIFF
--- a/run_streaming.py
+++ b/run_streaming.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import subprocess
 
 import structlog
@@ -6,28 +7,69 @@ import typer
 
 from skyvern.forge import app
 from skyvern.forge.sdk.api.files import get_skyvern_temp_dir
+from skyvern.forge.sdk.workflow.models.workflow import WorkflowRunStatus
+from skyvern.utils.files import get_json_from_file, get_skyvern_state_file_path, initialize_skyvern_state_file
 
 INTERVAL = 1
 LOG = structlog.get_logger()
 
 
 async def run() -> None:
-    file_name = "skyvern_screenshot.png"
-    png_file_path = f"{get_skyvern_temp_dir()}/{file_name}"
+    await initialize_skyvern_state_file(task_id=None, workflow_run_id=None, organization_id=None)
 
     while True:
+        await asyncio.sleep(INTERVAL)
+        try:
+            current_json = get_json_from_file(get_skyvern_state_file_path())
+        except Exception:
+            continue
+
+        task_id = current_json.get("task_id")
+        workflow_run_id = current_json.get("workflow_run_id")
+        organization_id = current_json.get("organization_id")
+        if not organization_id or (not task_id and not workflow_run_id):
+            continue
+
+        try:
+            if workflow_run_id:
+                workflow_run = await app.DATABASE.get_workflow_run(workflow_run_id=workflow_run_id)
+                if not workflow_run or workflow_run.status in [
+                    WorkflowRunStatus.completed,
+                    WorkflowRunStatus.failed,
+                    WorkflowRunStatus.terminated,
+                ]:
+                    continue
+                file_name = f"{workflow_run_id}.png"
+
+            elif task_id:
+                task = await app.DATABASE.get_task(task_id=task_id, organization_id=organization_id)
+                if not task or task.status.is_final():
+                    continue
+                file_name = f"{task_id}.png"
+            else:
+                continue
+        except Exception:
+            LOG.exception(
+                "Failed to get task or workflow run while taking streaming screenshot in worker",
+                task_id=task_id,
+                workflow_run_id=workflow_run_id,
+                organization_id=organization_id,
+            )
+            continue
+
+        # create f"{get_skyvern_temp_dir()}/{organization_id}" directory if it does not exists
+        os.makedirs(f"{get_skyvern_temp_dir()}/{organization_id}", exist_ok=True)
+        png_file_path = f"{get_skyvern_temp_dir()}/{organization_id}/{file_name}"
+
         # run subprocess to take screenshot
         subprocess.run(
             f"xwd -root | xwdtopnm 2>/dev/null | pnmtopng > {png_file_path}", shell=True, env={"DISPLAY": ":99"}
         )
 
-        # FIXME: upload screenshot to S3 with correct organization id
         try:
-            await app.STORAGE.save_streaming_file("placeholder_org", file_name)
+            await app.STORAGE.save_streaming_file(organization_id, file_name)
         except Exception:
-            LOG.info("Failed to save screenshot")
-
-        await asyncio.sleep(INTERVAL)
+            LOG.debug("Failed to upload screenshot", organization_id=organization_id, file_name=file_name)
 
 
 def main() -> None:


### PR DESCRIPTION
---

🔧 This PR fixes the open source streaming functionality by implementing proper state management and organization-aware screenshot handling. The changes replace hardcoded placeholder values with dynamic task/workflow tracking and ensure screenshots are saved with correct organization IDs.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **State Management**: Added initialization and monitoring of Skyvern state file to track active tasks and workflow runs
- **Dynamic Screenshot Naming**: Screenshots are now named based on task_id or workflow_run_id instead of a static filename
- **Organization-Aware Storage**: Replaced placeholder organization ID with actual organization ID from state file
- **Status Checking**: Added proper status validation to only capture screenshots for active tasks/workflows
- **Error Handling**: Improved exception handling with detailed logging for debugging

### Technical Implementation
```mermaid
flowchart TD
    A[Initialize State File] --> B[Read Current State]
    B --> C{Valid State?}
    C -->|No| B
    C -->|Yes| D{Workflow or Task?}
    D -->|Workflow| E[Check Workflow Status]
    D -->|Task| F[Check Task Status]
    E --> G{Active?}
    F --> G
    G -->|No| B
    G -->|Yes| H[Create Org Directory]
    H --> I[Take Screenshot]
    I --> J[Upload to Storage]
    J --> K[Sleep Interval]
    K --> B
```

### Impact
- **Functionality**: Streaming now works correctly in open source deployments with proper organization isolation
- **Resource Management**: Screenshots are organized by organization ID, preventing conflicts between different organizations
- **Performance**: Added status checks prevent unnecessary screenshot operations for completed tasks/workflows
- **Debugging**: Enhanced logging provides better visibility into streaming failures and state management

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves streaming screenshot handling in `run_streaming.py` by initializing state files, checking task/workflow statuses, and saving screenshots with organization IDs.
> 
>   - **Behavior**:
>     - Initializes state file with `initialize_skyvern_state_file()` in `run()`.
>     - Checks `task_id`, `workflow_run_id`, and `organization_id` from state file JSON.
>     - Handles cases where `workflow_run` or `task` is completed, failed, or terminated.
>     - Creates directory for screenshots using `os.makedirs()` with organization ID.
>     - Saves screenshots with correct organization ID using `app.STORAGE.save_streaming_file()`.
>   - **Error Handling**:
>     - Catches exceptions when reading state file and logs failures in `run()`.
>     - Logs exceptions when failing to get task or workflow run.
>     - Logs debug message on screenshot upload failure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c4015de1882932aa45351a74475d4aa6e47f46be. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->