### PR TITLE
downloaded files in pbs response

### DIFF
--- a/skyvern/forge/sdk/artifact/storage/base.py
+++ b/skyvern/forge/sdk/artifact/storage/base.py
@@ -136,6 +136,12 @@ class BaseStorage(ABC):
         pass
 
     @abstractmethod
+    async def get_shared_downloaded_files_in_browser_session(
+        self, organization_id: str, browser_session_id: str
+    ) -> list[FileInfo]:
+        pass
+
+    @abstractmethod
     async def save_downloaded_files(self, organization_id: str, run_id: str | None) -> None:
         pass
 

--- a/skyvern/forge/sdk/artifact/storage/local.py
+++ b/skyvern/forge/sdk/artifact/storage/local.py
@@ -215,6 +215,11 @@ class LocalStorage(BaseStorage):
     ) -> list[str]:
         return []
 
+    async def get_shared_downloaded_files_in_browser_session(
+        self, organization_id: str, browser_session_id: str
+    ) -> list[FileInfo]:
+        return []
+
     async def list_downloading_files_in_browser_session(
         self, organization_id: str, browser_session_id: str
     ) -> list[str]:

--- a/skyvern/webeye/schemas.py
+++ b/skyvern/webeye/schemas.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime
 
+import structlog
 from pydantic import BaseModel, Field
 
 from skyvern.config import settings
+from skyvern.constants import GET_DOWNLOADED_FILES_TIMEOUT
+from skyvern.forge.sdk.artifact.storage.base import BaseStorage
+from skyvern.forge.sdk.schemas.files import FileInfo
 from skyvern.forge.sdk.schemas.persistent_browser_sessions import PersistentBrowserSession
+
+LOG = structlog.get_logger()
 
 
 class BrowserSessionResponse(BaseModel):
@@ -40,6 +47,10 @@ class BrowserSessionResponse(BaseModel):
         examples=["https://app.skyvern.com/browser-session/pbs_123456"],
     )
     vnc_streaming_supported: bool = Field(False, description="Whether the browser session supports VNC streaming")
+    download_path: str | None = Field(None, description="The path where the browser session downloads files")
+    downloaded_files: list[FileInfo] | None = Field(
+        None, description="The list of files downloaded by the browser session"
+    )
     started_at: datetime | None = Field(None, description="Timestamp when the session was started")
     completed_at: datetime | None = Field(None, description="Timestamp when the session was completed")
     created_at: datetime = Field(
@@ -49,7 +60,9 @@ class BrowserSessionResponse(BaseModel):
     deleted_at: datetime | None = Field(None, description="Timestamp when the session was deleted, if applicable")
 
     @classmethod
-    def from_browser_session(cls, browser_session: PersistentBrowserSession) -> BrowserSessionResponse:
+    async def from_browser_session(
+        cls, browser_session: PersistentBrowserSession, storage: BaseStorage | None = None
+    ) -> BrowserSessionResponse:
         """
         Creates a BrowserSessionResponse from a PersistentBrowserSession object.
 
@@ -62,6 +75,22 @@ class BrowserSessionResponse(BaseModel):
         app_url = (
             f"{settings.SKYVERN_APP_URL.rstrip('/')}/browser-session/{browser_session.persistent_browser_session_id}"
         )
+        download_path = (
+            f"/app/downloads/{browser_session.organization_id}/{browser_session.persistent_browser_session_id}"
+        )
+        downloaded_files: list[FileInfo] = []
+        if storage:
+            try:
+                async with asyncio.timeout(GET_DOWNLOADED_FILES_TIMEOUT):
+                    downloaded_files = await storage.get_shared_downloaded_files_in_browser_session(
+                        organization_id=browser_session.organization_id,
+                        browser_session_id=browser_session.persistent_browser_session_id,
+                    )
+            except asyncio.TimeoutError:
+                LOG.warning(
+                    "Timeout getting downloaded files", browser_session_id=browser_session.persistent_browser_session_id
+                )
+
         return cls(
             browser_session_id=browser_session.persistent_browser_session_id,
             organization_id=browser_session.organization_id,
@@ -76,4 +105,6 @@ class BrowserSessionResponse(BaseModel):
             created_at=browser_session.created_at,
             modified_at=browser_session.modified_at,
             deleted_at=browser_session.deleted_at,
+            download_path=download_path,
+            downloaded_files=downloaded_files,
         )


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds functionality to retrieve and display downloaded files in browser sessions, updating storage classes and browser session responses.
> 
>   - **Behavior**:
>     - Adds `get_shared_downloaded_files_in_browser_session()` to `BaseStorage` and implements in `local.py` and `s3.py`.
>     - Updates `BrowserSessionResponse` in `schemas.py` to include `download_path` and `downloaded_files`.
>     - Updates `get_browser_session()` and `get_browser_sessions()` in `browser_sessions.py` to use `BrowserSessionResponse.from_browser_session()` with storage.
>   - **Misc**:
>     - Adds logging for timeout in `schemas.py` when retrieving downloaded files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 63cd1e700b024c0d80c439235e05b5ee092019eb. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

📁 This PR adds functionality to retrieve and include downloaded files information in browser session responses, enabling users to access files downloaded during their browser sessions through the API.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Storage Interface**: Added new abstract method `get_shared_downloaded_files_in_browser_session()` to `BaseStorage` class for retrieving downloaded files with metadata
- **S3 Implementation**: Implemented the method in `S3Storage` to fetch file metadata, generate presigned URLs, and return `FileInfo` objects with checksums and original filenames
- **Local Storage**: Added stub implementation in `LocalStorage` that returns empty list (no local file sharing support)
- **API Response Enhancement**: Extended `BrowserSessionResponse` schema to include `download_path` and `downloaded_files` fields
- **Async Conversion**: Modified browser session route handlers to use async `from_browser_session()` method with timeout handling

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant API
    participant Storage
    participant S3

    Client->>API: GET /browser-sessions/{id}
    API->>Storage: get_shared_downloaded_files_in_browser_session()
    Storage->>S3: list_downloaded_files_in_browser_session()
    S3-->>Storage: file keys
    Storage->>S3: get_file_metadata() for each file
    S3-->>Storage: metadata with checksums
    Storage->>S3: create_presigned_urls()
    S3-->>Storage: presigned URLs
    Storage-->>API: FileInfo objects
    API-->>Client: BrowserSessionResponse with downloaded_files
```

### Impact
- **Enhanced User Experience**: Users can now see and access files downloaded during browser sessions directly through the API
- **File Management**: Provides structured access to downloaded files with metadata including checksums and original filenames
- **Timeout Protection**: Implements timeout handling (GET_DOWNLOADED_FILES_TIMEOUT) to prevent API slowdowns when retrieving file information
- **Backward Compatibility**: New fields are optional, maintaining compatibility with existing API consumers

</details>

_Created with [Palmier](https://www.palmier.io)_