### PR TITLE
hostfix cua click

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -536,7 +536,7 @@ async def handle_click_action(
                     if (element.hasAttribute('unique_id')) {
                         return element.getAttribute('unique_id');
                     }
-                    
+
                     // If no unique_id attribute is found, return null
                     return null;
                 }
@@ -550,8 +550,8 @@ async def handle_click_action(
         LOG.info("Clicked element at location", x=action.x, y=action.y, element_id=element_id, button=action.button)
         if element_id:
             if skyvern_element := await dom.safe_get_skyvern_element_by_id(element_id):
-                await skyvern_element.navigate_to_a_href(page=page)
-                return [ActionSuccess()]
+                if await skyvern_element.navigate_to_a_href(page=page):
+                    return [ActionSuccess()]
 
         if action.repeat == 1:
             await page.mouse.click(x=action.x, y=action.y, button=action.button)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix `handle_click_action` in `handler.py` to ensure `ActionSuccess` is returned only if navigation is successful.
> 
>   - **Behavior**:
>     - Fix `handle_click_action` in `handler.py` to return `ActionSuccess` only if `navigate_to_a_href` returns `True`.
>   - **Misc**:
>     - Remove trailing whitespace in `handler.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for c98755522b11115dfa7b584b13d9e3b5861328c1. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->