### PR TITLE
support pdf parser block to fix script gen error

### DIFF
--- a/skyvern/__init__.py
+++ b/skyvern/__init__.py
@@ -38,6 +38,7 @@ from skyvern.services.script_service import (  # noqa: E402
     login,  # noqa: E402
     loop,  # noqa: E402
     parse_file,  # noqa: E402
+    parse_pdf,  # noqa: E402
     prompt,  # noqa: E402
     render_list,  # noqa: E402
     render_template,  # noqa: E402
@@ -64,6 +65,7 @@ __all__ = [
     "login",
     "loop",
     "parse_file",
+    "parse_pdf",
     "prompt",
     "render_list",
     "render_template",

--- a/skyvern/core/script_generations/generate_script.py
+++ b/skyvern/core/script_generations/generate_script.py
@@ -1044,6 +1044,55 @@ def _build_file_upload_statement(block: dict[str, Any]) -> cst.SimpleStatementLi
     return cst.SimpleStatementLine([cst.Expr(cst.Await(call))])
 
 
+def _build_pdf_parser_statement(block: dict[str, Any]) -> cst.SimpleStatementLine:
+    """Build a skyvern.parse_pdf statement."""
+    args = [
+        cst.Arg(
+            keyword=cst.Name("file_url"),
+            value=_value(block.get("file_url", "")),
+            whitespace_after_arg=cst.ParenthesizedWhitespace(
+                indent=True,
+                last_line=cst.SimpleWhitespace(INDENT),
+            ),
+        ),
+    ]
+
+    if block.get("json_schema") is not None:
+        args.append(
+            cst.Arg(
+                keyword=cst.Name("schema"),
+                value=_value(block.get("json_schema")),
+                whitespace_after_arg=cst.ParenthesizedWhitespace(
+                    indent=True,
+                    last_line=cst.SimpleWhitespace(INDENT),
+                ),
+            )
+        )
+
+    if block.get("label") is not None:
+        args.append(
+            cst.Arg(
+                keyword=cst.Name("label"),
+                value=_value(block.get("label")),
+                whitespace_after_arg=cst.ParenthesizedWhitespace(
+                    indent=True,
+                    last_line=cst.SimpleWhitespace(INDENT),
+                ),
+            )
+        )
+    _mark_last_arg_as_comma(args)
+
+    call = cst.Call(
+        func=cst.Attribute(value=cst.Name("skyvern"), attr=cst.Name("parse_pdf")),
+        args=args,
+        whitespace_before_args=cst.ParenthesizedWhitespace(
+            indent=True,
+            last_line=cst.SimpleWhitespace(INDENT),
+        ),
+    )
+    return cst.SimpleStatementLine([cst.Expr(cst.Await(call))])
+
+
 def _build_file_url_parser_statement(block: dict[str, Any]) -> cst.SimpleStatementLine:
     """Build a skyvern.parse_file statement."""
     args = [
@@ -1531,6 +1580,8 @@ def _build_block_statement(block: dict[str, Any], data_variable_name: str | None
         stmt = _build_file_url_parser_statement(block)
     elif block_type == "http_request":
         stmt = _build_http_request_statement(block)
+    elif block_type == "pdf_parser":
+        stmt = _build_pdf_parser_statement(block)
     else:
         # Default case for unknown block types
         stmt = cst.SimpleStatementLine([cst.Expr(cst.SimpleString(f"# Unknown block type: {block_type}"))])

--- a/skyvern/services/script_service.py
+++ b/skyvern/services/script_service.py
@@ -37,6 +37,7 @@ from skyvern.forge.sdk.workflow.models.block import (
     ForLoopBlock,
     HttpRequestBlock,
     LoginBlock,
+    PDFParserBlock,
     SendEmailBlock,
     TaskBlock,
     TextPromptBlock,
@@ -1815,6 +1816,29 @@ async def send_email(
         parameters=parameters or [],
     )
     await send_email_block.execute_safe(
+        workflow_run_id=block_validation_output.workflow_run_id,
+        parent_workflow_run_block_id=block_validation_output.context.parent_workflow_run_block_id,
+        organization_id=block_validation_output.organization_id,
+        browser_session_id=block_validation_output.browser_session_id,
+    )
+
+
+async def parse_pdf(
+    file_url: str,
+    schema: dict[str, Any] | None = None,
+    label: str | None = None,
+    parameters: list[PARAMETER_TYPE] | None = None,
+) -> None:
+    block_validation_output = await _validate_and_get_output_parameter(label)
+    file_url = _render_template_with_label(file_url, label)
+    pdf_parser_block = PDFParserBlock(
+        file_url=file_url,
+        json_schema=schema,
+        label=block_validation_output.label,
+        output_parameter=block_validation_output.output_parameter,
+        parameters=parameters or [],
+    )
+    await pdf_parser_block.execute_safe(
         workflow_run_id=block_validation_output.workflow_run_id,
         parent_workflow_run_block_id=block_validation_output.context.parent_workflow_run_block_id,
         organization_id=block_validation_output.organization_id,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for PDF parsing in Skyvern with a new `parse_pdf` function and script generation logic.
> 
>   - **Behavior**:
>     - Adds `parse_pdf` function in `script_service.py` to handle PDF parsing with optional `schema` and `label` parameters.
>     - Integrates PDF parsing into workflow by creating `PDFParserBlock` and executing it safely.
>   - **Script Generation**:
>     - Adds `_build_pdf_parser_statement()` in `generate_script.py` to generate `skyvern.parse_pdf` statements.
>     - Updates `_build_block_statement()` to handle `pdf_parser` block type.
>   - **Initialization**:
>     - Adds `parse_pdf` to imports and `__all__` in `__init__.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 4dacb751d41b0bf392949bc9fde257af5fbf6c5d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

📄 This PR adds comprehensive support for PDF parser blocks in Skyvern workflows, introducing a new `parse_pdf` function and updating the script generation system to handle PDF parsing operations with optional schema validation and labeling.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Script Service**: Added new `parse_pdf` async function in `script_service.py` that handles PDF parsing with configurable schema validation and labeling capabilities
- **Script Generation**: Implemented `_build_pdf_parser_statement()` function in `generate_script.py` to generate proper CST nodes for PDF parser blocks in workflow scripts
- **Module Exports**: Updated `__init__.py` to export the new `parse_pdf` function, making it available for workflow scripts
- **Block Type Support**: Added "pdf_parser" block type handling in the script generation pipeline

### Technical Implementation
```mermaid
flowchart TD
    A[PDF Parser Block] --> B[parse_pdf function]
    B --> C[PDFParserBlock creation]
    C --> D[Block validation & output parameter]
    D --> E[Template rendering with label]
    E --> F[Block execution]
    
    G[Script Generation] --> H[_build_pdf_parser_statement]
    H --> I[CST node creation]
    I --> J[Function call with args]
    J --> K[Generated script code]
```

### Impact
- **Workflow Capability**: Enables Skyvern workflows to parse PDF documents with structured data extraction using JSON schemas
- **Script Generation**: Fixes script generation errors by properly handling PDF parser blocks in the code generation pipeline
- **Developer Experience**: Provides a clean API for PDF parsing operations with optional parameters for schema validation and result labeling
- **Integration**: Seamlessly integrates with existing workflow block architecture and maintains consistency with other parser functions

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added PDF parsing capability via a new async parse_pdf function, enabling extraction of structured data from PDFs with optional schema and labels.
  - Script generator now supports a pdf_parser block, automatically generating awaited parse_pdf calls in scripts.
  - Exposed parse_pdf in the public API for direct use in applications and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->