### PR TITLE
Jon/allow block scripts to be fetched with status

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -107,7 +107,7 @@ from skyvern.forge.sdk.workflow.models.workflow import (
     WorkflowRunStatus,
 )
 from skyvern.schemas.runs import ProxyLocation, RunEngine, RunType
-from skyvern.schemas.scripts import Script, ScriptBlock, ScriptFile
+from skyvern.schemas.scripts import Script, ScriptBlock, ScriptFile, ScriptStatus
 from skyvern.schemas.steps import AgentStepOutput
 from skyvern.schemas.workflows import BlockStatus, BlockType, WorkflowStatus
 from skyvern.webeye.actions.actions import Action
@@ -4088,6 +4088,7 @@ class AgentDB:
         workflow_permanent_id: str,
         cache_key_value: str,
         cache_key: str | None = None,
+        statuses: list[ScriptStatus] | None = None,
     ) -> list[Script]:
         """Get latest script versions linked to a workflow by a specific cache_key_value."""
         try:
@@ -4103,6 +4104,9 @@ class AgentDB:
 
                 if cache_key is not None:
                     ws_script_ids_subquery = ws_script_ids_subquery.where(WorkflowScriptModel.cache_key == cache_key)
+
+                if statuses is not None and len(statuses) > 0:
+                    ws_script_ids_subquery = ws_script_ids_subquery.where(WorkflowScriptModel.status.in_(statuses))
 
                 # Latest version per script_id within the org and not deleted
                 latest_versions_subquery = (

--- a/skyvern/forge/sdk/routes/scripts.py
+++ b/skyvern/forge/sdk/routes/scripts.py
@@ -295,12 +295,14 @@ async def get_workflow_script_blocks(
         raise HTTPException(status_code=404, detail="Workflow not found")
 
     cache_key = block_script_request.cache_key or workflow.cache_key or ""
+    status = block_script_request.status
 
     scripts = await app.DATABASE.get_workflow_scripts_by_cache_key_value(
         organization_id=current_org.organization_id,
         workflow_permanent_id=workflow_permanent_id,
         cache_key_value=cache_key_value,
         cache_key=cache_key,
+        statuses=[status] if status else None,
     )
 
     if not scripts:

--- a/skyvern/schemas/scripts.py
+++ b/skyvern/schemas/scripts.py
@@ -154,6 +154,7 @@ class ScriptBlocksResponse(BaseModel):
 class ScriptBlocksRequest(BaseModel):
     cache_key_value: str
     cache_key: str | None = None
+    status: ScriptStatus | None = None
 
 
 class ScriptStatus(StrEnum):


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6446/allow-block-scripts-to-be-fetched-by-status
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add status-based filtering for fetching workflow scripts in `client.py` and update `get_workflow_script_blocks` in `scripts.py` to utilize this feature.
> 
>   - **Behavior**:
>     - `get_workflow_scripts_by_cache_key_value` in `client.py` now accepts a `statuses` parameter to filter scripts by status.
>     - `get_workflow_script_blocks` in `scripts.py` updated to pass `status` from `ScriptBlocksRequest` to `get_workflow_scripts_by_cache_key_value`.
>   - **Models**:
>     - `ScriptBlocksRequest` in `scripts.py` now includes a `status` field of type `ScriptStatus`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 02e8f9b3bbecd4bea3ff5a4d11f883e0abd36e9d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->