### PR TITLE
reduce debug session browser session timeout minutes to 20

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -334,7 +334,7 @@ class Settings(BaseSettings):
     TRACE_PROVIDER_API_KEY: str = "fillmein"
 
     # Debug Session Settings
-    DEBUG_SESSION_TIMEOUT_MINUTES: int = 60 * 4
+    DEBUG_SESSION_TIMEOUT_MINUTES: int = 20
     """
     The timeout for a persistent browser session backing a debug session,
     in minutes.


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6569/reduce-debug-session-browser-session-to-20-minutes-and-discuss-lease
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reduce `DEBUG_SESSION_TIMEOUT_MINUTES` from 240 to 20 in `Settings` class in `skyvern/config.py`.
> 
>   - **Behavior**:
>     - Reduce `DEBUG_SESSION_TIMEOUT_MINUTES` from 240 to 20 in `Settings` class in `skyvern/config.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5b47bccea4f9e91be8e97c96f98b05ff0a2171d1. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

⏱️ This PR reduces the debug session browser timeout from 4 hours (240 minutes) to 20 minutes to optimize resource usage and prevent long-running debug sessions from consuming excessive system resources. The change affects the persistent browser session duration during debugging operations in the Skyvern automation platform.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Configuration Update**: Modified `DEBUG_SESSION_TIMEOUT_MINUTES` in `skyvern/config.py` from 240 minutes (4 hours) to 20 minutes
- **Resource Management**: Significantly reduces the lifespan of persistent browser sessions used for debugging
- **System Optimization**: Prevents debug sessions from holding resources for extended periods

### Technical Implementation
```mermaid
flowchart TD
    A[Debug Session Started] --> B[Browser Session Created]
    B --> C{Session Active?}
    C -->|Yes| D[Continue Debug Operations]
    C -->|No| E[Check Timeout]
    D --> C
    E -->|< 20 min| F[Keep Session Alive]
    E -->|≥ 20 min| G[Terminate Session]
    F --> C
    G --> H[Release Resources]
    
    style G fill:#ff9999
    style H fill:#99ff99
```

### Impact
- **Resource Efficiency**: Reduces memory and CPU usage by terminating idle debug sessions more aggressively
- **System Stability**: Prevents accumulation of long-running browser processes that could impact system performance
- **Developer Experience**: May require developers to be more mindful of debug session duration, potentially encouraging more focused debugging sessions

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced default debug session timeout from 240 minutes to 20 minutes. Persistent browser debug sessions will expire sooner by default, requiring more frequent extensions during debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->