### PR TITLE
Revert "skip malformed css selector"

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -763,11 +763,7 @@ function isHoverPointerElement(element, hoverStylesMap) {
         }
       }
       if (shouldMatch || selector.includes(tagName)) {
-        if (
-          isValidCSSSelector(selector) &&
-          element.matches(selector) &&
-          styles.cursor === "pointer"
-        ) {
+        if (element.matches(selector) && styles.cursor === "pointer") {
           return true;
         }
       }
@@ -2196,11 +2192,6 @@ async function getHoverStylesMap() {
             // Get base selector without :hover
             const baseSelector = hoverPart.replace(/:hover/g, "").trim();
 
-            // Skip invalid CSS selectors
-            if (!isValidCSSSelector(baseSelector)) {
-              continue;
-            }
-
             // Get or create styles object for this selector
             let styles = hoverMap.get(baseSelector) || {};
 
@@ -2213,16 +2204,13 @@ async function getHoverStylesMap() {
             // store it in a special format
             if (parts.length > 1) {
               const fullSelector = selector;
-              // Skip if the full selector is invalid
-              if (isValidCSSSelector(fullSelector)) {
-                styles["__nested__"] = styles["__nested__"] || [];
-                styles["__nested__"].push({
-                  selector: fullSelector,
-                  styles: Object.fromEntries(
-                    [...rule.style].map((prop) => [prop, rule.style[prop]]),
-                  ),
-                });
-              }
+              styles["__nested__"] = styles["__nested__"] || [];
+              styles["__nested__"].push({
+                selector: fullSelector,
+                styles: Object.fromEntries(
+                  [...rule.style].map((prop) => [prop, rule.style[prop]]),
+                ),
+              });
             }
 
             // only need the style which includes the cursor attribute.


### PR DESCRIPTION
Reverts Skyvern-AI/skyvern#3577

---

🔄 This PR reverts a previous change that added CSS selector validation to DOM utilities, removing the `isValidCSSSelector` checks that were preventing malformed CSS selectors from being processed. The revert restores the original behavior where all CSS selectors are processed without validation.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **CSS Selector Validation Removal**: Removed `isValidCSSSelector()` checks from `isHoverPointerElement()` function that were preventing element matching with invalid selectors
- **Hover Styles Processing**: Eliminated validation guards in `getHoverStylesMap()` that skipped invalid base selectors and nested hover styles
- **Error Handling Rollback**: Reverted defensive programming approach that prevented runtime errors from malformed CSS selectors

### Technical Implementation
```mermaid
sequenceDiagram
    participant S as Scraper
    participant D as DOMUtils
    participant B as Browser
    
    Note over D: Before Revert (with validation)
    S->>D: Process CSS selector
    D->>D: Validate selector with isValidCSSSelector()
    alt Invalid selector
        D-->>S: Skip processing
    else Valid selector
        D->>B: element.matches(selector)
        B-->>D: Result
        D-->>S: Process result
    end
    
    Note over D: After Revert (no validation)
    S->>D: Process CSS selector
    D->>B: element.matches(selector) directly
    alt Malformed selector
        B-->>D: Throws error
        D-->>S: Error propagates
    else Valid selector
        B-->>D: Result
        D-->>S: Process result
    end
```

### Impact
- **Error Exposure**: Malformed CSS selectors will now cause runtime errors instead of being silently skipped, potentially breaking functionality
- **Processing Coverage**: All CSS selectors (including malformed ones) will be attempted for processing, which may be the intended behavior for certain edge cases
- **Debugging Complexity**: Errors from invalid selectors will now surface, making it easier to identify problematic CSS but potentially causing application instability

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts skipping of malformed CSS selectors in `domUtils.js`, allowing all selectors to be processed without validation.
> 
>   - **Behavior**:
>     - Reverts skipping of malformed CSS selectors in `isHoverPointerElement()` and `getHoverStylesMap()` in `domUtils.js`.
>     - Removes `isValidCSSSelector()` checks, allowing all selectors to be processed.
>   - **Functions**:
>     - `isHoverPointerElement()`: No longer checks if a selector is valid before matching.
>     - `getHoverStylesMap()`: Processes all selectors without skipping invalid ones.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 55905a414c6a03e13c9d2774486ec497df657163. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of hoverable, pointer-style elements, reducing missed hover states.
  * More consistent capture of hover styles, including nested rules.
  * Fewer skipped interactions caused by overly strict selector validation.

* **Refactor**
  * Simplified selector handling and validation to streamline hover style mapping and reduce unnecessary checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->