### PR TITLE
ensure browser control buttons in debugger are always on

### DIFF
--- a/skyvern-frontend/src/components/BrowserStream.tsx
+++ b/skyvern-frontend/src/components/BrowserStream.tsx
@@ -115,7 +115,7 @@ function BrowserStream({
   });
 
   const [hasBrowserSession, setHasBrowserSession] = useState(true); // be optimistic
-  const [userIsControlling, setUserIsControlling] = useState(interactive);
+  const [userIsControlling, setUserIsControlling] = useState(false);
   const [commandSocket, setCommandSocket] = useState<WebSocket | null>(null);
   const [vncDisconnectedTrigger, setVncDisconnectedTrigger] = useState(0);
   const prevVncConnectedRef = useRef<boolean>(false);

--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -158,7 +158,6 @@ function Workspace({
 
   const { data: workflowRun } = useWorkflowRunQuery();
   const isFinalized = workflowRun ? statusIsFinalized(workflowRun) : false;
-  const interactor = workflowRun && isFinalized === false ? "agent" : "human";
 
   const [openCycleBrowserDialogue, setOpenCycleBrowserDialogue] =
     useState(false);
@@ -1273,11 +1272,11 @@ function Workspace({
                         activeDebugSession.browser_session_id &&
                         !cycleBrowser.isPending ? (
                           <BrowserStream
-                            interactive={interactor === "human"}
+                            interactive={true}
                             browserSessionId={
                               activeDebugSession.browser_session_id
                             }
-                            showControlButtons={interactor === "human"}
+                            showControlButtons={true}
                             resizeTrigger={windowResizeTrigger}
                           />
                         ) : (


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6640/investigate-non-functional-control-buttons-in-browserstream-component
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure control buttons in `BrowserStream` are always visible and functional by setting `interactive` and `showControlButtons` to `true` in `Workspace.tsx`.
> 
>   - **Behavior**:
>     - `interactive` and `showControlButtons` set to `true` in `Workspace.tsx` when rendering `BrowserStream`, ensuring buttons are always visible.
>     - Initial state of `userIsControlling` set to `false` in `BrowserStream.tsx`.
>   - **Misc**:
>     - Remove `interactor` logic in `Workspace.tsx` related to control button visibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 71e7a36e5f2c241aabf894596908bf236c7e1dc2. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

---

🎮 This PR fixes non-functional browser control buttons in the debugger by ensuring they are always visible and interactive, removing conditional logic that was preventing users from controlling the browser during debugging sessions.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **BrowserStream Component**: Changed initial state of `userIsControlling` from `interactive` prop to hardcoded `false`, ensuring consistent behavior
- **Workspace Component**: Removed conditional `interactor` logic and set both `interactive` and `showControlButtons` props to `true` for all debugging sessions
- **Control Logic Simplification**: Eliminated the workflow run status-based determination of whether users can interact with the browser

### Technical Implementation
```mermaid
flowchart TD
    A[Workspace Component] --> B{Previous Logic}
    B --> C[Check workflowRun status]
    C --> D{isFinalized?}
    D -->|true| E[interactor = 'human']
    D -->|false| F[interactor = 'agent']
    E --> G[showControlButtons = true]
    F --> H[showControlButtons = false]
    
    A --> I{New Logic}
    I --> J[Always set interactive = true]
    I --> K[Always set showControlButtons = true]
    J --> L[BrowserStream always controllable]
    K --> L
```

### Impact
- **User Experience**: Debug sessions now consistently show browser control buttons, allowing users to interact with the browser regardless of workflow run status
- **Debugging Capability**: Developers can now properly control and interact with browser sessions during debugging, improving troubleshooting efficiency
- **Code Simplification**: Removes complex conditional logic that was causing the control buttons to be hidden inappropriately, making the codebase more maintainable

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified browser interaction: the browser stream is now always interactive with control buttons visible, removing previous interactor-dependent behavior. This provides a consistent experience across workflows.
  - Adjusted default control state: users no longer control the browser upon load, even in interactive mode. Control must be explicitly taken via the UI, preventing unintended input and making the handoff between viewing and controlling more deliberate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->