### PR TITLE
fix typing error in client.py

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -874,14 +874,14 @@ class AgentDB:
     async def get_valid_org_auth_token(
         self,
         organization_id: str,
-        token_type: Literal[OrganizationAuthTokenType.api, OrganizationAuthTokenType.onepassword_service_account],
+        token_type: Literal["api", "onepassword_service_account"],
     ) -> OrganizationAuthToken | None: ...
 
     @overload
     async def get_valid_org_auth_token(
         self,
         organization_id: str,
-        token_type: Literal[OrganizationAuthTokenType.azure_client_secret_credential],
+        token_type: Literal["azure_client_secret_credential"],
     ) -> AzureOrganizationAuthToken | None: ...
 
     async def get_valid_org_auth_token(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix typing error in `client.py` by updating `get_valid_org_auth_token` overloads to use string literals for `token_type`.
> 
>   - **Typing Fix**:
>     - In `client.py`, fix typing error in `get_valid_org_auth_token` overloads by changing `token_type` from `Literal[OrganizationAuthTokenType.api, OrganizationAuthTokenType.onepassword_service_account]` to `Literal["api", "onepassword_service_account"]` and from `Literal[OrganizationAuthTokenType.azure_client_secret_credential]` to `Literal["azure_client_secret_credential"]`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 8c41f8e5529db985480cb3462e00cf2c4a6926b8. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->