### PR TITLE
index for created_at for multiple tables

### DIFF
--- a/skyvern/forge/sdk/db/models.py
+++ b/skyvern/forge/sdk/db/models.py
@@ -573,6 +573,7 @@ class AISuggestionModel(Base):
 
 class TOTPCodeModel(Base):
     __tablename__ = "totp_codes"
+    __table_args__ = (Index("ix_totp_codes_org_created_at", "organization_id", "created_at"),)
 
     totp_code_id = Column(String, primary_key=True, default=generate_totp_code_id)
     totp_identifier = Column(String, nullable=False, index=True)
@@ -622,7 +623,10 @@ class ActionModel(Base):
 
 class WorkflowRunBlockModel(Base):
     __tablename__ = "workflow_run_blocks"
-    __table_args__ = (Index("wfrb_org_wfr_index", "organization_id", "workflow_run_id"),)
+    __table_args__ = (
+        Index("wfrb_org_wfr_index", "organization_id", "workflow_run_id"),
+        Index("ix_workflow_run_blocks_org_created_at", "organization_id", "created_at"),
+    )
 
     workflow_run_block_id = Column(String, primary_key=True, default=generate_workflow_run_block_id)
     workflow_run_id = Column(String, nullable=False)
@@ -672,7 +676,10 @@ class WorkflowRunBlockModel(Base):
 
 class TaskV2Model(Base):
     __tablename__ = "observer_cruises"
-    __table_args__ = (Index("oc_org_wfr_index", "organization_id", "workflow_run_id"),)
+    __table_args__ = (
+        Index("oc_org_wfr_index", "organization_id", "workflow_run_id"),
+        Index("ix_observer_cruises_org_created_at", "organization_id", "created_at"),
+    )
 
     # observer_cruise_id is the task_id for task v2
     observer_cruise_id = Column(String, primary_key=True, default=generate_task_v2_id)
@@ -710,7 +717,10 @@ class TaskV2Model(Base):
 
 class ThoughtModel(Base):
     __tablename__ = "observer_thoughts"
-    __table_args__ = (Index("observer_cruise_index", "organization_id", "observer_cruise_id"),)
+    __table_args__ = (
+        Index("observer_cruise_index", "organization_id", "observer_cruise_id"),
+        Index("ix_observer_thoughts_org_created_at", "organization_id", "created_at"),
+    )
 
     observer_thought_id = Column(String, primary_key=True, default=generate_thought_id)
     organization_id = Column(String, nullable=True)
@@ -763,6 +773,7 @@ class TaskRunModel(Base):
     __table_args__ = (
         Index("task_run_org_url_index", "organization_id", "url_hash", "cached"),
         Index("task_run_org_run_id_index", "organization_id", "run_id"),
+        Index("ix_task_runs_org_created_at", "organization_id", "created_at"),
     )
 
     task_run_id = Column(String, primary_key=True, default=generate_task_run_id)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `organization_id` and `created_at` indexes to multiple tables for improved query performance.
> 
>   - **Indexes**:
>     - Add `organization_id` and `created_at` indexes to `task_runs`, `observer_thoughts`, `workflow_run_blocks`, `totp_codes`, and `observer_cruises` in `alembic/versions/2025_09_20_2103-778f0ed2dca2_add_organization_id_created_at_indexes_.py`.
>     - Update `TOTPCodeModel`, `WorkflowRunBlockModel`, `TaskV2Model`, `ThoughtModel`, and `TaskRunModel` in `models.py` to include the new indexes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 61ec76469846454dcc4de619fc983dd01f283759. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->