### PR TITLE
Making ValidationBlock not count towards max_steps check

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -2204,8 +2204,8 @@ class WorkflowService:
                 terminate_criterion=block_yaml.terminate_criterion,
                 error_code_mapping=block_yaml.error_code_mapping,
                 continue_on_failure=block_yaml.continue_on_failure,
-                # only need one step for validation block
-                max_steps_per_run=1,
+                # Should only need one step for validation block, but we allow 2 in case the LLM has an unexpected failure and we need to retry.
+                max_steps_per_run=2,
                 model=block_yaml.model,
             )
 


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6503/validation-blocks-should-not-reach-max-steps-error
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Increase `max_steps_per_run` for `ValidationBlock` in `service.py` to 2 to allow retries for unexpected failures.
> 
>   - **Behavior**:
>     - In `block_yaml_to_block()` in `service.py`, `max_steps_per_run` for `ValidationBlock` increased from 1 to 2 to allow retries in case of unexpected failures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0aa24e94b573614ec47a747917e0d49dadcc576d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->