### PR TITLE
add more credential request retries

### DIFF
--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -881,7 +881,9 @@ class BitwardenService:
 
     @staticmethod
     async def _create_collection_using_server(bw_organization_id: str, name: str) -> str:
-        collection_template_response = await aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/object/template/collection")
+        collection_template_response = await aiohttp_get_json(
+            f"{BITWARDEN_SERVER_BASE_URL}/object/template/collection", retry=3, retry_timeout=15
+        )
         collection_template = collection_template_response["data"]["template"]
 
         collection_template["name"] = name
@@ -922,7 +924,10 @@ class BitwardenService:
     @staticmethod
     async def _get_items_by_item_ids_using_server(item_ids: list[str]) -> list[CredentialItem]:
         responses = await asyncio.gather(
-            *[aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}") for item_id in item_ids]
+            *[
+                aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, retry_timeout=15)
+                for item_id in item_ids
+            ]
         )
         if not responses or any(response.get("success") is False for response in responses):
             raise BitwardenGetItemError("Failed to get collection items")
@@ -942,7 +947,9 @@ class BitwardenService:
 
     @staticmethod
     async def _get_collection_items_using_server(collection_id: str) -> list[CredentialItem]:
-        response = await aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/list/object/items?collectionId={collection_id}")
+        response = await aiohttp_get_json(
+            f"{BITWARDEN_SERVER_BASE_URL}/list/object/items?collectionId={collection_id}", retry=3, retry_timeout=15
+        )
         if not response or response.get("success") is False:
             raise BitwardenGetItemError("Failed to get collection items")
 
@@ -963,7 +970,9 @@ class BitwardenService:
 
     @staticmethod
     async def _get_credential_item_by_id_using_server(item_id: str) -> CredentialItem:
-        response = await aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}")
+        response = await aiohttp_get_json(
+            f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, retry_timeout=15
+        )
         if not response or response.get("success") is False:
             raise BitwardenGetItemError(f"Failed to get credential item by ID: {item_id}")
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add retry logic to Bitwarden API calls in `bitwarden.py` to improve reliability.
> 
>   - **Behavior**:
>     - Added retry logic to `aiohttp_get_json` calls in `_create_collection_using_server`, `_get_items_by_item_ids_using_server`, `_get_collection_items_using_server`, and `_get_credential_item_by_id_using_server` with `retry=3` and `retry_timeout=15`.
>   - **Functions**:
>     - Updated `_create_collection_using_server` to include retry logic for collection template retrieval.
>     - Updated `_get_items_by_item_ids_using_server` to include retry logic for item retrieval by ID.
>     - Updated `_get_collection_items_using_server` to include retry logic for collection item retrieval.
>     - Updated `_get_credential_item_by_id_using_server` to include retry logic for credential item retrieval by ID.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 947c3e9ef9cf6a691606bc2eaebb2d01fccd976c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->