### PR TITLE
In Workflow Settings, disable the "Generate Code" toggle, and always set it to `true`.

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
@@ -72,7 +72,7 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
       ? data.maxScreenshotScrolls
       : null,
     extraHttpHeaders: data.withWorkflowSettings ? data.extraHttpHeaders : null,
-    useScriptCache: data.withWorkflowSettings ? data.useScriptCache : false,
+    useScriptCache: data.withWorkflowSettings ? data.useScriptCache : true, // TODO(jdo/always-generate): set to false
     scriptCacheKey: data.withWorkflowSettings ? data.scriptCacheKey : null,
     aiFallback: data.withWorkflowSettings ? data.aiFallback : true,
     runSequentially: data.withWorkflowSettings ? data.runSequentially : false,
@@ -211,11 +211,14 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
                             <Label>Generate Code</Label>
                             <HelpTooltip content="Generate & use cached code for faster execution." />
                             <Switch
+                              disabled={true} // TODO(jdo/always-generate): remove
                               className="ml-auto"
-                              checked={inputs.useScriptCache}
-                              onCheckedChange={(value) => {
-                                handleChange("useScriptCache", value);
-                              }}
+                              checked={true} // TODO(jdo/always-generate): set to `inputs.useScriptCache`
+                              onCheckedChange={
+                                (/*value*/) => {
+                                  // handleChange("useScriptCache", value); // TODO(jdo/always-generate): put back
+                                }
+                              }
                             />
                           </div>
                         </div>


### PR DESCRIPTION
In Workflow Settings, disable the "Generate Code" toggle, and always set it to `true`. 

https://linear.app/skyvern/issue/SKY-6445/make-generate-code-always-enabled-and-not-editable-in-debugger
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> In `StartNode.tsx`, disable 'Generate Code' toggle and set `useScriptCache` to always be `true`.
> 
>   - **Behavior**:
>     - In `StartNode.tsx`, the `useScriptCache` is always set to `true` when `data.withWorkflowSettings` is true.
>     - The 'Generate Code' toggle switch is disabled and always checked.
>   - **UI Changes**:
>     - The `Switch` component for 'Generate Code' is disabled and hardcoded to `true`.
>     - `onCheckedChange` handler for the switch is commented out.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2d649080d2aec44a305be9f649fe7c2142470447. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔒 This PR disables the "Generate Code" toggle in workflow settings and forces it to always be enabled (`true`), preventing users from turning off code generation functionality. The change affects the StartNode component by making the switch non-interactive and setting `useScriptCache` to always be true by default.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **UI Component**: The "Generate Code" switch in StartNode is now disabled and always shows as checked
- **Default Behavior**: `useScriptCache` property now defaults to `true` instead of `false` when workflow settings are not present
- **Event Handling**: The `onCheckedChange` handler for the switch is commented out, making it non-functional
- **Temporary Implementation**: All changes include TODO comments indicating this is a temporary solution with plans to revert

### Technical Implementation
```mermaid
flowchart TD
    A[StartNode Component] --> B{withWorkflowSettings?}
    B -->|Yes| C[Use data.useScriptCache]
    B -->|No| D[Set useScriptCache = true]
    C --> E[Render Disabled Switch]
    D --> E
    E --> F[Switch Always Checked = true]
    F --> G[onCheckedChange = no-op]
```

### Impact
- **User Experience**: Users can no longer disable code generation, ensuring consistent behavior across workflows
- **Performance**: Code caching will always be enabled, potentially improving execution speed
- **Maintainability**: The TODO comments suggest this is a temporary measure, indicating future refactoring is planned to make this configurable again

</details>

_Created with [Palmier](https://www.palmier.io)_