### PR TITLE
Revert "In Workflow Settings, disable the "Generate Code" toggle, and always set it to `true`."

### DIFF
--- a/skyvern-frontend/src/routes/workflows/Workflows.tsx
+++ b/skyvern-frontend/src/routes/workflows/Workflows.tsx
@@ -50,7 +50,7 @@ const emptyWorkflowRequest: WorkflowCreateYAMLRequest = {
   title: "New Workflow",
   description: "",
   ai_fallback: true,
-  generate_script: true,
+  generate_script: false,
   workflow_definition: {
     blocks: [],
     parameters: [],

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
@@ -72,7 +72,7 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
       ? data.maxScreenshotScrolls
       : null,
     extraHttpHeaders: data.withWorkflowSettings ? data.extraHttpHeaders : null,
-    useScriptCache: data.withWorkflowSettings ? data.useScriptCache : true, // TODO(jdo/always-generate): set to false
+    useScriptCache: data.withWorkflowSettings ? data.useScriptCache : false,
     scriptCacheKey: data.withWorkflowSettings ? data.scriptCacheKey : null,
     aiFallback: data.withWorkflowSettings ? data.aiFallback : true,
     runSequentially: data.withWorkflowSettings ? data.runSequentially : false,
@@ -211,14 +211,11 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
                             <Label>Generate Code</Label>
                             <HelpTooltip content="Generate & use cached code for faster execution." />
                             <Switch
-                              disabled={true} // TODO(jdo/always-generate): remove
                               className="ml-auto"
-                              checked={true} // TODO(jdo/always-generate): set to `inputs.useScriptCache`
-                              onCheckedChange={
-                                (/*value*/) => {
-                                  // handleChange("useScriptCache", value); // TODO(jdo/always-generate): put back
-                                }
-                              }
+                              checked={inputs.useScriptCache}
+                              onCheckedChange={(value) => {
+                                handleChange("useScriptCache", value);
+                              }}
                             />
                           </div>
                         </div>


### PR DESCRIPTION
Reverts Skyvern-AI/skyvern-cloud#6342
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reverts previous change to re-enable 'Generate Code' toggle in workflow settings, restoring user control over code generation.
> 
>   - **Behavior**:
>     - Reverts always-true setting for `generate_script` in `Workflows.tsx` to allow toggling.
>     - Restores `useScriptCache` toggle functionality in `StartNode.tsx`, allowing user control.
>   - **UI Changes**:
>     - Re-enables `Generate Code` toggle switch in `StartNode.tsx` UI.
>     - Removes `disabled` and `checked` hardcoding for `Switch` component in `StartNode.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for b8aba3e2fe2319a00c7f1d43b436e01c67c31c80. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->