### PR TITLE
fix workflow_run.run_with override

### DIFF
--- a/skyvern/core/script_generations/skyvern_page.py
+++ b/skyvern/core/script_generations/skyvern_page.py
@@ -367,7 +367,7 @@ class SkyvernPage:
         """
         new_xpath = xpath
 
-        if intention and data:
+        if intention:
             try:
                 # Build the element tree of the current page for the prompt
                 context = skyvern_context.ensure_context()

--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -1697,6 +1697,7 @@ class AgentDB:
         extra_http_headers: dict[str, str] | None = None,
         browser_address: str | None = None,
         sequential_key: str | None = None,
+        run_with: str | None = None,
     ) -> WorkflowRun:
         try:
             async with self.Session() as session:
@@ -1715,6 +1716,7 @@ class AgentDB:
                     extra_http_headers=extra_http_headers,
                     browser_address=browser_address,
                     sequential_key=sequential_key,
+                    run_with=run_with,
                 )
                 session.add(workflow_run)
                 await session.commit()

--- a/skyvern/forge/sdk/workflow/models/workflow.py
+++ b/skyvern/forge/sdk/workflow/models/workflow.py
@@ -26,6 +26,7 @@ class WorkflowRequestBody(BaseModel):
     max_screenshot_scrolls: int | None = None
     extra_http_headers: dict[str, str] | None = None
     browser_address: str | None = None
+    run_with: str | None = None
 
     @field_validator("webhook_callback_url", "totp_verification_url")
     @classmethod


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes `run_with` parameter handling in workflow execution to specify execution context in `skyvern_page.py`, `client.py`, and `service.py`.
> 
>   - **Behavior**:
>     - Fixes handling of `intention` in `click()` in `skyvern_page.py` by removing unnecessary `data` check.
>     - Adds `run_with` parameter to `create_workflow_run()` in `client.py` and `service.py` to specify execution context.
>     - Updates `execute_workflow()` and `_execute_workflow_blocks()` in `service.py` to set `run_with` to "agent".
>     - Updates `_execute_workflow_script()` in `service.py` to set `run_with` to "code".
>   - **Models**:
>     - Adds `run_with` field to `WorkflowRequestBody` in `workflow.py`.
>   - **Misc**:
>     - Removes `is_script_run` parameter and replaces it with `run_with` in various functions in `service.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9969aa2914d798e3a525c2ffdd02d316575db34b. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR refactors the workflow execution system by replacing the boolean `is_script_run` parameter with a more explicit `run_with` string parameter that can be set to "agent" or "code", improving clarity around workflow execution modes and fixing parameter override issues.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Parameter Refactoring**: Replaced `is_script_run: bool` parameter with `run_with: str | None` across all workflow status update methods
- **Model Enhancement**: Added `run_with` field to `WorkflowRequestBody` and `create_workflow_run()` database method
- **Execution Mode Tracking**: Explicitly set `run_with="agent"` for block-based workflows and `run_with="code"` for script-based workflows
- **Logic Simplification**: Removed unnecessary `data` parameter check in the `click()` method condition

### Technical Implementation
```mermaid
flowchart TD
    A[Workflow Request] --> B{Execution Mode}
    B -->|run_with="agent"| C[Execute Workflow Blocks]
    B -->|run_with="code"| D[Execute Workflow Script]
    B -->|Default Logic| E[Check generate_script flag]
    
    C --> F[mark_workflow_run_as_running with agent]
    D --> G[mark_workflow_run_as_running with code]
    
    F --> H[Update Status Methods]
    G --> H
    H --> I[Database Update with run_with]
```

### Impact
- **Improved Clarity**: The `run_with` parameter makes execution mode explicit rather than inferring from boolean flags
- **Better Tracking**: Database and logging now clearly indicate whether workflows ran with "agent" or "code" execution
- **Enhanced Flexibility**: The string-based approach allows for potential future execution modes beyond just agent/script
- **Bug Fix**: Resolves the workflow_run.run_with override issue mentioned in the PR title by properly propagating the parameter through the entire execution chain

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional run_with parameter to workflow requests and runs, letting you choose execution context (e.g., “agent” or “code”).
  * Workflow status updates and execution paths now respect the selected run_with context for clearer control and tracking.

* **Bug Fixes**
  * Improved click reliability: when only an intention is provided, selectors are now re-evaluated via prompts, with safe fallback to the original selector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->