### PR TITLE
Fix AsyncHttpClient sending empty body when everything OMITted

### DIFF
--- a/skyvern/client/core/http_client.py
+++ b/skyvern/client/core/http_client.py
@@ -371,6 +371,16 @@ class AsyncHttpClient:
 
         json_body, data_body = get_request_body(json=json, data=data, request_options=request_options, omit=omit)
 
+        # If omit/pruning removed everything, still send {} for methods that commonly expect a body.
+        if (
+            json_body is None
+            and data_body is None
+            and content is None
+            and files is None
+            and method.upper() in {"POST", "PUT", "PATCH"}
+        ):
+            json_body = {}
+
         # Add the input to each of these and do None-safety checks
         response = await self.httpx_client.request(
             method=method,


### PR DESCRIPTION
I noticed that `await client.create_browser_session()` fails with `422 Unprocessable Content
` content because whole POST body is OMITted so not body is send at all and server rejects such requests. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `AsyncHttpClient` to send `{}` as body for `POST`, `PUT`, `PATCH` when all content is omitted.
> 
>   - **Behavior**:
>     - In `AsyncHttpClient.request()`, send `{}` as the body for `POST`, `PUT`, `PATCH` methods if `json_body`, `data_body`, `content`, and `files` are all `None` due to omission.
>   - **Files**:
>     - Update in `http_client.py` to handle omitted body content for specific HTTP methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for a1cf2aee2f00d6f520f8889d659579b77b39649f. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->