### PR TITLE
skip malformed css selector

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skyvern"
-version = "0.2.16"
+version = "0.2.6"
 description = ""
 authors = [{ name = "Skyvern AI", email = "info@skyvern.com" }]
 requires-python = ">=3.11,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skyvern"
-version = "0.2.6"
+version = "0.2.16"
 description = ""
 authors = [{ name = "Skyvern AI", email = "info@skyvern.com" }]
 requires-python = ">=3.11,<3.14"

--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -763,7 +763,11 @@ function isHoverPointerElement(element, hoverStylesMap) {
         }
       }
       if (shouldMatch || selector.includes(tagName)) {
-        if (element.matches(selector) && styles.cursor === "pointer") {
+        if (
+          isValidCSSSelector(selector) &&
+          element.matches(selector) &&
+          styles.cursor === "pointer"
+        ) {
           return true;
         }
       }
@@ -2192,6 +2196,11 @@ async function getHoverStylesMap() {
             // Get base selector without :hover
             const baseSelector = hoverPart.replace(/:hover/g, "").trim();
 
+            // Skip invalid CSS selectors
+            if (!isValidCSSSelector(baseSelector)) {
+              continue;
+            }
+
             // Get or create styles object for this selector
             let styles = hoverMap.get(baseSelector) || {};
 
@@ -2204,13 +2213,16 @@ async function getHoverStylesMap() {
             // store it in a special format
             if (parts.length > 1) {
               const fullSelector = selector;
-              styles["__nested__"] = styles["__nested__"] || [];
-              styles["__nested__"].push({
-                selector: fullSelector,
-                styles: Object.fromEntries(
-                  [...rule.style].map((prop) => [prop, rule.style[prop]]),
-                ),
-              });
+              // Skip if the full selector is invalid
+              if (isValidCSSSelector(fullSelector)) {
+                styles["__nested__"] = styles["__nested__"] || [];
+                styles["__nested__"].push({
+                  selector: fullSelector,
+                  styles: Object.fromEntries(
+                    [...rule.style].map((prop) => [prop, rule.style[prop]]),
+                  ),
+                });
+              }
             }
 
             // only need the style which includes the cursor attribute.


### PR DESCRIPTION
## Problem Analysis
The error was caused by an invalid CSS selector `input[disabled])` with an extra closing parenthesis that was being processed by the JavaScript code running in the browser. This happened in the `isHoverPointerElement` function when it tried to call `element.matches(selector)` on a malformed selector.

## Solution Implemented
I added CSS selector validation in two key places in `skyvern/webeye/scraper/domUtils.js`:

1. **In the `isHoverPointerElement` function** (line 766): Added `isValidCSSSelector(selector)` check before calling `element.matches(selector)` to prevent invalid selectors from causing JavaScript errors.

2. **In the `getHoverStylesMap` function** (lines 2195-2198 and 2212-2213): Added validation to skip invalid CSS selectors when parsing stylesheets, preventing them from being added to the hover styles map in the first place.

## How the Fix Works
- The existing `isValidCSSSelector` function uses `document.querySelector(selector)` to test if a selector is valid
- Invalid selectors (like `input[disabled])`) will throw an exception and return `false`
- The code now skips these invalid selectors instead of trying to process them
- This prevents the `SyntaxError: Failed to execute 'matches' on 'Element'` error

The fix is backward-compatible and doesn't change the behavior for valid selectors - it just filters out the malformed ones that were causing the scraping to fail.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add validation to skip malformed CSS selectors in `isHoverPointerElement` and `getHoverStylesMap` in `domUtils.js`.
> 
>   - **Behavior**:
>     - Add `isValidCSSSelector(selector)` check in `isHoverPointerElement` to skip invalid CSS selectors before `element.matches(selector)`.
>     - Add validation in `getHoverStylesMap` to skip invalid CSS selectors when parsing stylesheets.
>   - **Functions**:
>     - `isHoverPointerElement` and `getHoverStylesMap` in `domUtils.js` now handle malformed selectors by skipping them.
>   - **Validation**:
>     - `isValidCSSSelector` uses `document.querySelector` to validate selectors, returning `false` for invalid ones.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for e6ac4c8b2f1a4b9fca96e5681febce31ed80dc3e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents errors and incorrect behavior when encountering invalid CSS selectors during hover detection.
  * Improves accuracy of hover style application, reducing false positives on non-interactive elements.

* **Performance**
  * Skips invalid selectors early, reducing unnecessary processing and improving responsiveness during DOM scraping.

* **Stability**
  * Adds stricter validation to avoid storing invalid hover rules, resulting in more reliable interaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->