### PR TITLE
allow max timeout 24h when creating browser sessions

### DIFF
--- a/skyvern/schemas/browser_sessions.py
+++ b/skyvern/schemas/browser_sessions.py
@@ -4,7 +4,7 @@ from skyvern.schemas.docs.doc_strings import PROXY_LOCATION_DOC_STRING
 from skyvern.schemas.runs import ProxyLocation
 
 MIN_TIMEOUT = 5
-MAX_TIMEOUT = 60 * 4  # 4 hours
+MAX_TIMEOUT = 60 * 24  # 24 hours
 DEFAULT_TIMEOUT = 60
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase `MAX_TIMEOUT` for browser sessions to 24 hours in `skyvern/schemas/browser_sessions.py`.
> 
>   - **Behavior**:
>     - Increase `MAX_TIMEOUT` from 4 hours to 24 hours in `skyvern/schemas/browser_sessions.py`.
>     - Affects `CreateBrowserSessionRequest` to allow session timeouts up to 24 hours.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 31f809f8809ffd7f07703736b7a58478ceca1467. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum browser session timeout from 4 hours to 24 hours.
  * Validation now accepts timeouts up to 24 hours while preserving the existing minimum.
  * Default timeout remains 60 minutes.
  * Enables longer-running sessions without requiring manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->