### PR TITLE
do not publish workflow when running task v2

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -567,6 +567,7 @@ async def create_workflow_from_prompt(
             extra_http_headers=data.extra_http_headers,
             max_iterations=x_max_iterations_override,
             max_steps=x_max_steps_override,
+            status=WorkflowStatus.published if data.publish_workflow else WorkflowStatus.auto_generated,
             run_with=data.run_with,
             ai_fallback=data.ai_fallback,
         )

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -736,6 +736,7 @@ class WorkflowService:
         extra_http_headers: dict[str, str] | None = None,
         max_iterations: int | None = None,
         max_steps: int | None = None,
+        status: WorkflowStatus = WorkflowStatus.auto_generated,
         run_with: str | None = None,
         ai_fallback: bool = True,
     ) -> Workflow:
@@ -779,6 +780,7 @@ class WorkflowService:
             totp_identifier=totp_identifier,
             max_screenshot_scrolling_times=max_screenshot_scrolling_times,
             extra_http_headers=extra_http_headers,
+            status=status,
             run_with=run_with,
             ai_fallback=ai_fallback,
         )


### PR DESCRIPTION
---

🔧 This PR modifies the workflow creation behavior to conditionally publish workflows based on a new `publish_workflow` parameter, preventing automatic publication when running task v2 operations.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Workflow Status Control**: Added a new `status` parameter to `create_workflow_from_prompt()` function with default value `WorkflowStatus.auto_generated`
- **Conditional Publishing**: Modified the agent protocol route to set workflow status based on `data.publish_workflow` flag - published if true, auto-generated if false
- **Parameter Propagation**: Updated both the route handler and service layer to properly pass the status parameter through the workflow creation pipeline

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant AgentProtocol
    participant WorkflowService
    participant Database

    Client->>AgentProtocol: create_workflow_from_prompt(publish_workflow=false)
    AgentProtocol->>AgentProtocol: Determine status based on publish_workflow flag
    Note over AgentProtocol: status = published if publish_workflow else auto_generated
    AgentProtocol->>WorkflowService: create_workflow_from_prompt(status=auto_generated)
    WorkflowService->>Database: Create workflow with specified status
    Database-->>WorkflowService: Workflow created
    WorkflowService-->>AgentProtocol: Return workflow
    AgentProtocol-->>Client: Workflow response
```

### Impact
- **Workflow Management**: Provides better control over workflow visibility and lifecycle management by allowing workflows to remain in auto-generated state
- **Task v2 Integration**: Specifically addresses the need to prevent automatic workflow publishing when running task v2 operations
- **Backward Compatibility**: Maintains existing behavior by defaulting to auto-generated status, ensuring no breaking changes for existing implementations

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `create_workflow_from_prompt()` to set workflow status based on `publish_workflow` flag in `agent_protocol.py` and `service.py`.
> 
>   - **Behavior**:
>     - In `agent_protocol.py` and `service.py`, `create_workflow_from_prompt()` now sets `status` to `WorkflowStatus.published` if `data.publish_workflow` is true, otherwise `WorkflowStatus.auto_generated`.
>   - **Functions**:
>     - Updates `create_workflow_from_prompt()` in both `agent_protocol.py` and `service.py` to handle `publish_workflow` flag.
>   - **Misc**:
>     - No changes to other parts of the codebase.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 30d910523e737e447d146418d3d88e69ed954eca. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompt-based workflow creation now supports setting the workflow’s status at creation time.
  * If publish_workflow is enabled, new workflows are immediately published; otherwise, they are created as auto-generated.
  * Backward compatible: default behavior remains auto-generated when no publish preference is provided.
  * Enables API consumers to control workflow lifecycle state on creation without additional steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->