### PR TITLE
remove browser_session_id local storage caching for workflow runs

### DIFF
--- a/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
+++ b/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
@@ -38,13 +38,11 @@ import { KeyValueInput } from "@/components/KeyValueInput";
 import { toast } from "@/components/ui/use-toast";
 import { useApiCredential } from "@/hooks/useApiCredential";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
-import { useSyncFormFieldToStorage } from "@/hooks/useSyncFormFieldToStorage";
-import { useLocalStorageFormDefault } from "@/hooks/useLocalStorageFormDefault";
 import { useBlockScriptsQuery } from "@/routes/workflows/hooks/useBlockScriptsQuery";
 import { constructCacheKeyValueFromParameters } from "@/routes/workflows/editor/utils";
 import { useWorkflowQuery } from "@/routes/workflows/hooks/useWorkflowQuery";
 import { type ApiCommandOptions } from "@/util/apiCommands";
-import { apiBaseUrl, lsKeys } from "@/util/env";
+import { apiBaseUrl } from "@/util/env";
 
 import { MAX_SCREENSHOT_SCROLLS_DEFAULT } from "./editor/nodes/Taskv2Node/types";
 import { getLabelForWorkflowParameterType } from "./editor/workflowEditorUtils";
@@ -188,10 +186,6 @@ function RunWorkflowForm({
   const credentialGetter = useCredentialGetter();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const browserSessionIdDefault = useLocalStorageFormDefault(
-    lsKeys.browserSessionId,
-    (initialValues.browserSessionId as string | undefined) ?? null,
-  );
   const apiCredential = useApiCredential();
   const { data: workflow } = useWorkflowQuery({ workflowPermanentId });
 
@@ -200,7 +194,7 @@ function RunWorkflowForm({
       ...initialValues,
       webhookCallbackUrl: initialSettings.webhookCallbackUrl,
       proxyLocation: initialSettings.proxyLocation,
-      browserSessionId: browserSessionIdDefault,
+      browserSessionId: null,
       cdpAddress: initialSettings.cdpAddress,
       maxScreenshotScrolls: initialSettings.maxScreenshotScrolls,
       extraHttpHeaders: initialSettings.extraHttpHeaders
@@ -210,8 +204,6 @@ function RunWorkflowForm({
       aiFallback: workflow?.ai_fallback ?? true,
     },
   });
-
-  useSyncFormFieldToStorage(form, "browserSessionId", lsKeys.browserSessionId);
 
   const runWorkflowMutation = useMutation({
     mutationFn: async (values: RunWorkflowFormType) => {


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6655/browser-session-id-not-cleared-after-page-refresh-or-navigation
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes local storage caching for `browser_session_id` in `RunWorkflowForm`, initializing it to `null`.
> 
>   - **Behavior**:
>     - Removes local storage caching for `browser_session_id` in `RunWorkflowForm`.
>     - Initializes `browserSessionId` to `null` in `RunWorkflowForm` default values.
>   - **Code Removal**:
>     - Removes `useSyncFormFieldToStorage` and `useLocalStorageFormDefault` hooks from `RunWorkflowForm.tsx`.
>     - Deletes `browserSessionIdDefault` variable and its usage in `RunWorkflowForm`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for fd9afea53b56b9766562cb0c2619feaaad2f7081. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->