### PR TITLE
use code/use ai in workflow run ui

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/utils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/utils.ts
@@ -120,7 +120,7 @@ const constructCacheKeyValue = (opts: {
   workflowRun?: WorkflowRunStatusApiResponse;
 }) => {
   const { workflow, workflowRun } = opts;
-  let codeKey = opts.codeKey;
+  const codeKey = opts.codeKey;
 
   if (!workflow) {
     return "";
@@ -138,7 +138,20 @@ const constructCacheKeyValue = (opts: {
           {} as Record<string, unknown>,
         );
 
-  for (const [name, value] of Object.entries(workflowParameters)) {
+  return constructCacheKeyValueFromParameters({
+    codeKey,
+    parameters: workflowParameters,
+  });
+};
+
+const constructCacheKeyValueFromParameters = (opts: {
+  codeKey: string;
+  parameters: Record<string, unknown>;
+}) => {
+  const parameters = opts.parameters;
+  let codeKey = opts.codeKey;
+
+  for (const [name, value] of Object.entries(parameters)) {
     if (value === null || value === undefined || value === "") {
       continue;
     }
@@ -153,4 +166,8 @@ const constructCacheKeyValue = (opts: {
   return codeKey;
 };
 
-export { constructCacheKeyValue, getInitialParameters };
+export {
+  constructCacheKeyValue,
+  constructCacheKeyValueFromParameters,
+  getInitialParameters,
+};


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6381/enable-use-codeuse-ai-at-the-start-of-the-run-in-ui

Does not have generated code, based on input params:

<img width="932" height="852" alt="image" src="https://github.com/user-attachments/assets/fa1e52f8-51e3-4c1b-924b-73a590e3d7b5" />

Has generated code, based on input params:

<img width="908" height="744" alt="image" src="https://github.com/user-attachments/assets/137d4133-7401-4846-90dc-a63efb6f89c2" />

Has generated code, based on input params, and has selected to run with code:

<img width="919" height="859" alt="image" src="https://github.com/user-attachments/assets/1ec03ee1-44ed-4f6f-8869-940de762e675" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add options to run workflows with generated code or Skyvern Agent and enable AI fallback in `RunWorkflowForm.tsx`.
> 
>   - **Behavior**:
>     - Adds `runWithCode` and `aiFallback` options to `RunWorkflowForm.tsx` for selecting execution method and AI fallback.
>     - Updates form submission to handle `runWithCode` and `aiFallback` states.
>     - Disables `runWithCode` option if no code is generated.
>   - **UI Components**:
>     - Adds `Select` and `Switch` components for `runWithCode` and `aiFallback` in `RunWorkflowForm.tsx`.
>     - Updates form layout to include new options under "Settings".
>   - **Utilities**:
>     - Adds `constructCacheKeyValueFromParameters` function in `utils.ts` for cache key construction based on parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 4b9cd90c4c4125491a8356396f5135a6e2febbda. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🚀 This PR enhances the workflow execution UI by adding the ability to choose between running workflows with generated code or the Skyvern Agent, along with an AI fallback option for self-healing when code execution fails.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Execution Mode Selection**: Added a new "Run With" dropdown that allows users to choose between "Skyvern Agent" and "Code" execution modes
- **AI Fallback Feature**: Introduced a toggle switch for AI fallback (self-healing) that activates when code execution fails
- **Dynamic UI State**: The form now dynamically enables/disables options based on whether generated code is available for the current input parameters
- **Cache Key Management**: Enhanced cache key construction to support parameter-based code generation detection
- **Form Structure Reorganization**: Moved Browser Session ID to the Advanced Settings accordion to make room for the new execution options

### Technical Implementation
```mermaid
flowchart TD
    A[User Opens Workflow Form] --> B[Form Loads with Parameters]
    B --> C[Check for Generated Code]
    C --> D{Code Available?}
    D -->|Yes| E[Enable Code/Agent Selection]
    D -->|No| F[Default to Agent Only]
    E --> G[User Selects Execution Mode]
    G --> H{Code Selected?}
    H -->|Yes| I[Enable AI Fallback Option]
    H -->|No| J[Disable AI Fallback]
    I --> K[Submit with Code + Fallback Settings]
    J --> L[Submit with Agent Mode]
    F --> L
```

### Impact
- **Enhanced User Control**: Users can now leverage previously generated code for faster, more consistent workflow execution
- **Improved Reliability**: AI fallback provides self-healing capabilities when code execution encounters issues
- **Better UX**: Dynamic form state provides clear visual feedback about available execution options
- **Backward Compatibility**: Changes are additive and don't break existing workflow execution patterns

</details>

_Created with [Palmier](https://www.palmier.io)_