### PR TITLE
debugger: show animated button and pulse code editor when we think co…

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
@@ -40,6 +40,7 @@ type Props = {
   cacheKeyValue: string | null;
   cacheKeyValues: CacheKeyValuesResponse | undefined;
   cacheKeyValuesPanelOpen: boolean;
+  isGeneratingCode?: boolean;
   parametersPanelOpen: boolean;
   saving: boolean;
   showAllCode: boolean;
@@ -59,6 +60,7 @@ function WorkflowHeader({
   cacheKeyValue,
   cacheKeyValues,
   cacheKeyValuesPanelOpen,
+  isGeneratingCode,
   parametersPanelOpen,
   saving,
   showAllCode,
@@ -132,76 +134,88 @@ function WorkflowHeader({
         />
       </div>
       <div className="flex h-full items-center justify-end gap-4">
-        {user && (cacheKeyValues?.total_count ?? 0) > 0 && (
-          <>
-            {debugStore.isDebugMode && (
-              <Button
-                className="pl-2 pr-3"
-                size="lg"
-                variant={!showAllCode ? "tertiary" : "default"}
-                onClick={handleShowAllCode}
+        {user &&
+          !isGeneratingCode &&
+          (cacheKeyValues?.total_count ?? 0) > 0 && (
+            <>
+              {debugStore.isDebugMode && (
+                <Button
+                  className="pl-2 pr-3"
+                  size="lg"
+                  variant={!showAllCode ? "tertiary" : "default"}
+                  onClick={handleShowAllCode}
+                >
+                  <CodeIcon className="mr-2 h-6 w-6" />
+                  Show Code
+                </Button>
+              )}
+              <div
+                tabIndex={1}
+                className="flex max-w-[10rem] items-center justify-center gap-1 rounded-md border border-input pr-1 focus-within:ring-1 focus-within:ring-ring"
               >
-                <CodeIcon className="mr-2 h-6 w-6" />
-                Show Code
-              </Button>
-            )}
-            <div
-              tabIndex={1}
-              className="flex max-w-[10rem] items-center justify-center gap-1 rounded-md border border-input pr-1 focus-within:ring-1 focus-within:ring-ring"
-            >
-              <Input
-                ref={dom.input}
-                className="focus-visible:transparent focus-visible:none h-[2.75rem] text-ellipsis whitespace-nowrap border-none focus-visible:outline-none focus-visible:ring-0"
-                onChange={(e) => {
-                  setChosenCacheKeyValue(e.target.value);
-                  onCacheKeyValuesFilter(e.target.value);
-                }}
-                onMouseDown={() => {
-                  if (!cacheKeyValuesPanelOpen) {
-                    onCacheKeyValuesClick();
-                  }
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    const numFiltered = cacheKeyValues?.values?.length ?? 0;
-
-                    if (numFiltered === 1) {
-                      const first = cacheKeyValues?.values?.[0];
-                      if (first) {
-                        setChosenCacheKeyValue(first);
-                        onCacheKeyValueAccept(first);
-                      }
-                      return;
+                <Input
+                  ref={dom.input}
+                  className="focus-visible:transparent focus-visible:none h-[2.75rem] text-ellipsis whitespace-nowrap border-none focus-visible:outline-none focus-visible:ring-0"
+                  onChange={(e) => {
+                    setChosenCacheKeyValue(e.target.value);
+                    onCacheKeyValuesFilter(e.target.value);
+                  }}
+                  onMouseDown={() => {
+                    if (!cacheKeyValuesPanelOpen) {
+                      onCacheKeyValuesClick();
                     }
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      const numFiltered = cacheKeyValues?.values?.length ?? 0;
 
-                    setChosenCacheKeyValue(chosenCacheKeyValue);
-                    onCacheKeyValueAccept(chosenCacheKeyValue);
-                  }
-                  onCacheKeyValuesKeydown(e);
-                }}
-                placeholder="Code Key Value"
-                value={chosenCacheKeyValue ?? undefined}
-                onBlur={(e) => {
-                  onCacheKeyValuesBlurred(e.target.value);
-                  setChosenCacheKeyValue(e.target.value);
-                }}
-              />
-              {cacheKeyValuesPanelOpen ? (
-                <ChevronUpIcon
-                  className="h-6 w-6 cursor-pointer"
-                  onClick={onCacheKeyValuesClick}
-                />
-              ) : (
-                <ChevronDownIcon
-                  className="h-6 w-6 cursor-pointer"
-                  onClick={() => {
-                    dom.input.current?.focus();
-                    onCacheKeyValuesClick();
+                      if (numFiltered === 1) {
+                        const first = cacheKeyValues?.values?.[0];
+                        if (first) {
+                          setChosenCacheKeyValue(first);
+                          onCacheKeyValueAccept(first);
+                        }
+                        return;
+                      }
+
+                      setChosenCacheKeyValue(chosenCacheKeyValue);
+                      onCacheKeyValueAccept(chosenCacheKeyValue);
+                    }
+                    onCacheKeyValuesKeydown(e);
+                  }}
+                  placeholder="Code Key Value"
+                  value={chosenCacheKeyValue ?? undefined}
+                  onBlur={(e) => {
+                    onCacheKeyValuesBlurred(e.target.value);
+                    setChosenCacheKeyValue(e.target.value);
                   }}
                 />
-              )}
-            </div>
-          </>
+                {cacheKeyValuesPanelOpen ? (
+                  <ChevronUpIcon
+                    className="h-6 w-6 cursor-pointer"
+                    onClick={onCacheKeyValuesClick}
+                  />
+                ) : (
+                  <ChevronDownIcon
+                    className="h-6 w-6 cursor-pointer"
+                    onClick={() => {
+                      dom.input.current?.focus();
+                      onCacheKeyValuesClick();
+                    }}
+                  />
+                )}
+              </div>
+            </>
+          )}
+        {isGeneratingCode && (
+          <Button
+            className="size-10 min-w-[6rem]"
+            variant={!showAllCode ? "tertiary" : "default"}
+            onClick={handleShowAllCode}
+          >
+            <ReloadIcon className="mr-2 h-4 w-4 animate-spin" />
+            Code
+          </Button>
         )}
         {isGlobalWorkflow ? (
           <Button


### PR DESCRIPTION
…de is being generated on the backend

https://linear.app/skyvern/issue/SKY-6620/render-pending-script-in-task-v2-debugger-while-running
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add UI indicators for backend code generation in `WorkflowHeader` and `Workspace` using `isGeneratingCode` flag.
> 
>   - **Behavior**:
>     - Add `isGeneratingCode` prop to `WorkflowHeader` to indicate backend code generation.
>     - Show spinning `ReloadIcon` on button and pulse animation on `CodeEditor` when `isGeneratingCode` is true.
>   - **Logic**:
>     - Determine `isGeneratingCode` in `Workspace.tsx` based on `blockScriptsPublished` count and `workflowRun` status.
>     - Poll `blockScriptsPending` every 3000ms if `isGeneratingCode` is true.
>   - **UI Changes**:
>     - Modify `WorkflowHeader.tsx` to conditionally render button with spinning icon when `isGeneratingCode`.
>     - Apply `animate-pulse` class to `CodeEditor` in `Workspace.tsx` when `isGeneratingCode`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a9faca077f8e6726ab2a7508ad4cb7e2d036e9d8. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Visual “Generating code” state in the header with a spinner.
  - Code editor shows live, in-progress output and subtle pulse animation during generation.

- Improvements
  - Code controls are hidden/disabled while generation is in progress for clearer UX.
  - Enhanced code key input: auto-selects the single matching key on Enter and improved focus/expand behavior.
  - More responsive updates via background polling while code is generating.
  - Cleaner, consolidated UI for code keys and chevrons; “Show Code” button appears only when applicable (e.g., debug).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->