### PR TITLE
cleanup precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,6 +105,12 @@ repos:
         types: [javascript]
   - repo: local
     hooks:
+      - id: frontend-precommit
+        name: Frontend Precommit (lint-staged)
+        entry: bash -c 'cd skyvern-frontend && npm run precommit'
+        language: system
+        files: ^skyvern-frontend/src/
+        pass_filenames: false
       - id: vitest-type-check
         name: vitest
         entry: bash -c 'cd skyvern-frontend && ([ -d node_modules ] || npm ci) && npm run test'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: check-python-version
         name: Check Python Version (3.11-3.13)
-        entry: python -c "import sys; assert (3,11) <= sys.version_info[:2] <= (3,13), f'Python {sys.version_info[:2]} not supported. Use Python 3.11-3.13'"
+        entry: uv run python -c "import sys; assert (3,11) <= sys.version_info[:2] <= (3,13), f'Python {sys.version_info[:2]} not supported. Use Python 3.11-3.13'"
         language: system
         pass_filenames: false
         always_run: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,15 +172,20 @@ Updating, improving and correcting the documentation
 ## Styleguides
 
 ### Pre Commit Hooks
-Make sure to run the pre-commit hooks before committing your code. 
-This will help you to automatically format your code and catch cicd failures early.
+Make sure to install and run the pre-commit hooks before committing your code.
+This will help you to automatically format your code and catch CI/CD failures early.
 ```bash
 # Make sure `pre-commit` is installed
 pip install pre-commit
 
-# Run pre-commit hooks on files in your commit
+# Install the git hook scripts (one-time setup)
+pre-commit install
+
+# (Optional) Run pre-commit hooks manually on all files
 pre-commit run --all-files
 ```
+
+Once installed, the hooks will run automatically on `git commit`.
 
 ### Commit Messages
 <!-- TODO

--- a/skyvern-frontend/.husky/pre-commit
+++ b/skyvern-frontend/.husky/pre-commit
@@ -1,3 +1,0 @@
-cd skyvern-frontend
-
-npm run precommit

--- a/skyvern-frontend/package-lock.json
+++ b/skyvern-frontend/package-lock.json
@@ -78,7 +78,6 @@
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.5",
-        "husky": "^9.0.11",
         "lint-staged": "^15.5.2",
         "postcss": "^8.4.37",
         "prettier": "^3.2.5",
@@ -6326,21 +6325,6 @@
       "dev": true,
       "engines": {
         "node": ">=16.17.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "9.0.11",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.0.11.tgz",
-      "integrity": "sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==",
-      "dev": true,
-      "bin": {
-        "husky": "bin.mjs"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/skyvern-frontend/package.json
+++ b/skyvern-frontend/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "format": "prettier --write .",
     "preview": "vite preview",
-    "prepare": "cd .. && husky skyvern-frontend/.husky",
+    "prepare": "cd .. && command -v pre-commit >/dev/null 2>&1 && pre-commit install || echo 'pre-commit not installed, skipping hook setup'",
     "precommit": "lint-staged",
     "run-artifact-server": "node artifactServer.js",
     "serve": "npm run build && node localServer.js",

--- a/skyvern-frontend/package.json
+++ b/skyvern-frontend/package.json
@@ -87,7 +87,6 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
-    "husky": "^9.0.11",
     "lint-staged": "^15.5.2",
     "postcss": "^8.4.37",
     "prettier": "^3.2.5",


### PR DESCRIPTION
1. removes husky and moves invocation of `npm run precommit` into the pre-commit config.
2. wraps python check hook with `uv run` so it uses the python from the project's venv.
3. updates npm prepare to automate the `pre-commit install` instead of using husky to configure hooks.