### PR TITLE
Add payload functionality to our experimentation framework

### DIFF
--- a/skyvern/forge/sdk/experimentation/providers.py
+++ b/skyvern/forge/sdk/experimentation/providers.py
@@ -53,9 +53,8 @@ class BaseExperimentationProvider(ABC):
             payload = self.get_payload(feature_name, distinct_id, properties)
             self.payload_map[feature_name][distinct_id] = payload
             if payload:
-                LOG.info("Feature payload is found", flag=feature_name, distinct_id=distinct_id, payload=payload)
+                LOG.info("Feature payload is found", flag=feature_name, distinct_id=distinct_id)
         return self.payload_map[feature_name][distinct_id]
-
 
 class NoOpExperimentationProvider(BaseExperimentationProvider):
     def is_feature_enabled(self, feature_name: str, distinct_id: str, properties: dict | None = None) -> bool:

--- a/skyvern/forge/sdk/experimentation/providers.py
+++ b/skyvern/forge/sdk/experimentation/providers.py
@@ -9,6 +9,7 @@ class BaseExperimentationProvider(ABC):
     # feature_name -> distinct_id -> result
     result_map: dict[str, dict[str, bool]] = {}
     variant_map: dict[str, dict[str, str | None]] = {}
+    payload_map: dict[str, dict[str, str | None]] = {}
 
     @abstractmethod
     def is_feature_enabled(self, feature_name: str, distinct_id: str, properties: dict | None = None) -> bool:
@@ -29,6 +30,10 @@ class BaseExperimentationProvider(ABC):
     def get_value(self, feature_name: str, distinct_id: str, properties: dict | None = None) -> str | None:
         """Get the value of a feature."""
 
+    @abstractmethod
+    def get_payload(self, feature_name: str, distinct_id: str, properties: dict | None = None) -> str | None:
+        """Get the payload for a feature flag if it exists."""
+
     def get_value_cached(self, feature_name: str, distinct_id: str, properties: dict | None = None) -> str | None:
         """Get the value of a feature."""
         if feature_name not in self.variant_map:
@@ -40,10 +45,24 @@ class BaseExperimentationProvider(ABC):
                 LOG.info("Feature is found", flag=feature_name, distinct_id=distinct_id, variant=variant)
         return self.variant_map[feature_name][distinct_id]
 
+    def get_payload_cached(self, feature_name: str, distinct_id: str, properties: dict | None = None) -> str | None:
+        """Get the payload for a feature flag if it exists."""
+        if feature_name not in self.payload_map:
+            self.payload_map[feature_name] = {}
+        if distinct_id not in self.payload_map[feature_name]:
+            payload = self.get_payload(feature_name, distinct_id, properties)
+            self.payload_map[feature_name][distinct_id] = payload
+            if payload:
+                LOG.info("Feature payload is found", flag=feature_name, distinct_id=distinct_id, payload=payload)
+        return self.payload_map[feature_name][distinct_id]
+
 
 class NoOpExperimentationProvider(BaseExperimentationProvider):
     def is_feature_enabled(self, feature_name: str, distinct_id: str, properties: dict | None = None) -> bool:
         return False
 
     def get_value(self, feature_name: str, distinct_id: str, properties: dict | None = None) -> str | None:
+        return None
+
+    def get_payload(self, feature_name: str, distinct_id: str, properties: dict | None = None) -> str | None:
         return None

--- a/skyvern/forge/sdk/experimentation/providers.py
+++ b/skyvern/forge/sdk/experimentation/providers.py
@@ -56,6 +56,7 @@ class BaseExperimentationProvider(ABC):
                 LOG.info("Feature payload is found", flag=feature_name, distinct_id=distinct_id)
         return self.payload_map[feature_name][distinct_id]
 
+
 class NoOpExperimentationProvider(BaseExperimentationProvider):
     def is_feature_enabled(self, feature_name: str, distinct_id: str, properties: dict | None = None) -> bool:
         return False


### PR DESCRIPTION
## Fix PostHog feature flag payload parsing for thinking budget experiments

**Problem**: The `THINKING_BUDGET_OPTIMIZATION` experiment was failing with JSON parsing errors because PostHog returns variant names (e.g., `"treatment_1"`) instead of direct JSON configurations.

