### PR TITLE
fix input on blocking element issue

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -1178,7 +1178,9 @@ async def handle_input_text_action(
             LOG.warning(
                 "Find a blocking element to the current element, going to input on the blocking element",
             )
-            skyvern_element = blocking_element
+            if await blocking_element.is_editable():
+                skyvern_element = blocking_element
+                tag_name = blocking_element.get_tag_name()
     except Exception:
         LOG.info(
             "Failed to find the blocking element, continue with the original element",

--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -285,6 +285,17 @@ class SkyvernElement:
         skyvern_frame = await SkyvernFrame.create_instance(self.get_frame())
         return await skyvern_frame.get_element_visible(await self.get_element_handler())
 
+    async def is_editable(self, timeout: float = settings.BROWSER_ACTION_TIMEOUT_MS) -> bool:
+        try:
+            return await self.get_locator().is_editable(timeout=timeout)
+        except Exception:
+            LOG.info(
+                "Failed to check element editable, considering it's not editable",
+                exc_info=True,
+                element_id=self.get_id(),
+            )
+            return False
+
     async def is_parent_of(self, target: ElementHandle) -> bool:
         skyvern_frame = await SkyvernFrame.create_instance(self.get_frame())
         return await skyvern_frame.is_parent(await self.get_element_handler(), target)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix input on blocking element by checking if it's editable in `handle_input_text_action()` in `handler.py`.
> 
>   - **Behavior**:
>     - In `handle_input_text_action()` in `handler.py`, added a check to ensure `blocking_element` is editable before inputting text on it.
>   - **Functions**:
>     - Added `is_editable()` method to `SkyvernElement` in `dom.py` to check if an element is editable, with a timeout parameter.
>   - **Logging**:
>     - Logs a message if checking editability fails in `is_editable()` in `dom.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 598f794c42afde419c166933e647328494545717. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents text from being redirected to non-editable blocking elements, ensuring input goes to the intended field.
  - Reduces errors when overlays or intercepting elements appear during typing.

- Improvements
  - Adds editability detection for elements to make input handling more reliable.
  - Falls back safely when editability checks fail, improving stability and reducing unexpected exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->