### PR TITLE
public run endpoint with error code

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -1592,6 +1592,7 @@ class WorkflowService:
                 totp_url=workflow_run.totp_verification_url or None,
                 totp_identifier=workflow_run.totp_identifier,
             ),
+            errors=workflow_run_status_response.errors,
         )
         payload_dict = json.loads(workflow_run_status_response.model_dump_json())
         workflow_run_response_dict = json.loads(workflow_run_response.model_dump_json())

--- a/skyvern/schemas/runs.py
+++ b/skyvern/schemas/runs.py
@@ -427,6 +427,10 @@ class BaseRunResponse(BaseModel):
         default=None,
         description="The script run result",
     )
+    errors: list[dict[str, Any]] | None = Field(
+        default=None,
+        description="The errors for the run",
+    )
 
 
 class TaskRunResponse(BaseRunResponse):

--- a/skyvern/services/run_service.py
+++ b/skyvern/services/run_service.py
@@ -69,6 +69,7 @@ async def get_run_response(run_id: str, organization_id: str | None = None) -> R
                 error_code_mapping=task_v1_response.request.error_code_mapping,
                 max_screenshot_scrolls=task_v1_response.request.max_screenshot_scrolls,
             ),
+            errors=task_v1_response.errors,
         )
     elif run.task_run_type == RunType.task_v2:
         task_v2 = await app.DATABASE.get_task_v2(run.run_id, organization_id=organization_id)

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -1711,6 +1711,7 @@ async def build_task_v2_run_response(task_v2: TaskV2) -> TaskRunResponse:
             data_extraction_schema=task_v2.extracted_information_schema,
             error_code_mapping=task_v2.error_code_mapping,
         ),
+        errors=workflow_run_resp.errors if workflow_run_resp else None,
     )
 
 

--- a/skyvern/services/workflow_service.py
+++ b/skyvern/services/workflow_service.py
@@ -138,4 +138,5 @@ async def get_workflow_run_response(
             browser_address=workflow_run.browser_address,
             # TODO: add browser session id
         ),
+        errors=workflow_run_resp.errors,
     )


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add error handling to workflow and task responses by including an `errors` field in response models across multiple services.
> 
>   - **Behavior**:
>     - Add `errors` field to `WorkflowRunResponse` in `service.py` to capture errors during workflow execution.
>     - Include `errors` in `TaskRunResponse` and `WorkflowRunResponse` in `run_service.py` and `task_v2_service.py`.
>   - **Models**:
>     - Add `errors` field to `BaseRunResponse` in `runs.py` to store error details.
>   - **Misc**:
>     - Update `execute_workflow_webhook()` in `service.py` to include `errors` in the webhook payload.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 613c6a2235e07ada3655d59927e9a205c9b0a901. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR enhances error reporting across the Skyvern platform by adding an `errors` field to all run response models, enabling better error visibility and debugging for workflow and task executions.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Schema Enhancement**: Added `errors` field to `BaseRunResponse` model to capture error information across all run types
- **Workflow Service**: Updated `execute_workflow_webhook` to include errors in the workflow run response
- **Task Services**: Modified both task v1 and v2 services to propagate error information through their response chains
- **Run Service**: Enhanced `get_run_response` to include errors from underlying task responses

### Technical Implementation
```mermaid
flowchart TD
    A[BaseRunResponse Schema] --> B[TaskRunResponse]
    A --> C[WorkflowRunResponse]
    B --> D[Task V1 Service]
    B --> E[Task V2 Service]
    C --> F[Workflow Service]
    D --> G[Run Service]
    E --> G
    F --> G
    G --> H[Public API Response]
    
    style A fill:#e1f5fe
    style H fill:#f3e5f5
```

### Impact
- **Better Error Visibility**: Users can now access detailed error information through public API endpoints
- **Improved Debugging**: Error propagation from internal services to public responses enables better troubleshooting
- **Consistent Error Handling**: Standardized error field across all run types (workflow, task v1, task v2) provides uniform error reporting
- **Backward Compatibility**: The `errors` field is optional with `default=None`, ensuring existing integrations continue to work

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Run responses now include an optional errors field with structured error details.
  * Errors are surfaced across workflow and task runs (v1 and v2), as well as in webhook payloads.
  * This provides clearer visibility into issues encountered during runs to aid debugging and monitoring.
  * The addition is backward-compatible and only extends the returned data without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->