### PR TITLE
Update API specifications with fern api update

### DIFF
--- a/fern/openapi/skyvern_openapi.json
+++ b/fern/openapi/skyvern_openapi.json
@@ -11909,10 +11909,16 @@
             ],
             "title": "Extra Http Headers"
           },
-          "generate_script": {
-            "type": "boolean",
-            "title": "Generate Script",
-            "default": false
+          "run_with": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run With"
           },
           "ai_fallback": {
             "type": "boolean",
@@ -12103,10 +12109,16 @@
             "$ref": "#/components/schemas/WorkflowStatus",
             "default": "published"
           },
-          "generate_script": {
-            "type": "boolean",
-            "title": "Generate Script",
-            "default": false
+          "run_with": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run With"
           },
           "ai_fallback": {
             "type": "boolean",


### PR DESCRIPTION
Update API specifications by running fern api update.

---

🔄 This PR updates the API specifications by replacing the `generate_script` boolean field with a new `run_with` field that accepts either a string or null value in the OpenAPI schema.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Field Replacement**: Removed `generate_script` boolean field (with default `false`) and replaced it with `run_with` field
- **Type Flexibility**: The new `run_with` field uses `anyOf` schema allowing either string or null values
- **Schema Consistency**: Applied the same change across multiple schema definitions in the OpenAPI specification

### Technical Implementation
```mermaid
flowchart TD
    A[Old Schema] --> B[generate_script: boolean]
    B --> C[Default: false]
    
    D[New Schema] --> E[run_with: string | null]
    E --> F[More flexible execution options]
    
    A -.->|Migration| D
    
    style A fill:#ffcccc
    style D fill:#ccffcc
```

### Impact
- **API Flexibility**: The new `run_with` field provides more granular control over execution parameters compared to the binary `generate_script` option
- **Type Safety**: Using `anyOf` with explicit string and null types maintains strong typing while allowing optional values
- **Breaking Change**: This is a breaking change that will require client applications to update their API calls from `generate_script` to `run_with`

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `generate_script` with `run_with` in `skyvern_openapi.json`, supporting `string` or `null` types.
> 
>   - **API Specification Update**:
>     - Replaces `generate_script` field with `run_with` in `skyvern_openapi.json`.
>     - `run_with` supports `string` or `null` types, with title "Run With".
>     - Changes occur in two sections of the JSON file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1d371df4cdf93b41acaa0ffb5e4dcab01b68b4f7. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a run_with option for workflows and YAML-based workflow creation, allowing you to specify how a workflow should run (string or null).

- Breaking Changes
  - Removed the generate_script flag from workflows and YAML-based workflow creation. Update any integrations to use run_with instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->