### PR TITLE
ensure default cache key for workflows is set

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
 
 from skyvern.config import settings
+from skyvern.constants import DEFAULT_SCRIPT_RUN_ID
 from skyvern.exceptions import WorkflowParameterNotFound, WorkflowRunNotFound
 from skyvern.forge.sdk.artifact.models import Artifact, ArtifactType
 from skyvern.forge.sdk.db.enums import OrganizationAuthTokenType, TaskType
@@ -1422,7 +1423,7 @@ class AgentDB:
                 status=status,
                 run_with=run_with,
                 ai_fallback=ai_fallback,
-                cache_key=cache_key,
+                cache_key=cache_key or DEFAULT_SCRIPT_RUN_ID,
                 run_sequentially=run_sequentially,
                 sequential_key=sequential_key,
             )


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6635/set-default-script-cache-key-for-new-workflows
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Set default cache key to `DEFAULT_SCRIPT_RUN_ID` in `create_workflow()` if not provided.
> 
>   - **Behavior**:
>     - In `create_workflow()` in `client.py`, set `cache_key` to `DEFAULT_SCRIPT_RUN_ID` if `cache_key` is not provided.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1b3bf55602cc08d6e7c72218c474942787aab653. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR ensures that workflows always have a default cache key by setting `DEFAULT_SCRIPT_RUN_ID` when no cache key is provided during workflow creation. This prevents potential issues with workflows that lack proper cache key configuration and standardizes the caching behavior across the system.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Database Client**: Modified `create_workflow()` function in `skyvern/forge/sdk/db/client.py` to use a fallback cache key
- **Import Addition**: Added import for `DEFAULT_SCRIPT_RUN_ID` from `skyvern.constants` module
- **Default Value Logic**: Implemented `cache_key or DEFAULT_SCRIPT_RUN_ID` to ensure cache_key is never None/empty

### Technical Implementation
```mermaid
flowchart TD
    A[create_workflow called] --> B{cache_key provided?}
    B -->|Yes| C[Use provided cache_key]
    B -->|No| D[Use DEFAULT_SCRIPT_RUN_ID]
    C --> E[Create workflow with cache_key]
    D --> E
    E --> F[Workflow created successfully]
```

### Impact
- **Reliability**: Prevents workflows from being created without proper cache keys, avoiding potential runtime issues
- **Consistency**: Standardizes cache key behavior across all workflow creation scenarios
- **Backward Compatibility**: Non-breaking change that maintains existing functionality while adding safety defaults

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workflows now automatically use a default cache key when none is provided, preventing failures and inconsistent behavior during execution.
  * Reduces unexpected cache misses and improves stability across runs.
  * Ensures more predictable performance and results for users who do not specify a cache key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->