### PR TITLE
Jon/sky 6560 enrich browser session creation via UI and place inside main layout

### DIFF
--- a/skyvern-frontend/src/components/ui/drawer.tsx
+++ b/skyvern-frontend/src/components/ui/drawer.tsx
@@ -41,7 +41,7 @@ const DrawerContent = React.forwardRef<
     <DrawerPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        "fixed bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
         className,
       )}
       {...props}


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6560/enrich-browser-session-creation-via-ui-and-place-inside-main-layout

Clicking "+ Create" now opens a right-side drawer with browser session options:

<img width="1710" height="948" alt="image" src="https://github.com/user-attachments/assets/cfa157eb-deb8-431c-83d9-308070adf608" />

`/browser-session/pbs_xxx` URL's now appear embedded within main app layout:

<img width="1710" height="948" alt="image" src="https://github.com/user-attachments/assets/b9777430-a595-4164-850f-9b4fc4335234" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance browser session creation UI with a drawer and embed session URLs in the main layout, updating routing and header logic accordingly.
> 
>   - **UI Enhancements**:
>     - Clicking "+ Create" in `BrowserSessions.tsx` opens a right-side drawer for browser session options.
>     - Drawer includes options for `Proxy Location` and `Timeout (Minutes)`.
>   - **Routing Changes**:
>     - Moved `browser-session/:browserSessionId` route under `browser-sessions` in `router.tsx`.
>     - Updated `Header.tsx` to hide header when `browser-session` path is active.
>   - **Behavior**:
>     - `handleRowClick` in `BrowserSessions.tsx` now navigates within the app instead of opening a new tab unless `ctrl` or `meta` key is pressed.
>   - **Misc**:
>     - Removed unused `ExternalLinkIcon` in `BrowserSessions.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 02441c8e1875408e71f648d9ce39b1d895f1a632. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->