### PR TITLE
make browser download timeout configurable for blocks and tasks

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -172,6 +172,7 @@ class AgentDB:
         extra_http_headers: dict[str, str] | None = None,
         browser_session_id: str | None = None,
         browser_address: str | None = None,
+        download_timeout: float | None = None,
     ) -> Task:
         try:
             async with self.Session() as session:
@@ -203,6 +204,7 @@ class AgentDB:
                     extra_http_headers=extra_http_headers,
                     browser_session_id=browser_session_id,
                     browser_address=browser_address,
+                    download_timeout=download_timeout,
                 )
                 session.add(new_task)
                 await session.commit()

--- a/skyvern/forge/sdk/db/models.py
+++ b/skyvern/forge/sdk/db/models.py
@@ -109,6 +109,7 @@ class TaskModel(Base):
     )
     model = Column(JSON, nullable=True)
     browser_address = Column(String, nullable=True)
+    download_timeout = Column(Numeric, nullable=True)
 
 
 class StepModel(Base):

--- a/skyvern/forge/sdk/db/utils.py
+++ b/skyvern/forge/sdk/db/utils.py
@@ -158,6 +158,7 @@ def convert_to_task(task_obj: TaskModel, debug_enabled: bool = False, workflow_p
         max_screenshot_scrolls=task_obj.max_screenshot_scrolling_times,
         browser_session_id=task_obj.browser_session_id,
         browser_address=task_obj.browser_address,
+        download_timeout=task_obj.download_timeout,
     )
     return task
 

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -113,6 +113,11 @@ class TaskBase(BaseModel):
         description="The CDP address for the task.",
         examples=["http://127.0.0.1:9222", "ws://127.0.0.1:9222/devtools/browser/1234567890"],
     )
+    download_timeout: float | None = Field(
+        default=None,
+        description="The maximum time to wait for downloads to complete, in minutes. If not set, defaults to BROWSER_DOWNLOAD_TIMEOUT minutes.",
+        examples=[15.0],
+    )
 
 
 class TaskRequest(TaskBase):

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -422,6 +422,7 @@ class BaseTaskBlock(Block):
     cache_actions: bool = False
     complete_verification: bool = True
     include_action_history_in_verification: bool = False
+    download_timeout: float | None = None  # minutes
 
     def get_all_parameters(
         self,
@@ -631,6 +632,7 @@ class BaseTaskBlock(Block):
                         failure_reason=str(e),
                     )
                     raise e
+
                 try:
                     # add screenshot artifact for the first task
                     screenshot = await browser_state.take_fullpage_screenshot(

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -2490,6 +2490,7 @@ class WorkflowService:
                 cache_actions=block_yaml.cache_actions,
                 complete_on_download=True,
                 complete_verification=True,
+                download_timeout=block_yaml.download_timeout,
             )
         elif block_yaml.block_type == BlockType.TaskV2:
             return TaskV2Block(

--- a/skyvern/schemas/workflows.py
+++ b/skyvern/schemas/workflows.py
@@ -433,6 +433,7 @@ class FileDownloadBlockYAML(BlockYAML):
     totp_verification_url: str | None = None
     totp_identifier: str | None = None
     cache_actions: bool = False
+    download_timeout: float | None = None
 
 
 class UrlBlockYAML(BlockYAML):

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -17,6 +17,7 @@ from skyvern.config import settings
 from skyvern.constants import (
     AUTO_COMPLETION_POTENTIAL_VALUES_COUNT,
     BROWSER_DOWNLOAD_MAX_WAIT_TIME,
+    BROWSER_DOWNLOAD_TIMEOUT,
     DROPDOWN_MENU_MAX_DISTANCE,
     REPO_ROOT_DIR,
     SKYVERN_ID_ATTR,
@@ -864,7 +865,7 @@ async def handle_click_to_download_file_action(
             "Checking if there is any new files after click",
             download_dir=download_dir,
         )
-        async with asyncio.timeout(BROWSER_DOWNLOAD_MAX_WAIT_TIME):
+        async with asyncio.timeout(task.download_timeout or BROWSER_DOWNLOAD_MAX_WAIT_TIME):
             while True:
                 list_files_after = list_files_in_directory(download_dir)
                 if task.browser_session_id:
@@ -913,7 +914,9 @@ async def handle_click_to_download_file_action(
         workflow_run_id=task.workflow_run_id,
     )
     try:
-        await wait_for_download_finished(downloading_files=downloading_files)
+        await wait_for_download_finished(
+            downloading_files=downloading_files, timeout=task.download_timeout or BROWSER_DOWNLOAD_TIMEOUT
+        )
     except DownloadFileMaxWaitingTime as e:
         LOG.warning(
             "There're several long-time downloading files, these files might be broken",

--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -70,12 +70,14 @@ def set_browser_console_log(browser_context: BrowserContext, browser_artifacts: 
     browser_context.on("console", browser_console_log)
 
 
-def set_download_file_listener(browser_context: BrowserContext, **kwargs: Any) -> None:
+def set_download_file_listener(
+    browser_context: BrowserContext, download_timeout: float | None = None, **kwargs: Any
+) -> None:
     async def listen_to_download(download: Download) -> None:
         workflow_run_id = kwargs.get("workflow_run_id")
         task_id = kwargs.get("task_id")
         try:
-            async with asyncio.timeout(BROWSER_DOWNLOAD_TIMEOUT):
+            async with asyncio.timeout(download_timeout or BROWSER_DOWNLOAD_TIMEOUT):
                 file_path = await download.path()
                 if file_path.suffix:
                     return


### PR DESCRIPTION
BE part of https://linear.app/skyvern/issue/SKY-6575/make-browser-download-timeout-configurable-for-blocks-and-tasks

Only supports file download block.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add configurable `download_timeout` for file download blocks and tasks, updating database schema, models, and logic accordingly.
> 
>   - **Behavior**:
>     - Adds `download_timeout` to `tasks` table in `2025_10_03_2006-485bf0f1203f_add_download_timeout_to_tasks_table.py`.
>     - Supports configurable `download_timeout` for file download blocks in `agent.py` and `handler.py`.
>   - **Models**:
>     - Adds `download_timeout` field to `TaskModel` in `models.py`.
>     - Updates `TaskBase` schema in `schemas/tasks.py` to include `download_timeout`.
>   - **Logic**:
>     - Modifies `create_task()` in `client.py` to accept `download_timeout`.
>     - Updates `execute_step()` in `agent.py` to use `download_timeout` or default.
>     - Adjusts `set_download_file_listener()` in `browser_factory.py` to use `download_timeout`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 3865a63b9608fd4c17adc2ec0230ec2917ce8f45. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->