### PR TITLE
show turn off browser button

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
@@ -206,38 +206,36 @@ function WorkflowHeader({
           </Button>
         ) : (
           <>
-            {user && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      size="icon"
-                      variant={debugStore.isDebugMode ? "default" : "tertiary"}
-                      className="size-10 min-w-[2.5rem]"
-                      disabled={workflowRunIsRunningOrQueued}
-                      onClick={() => {
-                        if (debugStore.isDebugMode) {
-                          navigate(`/workflows/${workflowPermanentId}/edit`);
-                        } else {
-                          navigate(`/workflows/${workflowPermanentId}/debug`);
-                        }
-                      }}
-                    >
-                      {debugStore.isDebugMode ? (
-                        <BrowserIcon className="h-6 w-6" />
-                      ) : (
-                        <BrowserIcon className="h-6 w-6" />
-                      )}
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {debugStore.isDebugMode
-                      ? "Turn off Browser"
-                      : "Turn on Browser"}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="icon"
+                    variant={debugStore.isDebugMode ? "default" : "tertiary"}
+                    className="size-10 min-w-[2.5rem]"
+                    disabled={workflowRunIsRunningOrQueued}
+                    onClick={() => {
+                      if (debugStore.isDebugMode) {
+                        navigate(`/workflows/${workflowPermanentId}/edit`);
+                      } else {
+                        navigate(`/workflows/${workflowPermanentId}/debug`);
+                      }
+                    }}
+                  >
+                    {debugStore.isDebugMode ? (
+                      <BrowserIcon className="h-6 w-6" />
+                    ) : (
+                      <BrowserIcon className="h-6 w-6" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {debugStore.isDebugMode
+                    ? "Turn off Browser"
+                    : "Turn on Browser"}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>


### PR DESCRIPTION
---

🔧 This PR removes a user authentication check that was preventing the browser toggle button from being displayed, making the "Turn off Browser" functionality accessible to all users in the workflow editor.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Authentication Gate Removal**: Removed the `{user && (...)}` conditional wrapper around the browser toggle button
- **UI Accessibility**: The browser toggle button (with "Turn on Browser"/"Turn off Browser" tooltip) is now always visible
- **Code Structure**: Simplified the component structure by removing unnecessary nesting while maintaining all existing functionality

### Technical Implementation
```mermaid
flowchart TD
    A[WorkflowHeader Component] --> B{Debug Mode Check}
    B -->|Debug Mode ON| C[Show "Turn off Browser" tooltip]
    B -->|Debug Mode OFF| D[Show "Turn on Browser" tooltip]
    C --> E[Navigate to /edit route]
    D --> F[Navigate to /debug route]
    
    G[Previous: User Auth Check] -.->|REMOVED| B
    style G fill:#ffcccc,stroke:#ff0000,stroke-dasharray: 5 5
```

### Impact
- **Improved Accessibility**: All users can now access the browser toggle functionality regardless of authentication state
- **Consistent UI**: Eliminates potential confusion where the button might be hidden for some users
- **Simplified Logic**: Reduces conditional rendering complexity while maintaining the same core functionality for debug mode switching

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `user` check for browser toggle button in `WorkflowHeader.tsx`, always rendering it with tooltip based on `debugStore.isDebugMode`.
> 
>   - **Behavior**:
>     - Removes `user` check before rendering browser toggle button and tooltip in `WorkflowHeader.tsx`.
>     - Browser toggle button and tooltip are now always rendered, regardless of `user` state.
>   - **UI**:
>     - Tooltip for browser toggle button shows "Turn off Browser" or "Turn on Browser" based on `debugStore.isDebugMode`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a57faecffbfb4607851de5b48aa57af2da19702d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->