### PR TITLE
fix empty cache_key_value for block run cache

### DIFF
--- a/skyvern/services/workflow_script_service.py
+++ b/skyvern/services/workflow_script_service.py
@@ -61,10 +61,6 @@ async def get_workflow_script(
     cache_key = workflow.cache_key or ""
     rendered_cache_key_value = ""
 
-    if block_labels:
-        # Do not generate script or run script if block_labels is provided
-        return None, rendered_cache_key_value
-
     try:
         parameter_tuples = await app.DATABASE.get_workflow_run_parameters(
             workflow_run_id=workflow_run.workflow_run_id,
@@ -72,6 +68,10 @@ async def get_workflow_script(
         parameters = {wf_param.key: run_param.value for wf_param, run_param in parameter_tuples}
 
         rendered_cache_key_value = jinja_sandbox_env.from_string(cache_key).render(parameters)
+
+        if block_labels:
+            # Do not generate script or run script if block_labels is provided
+            return None, rendered_cache_key_value
 
         # Check if there are existing cached scripts for this workflow + cache_key_value
         existing_scripts = await app.DATABASE.get_workflow_scripts_by_cache_key_value(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes `get_workflow_script` to always compute `rendered_cache_key_value` even when `block_labels` are provided.
> 
>   - **Behavior**:
>     - In `get_workflow_script`, moved `block_labels` check after `rendered_cache_key_value` computation to ensure cache key value is always computed.
>     - Returns `None` and `rendered_cache_key_value` if `block_labels` is provided, ensuring cache key value integrity.
>   - **Misc**:
>     - No changes to other functions or files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 05099a4fa0affaf451e42d606f1b94a2d5308db9. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes a bug in the workflow script service where `rendered_cache_key_value` was being returned empty when `block_labels` were provided, by reordering the logic to compute the cache key value before the early return check.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Logic Reordering**: Moved the `block_labels` check after the cache key rendering logic in `get_workflow_script` function
- **Cache Key Computation**: Ensures `rendered_cache_key_value` is properly computed using Jinja templating before any early returns
- **Parameter Processing**: Maintains the workflow run parameter retrieval and rendering process regardless of block labels presence

### Technical Implementation
```mermaid
flowchart TD
    A[get_workflow_script called] --> B[Initialize cache_key and rendered_cache_key_value]
    B --> C[Get workflow run parameters]
    C --> D[Render cache key using Jinja template]
    D --> E{block_labels provided?}
    E -->|Yes| F[Return None, rendered_cache_key_value]
    E -->|No| G[Check existing cached scripts]
    G --> H[Continue with script generation]
```

### Impact
- **Bug Resolution**: Fixes the issue where `rendered_cache_key_value` was empty when `block_labels` were provided, ensuring proper cache key handling for block run caching
- **Improved Logic Flow**: The reordered logic is more intuitive and ensures all necessary computations happen before conditional exits
- **Backward Compatibility**: No breaking changes - the function signature and return behavior remain the same, only the internal logic order is improved

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * API now accepts an optional parameter to provide labels to block, allowing exclusion of matching workflow scripts during retrieval.

* Refactor
  * Adjusted internal execution order around rendering and early-return checks with no expected behavior change for typical usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->