### PR TITLE
update download_timeout descriptor to seconds, which is what is actua…

### DIFF
--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -115,7 +115,7 @@ class TaskBase(BaseModel):
     )
     download_timeout: float | None = Field(
         default=None,
-        description="The maximum time to wait for downloads to complete, in minutes. If not set, defaults to BROWSER_DOWNLOAD_TIMEOUT minutes.",
+        description="The maximum time to wait for downloads to complete, in seconds. If not set, defaults to BROWSER_DOWNLOAD_TIMEOUT seconds.",
         examples=[15.0],
     )
 


### PR DESCRIPTION
…lly being used

Part of https://linear.app/skyvern/issue/SKY-6575/make-browser-download-timeout-configurable-for-blocks-and-tasks
Fixes https://github.com/Skyvern-AI/skyvern-cloud/pull/6619
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `download_timeout` description in `TaskBase` class to specify time in seconds.
> 
>   - **Behavior**:
>     - Update `download_timeout` description in `TaskBase` class in `tasks.py` to specify time in seconds instead of minutes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d1ee45c8a3e58d0b68ec8e05b70f1886497c47e4. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

📝 This PR corrects the documentation for the `download_timeout` parameter in the `TaskBase` class, updating the description to accurately reflect that the timeout is measured in seconds rather than minutes, aligning the documentation with the actual implementation.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Documentation Fix**: Updated the `download_timeout` field description in `skyvern/forge/sdk/schemas/tasks.py` to specify "seconds" instead of "minutes"
- **Consistency Improvement**: Aligned the field description with the actual behavior of the timeout parameter
- **Reference Update**: Updated both the main description and the default value reference to use consistent time units

### Technical Implementation
```mermaid
flowchart TD
    A[TaskBase Schema] --> B[download_timeout Field]
    B --> C[Field Description]
    C --> D[Updated: 'seconds' instead of 'minutes']
    B --> E[Default Value Reference]
    E --> F[Updated: BROWSER_DOWNLOAD_TIMEOUT seconds]
    
    style D fill:#e1f5fe
    style F fill:#e1f5fe
```

### Impact
- **Documentation Accuracy**: Eliminates confusion for developers who rely on the schema documentation to understand timeout units
- **API Clarity**: Ensures that API consumers have correct expectations about timeout behavior
- **Maintenance Improvement**: Reduces potential bugs caused by incorrect timeout calculations based on wrong unit assumptions

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the download timeout for tasks is expressed in seconds, not minutes.
  * Updated descriptions across API/SDK references to reflect the correct unit.
  * No functional changes or default values were altered.
  * Helps prevent misconfiguration by aligning wording with actual behavior.
  * No action required for existing setups; only users who previously assumed minutes may wish to review their timeout values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->