### PR TITLE
Increase bitwarden timeout to 2m

### DIFF
--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -36,6 +36,8 @@ from skyvern.forge.sdk.services.credentials import parse_totp_secret
 LOG = structlog.get_logger()
 BITWARDEN_SERVER_BASE_URL = f"{settings.BITWARDEN_SERVER}:{settings.BITWARDEN_SERVER_PORT or 8002}"
 
+BITWARDEN_TIMEOUT = 120  # 2 min
+
 
 class BitwardenItemType(IntEnum):
     LOGIN = 1
@@ -723,7 +725,7 @@ class BitwardenService:
     @staticmethod
     async def _get_login_item_by_id_using_server(item_id: str) -> PasswordCredential:
         response = await aiohttp_get_json(
-            f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, retry_timeout=30
+            f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, retry_timeout=BITWARDEN_TIMEOUT
         )
         if not response or response.get("success") is False:
             raise BitwardenGetItemError(f"Failed to get login item by ID: {item_id}")
@@ -882,7 +884,7 @@ class BitwardenService:
     @staticmethod
     async def _create_collection_using_server(bw_organization_id: str, name: str) -> str:
         collection_template_response = await aiohttp_get_json(
-            f"{BITWARDEN_SERVER_BASE_URL}/object/template/collection", retry=3, retry_timeout=30
+            f"{BITWARDEN_SERVER_BASE_URL}/object/template/collection", retry=3, retry_timeout=BITWARDEN_TIMEOUT
         )
         collection_template = collection_template_response["data"]["template"]
 
@@ -925,7 +927,9 @@ class BitwardenService:
     async def _get_items_by_item_ids_using_server(item_ids: list[str]) -> list[CredentialItem]:
         responses = await asyncio.gather(
             *[
-                aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, retry_timeout=30)
+                aiohttp_get_json(
+                    f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, retry_timeout=BITWARDEN_TIMEOUT
+                )
                 for item_id in item_ids
             ]
         )
@@ -948,7 +952,9 @@ class BitwardenService:
     @staticmethod
     async def _get_collection_items_using_server(collection_id: str) -> list[CredentialItem]:
         response = await aiohttp_get_json(
-            f"{BITWARDEN_SERVER_BASE_URL}/list/object/items?collectionId={collection_id}", retry=3, retry_timeout=30
+            f"{BITWARDEN_SERVER_BASE_URL}/list/object/items?collectionId={collection_id}",
+            retry=3,
+            retry_timeout=BITWARDEN_TIMEOUT,
         )
         if not response or response.get("success") is False:
             raise BitwardenGetItemError("Failed to get collection items")
@@ -971,7 +977,7 @@ class BitwardenService:
     @staticmethod
     async def _get_credential_item_by_id_using_server(item_id: str) -> CredentialItem:
         response = await aiohttp_get_json(
-            f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, retry_timeout=30
+            f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, retry_timeout=BITWARDEN_TIMEOUT
         )
         if not response or response.get("success") is False:
             raise BitwardenGetItemError(f"Failed to get credential item by ID: {item_id}")


### PR DESCRIPTION
---

⏱️ This PR increases the timeout for Bitwarden server API calls from 30 seconds to 3 minutes (180 seconds) to improve reliability when communicating with the Bitwarden server. The change affects all HTTP requests to the Bitwarden server by introducing a centralized timeout constant and updating all relevant API calls.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Timeout Configuration**: Added a new constant `BITWARDEN_TIMEOUT = 180` (3 minutes) to centralize timeout configuration
- **API Call Updates**: Updated 5 different Bitwarden server API endpoints to use the new timeout value instead of the hardcoded 30-second timeout
- **Affected Operations**: Modified timeout for login item retrieval, collection template fetching, bulk item retrieval, collection items fetching, and credential item retrieval

### Technical Implementation
```mermaid
flowchart TD
    A[Bitwarden API Calls] --> B[Old: 30s timeout]
    A --> C[New: 180s timeout]
    B --> D[Potential timeouts on slow operations]
    C --> E[More reliable operations]
    
    F[Affected Methods] --> G[_get_login_item_by_id_using_server]
    F --> H[_create_collection_using_server]
    F --> I[_get_items_by_item_ids_using_server]
    F --> J[_get_collection_items_using_server]
    F --> K[_get_credential_item_by_id_using_server]
```

### Impact
- **Reliability Improvement**: Reduces the likelihood of timeout errors when Bitwarden server responses are slow, improving overall system stability
- **User Experience**: Prevents premature failures that could interrupt credential management workflows
- **Maintainability**: Centralizes timeout configuration making it easier to adjust in the future and ensures consistency across all Bitwarden API calls

</details>

_Created with [Palmier](https://www.palmier.io)_

---

⏱️ This PR increases the timeout for Bitwarden server API calls from 30 seconds to 3 minutes (180 seconds) to improve reliability when communicating with the Bitwarden server. The change affects all HTTP requests to the Bitwarden server by introducing a centralized timeout constant and updating all relevant API calls.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Timeout Configuration**: Added a new constant `BITWARDEN_TIMEOUT = 180` (3 minutes) to centralize timeout configuration
- **API Call Updates**: Updated 5 different Bitwarden server API endpoints to use the new timeout value instead of the hardcoded 30-second timeout
- **Affected Operations**: Modified timeout for login item retrieval, collection template fetching, bulk item retrieval, collection items fetching, and credential item retrieval

### Technical Implementation
```mermaid
flowchart TD
    A[Bitwarden API Calls] --> B[Old: 30s timeout]
    A --> C[New: 180s timeout]
    B --> D[Potential timeouts on slow operations]
    C --> E[More reliable operations]
    
    F[Affected Methods] --> G[_get_login_item_by_id_using_server]
    F --> H[_create_collection_using_server]
    F --> I[_get_items_by_item_ids_using_server]
    F --> J[_get_collection_items_using_server]
    F --> K[_get_credential_item_by_id_using_server]
```

### Impact
- **Reliability Improvement**: Reduces the likelihood of timeout errors when Bitwarden server responses are slow, improving overall system stability
- **User Experience**: Prevents premature failures that could interrupt credential management workflows
- **Maintainability**: Centralizes timeout configuration making it easier to adjust in the future and ensures consistency across all Bitwarden API calls

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Increases Bitwarden server API call timeout to 2 minutes by centralizing timeout configuration and updating relevant functions.
> 
>   - **Behavior**:
>     - Increases Bitwarden server API call timeout from 30 seconds to 2 minutes by setting `BITWARDEN_TIMEOUT = 120`.
>     - Updates timeout for `_get_login_item_by_id_using_server`, `_create_collection_using_server`, `_get_items_by_item_ids_using_server`, `_get_collection_items_using_server`, and `_get_credential_item_by_id_using_server`.
>   - **Maintainability**:
>     - Centralizes timeout configuration with `BITWARDEN_TIMEOUT` constant in `bitwarden.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 51540c870ef4e218c6cdb0c0e183c673677b6575. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased timeout for Bitwarden operations from 30 seconds to 2 minutes, reducing intermittent timeouts and improving reliability when fetching credentials and collections, especially on slower networks or with larger vaults.
  * Enhances overall stability of Bitwarden-related actions without changing user workflows or interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->