### PR TITLE
Jon/sky 5969 ensure generate script and script key cross export import boundary

### DIFF
--- a/skyvern-frontend/src/routes/workflows/Workflows.tsx
+++ b/skyvern-frontend/src/routes/workflows/Workflows.tsx
@@ -50,6 +50,7 @@ const emptyWorkflowRequest: WorkflowCreateYAMLRequest = {
   title: "New Workflow",
   description: "",
   ai_fallback: true,
+  generate_script: true,
   workflow_definition: {
     blocks: [],
     parameters: [],

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -2130,6 +2130,10 @@ function convert(workflow: WorkflowApiResponse): WorkflowCreateYAMLRequest {
       blocks: convertBlocksToBlockYAML(workflow.workflow_definition.blocks),
     },
     is_saved_task: workflow.is_saved_task,
+    generate_script: workflow.generate_script,
+    cache_key: workflow.cache_key,
+    ai_fallback: workflow.ai_fallback ?? undefined,
+    run_sequentially: workflow.run_sequentially ?? undefined,
   };
 }
 

--- a/skyvern/forge/sdk/routes/scripts.py
+++ b/skyvern/forge/sdk/routes/scripts.py
@@ -248,10 +248,6 @@ async def deploy_script(
     description="Run a script",
     tags=["Scripts"],
 )
-@base_router.post(
-    "/scripts/{script_id}/run/",
-    include_in_schema=False,
-)
 async def run_script(
     request: Request,
     background_tasks: BackgroundTasks,
@@ -279,11 +275,6 @@ async def run_script(
 
 @base_router.post(
     "/scripts/{workflow_permanent_id}/blocks",
-    include_in_schema=False,
-    response_model=ScriptBlocksResponse,
-)
-@base_router.post(
-    "/scripts/{workflow_permanent_id}/blocks/",
     include_in_schema=False,
     response_model=ScriptBlocksResponse,
 )
@@ -441,11 +432,6 @@ async def get_workflow_script_blocks(
     include_in_schema=False,
     response_model=ScriptCacheKeyValuesResponse,
 )
-@base_router.get(
-    "/scripts/{workflow_permanent_id}/{cache_key}/values/",
-    include_in_schema=False,
-    response_model=ScriptCacheKeyValuesResponse,
-)
 async def get_workflow_cache_key_values(
     workflow_permanent_id: str,
     cache_key: str,
@@ -503,10 +489,6 @@ async def get_workflow_cache_key_values(
 
 @base_router.delete(
     "/scripts/{workflow_permanent_id}/value",
-    include_in_schema=False,
-)
-@base_router.delete(
-    "/scripts/{workflow_permanent_id}/value/",
     include_in_schema=False,
 )
 async def delete_workflow_cache_key_value(


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-5969/ensure-generate-script-and-script-key-cross-export-import-boundary
- add missing workflow attrs to export
- ensure new workflows via '+ Create' button have 'generate_script' set to true
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure new workflows have `generate_script` set to true and add missing attributes to workflow exports, while removing unused API endpoints.
> 
>   - **Behavior**:
>     - Ensure new workflows created via '+ Create' button in `Workflows.tsx` have `generate_script` set to true.
>     - Add `generate_script`, `cache_key`, `ai_fallback`, and `run_sequentially` to export in `convert()` in `workflowEditorUtils.ts`.
>   - **API Changes**:
>     - Remove unused endpoints in `scripts.py`: `/scripts/{script_id}/run/`, `/scripts/{workflow_permanent_id}/blocks/`, `/scripts/{workflow_permanent_id}/{cache_key}/values/`, and `/scripts/{workflow_permanent_id}/value/`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6fa679d8f88f8a6a129eda97d275677381ad8f0a. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR ensures workflow script generation and caching attributes are properly preserved across export/import operations and sets appropriate defaults for new workflows.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Frontend Workflow Creation**: Added `generate_script: true` to the default workflow template in `Workflows.tsx` to ensure new workflows have script generation enabled by default
- **Export/Import Completeness**: Enhanced the `convert()` function in `workflowEditorUtils.ts` to include missing workflow attributes (`generate_script`, `cache_key`, `ai_fallback`, `run_sequentially`) during export operations
- **API Route Cleanup**: Removed duplicate route definitions in `scripts.py` that were causing schema conflicts (removed `include_in_schema=False` duplicates)

### Technical Implementation
```mermaid
flowchart TD
    A[User Creates New Workflow] --> B[emptyWorkflowRequest Template]
    B --> C[generate_script: true Set]
    
    D[Workflow Export] --> E[convert() Function]
    E --> F[Include generate_script]
    E --> G[Include cache_key]
    E --> H[Include ai_fallback]
    E --> I[Include run_sequentially]
    
    J[API Routes] --> K[Remove Duplicate Definitions]
    K --> L[Clean Schema Generation]
```

### Impact
- **Data Integrity**: Ensures all workflow configuration attributes are preserved during export/import cycles, preventing loss of script generation settings
- **User Experience**: New workflows automatically have script generation enabled, providing consistent behavior for users
- **API Consistency**: Cleaned up duplicate route definitions that could cause confusion in API documentation and schema generation

</details>

_Created with [Palmier](https://www.palmier.io)_