### PR TITLE
Update API specifications with fern api update

### DIFF
--- a/fern/openapi/skyvern_openapi.json
+++ b/fern/openapi/skyvern_openapi.json
@@ -4536,7 +4536,7 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 240,
+                "maximum": 1440,
                 "minimum": 5
               },
               {
@@ -4544,7 +4544,7 @@
               }
             ],
             "title": "Timeout",
-            "description": "Timeout in minutes for the session. Timeout is applied after the session is started. Must be between 5 and 240. Defaults to 60.",
+            "description": "Timeout in minutes for the session. Timeout is applied after the session is started. Must be between 5 and 1440. Defaults to 60.",
             "default": 60
           },
           "proxy_location": {
@@ -6320,6 +6320,17 @@
               }
             ],
             "title": "Azure Blob Container Name"
+          },
+          "azure_folder_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Azure Folder Path"
           },
           "path": {
             "anyOf": [


### PR DESCRIPTION
Update API specifications by running fern api update.

---

📋 This PR updates the API specifications by running `fern api update`, extending session timeout limits from 240 to 1440 minutes and adding support for Azure folder path configuration in blob storage operations.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Session Timeout Extension**: Maximum timeout increased from 240 minutes (4 hours) to 1440 minutes (24 hours) while maintaining minimum of 5 minutes
- **Azure Blob Storage Enhancement**: Added new optional `azure_folder_path` field to support folder-based organization within Azure blob containers
- **API Documentation**: Updated OpenAPI specification descriptions to reflect the new timeout limits

### Technical Implementation
```mermaid
flowchart TD
    A[Session Creation] --> B{Timeout Validation}
    B --> C[5-1440 minutes range]
    C --> D[Session Started]
    
    E[Azure Blob Storage] --> F[Container Selection]
    F --> G[Folder Path Optional]
    G --> H[File Operations]
```

### Impact
- **Extended Session Duration**: Users can now run longer automation sessions up to 24 hours, supporting complex workflows that require extended execution time
- **Improved Azure Integration**: Better organization of files within Azure blob storage through optional folder path specification
- **Backward Compatibility**: Changes are non-breaking as they extend existing limits and add optional fields

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update API specifications in `skyvern_openapi.json` to increase timeout maximum and add `azure_folder_path` field.
> 
>   - **API Specification Update**:
>     - Increase `maximum` timeout from 240 to 1440 in `skyvern_openapi.json`.
>     - Update `description` for `Timeout` to reflect new maximum value.
>     - Add `azure_folder_path` field with `string` or `null` type in `skyvern_openapi.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9b46fb5b0f39c2dbf2838bb218a29fa541d155c2. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased maximum browser session timeout to 1440 minutes (24 hours).
  * Added azure_folder_path option to file upload blocks to target a specific Azure folder.
* **Documentation**
  * Updated API docs to reflect the new timeout range (5–1440 minutes).
  * Documented the new azure_folder_path field and its usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->