### PR TITLE
Bring it back: turn on run_with code and ai fallback by default for task v2 (#3593)

### DIFF
--- a/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
@@ -150,6 +150,9 @@ function PromptBox() {
           proxy_location: proxyLocation,
           totp_identifier: totpIdentifier,
           max_screenshot_scrolls: maxScreenshotScrolls,
+          publish_workflow: publishWorkflow,
+          run_with: "code",
+          ai_fallback: true,
           extracted_information_schema: dataSchema
             ? (() => {
                 try {

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -2136,6 +2136,7 @@ function convert(workflow: WorkflowApiResponse): WorkflowCreateYAMLRequest {
       blocks: convertBlocksToBlockYAML(workflow.workflow_definition.blocks),
     },
     is_saved_task: workflow.is_saved_task,
+    status: workflow.status,
     run_with: workflow.run_with,
     cache_key: workflow.cache_key,
     ai_fallback: workflow.ai_fallback ?? undefined,

--- a/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
@@ -524,6 +524,7 @@ export type WorkflowApiResponse = {
   totp_verification_url: string | null;
   totp_identifier: string | null;
   max_screenshot_scrolls: number | null;
+  status: string | null;
   created_at: string;
   modified_at: string;
   deleted_at: string | null;

--- a/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
@@ -14,6 +14,7 @@ export type WorkflowCreateYAMLRequest = {
   is_saved_task?: boolean;
   max_screenshot_scrolls?: number | null;
   extra_http_headers?: Record<string, string> | null;
+  status?: string | null;
   run_with?: string | null;
   cache_key?: string | null;
   ai_fallback?: boolean;

--- a/skyvern-frontend/src/store/WorkflowHasChangesStore.ts
+++ b/skyvern-frontend/src/store/WorkflowHasChangesStore.ts
@@ -122,6 +122,7 @@ const useWorkflowSave = () => {
           blocks: saveData.blocks,
         },
         is_saved_task: saveData.workflow.is_saved_task,
+        status: saveData.workflow.status,
         run_sequentially: saveData.settings.runSequentially,
         sequential_key: saveData.settings.sequentialKey,
       };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enable `run_with` as `"code"` and `ai_fallback` by default for task v2, and add `status` handling in workflow-related types and functions.
> 
>   - **Behavior**:
>     - Default `run_with` set to `"code"` and `ai_fallback` to `true` in `PromptBox.tsx` for task v2.
>     - Adds `status` to `convert()` in `workflowEditorUtils.ts`.
>   - **Types**:
>     - Adds `status` to `WorkflowApiResponse` in `workflowTypes.ts`.
>     - Adds `status` to `WorkflowCreateYAMLRequest` in `workflowYamlTypes.ts`.
>   - **Store**:
>     - Adds `status` to `saveWorkflowMutation` in `WorkflowHasChangesStore.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a9841cf4e79a76e313dfe4a0bcca7b52da323e24. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Task creation now supports publishing the associated workflow, AI fallback, and a “code” run mode.
  - Workflow status is now included when creating/saving workflows, improving visibility and persistence across edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->