### PR TITLE
Add endpoint for browser sessions history

### DIFF
--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -1174,44 +1174,6 @@ if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
         ),
     )
     LLMConfigRegistry.register_config(
-        "VERTEX_GEMINI_2.5_FLASH_PREVIEW_09_2025",
-        LLMConfig(
-            "vertex_ai/gemini-2.5-flash-preview-09-2025",
-            ["VERTEX_CREDENTIALS"],
-            supports_vision=True,
-            add_assistant_prefix=False,
-            max_completion_tokens=65535,
-            litellm_params=LiteLLMParams(
-                vertex_credentials=settings.VERTEX_CREDENTIALS,
-                api_base=f"{api_base}/gemini-2.5-flash-preview-09-2025" if api_base else None,
-                vertex_location=settings.VERTEX_LOCATION,
-                thinking={
-                    "budget_tokens": settings.GEMINI_THINKING_BUDGET,
-                    "type": "enabled" if settings.GEMINI_INCLUDE_THOUGHT else None,
-                },
-            ),
-        ),
-    )
-    LLMConfigRegistry.register_config(
-        "VERTEX_GEMINI_2.5_FLASH_LITE_PREVIEW_09_2025",
-        LLMConfig(
-            "vertex_ai/gemini-2.5-flash-lite-preview-09-2025",
-            ["VERTEX_CREDENTIALS"],
-            supports_vision=True,
-            add_assistant_prefix=False,
-            max_completion_tokens=65535,
-            litellm_params=LiteLLMParams(
-                vertex_credentials=settings.VERTEX_CREDENTIALS,
-                api_base=f"{api_base}/gemini-2.5-flash-lite-preview-09-2025" if api_base else None,
-                vertex_location=settings.VERTEX_LOCATION,
-                thinking={
-                    "budget_tokens": settings.GEMINI_THINKING_BUDGET,
-                    "type": "enabled" if settings.GEMINI_INCLUDE_THOUGHT else None,
-                },
-            ),
-        ),
-    )
-    LLMConfigRegistry.register_config(
         "VERTEX_GEMINI_FLASH_2_0",
         LLMConfig(
             "vertex_ai/gemini-2.0-flash-001",

--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, List, Literal, Sequence, overload
 
 import structlog
-from sqlalchemy import and_, asc, delete, distinct, func, or_, pool, select, tuple_, update
+from sqlalchemy import and_, asc, case, delete, distinct, func, or_, pool, select, tuple_, update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
 
@@ -874,14 +874,14 @@ class AgentDB:
     async def get_valid_org_auth_token(
         self,
         organization_id: str,
-        token_type: Literal[OrganizationAuthTokenType.api, OrganizationAuthTokenType.onepassword_service_account],
+        token_type: Literal[OrganizationAuthTokenType.api, OrganizationAuthTokenType.onepassword_service_account],  # type:ignore
     ) -> OrganizationAuthToken | None: ...
 
     @overload
-    async def get_valid_org_auth_token(
+    async def get_valid_org_auth_token(  # type: ignore
         self,
         organization_id: str,
-        token_type: Literal[OrganizationAuthTokenType.azure_client_secret_credential],
+        token_type: Literal[OrganizationAuthTokenType.azure_client_secret_credential],  # type:ignore
     ) -> AzureOrganizationAuthToken | None: ...
 
     async def get_valid_org_auth_token(
@@ -3197,6 +3197,50 @@ class AgentDB:
                     .filter(
                         PersistentBrowserSessionModel.created_at > datetime.utcnow() - timedelta(hours=active_hours)
                     )
+                )
+                sessions = result.scalars().all()
+                return [PersistentBrowserSession.model_validate(session) for session in sessions]
+        except SQLAlchemyError:
+            LOG.error("SQLAlchemyError", exc_info=True)
+            raise
+        except Exception:
+            LOG.error("UnexpectedError", exc_info=True)
+            raise
+
+    async def get_persistent_browser_sessions_history(
+        self,
+        organization_id: str,
+        page: int = 1,
+        page_size: int = 10,
+        lookback_hours: int = 24 * 7,
+    ) -> list[PersistentBrowserSession]:
+        """Get persistent browser sessions history for an organization."""
+        try:
+            async with self.Session() as session:
+                open_first = case(
+                    (
+                        and_(
+                            PersistentBrowserSessionModel.started_at.is_not(None),
+                            PersistentBrowserSessionModel.completed_at.is_(None),
+                        ),
+                        0,  # open
+                    ),
+                    else_=1,  # not open
+                )
+
+                result = await session.execute(
+                    select(PersistentBrowserSessionModel)
+                    .filter_by(organization_id=organization_id)
+                    .filter_by(deleted_at=None)
+                    .filter(
+                        PersistentBrowserSessionModel.created_at > datetime.utcnow() - timedelta(hours=lookback_hours)
+                    )
+                    .order_by(
+                        open_first.asc(),  # open sessions first
+                        PersistentBrowserSessionModel.created_at.desc(),  # then newest within each group
+                    )
+                    .offset((page - 1) * page_size)
+                    .limit(page_size)
                 )
                 sessions = result.scalars().all()
                 return [PersistentBrowserSession.model_validate(session) for session in sessions]


### PR DESCRIPTION
Backend part of https://linear.app/skyvern/issue/SKY-6500/allow-users-to-visualize-open-browser-sessions-in-the-left-hand-tab

For type ignores, see https://skyvern.slack.com/archives/C05B62MHYKW/p1758898155331899
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds endpoint for browser session history and removes unused LLM configurations.
> 
>   - **Endpoints**:
>     - Adds `get_browser_sessions_all()` in `browser_sessions.py` to retrieve browser session history with pagination.
>     - Modifies `get_browser_sessions_all()` to include type ignores for `token_type` in `client.py`.
>   - **Database**:
>     - Adds `get_persistent_browser_sessions_history()` in `client.py` to fetch browser session history with pagination and ordering.
>   - **Configuration**:
>     - Removes unused LLM configurations `VERTEX_GEMINI_2.5_FLASH_PREVIEW_09_2025` and `VERTEX_GEMINI_2.5_FLASH_LITE_PREVIEW_09_2025` in `config_registry.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ebde70b52609e450ffd0d63e39d7b5ca82f765e4. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🌐 This PR adds a new `/browser_sessions/history` endpoint that allows users to retrieve and paginate through their organization's persistent browser session history, supporting the frontend visualization of open browser sessions in the left-hand tab. The implementation includes database queries with smart ordering (open sessions first) and comprehensive pagination support.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Database Layer**: Added `get_persistent_browser_sessions_history()` method in `client.py` with sophisticated ordering logic that prioritizes open sessions over closed ones
- **API Endpoint**: New `/browser_sessions/history` route in `browser_sessions.py` with pagination support and analytics tracking
- **Configuration Cleanup**: Removed deprecated Gemini 2.5 Flash preview model configurations from the LLM config registry
- **Type Safety**: Added type ignore comments to resolve mypy issues with SQLAlchemy literal types

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant API as /browser_sessions/history
    participant DB as Database Client
    participant Storage as Storage Service
    
    Client->>API: GET /browser_sessions/history?page=1&page_size=10
    API->>DB: get_persistent_browser_sessions_history()
    DB->>DB: Query with CASE ordering (open sessions first)
    DB->>API: Return paginated sessions
    API->>Storage: BrowserSessionResponse.from_browser_session()
    Storage->>API: Enriched session responses
    API->>Client: JSON response with session history
```

### Impact
- **User Experience**: Enables frontend visualization of browser session history with open sessions prominently displayed first
- **Performance**: Implements efficient pagination (1-100 items per page) and configurable lookback period (default 7 days) to manage query performance
- **Analytics**: Tracks usage of the new endpoint for product insights and monitoring
- **Maintainability**: Removes outdated LLM configurations while adding well-structured database queries with proper error handling

</details>

_Created with [Palmier](https://www.palmier.io)_