### PR TITLE
Increase bitwarden timeout to 30s

### DIFF
--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -723,7 +723,7 @@ class BitwardenService:
     @staticmethod
     async def _get_login_item_by_id_using_server(item_id: str) -> PasswordCredential:
         response = await aiohttp_get_json(
-            f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, retry_timeout=15
+            f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, retry_timeout=30
         )
         if not response or response.get("success") is False:
             raise BitwardenGetItemError(f"Failed to get login item by ID: {item_id}")
@@ -882,7 +882,7 @@ class BitwardenService:
     @staticmethod
     async def _create_collection_using_server(bw_organization_id: str, name: str) -> str:
         collection_template_response = await aiohttp_get_json(
-            f"{BITWARDEN_SERVER_BASE_URL}/object/template/collection", retry=3, retry_timeout=15
+            f"{BITWARDEN_SERVER_BASE_URL}/object/template/collection", retry=3, retry_timeout=30
         )
         collection_template = collection_template_response["data"]["template"]
 
@@ -925,7 +925,7 @@ class BitwardenService:
     async def _get_items_by_item_ids_using_server(item_ids: list[str]) -> list[CredentialItem]:
         responses = await asyncio.gather(
             *[
-                aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, retry_timeout=15)
+                aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, retry_timeout=30)
                 for item_id in item_ids
             ]
         )
@@ -948,7 +948,7 @@ class BitwardenService:
     @staticmethod
     async def _get_collection_items_using_server(collection_id: str) -> list[CredentialItem]:
         response = await aiohttp_get_json(
-            f"{BITWARDEN_SERVER_BASE_URL}/list/object/items?collectionId={collection_id}", retry=3, retry_timeout=15
+            f"{BITWARDEN_SERVER_BASE_URL}/list/object/items?collectionId={collection_id}", retry=3, retry_timeout=30
         )
         if not response or response.get("success") is False:
             raise BitwardenGetItemError("Failed to get collection items")
@@ -971,7 +971,7 @@ class BitwardenService:
     @staticmethod
     async def _get_credential_item_by_id_using_server(item_id: str) -> CredentialItem:
         response = await aiohttp_get_json(
-            f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, retry_timeout=15
+            f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, retry_timeout=30
         )
         if not response or response.get("success") is False:
             raise BitwardenGetItemError(f"Failed to get credential item by ID: {item_id}")


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Increase Bitwarden API request timeout from 15s to 30s in several functions in `bitwarden.py`.
> 
>   - **Timeout Increase**:
>     - Increase `retry_timeout` from 15s to 30s in `aiohttp_get_json` calls in `_get_login_item_by_id_using_server`, `_create_collection_using_server`, `_get_items_by_item_ids_using_server`, `_get_collection_items_using_server`, and `_get_credential_item_by_id_using_server` in `bitwarden.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 198cc2706d5acf3239c051c85a9318728e55f903. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

⏱️ This PR increases the timeout for Bitwarden API requests from 15 seconds to 30 seconds across all server-based operations. The change addresses potential timeout issues when communicating with the Bitwarden server, providing more time for API calls to complete successfully.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Timeout Configuration**: Updated `retry_timeout` parameter from 15s to 30s in all `aiohttp_get_json` calls
- **Affected Methods**: Modified 5 server-based methods that interact with Bitwarden API endpoints
- **Scope**: Changes apply to login item retrieval, collection operations, and credential management functions

### Technical Implementation
```mermaid
sequenceDiagram
    participant App as Application
    participant BW as Bitwarden Service
    participant API as Bitwarden Server API
    
    App->>BW: Request credential/collection
    BW->>API: HTTP GET (30s timeout)
    Note over API: Previously 15s timeout
    API-->>BW: Response (within 30s)
    BW-->>App: Processed result
    
    Note over BW,API: Retry up to 3 times if needed
```

### Impact
- **Reliability Improvement**: Reduces likelihood of timeout failures for slower Bitwarden server responses
- **User Experience**: Fewer failed requests due to network latency or server processing delays
- **Backward Compatibility**: Fully backward compatible change with no breaking modifications to API contracts

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Increased retry timeouts for Bitwarden server interactions to reduce intermittent timeout errors in slow or congested conditions.
  - Improves reliability when retrieving items, accessing credentials, and working with collections, leading to fewer failed operations and smoother workflows.
  - No changes to user-facing behavior or configuration required; existing actions will simply be more resilient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->