### PR TITLE
Jon/sky 6395 refresh code while workflow is running

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -143,7 +143,7 @@ function Workspace({
       ? ""
       : cacheKeyValueParam
         ? cacheKeyValueParam
-        : constructCacheKeyValue(cacheKey, workflow),
+        : constructCacheKeyValue({ codeKey: cacheKey, workflow }),
   );
 
   useEffect(() => {

--- a/skyvern-frontend/src/routes/workflows/editor/utils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/utils.ts
@@ -1,4 +1,5 @@
 import { WorkflowApiResponse } from "@/routes/workflows/types/workflowTypes";
+import { WorkflowRunStatusApiResponse } from "@/api/types";
 import {
   isDisplayedInWorkflowEditor,
   WorkflowEditorParameterTypes,
@@ -113,23 +114,29 @@ const getInitialParameters = (workflow: WorkflowApiResponse) => {
 /**
  * Attempt to construct a valid code key value from the workflow parameters.
  */
-const constructCacheKeyValue = (
-  codeKey: string,
-  workflow?: WorkflowApiResponse,
-) => {
+const constructCacheKeyValue = (opts: {
+  codeKey: string;
+  workflow?: WorkflowApiResponse;
+  workflowRun?: WorkflowRunStatusApiResponse;
+}) => {
+  const { workflow, workflowRun } = opts;
+  let codeKey = opts.codeKey;
+
   if (!workflow) {
     return "";
   }
 
-  const workflowParameters = getInitialParameters(workflow)
-    .filter((p) => p.parameterType === "workflow")
-    .reduce(
-      (acc, parameter) => {
-        acc[parameter.key] = parameter.defaultValue;
-        return acc;
-      },
-      {} as Record<string, unknown>,
-    );
+  const workflowParameters = workflowRun
+    ? workflowRun?.parameters ?? {}
+    : getInitialParameters(workflow)
+        .filter((p) => p.parameterType === "workflow")
+        .reduce(
+          (acc, parameter) => {
+            acc[parameter.key] = parameter.defaultValue;
+            return acc;
+          },
+          {} as Record<string, unknown>,
+        );
 
   for (const [name, value] of Object.entries(workflowParameters)) {
     if (value === null || value === undefined || value === "") {

--- a/skyvern-frontend/src/routes/workflows/hooks/useBlockScriptsQuery.ts
+++ b/skyvern-frontend/src/routes/workflows/hooks/useBlockScriptsQuery.ts
@@ -7,17 +7,25 @@ type Props = {
   cacheKey?: string;
   cacheKeyValue?: string;
   workflowPermanentId?: string;
+  pollIntervalMs?: number;
 };
 
 function useBlockScriptsQuery({
   cacheKey,
   cacheKeyValue,
   workflowPermanentId,
+  pollIntervalMs,
 }: Props) {
   const credentialGetter = useCredentialGetter();
 
   return useQuery<{ [blockName: string]: string }>({
-    queryKey: ["block-scripts", workflowPermanentId, cacheKey, cacheKeyValue],
+    queryKey: [
+      "block-scripts",
+      workflowPermanentId,
+      cacheKey,
+      cacheKeyValue,
+      pollIntervalMs,
+    ],
     queryFn: async () => {
       const client = await getClient(credentialGetter, "sans-api-v1");
 
@@ -29,6 +37,12 @@ function useBlockScriptsQuery({
         .then((response) => response.data);
 
       return result.blocks;
+    },
+    refetchInterval: () => {
+      if (!pollIntervalMs || pollIntervalMs === 0) {
+        return false;
+      }
+      return Math.max(2000, pollIntervalMs);
     },
     enabled: !!workflowPermanentId,
   });


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6395/refresh-code-while-workflow-is-running
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable code refresh during workflow execution by updating cache key value construction and query polling intervals in `Workspace.tsx`, `utils.ts`, and `useBlockScriptsQuery.ts`.
> 
>   - **Behavior**:
>     - Modify `constructCacheKeyValue` in `utils.ts` to accept `workflowRun` and use its parameters if available.
>     - Update `useBlockScriptsQuery` in `useBlockScriptsQuery.ts` to include `pollIntervalMs` in `queryKey` and adjust `refetchInterval` based on `pollIntervalMs`.
>     - In `Workspace.tsx` and `WorkflowRunCode.tsx`, use `constructCacheKeyValue` with `workflowRun` and adjust cache key value handling.
>   - **UI**:
>     - Add `pollIntervalMs` prop to `useBlockScriptsQuery` in `useBlockScriptsQuery.ts` to control polling frequency.
>     - Update `WorkflowRunCode.tsx` to display code key values with a selector, highlighting the current workflow run's value.
>   - **Misc**:
>     - Adjust `useEffect` dependencies in `WorkflowRunCode.tsx` to include `workflowRun` and `parameters` for cache key value updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 13f5ad426396deac93b6875a6fdc01502cc3fe6b. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔄 This PR implements real-time code refreshing for workflow runs by adding polling capabilities to the block scripts query and enhancing cache key value management to use workflow run parameters when available.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Polling Infrastructure**: Added `pollIntervalMs` parameter to `useBlockScriptsQuery` with automatic polling every 3 seconds for running workflows (minimum 2000ms interval)
- **Cache Key Construction**: Enhanced `constructCacheKeyValue` function to prioritize workflow run parameters over default workflow parameters when available
- **UI Enhancements**: Updated `WorkflowRunCode.tsx` to disable cache key value selector during execution and highlight the current workflow run's cache key value
- **Query Management**: Added proper query invalidation and refetch logic based on workflow run status changes

### Technical Implementation
```mermaid
sequenceDiagram
    participant UI as WorkflowRunCode
    participant Hook as useBlockScriptsQuery
    participant API as Block Scripts API
    participant Cache as Query Cache
    
    UI->>Hook: Request with pollIntervalMs=3000
    Hook->>API: Fetch block scripts
    API-->>Hook: Return scripts
    Hook-->>UI: Display code
    
    Note over Hook: If workflow not finalized
    Hook->>Hook: Wait 3000ms
    Hook->>API: Refetch scripts
    API-->>Hook: Updated scripts
    Hook-->>UI: Update code display
    
    Note over UI: When workflow finalizes
    UI->>Cache: Invalidate queries
    Hook->>Hook: Stop polling
```

### Impact
- **Real-time Updates**: Users can now see generated code updating in real-time as workflows execute, providing better visibility into the automation process
- **Improved UX**: Cache key value selector is intelligently disabled during execution and shows the current run's value with visual emphasis
- **Performance Optimization**: Polling only occurs for non-finalized workflows with a sensible minimum interval to prevent excessive API calls
- **Data Consistency**: Proper query invalidation ensures the UI stays synchronized with the latest workflow run state and parameters

</details>

_Created with [Palmier](https://www.palmier.io)_