### PR TITLE
send debug_session_id when running a block

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
@@ -73,6 +73,7 @@ const getPayload = (opts: {
   blockLabel: string;
   blockOutputs: Record<string, unknown>;
   browserSessionId: string | null;
+  debugSessionId: string;
   codeGen: boolean | null;
   parameters: Record<string, unknown>;
   totpIdentifier: string | null;
@@ -117,6 +118,7 @@ const getPayload = (opts: {
     block_labels: [opts.blockLabel],
     block_outputs: opts.blockOutputs,
     browser_session_id: opts.browserSessionId,
+    debug_session_id: opts.debugSessionId,
     code_gen: opts.codeGen,
     extra_http_headers: extraHttpHeaders,
     max_screenshot_scrolls: opts.workflowSettings.maxScreenshotScrollingTimes,
@@ -315,6 +317,7 @@ function NodeHeader({
         blockOutputs:
           blockOutputsStore.getOutputsWithOverrides(workflowPermanentId),
         browserSessionId: debugSession.browser_session_id,
+        debugSessionId: debugSession.debug_session_id,
         codeGen: opts?.codeGen ?? false,
         parameters,
         totpIdentifier,


### PR DESCRIPTION
Part of https://linear.app/skyvern/issue/SKY-6307/hide-debugger-runs-and-group-runs-by-browser-sessions
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `debugSessionId` to payload in `NodeHeader.tsx` to support grouping runs by browser sessions.
> 
>   - **Behavior**:
>     - Add `debugSessionId` to payload in `getPayload()` in `NodeHeader.tsx`.
>     - Pass `debugSessionId` from `debugSession` to `getPayload()` call in `NodeHeader()`.
>   - **Context**:
>     - Part of task to hide debugger runs and group runs by browser sessions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for af63c2ec6da25f15a54eab60c874a05dfc7654dd. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adds propagation of a debug session identifier in workflow requests, improving end-to-end traceability during debugging.
  * Enhances correlation between UI debug sessions and backend processing for clearer insights and faster troubleshooting.
  * No changes to the visible interface; applies when running workflows in debug mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->