### PR TITLE
Delete workflow scripts (bust cache) when workflow definition is updated

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import uuid
+from collections import deque
 from datetime import UTC, datetime
 from typing import Any
 
@@ -112,6 +113,53 @@ LOG = structlog.get_logger()
 
 DEFAULT_FIRST_BLOCK_LABEL = "block_1"
 DEFAULT_WORKFLOW_TITLE = "New Workflow"
+
+
+def _get_workflow_definition_without_dates(workflow_definition: WorkflowDefinition) -> dict[str, Any]:
+    """
+    This function dumps the workflow definition and removes the created_at and modified_at fields inside:
+    - list of blocks
+    - list of parameters
+    And return the dumped workflow definition as a python dictionary.
+    """
+    # Convert the workflow definition to a dictionary
+    workflow_dict = workflow_definition.model_dump()
+    fields_to_remove = [
+        "created_at",
+        "modified_at",
+        "deleted_at",
+        "output_parameter_id",
+        "workflow_id",
+        "workflow_parameter_id",
+        "",
+    ]
+
+    # Use BFS to recursively remove fields from all nested objects
+
+    # Queue to store objects to process
+    queue = deque([workflow_dict])
+
+    while queue:
+        current_obj = queue.popleft()
+
+        if isinstance(current_obj, dict):
+            # Remove specified fields from current dictionary
+            for field in fields_to_remove:
+                if field:  # Skip empty string
+                    current_obj.pop(field, None)
+
+            # Add all nested dictionaries and lists to queue for processing
+            for value in current_obj.values():
+                if isinstance(value, (dict, list)):
+                    queue.append(value)
+
+        elif isinstance(current_obj, list):
+            # Add all items in the list to queue for processing
+            for item in current_obj:
+                if isinstance(item, (dict, list)):
+                    queue.append(item)
+
+    return workflow_dict
 
 
 class WorkflowService:
@@ -877,13 +925,55 @@ class WorkflowService:
         if workflow_definition:
             workflow_definition.validate()
 
-        return await app.DATABASE.update_workflow(
+        # Update the workflow
+        updated_workflow = await app.DATABASE.update_workflow(
             workflow_id=workflow_id,
             title=title,
             organization_id=organization_id,
             description=description,
             workflow_definition=(workflow_definition.model_dump() if workflow_definition else None),
         )
+        updated_version = updated_workflow.version
+        previous_workflow = None
+        if updated_version > 1:
+            previous_workflow = await app.DATABASE.get_workflow_by_permanent_id(
+                workflow_permanent_id=updated_workflow.workflow_permanent_id,
+                organization_id=organization_id,
+                version=updated_version - 1,
+            )
+
+        # Check if workflow definition changed and delete published workflow scripts if so
+        if (
+            workflow_definition
+            and previous_workflow
+            and organization_id
+            and _get_workflow_definition_without_dates(previous_workflow.workflow_definition)
+            != _get_workflow_definition_without_dates(workflow_definition)
+        ):
+            try:
+                deleted_count = await app.DATABASE.delete_workflow_scripts_by_permanent_id(
+                    organization_id=organization_id,
+                    workflow_permanent_id=updated_workflow.workflow_permanent_id,
+                )
+                if deleted_count > 0:
+                    LOG.info(
+                        "Deleted published workflow scripts due to workflow definition change",
+                        workflow_id=workflow_id,
+                        workflow_permanent_id=updated_workflow.workflow_permanent_id,
+                        organization_id=organization_id,
+                        deleted_count=deleted_count,
+                    )
+            except Exception as e:
+                LOG.error(
+                    "Failed to delete published workflow scripts after workflow definition change",
+                    workflow_id=workflow_id,
+                    workflow_permanent_id=updated_workflow.workflow_permanent_id,
+                    organization_id=organization_id,
+                    error=str(e),
+                    exc_info=True,
+                )
+
+        return updated_workflow
 
     async def delete_workflow_by_permanent_id(
         self,

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -131,7 +131,6 @@ def _get_workflow_definition_without_dates(workflow_definition: WorkflowDefiniti
         "output_parameter_id",
         "workflow_id",
         "workflow_parameter_id",
-        "",
     ]
 
     # Use BFS to recursively remove fields from all nested objects


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Automatically delete workflow scripts when workflow definitions change by comparing definitions without timestamp fields and soft-deleting outdated scripts.
> 
>   - **Behavior**:
>     - Automatically soft-delete workflow scripts when workflow definitions change, ignoring timestamp fields, to prevent outdated executions.
>     - Enhanced `update_workflow()` in `service.py` to compare new and old workflow definitions and trigger script deletion if they differ.
>   - **Database Layer**:
>     - Added `delete_workflow_scripts_by_permanent_id()` in `client.py` to soft delete scripts by setting `deleted_at` timestamp.
>   - **Utility Function**:
>     - Implemented `_get_workflow_definition_without_dates()` in `service.py` to normalize workflow definitions by removing timestamp fields for comparison.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 665f8aa6203b0e797e8e3ad31182c7536679ca8e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🗑️ This PR implements automatic cache invalidation for workflow scripts when workflow definitions are updated, ensuring that published scripts are deleted when the underlying workflow logic changes to prevent stale executions.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Database Layer**: Added `delete_workflow_scripts_by_permanent_id()` method in `client.py` to soft delete workflow scripts by setting `deleted_at` timestamp
- **Service Layer**: Enhanced `update_workflow()` in `service.py` to detect workflow definition changes and trigger script deletion
- **Utility Function**: Implemented `_get_workflow_definition_without_dates()` to normalize workflow definitions for comparison by removing timestamp fields

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client as Client
    participant Service as WorkflowService
    participant DB as Database
    
    Client->>Service: update_workflow()
    Service->>DB: update_workflow()
    DB-->>Service: updated_workflow
    Service->>DB: get_workflow_by_permanent_id() (previous version)
    DB-->>Service: previous_workflow
    Service->>Service: _get_workflow_definition_without_dates() (both versions)
    Service->>Service: Compare normalized definitions
    alt Definitions differ
        Service->>DB: delete_workflow_scripts_by_permanent_id()
        DB-->>Service: deleted_count
        Service->>Service: Log deletion success/failure
    end
    Service-->>Client: updated_workflow
```

### Impact
- **Cache Consistency**: Prevents execution of outdated workflow scripts when definitions change, ensuring users always run the latest version
- **Data Integrity**: Soft deletion approach maintains audit trail while effectively removing stale scripts from active use
- **Automated Cleanup**: Eliminates manual intervention needed to clear cached scripts after workflow updates, reducing operational overhead

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - When a workflow is updated and its definition has materially changed (ignoring timestamp fields), previously published scripts for that workflow are automatically soft-deleted to prevent running outdated logic.
  - Improved resilience and logging during cleanup, with clear success/error messages if script deletions occur or fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->