### PR TITLE
show block outputs only in debugger, not in editor

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeTabs.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeTabs.tsx
@@ -13,6 +13,7 @@ import { statusIsRunningOrQueued } from "@/routes/tasks/types";
 import { BlockOutputs } from "@/routes/workflows/components/BlockOutputs";
 import { useWorkflowRunQuery } from "@/routes/workflows/hooks/useWorkflowRunQuery";
 import { useBlockOutputStore } from "@/store/BlockOutputStore";
+import { useDebugStore } from "@/store/useDebugStore";
 import { cn } from "@/util/utils";
 
 interface Props {
@@ -22,6 +23,7 @@ interface Props {
 function NodeTabs({ blockLabel }: Props) {
   const { blockLabel: urlBlockLabel } = useParams();
   const blockOutput = useBlockOutputStore((state) => state.outputs[blockLabel]);
+  const debugStore = useDebugStore();
   const [isExpanded, setIsExpanded] = useState(false);
   const { data: workflowRun } = useWorkflowRunQuery();
   const workflowRunIsRunningOrQueued =
@@ -34,6 +36,10 @@ function NodeTabs({ blockLabel }: Props) {
     urlBlockLabel !== undefined && urlBlockLabel === blockLabel;
 
   if (thisBlockIsPlaying) {
+    return null;
+  }
+
+  if (!debugStore.isDebugMode) {
     return null;
   }
 


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6499/show-block-outputs-only-in-debugger-not-in-editor
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Modify `NodeTabs` to show block outputs only in debug mode by checking `debugStore.isDebugMode`.
> 
>   - **Behavior**:
>     - Modify `NodeTabs` in `NodeTabs.tsx` to only render block outputs when `debugStore.isDebugMode` is `true`.
>     - Returns `null` if `debugStore.isDebugMode` is `false`, preventing block outputs from showing in the editor.
>   - **Stores**:
>     - Import `useDebugStore` from `@/store/useDebugStore` to access debug mode status.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d307a66074c365b219b7c45b40de5424263a3c2d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR restricts block outputs visibility to debug mode only, preventing them from appearing in the workflow editor interface. The change adds a debug mode check to the NodeTabs component, ensuring block outputs are only rendered when debugging is active.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Component Logic**: Added debug mode conditional rendering to `NodeTabs` component in the workflow editor
- **State Management**: Imported and integrated `useDebugStore` to access debug mode state
- **UI Behavior**: Block outputs now only display when `debugStore.isDebugMode` is true, returning null otherwise

### Technical Implementation
```mermaid
flowchart TD
    A[NodeTabs Component] --> B{Block Output Exists?}
    B -->|No| C[Return null]
    B -->|Yes| D{Debug Mode Active?}
    D -->|No| E[Return null - Hide Outputs]
    D -->|Yes| F[Render Block Outputs]
    F --> G[Display NodeTabs UI]
```

### Impact
- **User Experience**: Cleaner workflow editor interface without debug information cluttering the view
- **Development Workflow**: Block outputs remain accessible in debug mode for troubleshooting and development
- **Code Organization**: Clear separation between editor and debugger functionality through conditional rendering

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Node Tabs are now visible only when Debug Mode is enabled, keeping the editor cleaner for standard use.
  - Existing behavior during block playback remains unchanged; tabs will not render while blocks are playing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->