### PR TITLE
Ensure scripts are freshly fetched for Workspace (they need to show up after a wf run)

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -350,13 +350,20 @@ function Workspace({
   });
 
   // Add window resize listener to trigger NoVNC canvas resize
+  // invalidate block scripts (so we always fetch latest on mount)
   useEffect(() => {
     const handleResize = () => {
       setWindowResizeTrigger((prev) => prev + 1);
     };
 
     window.addEventListener("resize", handleResize);
+
+    queryClient.invalidateQueries({
+      queryKey: ["block-scripts"],
+    });
+
     return () => window.removeEventListener("resize", handleResize);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6132/after-running-workflow-with-ai-and-caching-the-script-code-is-not
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Invalidate `block-scripts` query on `Workspace` mount to ensure fresh script fetch.
> 
>   - **Behavior**:
>     - In `Workspace.tsx`, added `queryClient.invalidateQueries` for `block-scripts` in `useEffect` to ensure fresh fetch on component mount.
>   - **Misc**:
>     - Added comment to explain the purpose of invalidating block scripts on mount.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c34d796b8deebd1882c432df40517f60ba91a49d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔄 This PR fixes a caching issue where block scripts weren't being refreshed after workflow runs, ensuring that the latest script code is always displayed in the Workspace component by invalidating the query cache on component mount.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Query Cache Management**: Added `queryClient.invalidateQueries` call for "block-scripts" query key in the Workspace component's useEffect hook
- **Component Lifecycle**: Integrated cache invalidation with the existing window resize listener effect to ensure fresh data on mount
- **Code Documentation**: Added explanatory comment clarifying the purpose of invalidating block scripts on component mount

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant Workspace
    participant QueryClient
    participant API
    
    User->>Workspace: Navigate to Workspace
    Workspace->>QueryClient: invalidateQueries("block-scripts")
    QueryClient->>API: Fetch fresh block scripts
    API-->>QueryClient: Return latest scripts
    QueryClient-->>Workspace: Provide updated data
    Workspace-->>User: Display current script code
```

### Impact
- **Data Freshness**: Ensures users always see the most up-to-date script code after workflow executions
- **User Experience**: Eliminates confusion caused by stale cached script data being displayed
- **Cache Strategy**: Implements proactive cache invalidation without affecting other cached data or performance

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Workflow Editor Workspace now automatically refreshes block scripts when the editor opens and on window resize. This prevents stale or outdated scripts from appearing and ensures the latest updates are consistently shown without manual reloads. Improves reliability of the editor panel and keeps script lists in sync after layout changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->