### PR TITLE
Update API specifications with fern api update

### DIFF
--- a/fern/openapi/skyvern_openapi.json
+++ b/fern/openapi/skyvern_openapi.json
@@ -8673,6 +8673,17 @@
         "title": "ScriptFileCreate",
         "description": "Model representing a file in a script."
       },
+      "ScriptRunResponse": {
+        "properties": {
+          "ai_fallback_triggered": {
+            "type": "boolean",
+            "title": "Ai Fallback Triggered",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "ScriptRunResponse"
+      },
       "SelectOption": {
         "properties": {
           "label": {
@@ -10082,6 +10093,17 @@
             ],
             "title": "Max Screenshot Scrolls",
             "description": "The maximum number of scrolls for the post action screenshot. When it's None or 0, it takes the current viewpoint screenshot"
+          },
+          "script_run": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ScriptRunResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The script run result"
           },
           "run_type": {
             "type": "string",
@@ -13232,6 +13254,17 @@
             ],
             "title": "Max Screenshot Scrolls",
             "description": "The maximum number of scrolls for the post action screenshot. When it's None or 0, it takes the current viewpoint screenshot"
+          },
+          "script_run": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ScriptRunResponse"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The script run result"
           },
           "run_type": {
             "type": "string",


### PR DESCRIPTION
Update API specifications by running fern api update.

---

📋 This PR updates the OpenAPI specification by adding a new `ScriptRunResponse` schema and integrating script run results into workflow and task run responses through automated API specification updates.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **New Schema Addition**: Introduced `ScriptRunResponse` schema with an `ai_fallback_triggered` boolean field (defaults to false)
- **API Response Enhancement**: Added optional `script_run` field to both workflow run and task run response schemas
- **Specification Synchronization**: Updated OpenAPI JSON specification file to reflect recent backend changes

### Technical Implementation
```mermaid
flowchart TD
    A[ScriptRunResponse Schema] --> B[ai_fallback_triggered: boolean]
    A --> C[Used in Workflow Runs]
    A --> D[Used in Task Runs]
    C --> E[Optional script_run field]
    D --> F[Optional script_run field]
    E --> G[Can be null or ScriptRunResponse]
    F --> H[Can be null or ScriptRunResponse]
```

### Impact
- **API Consistency**: Ensures OpenAPI specification matches the current backend implementation
- **Script Execution Tracking**: Enables clients to access script run results and AI fallback status
- **Backward Compatibility**: Changes are additive with optional fields, maintaining compatibility with existing clients

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update API specifications by adding `ScriptRunResponse` model and integrating it into existing schemas in `skyvern_openapi.json`.
> 
>   - **API Specification Update**:
>     - Adds new model `ScriptRunResponse` in `skyvern_openapi.json` with property `ai_fallback_triggered` (boolean, default: false).
>     - Integrates `ScriptRunResponse` into existing schemas with `script_run` property allowing `ScriptRunResponse` or `null` values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0915443f1e7c8f0d649af15f44c7db36c1f364f7. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->