### PR TITLE
Fix unpacking error in build_and_record_step_prompt

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1891,7 +1891,7 @@ class ForgeAgent:
         browser_state: BrowserState,
         scrape_type: ScrapeType,
         engine: RunEngine,
-    ) -> tuple[ScrapedPage, str, bool]:
+    ) -> ScrapedPage:
         if scrape_type == ScrapeType.NORMAL:
             pass
 
@@ -1948,7 +1948,7 @@ class ForgeAgent:
         use_caching = False
         for idx, scrape_type in enumerate(SCRAPE_TYPE_ORDER):
             try:
-                scraped_page, extract_action_prompt, use_caching = await self._scrape_with_type(
+                scraped_page = await self._scrape_with_type(
                     task=task,
                     step=step,
                     browser_state=browser_state,


### PR DESCRIPTION
My prompt-caching PR inadvertently broke _scrape_with_type [here](https://github.com/Skyvern-AI/skyvern-cloud/pull/6461/files#diff-97d27efc4f9823539ec219d1cc210dd6a7bf7d4c5ef4b1f9a1dfe937eff5774eL1887)

This PR reverts those lines. My caching test still passes.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reverts `_scrape_with_type()` return type in `agent.py` to fix unpacking error in `build_and_record_step_prompt()`.
> 
>   - **Behavior**:
>     - Reverts return type of `_scrape_with_type()` in `agent.py` from `tuple[ScrapedPage, str, bool]` to `ScrapedPage`.
>     - Fixes unpacking error in `build_and_record_step_prompt()` by adjusting the call to `_scrape_with_type()` to expect a single return value.
>   - **Testing**:
>     - Caching test still passes after the revert.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9b2214ea60870204cb84091715a568b286f590d3. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes an unpacking error in `build_and_record_step_prompt()` by correcting the return type of `_scrape_with_type()` from a tuple to a single `ScrapedPage` object. The change resolves a bug introduced by a previous prompt-caching PR that inadvertently modified the function signature.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Function Signature**: Updated `_scrape_with_type()` return type from `tuple[ScrapedPage, str, bool]` to `ScrapedPage`
- **Variable Assignment**: Modified `build_and_record_step_prompt()` to assign only `scraped_page` instead of unpacking three values
- **Bug Reversion**: Reverted changes that were accidentally introduced in a previous prompt-caching PR

### Technical Implementation
```mermaid
sequenceDiagram
    participant BSRP as build_and_record_step_prompt
    participant SWT as _scrape_with_type
    
    Note over BSRP: Before Fix (Broken)
    BSRP->>SWT: Call _scrape_with_type()
    SWT-->>BSRP: Returns ScrapedPage only
    Note over BSRP: Tries to unpack 3 values ❌
    
    Note over BSRP: After Fix (Working)
    BSRP->>SWT: Call _scrape_with_type()
    SWT-->>BSRP: Returns ScrapedPage only
    Note over BSRP: Assigns single value ✅
```

### Impact
- **Bug Resolution**: Eliminates unpacking errors that would cause runtime failures in the scraping functionality
- **Code Consistency**: Aligns function signature with actual return behavior, preventing confusion
- **Test Compatibility**: Maintains existing test functionality as confirmed by the author's caching tests

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the internal scraping workflow by consolidating return values, reducing complexity in downstream handling.
  * Deferred prompt-generation and caching decisions to later steps for clearer separation of concerns.
  * Improves maintainability and reduces potential edge-case errors without changing observable behavior.

* **Chores**
  * Updated internal call sites to align with the streamlined interface, ensuring consistent behavior across scraping scenarios.

No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->