### PR TITLE
Input > WorkflowBlockInputArea for filename in FileDownloadNode

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/FileDownloadNode/FileDownloadNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/FileDownloadNode/FileDownloadNode.tsx
@@ -313,7 +313,7 @@ function FileDownloadNode({ id, data }: NodeProps<FileDownloadNode>) {
                     </div>
                   </div>
                   <Separator />
-                  <div className="flex items-center justify-between">
+                  <div className="space-y-2">
                     <div className="flex gap-2">
                       <Label className="text-xs font-normal text-slate-300">
                         File Name
@@ -322,14 +322,14 @@ function FileDownloadNode({ id, data }: NodeProps<FileDownloadNode>) {
                         content={helpTooltips["download"]["fileSuffix"]}
                       />
                     </div>
-                    <Input
-                      type="text"
-                      placeholder={placeholders["download"]["downloadSuffix"]}
-                      className="nopan w-52 text-xs"
-                      value={inputs.downloadSuffix ?? ""}
-                      onChange={(event) => {
-                        handleChange("downloadSuffix", event.target.value);
+                    <WorkflowBlockInputTextarea
+                      nodeId={id}
+                      onChange={(value) => {
+                        handleChange("downloadSuffix", value);
                       }}
+                      value={inputs.downloadSuffix ?? ""}
+                      placeholder={placeholders["download"]["downloadSuffix"]}
+                      className="nopan text-xs"
                     />
                   </div>
                   <Separator />


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6570/add-a-in-the-file-name-selector-of-a-file-download-block
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `Input` with `WorkflowBlockInputTextarea` for `downloadSuffix` in `FileDownloadNode`, adjusting layout accordingly.
> 
>   - **Component Update**:
>     - Replaces `Input` with `WorkflowBlockInputTextarea` for `downloadSuffix` in `FileDownloadNode`.
>     - Adjusts layout by changing `div` class from `flex items-center justify-between` to `space-y-2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 02a11d67ba722e7d2314ac5cfa78559d9095be9f. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->