### PR TITLE
fix generate error code bug

### DIFF
--- a/skyvern/forge/prompts/skyvern/surface-user-defined-errors.j2
+++ b/skyvern/forge/prompts/skyvern/surface-user-defined-errors.j2
@@ -3,6 +3,7 @@ Do not return any error that's not defined by the user.
 
 Reply in JSON format with the following keys:
 {
+    "reasoning": str, // A string to explain the reason for inferring the result.
     "errors": array // A list of errors. If no error description suits the current situation on the screenshots, return an empty list. You are allowed to return multiple errors if there are multiple errors on the page.
     [{
         "error_code": str, // The error code from the user's error code list

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -3736,8 +3736,8 @@ async def extract_user_defined_errors(task: Task, step: Step, scraped_page: Scra
         navigation_goal=task.navigation_goal,
         navigation_payload_str=json.dumps(task.navigation_payload),
         elements=scraped_page_refreshed.build_element_tree(fmt=ElementTreeFormat.HTML),
-        current_url=task.url,
-        error_code_mapping_str=json.dumps(task.error_code_mapping) if task.error_code_mapping else {},
+        current_url=scraped_page_refreshed.url,
+        error_code_mapping_str=json.dumps(task.error_code_mapping) if task.error_code_mapping else "{}",
         local_datetime=datetime.now(skyvern_context.ensure_context().tz_info).isoformat(),
     )
     json_response = await app.EXTRACTION_LLM_API_HANDLER(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix bug in error code generation by updating JSON response template and correcting URL and error code mapping logic in handler.
> 
>   - **Template Update**:
>     - Add `"reasoning"` key to JSON response in `surface-user-defined-errors.j2`.
>   - **Handler Logic Fix**:
>     - In `extract_user_defined_errors()` in `handler.py`, change `current_url` to `scraped_page_refreshed.url`.
>     - Correct `error_code_mapping_str` to use empty JSON object `{}` when `task.error_code_mapping` is `None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 03b955be935f10a6f6974e3e1bb8c0ba32c4dc94. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🐛 This PR fixes a bug in the error code generation system by adding a missing `reasoning` field to the JSON response format and correcting URL and error mapping parameters in the `extract_user_defined_errors()` function. The changes ensure proper error extraction and prevent potential JSON parsing issues.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Template Enhancement**: Added `reasoning` field to the JSON response format in `surface-user-defined-errors.j2` to provide explanatory context for error inference
- **URL Correction**: Fixed `current_url` parameter to use `scraped_page_refreshed.url` instead of `task.url` for accurate page context
- **Error Mapping Fix**: Corrected `error_code_mapping_str` to properly default to `"{}"` string instead of empty dict when `task.error_code_mapping` is None

### Technical Implementation
```mermaid
sequenceDiagram
    participant Handler as handler.py
    participant Template as surface-user-defined-errors.j2
    participant LLM as LLM API
    
    Handler->>Template: Pass parameters including current_url and error_code_mapping_str
    Note over Handler: Uses scraped_page_refreshed.url (fixed)
    Note over Handler: Defaults to "{}" string (fixed)
    Template->>LLM: Generate JSON with reasoning field (added)
    LLM->>Handler: Return structured error response
```

### Impact
- **Error Detection Reliability**: The `reasoning` field provides better transparency in error inference logic
- **URL Accuracy**: Using the refreshed page URL ensures error detection operates on the current page state
- **JSON Parsing Stability**: Proper string formatting of error_code_mapping prevents potential serialization issues when the mapping is None

</details>

_Created with [Palmier](https://www.palmier.io)_