### PR TITLE
Jon/hotfix always allow cache key edit

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
@@ -222,41 +222,39 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
                             />
                           </div>
                         </div>
-                        {inputs.useScriptCache && (
-                          <div className="flex flex-col gap-4 rounded-md bg-slate-elevation4 p-4 pl-4">
-                            <div className="space-y-2">
-                              <div className="flex gap-2">
-                                <Label>Code Key (optional)</Label>
-                                <HelpTooltip content="A static or dynamic key for directing code generation." />
-                              </div>
-                              <WorkflowBlockInputTextarea
-                                nodeId={id}
-                                onChange={(value) => {
-                                  const v = value.length ? value : null;
-                                  handleChange("scriptCacheKey", v);
+                        {/* {inputs.useScriptCache && (  .. // TODO(jdo/always-generate): put back */}
+                        <div className="flex flex-col gap-4 rounded-md bg-slate-elevation4 p-4 pl-4">
+                          <div className="space-y-2">
+                            <div className="flex gap-2">
+                              <Label>Code Key (optional)</Label>
+                              <HelpTooltip content="A static or dynamic key for directing code generation." />
+                            </div>
+                            <WorkflowBlockInputTextarea
+                              nodeId={id}
+                              onChange={(value) => {
+                                const v = value.length ? value : null;
+                                handleChange("scriptCacheKey", v);
+                              }}
+                              value={inputs.scriptCacheKey ?? ""}
+                              placeholder={placeholders["scripts"]["scriptKey"]}
+                              className="nopan text-xs"
+                            />
+                          </div>
+                          <div className="space-y-2">
+                            <div className="flex items-center gap-2">
+                              <Label>Fallback To AI On Failure</Label>
+                              <HelpTooltip content="If cached code fails, fallback to AI." />
+                              <Switch
+                                className="ml-auto"
+                                checked={inputs.aiFallback}
+                                onCheckedChange={(value) => {
+                                  handleChange("aiFallback", value);
                                 }}
-                                value={inputs.scriptCacheKey ?? ""}
-                                placeholder={
-                                  placeholders["scripts"]["scriptKey"]
-                                }
-                                className="nopan text-xs"
                               />
                             </div>
-                            <div className="space-y-2">
-                              <div className="flex items-center gap-2">
-                                <Label>Fallback To AI On Failure</Label>
-                                <HelpTooltip content="If cached code fails, fallback to AI." />
-                                <Switch
-                                  className="ml-auto"
-                                  checked={inputs.aiFallback}
-                                  onCheckedChange={(value) => {
-                                    handleChange("aiFallback", value);
-                                  }}
-                                />
-                              </div>
-                            </div>
                           </div>
-                        )}
+                        </div>
+                        {/* )} */}
                       </div>
                       <div className="space-y-2">
                         <div className="flex items-center gap-2">


### PR DESCRIPTION
https://github.com/Skyvern-AI/skyvern-cloud/pull/6342 always set "Generate Code" to `true`. But it did not show the cache key, which we must always allow folks to edit.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Always display cache key input in `StartNode.tsx`, regardless of `useScriptCache` setting, with `Generate Code` switch disabled and checked.
> 
>   - **Behavior**:
>     - Always display the cache key input in `StartNode.tsx`, regardless of `useScriptCache` setting.
>     - Keeps `Generate Code` switch disabled and always checked.
>   - **Comments**:
>     - Adds TODO comments for future re-enabling of `useScriptCache` logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a6fd147074df405ba9e96a05d49245aefb7cc5f2. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This hotfix removes conditional rendering of the cache key input field in the StartNode component, ensuring users can always edit the cache key regardless of the `useScriptCache` setting. This addresses an issue where a previous change always enabled code generation but inadvertently hid the cache key input field.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **UI Visibility**: Removed conditional rendering that previously hid the cache key input when `useScriptCache` was false
- **Code Structure**: Commented out the `useScriptCache` conditional wrapper while preserving the original logic for future reference
- **User Experience**: Cache key input and AI fallback switch are now always visible and editable

### Technical Implementation
```mermaid
flowchart TD
    A[StartNode Component] --> B{Previous: useScriptCache?}
    B -->|Yes| C[Show Cache Key Input]
    B -->|No| D[Hide Cache Key Input]
    
    A --> E[New: Always Show]
    E --> F[Cache Key Input Always Visible]
    E --> G[AI Fallback Switch Always Visible]
    
    style C fill:#90EE90
    style F fill:#90EE90
    style D fill:#FFB6C1
```

### Impact
- **User Control**: Users can now always configure cache keys, providing consistent access to caching functionality
- **Workflow Flexibility**: Maintains the ability to set cache keys even when code generation is always enabled
- **Backward Compatibility**: No breaking changes to existing functionality, only expands UI availability

</details>

_Created with [Palmier](https://www.palmier.io)_