### PR TITLE
fix cant turn off browser session browser

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -139,7 +139,7 @@ function Workspace({
 
   const enableDebugBrowser = useMemo(() => {
     return (
-      showBrowser || (activeDebugSession?.vnc_streaming_supported ?? false)
+      showBrowser && (activeDebugSession?.vnc_streaming_supported ?? false)
     );
   }, [showBrowser, activeDebugSession?.vnc_streaming_supported]);
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes logic in `Workspace.tsx` to correctly handle turning off the browser session by requiring both `showBrowser` and `vnc_streaming_supported` to be true.
> 
>   - **Behavior**:
>     - Fixes logic in `enableDebugBrowser` in `Workspace.tsx` to require both `showBrowser` and `activeDebugSession?.vnc_streaming_supported` to be true.
>     - Resolves issue where browser session could not be turned off when `showBrowser` was true but `vnc_streaming_supported` was false.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 75860122bb919fb53dcf7e9a2d6a4792db6b845e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes a critical logic bug in the browser session control that prevented users from turning off the debug browser when needed. The change corrects the boolean logic from OR to AND, ensuring the debug browser is only enabled when both conditions are met.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Logic Fix**: Changed `showBrowser || (activeDebugSession?.vnc_streaming_supported ?? false)` to `showBrowser && (activeDebugSession?.vnc_streaming_supported ?? false)`
- **Boolean Operator**: Replaced OR (`||`) with AND (`&&`) in the `enableDebugBrowser` useMemo hook
- **Control Flow**: Now requires both `showBrowser` flag and VNC streaming support to enable the debug browser

### Technical Implementation
```mermaid
flowchart TD
    A[User toggles showBrowser] --> B{showBrowser = true?}
    B -->|No| D[Debug Browser Disabled]
    B -->|Yes| C{VNC Streaming Supported?}
    C -->|No| D
    C -->|Yes| E[Debug Browser Enabled]
    
    style D fill:#ffcccc
    style E fill:#ccffcc
```

### Impact
- **User Control**: Users can now properly turn off the browser session when `showBrowser` is false
- **Resource Management**: Prevents unnecessary browser sessions when VNC streaming isn't supported
- **Logical Consistency**: Ensures debug browser only activates when both user preference and technical capability align

</details>

_Created with [Palmier](https://www.palmier.io)_