### PR TITLE
add run_with to workflow_runs table

### DIFF
--- a/skyvern/forge/sdk/db/models.py
+++ b/skyvern/forge/sdk/db/models.py
@@ -286,6 +286,7 @@ class WorkflowRunModel(Base):
     browser_address = Column(String, nullable=True)
     script_run = Column(JSON, nullable=True)
     job_id = Column(String, nullable=True)
+    run_with = Column(String, nullable=True)  # 'agent' or 'code'
 
     queued_at = Column(DateTime, nullable=True)
     started_at = Column(DateTime, nullable=True)


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6449/add-run-with-column-to-workflow-runs-table
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `run_with` column to `workflow_runs` table and `WorkflowRunModel` to specify execution context ('agent' or 'code').
> 
>   - **Database Schema**:
>     - Add `run_with` column to `workflow_runs` table in `add_run_with_to_workflow_runs_table.py`.
>     - Supports `upgrade` and `downgrade` operations for adding and removing the column.
>   - **Models**:
>     - Add `run_with` column to `WorkflowRunModel` in `models.py`, allowing values 'agent' or 'code'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 788882036b0d2f20a9c0bb8d673cc97b17a35169. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->