### PR TITLE
add Download Timeout to FileDownloadNode

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -486,3 +486,5 @@ export type RunEngine = (typeof RunEngine)[keyof typeof RunEngine];
 export type PylonEmailHash = {
   hash: string;
 };
+
+export const BROWSER_DOWNLOAD_TIMEOUT_SECONDS = 600 as const;

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/FileDownloadNode/FileDownloadNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/FileDownloadNode/FileDownloadNode.tsx
@@ -40,6 +40,7 @@ import { useParams } from "react-router-dom";
 import { statusIsRunningOrQueued } from "@/routes/tasks/types";
 import { useWorkflowRunQuery } from "@/routes/workflows/hooks/useWorkflowRunQuery";
 import { useRerender } from "@/hooks/useRerender";
+import { BROWSER_DOWNLOAD_TIMEOUT_SECONDS } from "@/api/types";
 
 const urlTooltip =
   "The URL Skyvern is navigating to. Leave this field blank to pick up from where the last block left off.";
@@ -74,6 +75,7 @@ function FileDownloadNode({ id, data }: NodeProps<FileDownloadNode>) {
     totpIdentifier: data.totpIdentifier,
     engine: data.engine,
     model: data.model,
+    downloadTimeout: data.downloadTimeout,
   });
   const rerender = useRerender({ prefix: "accordian" });
   const nodes = useNodes<AppNode>();
@@ -84,6 +86,7 @@ function FileDownloadNode({ id, data }: NodeProps<FileDownloadNode>) {
     if (!editable) {
       return;
     }
+
     setInputs({ ...inputs, [key]: value });
     updateNodeData(id, { [key]: value });
   }
@@ -163,6 +166,32 @@ function FileDownloadNode({ id, data }: NodeProps<FileDownloadNode>) {
                 placeholder={navigationGoalPlaceholder}
                 className="nopan text-xs"
               />
+            </div>
+            <div className="space-y-2">
+              <div className="space-between flex items-center gap-2">
+                <Label className="text-xs text-slate-300">
+                  Download Timeout (sec)
+                </Label>
+                <HelpTooltip
+                  content={`The maximum time to wait for downloads to complete, in seconds. If not set, defaults to ${BROWSER_DOWNLOAD_TIMEOUT_SECONDS} seconds.`}
+                />
+
+                <Input
+                  className="ml-auto w-16 text-right"
+                  value={inputs.downloadTimeout ?? undefined}
+                  placeholder={`${BROWSER_DOWNLOAD_TIMEOUT_SECONDS}`}
+                  onChange={(event) => {
+                    const value =
+                      event.target.value === ""
+                        ? null
+                        : Number(event.target.value);
+
+                    if (value) {
+                      handleChange("downloadTimeout", value);
+                    }
+                  }}
+                />
+              </div>
             </div>
             <div className="rounded-md bg-slate-800 p-2 text-xs text-slate-400">
               Once the file is downloaded, this block will complete.

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/FileDownloadNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/FileDownloadNode/types.ts
@@ -15,6 +15,7 @@ export type FileDownloadNodeData = NodeBaseData & {
   totpIdentifier: string | null;
   engine: RunEngine | null;
   cacheActions: boolean;
+  downloadTimeout: number | null;
 };
 
 export type FileDownloadNode = Node<FileDownloadNodeData, "fileDownload">;
@@ -36,6 +37,7 @@ export const fileDownloadNodeDefaultData: FileDownloadNodeData = {
   cacheActions: false,
   engine: RunEngine.SkyvernV1,
   model: null,
+  downloadTimeout: null,
 } as const;
 
 export function isFileDownloadNode(node: Node): node is FileDownloadNode {

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -402,6 +402,7 @@ function convertToNode(
           cacheActions: block.cache_actions,
           maxStepsOverride: block.max_steps_per_run ?? null,
           engine: block.engine ?? RunEngine.SkyvernV1,
+          downloadTimeout: block.download_timeout ?? null, // seconds
         },
       };
     }
@@ -1213,6 +1214,7 @@ function getWorkflowBlock(node: WorkflowBlockNode): BlockYAML {
         totp_verification_url: node.data.totpVerificationUrl,
         cache_actions: node.data.cacheActions,
         engine: node.data.engine,
+        download_timeout: node.data.downloadTimeout, // seconds
       };
     }
     case "sendEmail": {
@@ -1991,6 +1993,7 @@ function convertBlocksToBlockYAML(
           totp_verification_url: block.totp_verification_url,
           cache_actions: block.cache_actions,
           engine: block.engine,
+          download_timeout: null, // seconds
         };
         return blockYaml;
       }

--- a/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
@@ -478,6 +478,7 @@ export type FileDownloadBlock = WorkflowBlockBase & {
   totp_identifier?: string | null;
   cache_actions: boolean;
   engine: RunEngine | null;
+  download_timeout: number | null; // seconds
 };
 
 export type PDFParserBlock = WorkflowBlockBase & {

--- a/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
@@ -269,6 +269,7 @@ export type FileDownloadBlockYAML = BlockYAMLBase & {
   totp_identifier?: string | null;
   cache_actions: boolean;
   engine: RunEngine | null;
+  download_timeout?: number | null;
 };
 
 export type CodeBlockYAML = BlockYAMLBase & {


### PR DESCRIPTION
FE part of https://linear.app/skyvern/issue/SKY-6575/make-browser-download-timeout-configurable-for-blocks-and-tasks

Only supports file download block.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add configurable download timeout to `FileDownloadNode` with default of 600 seconds.
> 
>   - **Behavior**:
>     - Adds `downloadTimeout` property to `FileDownloadNode` in `FileDownloadNode.tsx` to set maximum download time.
>     - Default timeout is set to `BROWSER_DOWNLOAD_TIMEOUT_SECONDS` (600 seconds) if not specified.
>   - **Types**:
>     - Updates `FileDownloadNodeData` in `types.ts` to include `downloadTimeout`.
>     - Adds `download_timeout` to `FileDownloadBlock` in `workflowTypes.ts` and `FileDownloadBlockYAML` in `workflowYamlTypes.ts`.
>   - **Utils**:
>     - Modifies `convertToNode()` and `getWorkflowBlock()` in `workflowEditorUtils.ts` to handle `downloadTimeout`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 21923d66d4fbb28b50976079aa7aa3d31d5ee47e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->