### PR TITLE
Replace file_suffix with file_name (but keep vairable name for backwards compatibility), Add path to Azure Blob, remove defaulted {workflow_run_id}

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/helpContent.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/helpContent.ts
@@ -14,7 +14,7 @@ export const baseHelpTooltipContent = {
   completeOnDownload:
     "Allow Skyvern to auto-complete the block when it downloads a file.",
   fileSuffix:
-    "A file suffix that's automatically added to all downloaded files.",
+    "The complete filename (without extension) for downloaded files. This replaces the entire filename instead of being appended to a random name.",
   errorCodeMapping:
     "Knowing about why a block terminated can be important, specify error messages here.",
   totpVerificationUrl:
@@ -34,7 +34,7 @@ export const basePlaceholderContent = {
   dataExtractionGoal: "What data do you need to extract?",
   maxRetries: "Default: 3",
   maxStepsOverride: "Default: 10",
-  downloadSuffix: "Add an ID for downloaded files",
+  downloadSuffix: "Enter the complete filename (without extension)",
   totpVerificationUrl: "Provide your 2FA endpoint",
   totpIdentifier: "Add an ID that links your TOTP to the block",
 };

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/ActionNode/ActionNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/ActionNode/ActionNode.tsx
@@ -342,7 +342,7 @@ function ActionNode({ id, data, type }: NodeProps<ActionNode>) {
                   <div className="flex items-center justify-between">
                     <div className="flex gap-2">
                       <Label className="text-xs font-normal text-slate-300">
-                        File Suffix
+                        File Name
                       </Label>
                       <HelpTooltip
                         content={helpTooltips["action"]["fileSuffix"]}

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/FileDownloadNode/FileDownloadNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/FileDownloadNode/FileDownloadNode.tsx
@@ -316,7 +316,7 @@ function FileDownloadNode({ id, data }: NodeProps<FileDownloadNode>) {
                   <div className="flex items-center justify-between">
                     <div className="flex gap-2">
                       <Label className="text-xs font-normal text-slate-300">
-                        File Suffix
+                        File Name
                       </Label>
                       <HelpTooltip
                         content={helpTooltips["download"]["fileSuffix"]}

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/FileUploadNode/FileUploadNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/FileUploadNode/FileUploadNode.tsx
@@ -261,6 +261,22 @@ function FileUploadNode({ id, data }: NodeProps<FileUploadNode>) {
                   className="nopan text-xs"
                 />
               </div>
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <Label className="text-sm text-slate-400">
+                    (Optional) Folder Path
+                  </Label>
+                  <HelpTooltip content="Optional folder path within the blob container. Defaults to {{ workflow_run_id }} if not specified." />
+                </div>
+                <WorkflowBlockInputTextarea
+                  nodeId={id}
+                  onChange={(value) => {
+                    handleChange("path", value);
+                  }}
+                  value={inputs.path as string}
+                  className="nopan text-xs"
+                />
+              </div>
             </>
           )}
         </div>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/FileUploadNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/FileUploadNode/types.ts
@@ -22,7 +22,7 @@ export const fileUploadNodeDefaultData: FileUploadNodeData = {
   editable: true,
   storageType: "s3",
   label: "",
-  path: "",
+  path: "{{ workflow_run_id }}",
   s3Bucket: null,
   awsAccessKeyId: null,
   awsSecretAccessKey: null,

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/NavigationNode/NavigationNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/NavigationNode/NavigationNode.tsx
@@ -402,7 +402,7 @@ function NavigationNode({ id, data, type }: NodeProps<NavigationNode>) {
                   <div className="flex items-center justify-between">
                     <div className="flex gap-2">
                       <Label className="text-xs font-normal text-slate-300">
-                        File Suffix
+                        File Name
                       </Label>
                       <HelpTooltip
                         content={helpTooltips["navigation"]["fileSuffix"]}

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/TaskNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/TaskNode.tsx
@@ -417,7 +417,7 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
                   <div className="flex items-center justify-between">
                     <div className="flex gap-2">
                       <Label className="text-xs font-normal text-slate-300">
-                        File Suffix
+                        File Name
                       </Label>
                       <HelpTooltip
                         content={helpTooltips["task"]["fileSuffix"]}

--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -538,11 +538,14 @@ class ForgeAgent:
                             )
                             continue
 
-                        random_file_id = "".join(random.choices(string.ascii_uppercase + string.digits, k=4))
-                        random_file_name = f"download-{datetime.now().strftime('%Y%m%d%H%M%S%f')}-{random_file_id}"
                         if task_block.download_suffix:
-                            random_file_name = f"{random_file_name}-{task_block.download_suffix}"
-                        rename_file(os.path.join(workflow_download_directory, file), random_file_name + file_extension)
+                            # Use download_suffix as the complete filename (without extension)
+                            final_file_name = task_block.download_suffix
+                        else:
+                            # Fallback to random filename if no download_suffix provided
+                            random_file_id = "".join(random.choices(string.ascii_uppercase + string.digits, k=4))
+                            final_file_name = f"download-{datetime.now().strftime('%Y%m%d%H%M%S%f')}-{random_file_id}"
+                        rename_file(os.path.join(workflow_download_directory, file), final_file_name + file_extension)
 
                     LOG.info(
                         "Task marked as completed due to download",

--- a/skyvern/forge/sdk/workflow/context_manager.py
+++ b/skyvern/forge/sdk/workflow/context_manager.py
@@ -58,6 +58,10 @@ class WorkflowRunContext:
         cls,
         aws_client: AsyncAWSClient,
         organization: Organization,
+        workflow_run_id: str,
+        workflow_title: str,
+        workflow_id: str,
+        workflow_permanent_id: str,
         workflow_parameter_tuples: list[tuple[WorkflowParameter, "WorkflowRunParameter"]],
         workflow_output_parameters: list[OutputParameter],
         context_parameters: list[ContextParameter],
@@ -71,7 +75,14 @@ class WorkflowRunContext:
         block_outputs: dict[str, Any] | None = None,
     ) -> Self:
         # key is label name
-        workflow_run_context = cls(aws_client=aws_client)
+        workflow_run_context = cls(
+            workflow_title=workflow_title,
+            workflow_id=workflow_id,
+            workflow_permanent_id=workflow_permanent_id,
+            workflow_run_id=workflow_run_id,
+            aws_client=aws_client,
+        )
+
         for parameter, run_parameter in workflow_parameter_tuples:
             if parameter.workflow_parameter_type == WorkflowParameterType.CREDENTIAL_ID:
                 await workflow_run_context.register_secret_workflow_parameter_value(
@@ -133,7 +144,18 @@ class WorkflowRunContext:
 
         return workflow_run_context
 
-    def __init__(self, aws_client: AsyncAWSClient) -> None:
+    def __init__(
+        self,
+        workflow_title: str,
+        workflow_id: str,
+        workflow_permanent_id: str,
+        workflow_run_id: str,
+        aws_client: AsyncAWSClient,
+    ) -> None:
+        self.workflow_title = workflow_title
+        self.workflow_id = workflow_id
+        self.workflow_permanent_id = workflow_permanent_id
+        self.workflow_run_id = workflow_run_id
         self.blocks_metadata: dict[str, BlockMetadata] = {}
         self.parameters: dict[str, PARAMETER_TYPE] = {}
         self.values: dict[str, Any] = {}
@@ -953,6 +975,9 @@ class WorkflowContextManager:
         self,
         organization: Organization,
         workflow_run_id: str,
+        workflow_title: str,
+        workflow_id: str,
+        workflow_permanent_id: str,
         workflow_parameter_tuples: list[tuple[WorkflowParameter, "WorkflowRunParameter"]],
         workflow_output_parameters: list[OutputParameter],
         context_parameters: list[ContextParameter],
@@ -967,6 +992,10 @@ class WorkflowContextManager:
         workflow_run_context = await WorkflowRunContext.init(
             self.aws_client,
             organization,
+            workflow_run_id,
+            workflow_title,
+            workflow_id,
+            workflow_permanent_id,
             workflow_parameter_tuples,
             workflow_output_parameters,
             context_parameters,

--- a/skyvern/forge/sdk/workflow/models/parameter.py
+++ b/skyvern/forge/sdk/workflow/models/parameter.py
@@ -8,7 +8,15 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from skyvern.exceptions import InvalidWorkflowParameter
 
-RESERVED_PARAMETER_KEYS = ["current_item", "current_value", "current_index"]
+RESERVED_PARAMETER_KEYS = [
+    "current_item",
+    "current_value",
+    "current_index",
+    "workflow_title",
+    "workflow_id",
+    "workflow_permanent_id",
+    "workflow_run_id",
+]
 
 
 class ParameterType(StrEnum):

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -320,6 +320,9 @@ class WorkflowService:
             await app.WORKFLOW_CONTEXT_MANAGER.initialize_workflow_run_context(
                 organization,
                 workflow_run_id,
+                workflow.title,
+                workflow.workflow_id,
+                workflow.workflow_permanent_id,
                 wp_wps_tuples,
                 workflow_output_parameters,
                 context_parameters,

--- a/skyvern/schemas/workflows.py
+++ b/skyvern/schemas/workflows.py
@@ -210,7 +210,9 @@ class TaskBlockYAML(BlockYAML):
     max_steps_per_run: int | None = None
     parameter_keys: list[str] | None = None
     complete_on_download: bool = False
-    download_suffix: str | None = None
+    download_suffix: str | None = (
+        None  # DEPRECATED: This field now sets the complete filename instead of appending to a random name
+    )
     totp_verification_url: str | None = None
     totp_identifier: str | None = None
     cache_actions: bool = False
@@ -287,6 +289,7 @@ class FileUploadBlockYAML(BlockYAML):
     azure_storage_account_name: str | None = None
     azure_storage_account_key: str | None = None
     azure_blob_container_name: str | None = None
+    azure_folder_path: str | None = None
     path: str | None = None
 
 
@@ -343,7 +346,9 @@ class ActionBlockYAML(BlockYAML):
     max_retries: int = 0
     parameter_keys: list[str] | None = None
     complete_on_download: bool = False
-    download_suffix: str | None = None
+    download_suffix: str | None = (
+        None  # DEPRECATED: This field now sets the complete filename instead of appending to a random name
+    )
     totp_verification_url: str | None = None
     totp_identifier: str | None = None
     cache_actions: bool = False
@@ -361,7 +366,9 @@ class NavigationBlockYAML(BlockYAML):
     max_steps_per_run: int | None = None
     parameter_keys: list[str] | None = None
     complete_on_download: bool = False
-    download_suffix: str | None = None
+    download_suffix: str | None = (
+        None  # DEPRECATED: This field now sets the complete filename instead of appending to a random name
+    )
     totp_verification_url: str | None = None
     totp_identifier: str | None = None
     cache_actions: bool = False
@@ -420,7 +427,9 @@ class FileDownloadBlockYAML(BlockYAML):
     max_retries: int = 0
     max_steps_per_run: int | None = None
     parameter_keys: list[str] | None = None
-    download_suffix: str | None = None
+    download_suffix: str | None = (
+        None  # DEPRECATED: This field now sets the complete filename instead of appending to a random name
+    )
     totp_verification_url: str | None = None
     totp_identifier: str | None = None
     cache_actions: bool = False


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use `download_suffix` as the complete download filename, inject workflow-level context variables, refine upload paths (S3/Azure), and update UI labels/tooltips from “File Suffix” to “File Name” with optional folder path.
> 
> - **Backend/Core**:
>   - Downloads: `download_suffix` now sets the entire filename (without extension); fallback to random when absent (`forge/agent.py`).
>   - Context: `WorkflowRunContext` now stores `workflow` and `workflow_run_id`; injects `workflow_title`, `workflow_id`, `workflow_permanent_id`, `workflow_run_id` into templates; added to reserved keys. Updated initializers to pass `workflow` and `workflow_run_id`.
>   - File Upload: Adjust S3/Azure URI construction to use optional `path` (defaults to `{{ workflow_run_id }}`) for foldering (`block.py`).
> - **Schemas**:
>   - Mark `download_suffix` as deprecated note (now used as full filename) across task/navigation/download/workflow YAMLs.
>   - Add `azure_folder_path` to file upload YAML.
> - **Frontend/UI**:
>   - Rename label “File Suffix” → “File Name” and update help/placeholder texts in `TaskNode`, `NavigationNode`, `ActionNode`, `FileDownloadNode`, and `helpContent`.
>   - File Upload: Add optional “Folder Path” input for Azure; default `path` to `{{ workflow_run_id }}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f61e0c5475b2f6d80a777744f9b24f3de497eb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replaces `download_suffix` with full filename usage, enhances workflow context, refines upload paths, and updates UI labels.
> 
>   - **Behavior**:
>     - `download_suffix` now sets the complete filename (without extension) in `agent.py`; defaults to random if absent.
>     - `WorkflowRunContext` in `context_manager.py` now includes `workflow_title`, `workflow_id`, `workflow_permanent_id`, `workflow_run_id`.
>     - S3/Azure upload paths in `block.py` use optional `path`, defaulting to `{{ workflow_run_id }}`.
>   - **Schemas**:
>     - `download_suffix` marked as deprecated in YAML schemas.
>     - Added `azure_folder_path` to file upload YAML.
>   - **Frontend/UI**:
>     - Renamed "File Suffix" to "File Name" in `TaskNode`, `NavigationNode`, `ActionNode`, `FileDownloadNode`.
>     - Added "Folder Path" input for Azure uploads; defaults to `{{ workflow_run_id }}`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1d23e5a31a3d5b6a36b8ababce5855979ae1a9ea. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔄 This PR refactors file handling by changing `download_suffix` from an appendable suffix to a complete filename, adds workflow context variables for templating, and enhances file upload path management for both S3 and Azure storage.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **File Download Behavior**: `download_suffix` now sets the complete filename (without extension) instead of being appended to a random name, with fallback to random generation when not provided
- **Workflow Context Enhancement**: Added `workflow_title`, `workflow_id`, `workflow_permanent_id`, and `workflow_run_id` as injectable template variables throughout the workflow execution context
- **Storage Path Management**: Improved S3 and Azure Blob storage path construction to use optional `path` parameter, defaulting to `{{ workflow_run_id }}` for better organization
- **UI/UX Improvements**: Updated frontend labels from "File Suffix" to "File Name" across all node types and added optional folder path input for file uploads

### Technical Implementation
```mermaid
flowchart TD
    A[Download Request] --> B{download_suffix provided?}
    B -->|Yes| C[Use as complete filename]
    B -->|No| D[Generate random filename]
    C --> E[Add file extension]
    D --> E
    E --> F[Save to workflow directory]
    
    G[Workflow Context] --> H[Inject workflow variables]
    H --> I[workflow_title, workflow_id, etc.]
    I --> J[Available in templates]
    
    K[File Upload] --> L[Check path parameter]
    L --> M[Use path or default to workflow_run_id]
    M --> N[Construct S3/Azure URI]
```

### Impact
- **Improved File Management**: Users can now specify exact filenames for downloads, making file organization more predictable and user-friendly
- **Enhanced Template System**: Workflow-level variables are now accessible in all template contexts, enabling more dynamic and flexible workflow configurations
- **Better Storage Organization**: File uploads now support custom folder structures while maintaining backward compatibility with automatic workflow-based organization
- **Backward Compatibility**: The `download_suffix` field is marked as deprecated but continues to work, ensuring existing workflows remain functional

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added optional Folder Path input for File Upload (S3 and Azure); defaults to workflow run ID.
  * Exposed new templating variables: workflow_title, workflow_id, workflow_permanent_id, workflow_run_id.

* Changes
  * File naming: provided value now sets the complete filename (without extension); otherwise a random name is used.
  * Storage URIs use a consistent folder path and UUID-based filenames.
  * UI updates: “File Suffix” relabeled to “File Name”; tooltips/placeholders clarified.

* Deprecations
  * download_suffix deprecated in blocks; no longer appends to a random name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->