### PR TITLE
selfhost debugger support part 1 -- give a VNC support flag in backend

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -3176,7 +3176,7 @@ class AgentDB:
     async def set_persistent_browser_session_browser_address(
         self,
         browser_session_id: str,
-        browser_address: str,
+        browser_address: str | None,
         ip_address: str,
         ecs_task_arn: str | None,
         organization_id: str | None = None,
@@ -3193,11 +3193,14 @@ class AgentDB:
                     )
                 ).first()
                 if persistent_browser_session:
-                    persistent_browser_session.browser_address = browser_address
-                    persistent_browser_session.ip_address = ip_address
-                    persistent_browser_session.ecs_task_arn = ecs_task_arn
-                    # once the address is set, the session is started
-                    persistent_browser_session.started_at = datetime.utcnow()
+                    if browser_address:
+                        persistent_browser_session.browser_address = browser_address
+                        # once the address is set, the session is started
+                        persistent_browser_session.started_at = datetime.utcnow()
+                    if ip_address:
+                        persistent_browser_session.ip_address = ip_address
+                    if ecs_task_arn:
+                        persistent_browser_session.ecs_task_arn = ecs_task_arn
                     await session.commit()
                     await session.refresh(persistent_browser_session)
                 else:

--- a/skyvern/webeye/schemas.py
+++ b/skyvern/webeye/schemas.py
@@ -39,6 +39,7 @@ class BrowserSessionResponse(BaseModel):
         description="Url for the browser session page",
         examples=["https://app.skyvern.com/browser-session/pbs_123456"],
     )
+    vnc_streaming_supported: bool = Field(False, description="Whether the browser session supports VNC streaming")
     started_at: datetime | None = Field(None, description="Timestamp when the session was started")
     completed_at: datetime | None = Field(None, description="Timestamp when the session was completed")
     created_at: datetime = Field(
@@ -68,6 +69,7 @@ class BrowserSessionResponse(BaseModel):
             runnable_id=browser_session.runnable_id,
             timeout=browser_session.timeout_minutes,
             browser_address=browser_session.browser_address,
+            vnc_streaming_supported=True if browser_session.ip_address else False,
             app_url=app_url,
             started_at=browser_session.started_at,
             completed_at=browser_session.completed_at,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add VNC streaming support flag to `BrowserSessionResponse` and update browser session attribute setting in `client.py`.
> 
>   - **Behavior**:
>     - Add `vnc_streaming_supported` boolean field to `BrowserSessionResponse` in `schemas.py` to indicate VNC streaming support.
>     - Modify `from_browser_session()` in `schemas.py` to set `vnc_streaming_supported` to `True` if `ip_address` is present.
>   - **Database Client**:
>     - Update `set_persistent_browser_session_browser_address()` in `client.py` to conditionally set `browser_address`, `ip_address`, and `ecs_task_arn` only if they are provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for cecaabaf7ae1178450c12f7d0a6da83604b9fcc6. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🖥️ This PR introduces VNC streaming support for self-hosted debugger functionality by adding a support flag to browser sessions and updating database handling to conditionally set browser addresses. The changes prepare the backend infrastructure for VNC-based remote debugging capabilities.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Database Layer**: Modified `set_persistent_browser_session_browser_address()` to accept nullable `browser_address` and conditionally update session fields based on parameter availability
- **API Schema**: Added `vnc_streaming_supported` boolean field to `BrowserSessionResponse` that indicates VNC capability based on IP address presence
- **Session Management**: Updated browser session logic to only set `started_at` timestamp when a valid browser address is provided

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant API
    participant Database
    participant BrowserSession
    
    Client->>API: Request browser session
    API->>Database: set_persistent_browser_session_browser_address()
    Note over Database: Conditionally set fields:<br/>- browser_address (if provided)<br/>- ip_address (if provided)<br/>- ecs_task_arn (if provided)
    Database->>API: Updated session
    API->>Client: BrowserSessionResponse with vnc_streaming_supported flag
    Note over Client: vnc_streaming_supported = true if ip_address exists
```

### Impact
- **VNC Support Detection**: Clients can now determine if a browser session supports VNC streaming through the `vnc_streaming_supported` flag
- **Flexible Session Initialization**: Database operations are more robust by handling partial session data updates without requiring all fields
- **Self-hosted Debugging Foundation**: Establishes the groundwork for remote debugging capabilities in self-hosted environments

</details>

_Created with [Palmier](https://www.palmier.io)_