### PR TITLE
fix false positive for isDirty check via StartNode

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
@@ -105,6 +105,11 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
     if (!data.editable) {
       return;
     }
+
+    if (inputs[key as keyof typeof inputs] === value) {
+      return;
+    }
+
     setInputs({ ...inputs, [key]: value });
     updateNodeData(id, { [key]: value });
   }
@@ -324,7 +329,7 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
                         <KeyValueInput
                           value={inputs.extraHttpHeaders ?? null}
                           onChange={(val) =>
-                            handleChange("extraHttpHeaders", val)
+                            handleChange("extraHttpHeaders", val || "{}")
                           }
                           addButtonText="Add Header"
                         />


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-5873/faulty-save-state-expand-workflow-settings-without-making-changes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix false positive in `StartNode.tsx` `isDirty` check by adding input value change verification.
> 
>   - **Behavior**:
>     - Fix false positive in `handleChange()` in `StartNode.tsx` by adding a check to prevent updates if the input value hasn't changed.
>     - Modify `handleChange()` call for `extraHttpHeaders` to use default value `{}` if `val` is falsy.
>   - **Misc**:
>     - No changes to other files or functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for ea760b3f8f16f5da70c5fa4af43cf52033f991d6. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->