### PR TITLE
fix webhook payload schema doc

### DIFF
--- a/fern/running-tasks/webhooks-faq.mdx
+++ b/fern/running-tasks/webhooks-faq.mdx
@@ -28,16 +28,15 @@ The webhook request body is a JSON object with the following fields:
    "screenshot_urls": "URLs of the last three screenshots. The first one in the list is the latest screenshot.",
    "failure_reason": "The reason for the failure if any",
    "app_url": "The URL to the run in the Skyvern app",
-   "created_at": "The timestamp when the run was created",
-   "modified_at": "The timestamp when the run was last modified",
-   "queued_at": "The timestamp when the run was queued",
-   "started_at": "The timestamp when the run started",
-   "finished_at": "The timestamp when the run finished",
-   "app_url": "The URL to the run in the Skyvern app",
    "browser_session_id": "The ID of the browser session",
    "max_screenshot_scrolls": "The maximum number of scrolls for the post action screenshot. When it's None or 0, it takes the current viewpoint screenshot",
    "run_request": "The original request parameters used to start this task or workflow run",
    "script_run": "The script run result containing information like whether AI fallback is triggered when the script fails",
+   "created_at": "The timestamp when the run was created",
+   "modified_at": "The timestamp when the run was last modified",
+   "queued_at": "The timestamp when the run was queued",
+   "started_at": "The timestamp when the run started",
+   "finished_at": "The timestamp when the run finished"
 }
 ```
 For detailed schema, please refer to the [Run Response](/api-reference/api-reference/agent/get-run#response).


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes field order in webhook payload schema documentation in `webhooks-faq.mdx`.
> 
>   - **Documentation**:
>     - Fixes field order in webhook payload schema in `webhooks-faq.mdx` to match intended structure.
>     - Moves `created_at`, `modified_at`, `queued_at`, `started_at`, and `finished_at` fields to the end of the JSON object.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for dcfb0c7079f6ca298bce11f9f605ac6560c0c99e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->