### PR TITLE
pass code_gen flag as True when auto-playing v2 tasks via discover pr…

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
@@ -73,6 +73,7 @@ const getPayload = (opts: {
   blockLabel: string;
   blockOutputs: Record<string, unknown>;
   browserSessionId: string | null;
+  codeGen: boolean | null;
   parameters: Record<string, unknown>;
   totpIdentifier: string | null;
   totpUrl: string | null;
@@ -116,6 +117,7 @@ const getPayload = (opts: {
     block_labels: [opts.blockLabel],
     block_outputs: opts.blockOutputs,
     browser_session_id: opts.browserSessionId,
+    code_gen: opts.codeGen,
     extra_http_headers: extraHttpHeaders,
     max_screenshot_scrolls: opts.workflowSettings.maxScreenshotScrollingTimes,
     parameters: opts.parameters,
@@ -202,7 +204,7 @@ function NodeHeader({
     ) {
       setAutoplay(null, null);
       setTimeout(() => {
-        runBlock.mutateAsync();
+        runBlock.mutateAsync({ codeGen: true });
       }, 100);
     }
 
@@ -260,7 +262,7 @@ function NodeHeader({
   ]);
 
   const runBlock = useMutation({
-    mutationFn: async () => {
+    mutationFn: async (opts?: { codeGen: boolean }) => {
       closeWorkflowPanel();
 
       await saveWorkflow.mutateAsync();
@@ -313,6 +315,7 @@ function NodeHeader({
         blockOutputs:
           blockOutputsStore.getOutputsWithOverrides(workflowPermanentId),
         browserSessionId: debugSession.browser_session_id,
+        codeGen: opts?.codeGen ?? false,
         parameters,
         totpIdentifier,
         totpUrl,
@@ -452,7 +455,7 @@ function NodeHeader({
   });
 
   const handleOnPlay = () => {
-    runBlock.mutate();
+    runBlock.mutate({ codeGen: false });
   };
 
   const handleOnCancel = () => {


### PR DESCRIPTION
…ompt

Part of https://linear.app/skyvern/issue/SKY-6571/unblock-script-generation-for-task-v2-in-debugger-runs-ensure-code
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Pass `codeGen` flag as `true` when auto-playing v2 tasks in `NodeHeader.tsx`.
> 
>   - **Behavior**:
>     - Pass `codeGen` flag as `true` in `runBlock.mutateAsync()` when auto-playing v2 tasks in `NodeHeader.tsx`.
>     - Default `codeGen` to `false` in `handleOnPlay()`.
>   - **Functions**:
>     - Update `getPayload()` to include `codeGen` in the payload.
>     - Modify `runBlock` mutation function to accept `codeGen` as an optional parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for bc3ded833a3ea651c7be4ae38a56d53db11d5800. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->