### PR TITLE
cache_key for workflow creation is still optional

### DIFF
--- a/skyvern/schemas/workflows.py
+++ b/skyvern/schemas/workflows.py
@@ -525,7 +525,7 @@ class WorkflowCreateYAMLRequest(BaseModel):
     status: WorkflowStatus = WorkflowStatus.published
     run_with: str | None = None
     ai_fallback: bool = False
-    cache_key: str = "default"
+    cache_key: str | None = "default"
     run_sequentially: bool = False
     sequential_key: str | None = None
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `cache_key` in `WorkflowCreateYAMLRequest` is now optional, allowing `None` as a valid value.
> 
>   - **Behavior**:
>     - `cache_key` in `WorkflowCreateYAMLRequest` is now optional, allowing `None` as a valid value.
>   - **Files**:
>     - Change made in `skyvern/schemas/workflows.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for bbfb86820f9941eaf4bd9020f6951fb8f188e02e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Workflow creation via YAML now accepts an optional cache key, including null values; if not provided, a default is used. This broadens accepted input without impacting existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->