**Solution**: 
- Added `get_payload()` method to experimentation providers to retrieve PostHog feature flag payloads
- Added `get_payload_cached()` for performance optimization with in-memory caching
- Updated `get_thinking_budget_settings()` to use payloads when experiment value is not falsy
- Early exit for control groups (False/None values)

**Changes**:
- `BaseExperimentationProvider`: Added abstract `get_payload()` method and `get_payload_cached()` implementation
- `PostHogExperimentationProvider`: Implemented `get_payload()` using `get_feature_flag_payload()`
- `NoOpExperimentationProvider`: Added null implementation for `get_payload()`
- `get_thinking_budget_settings()`: Now fetches and parses payloads instead of trying to parse variant names as JSON

**Result**: Eliminates "Failed to parse thinking budget experiment" errors in Datadog logs.


----

> [!IMPORTANT]
> Add `get_payload` method to handle feature flag payloads, avoiding JSON parsing errors for control groups.
> 
>   - **Behavior**:
>     - Add `get_payload` method in `PostHogExperimentationProvider` to fetch feature flag payloads, returning `None` if payload is `None` or `False`.
>     - Update `get_thinking_budget_settings` in `skyvern_run_script_helper.py` to use `get_payload_cached`, skipping control group or disabled experiments without logging errors.
>   - **Providers**:
>     - Add `get_payload` and `get_payload_cached` methods to `BaseExperimentationProvider`.
>     - Implement `get_payload` in `NoOpExperimentationProvider` to return `None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for ed73441c186dd86845af32be20c6cd78ed2d4841. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add payload handling to experimentation framework to fix JSON parsing errors in PostHog feature flags.
> 
>   - **Behavior**:
>     - Add `get_payload` method in `PostHogExperimentationProvider` to fetch feature flag payloads.
>     - Update `get_thinking_budget_settings` to use `get_payload_cached`, skipping control group or disabled experiments.
>   - **Providers**:
>     - Add `get_payload` and `get_payload_cached` methods to `BaseExperimentationProvider`.
>     - Implement `get_payload` in `NoOpExperimentationProvider` to return `None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1f3a72df9eae5a34f363fb2e75b8bc7794ed1504. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🧪 This PR adds payload functionality to the experimentation framework to fix PostHog feature flag parsing errors. The changes introduce a new `get_payload()` method that properly retrieves feature flag payloads instead of attempting to parse variant names as JSON, eliminating "Failed to parse thinking budget experiment" errors in production logs.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Base Provider Enhancement**: Added abstract `get_payload()` method and concrete `get_payload_cached()` implementation to `BaseExperimentationProvider`
- **Caching Infrastructure**: Introduced `payload_map` dictionary for in-memory caching of payload results, following the same pattern as existing `result_map` and `variant_map`
- **NoOp Implementation**: Added null implementation of `get_payload()` in `NoOpExperimentationProvider` for consistency

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant BaseProvider
    participant Cache
    participant PostHog
    
    Client->>BaseProvider: get_payload_cached(feature, id)
    BaseProvider->>Cache: Check payload_map
    alt Cache Miss
        BaseProvider->>PostHog: get_payload(feature, id)
        PostHog-->>BaseProvider: payload data
        BaseProvider->>Cache: Store in payload_map
    else Cache Hit
        Cache-->>BaseProvider: cached payload
    end
    BaseProvider-->>Client: payload result
```

### Impact
- **Error Reduction**: Eliminates JSON parsing errors when PostHog returns variant names instead of JSON configurations
- **Performance Optimization**: Implements caching to avoid repeated API calls for the same feature/user combinations
- **Framework Consistency**: Maintains the same architectural patterns as existing feature flag methods with both direct and cached variants
- **Backward Compatibility**: All changes are additive - existing functionality remains unchanged

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature flags can now include per-user payloads for dynamic configuration.
  * Payloads are cached to reduce latency and repeated lookups.
  * Clear logging when a payload is returned improves observability.
  * Graceful fallback when no payload exists ensures consistent behavior.
  * Backwards compatible: existing flag checks continue to work unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->