### PR TITLE
code block support credential

### DIFF
--- a/skyvern/forge/sdk/workflow/models/parameter.py
+++ b/skyvern/forge/sdk/workflow/models/parameter.py
@@ -32,6 +32,18 @@ class ParameterType(StrEnum):
     CREDENTIAL = "credential"
     AZURE_SECRET = "azure_secret"
 
+    def is_secret_or_credential(self) -> bool:
+        return self in [
+            ParameterType.AWS_SECRET,
+            ParameterType.BITWARDEN_LOGIN_CREDENTIAL,
+            ParameterType.BITWARDEN_SENSITIVE_INFORMATION,
+            ParameterType.BITWARDEN_CREDIT_CARD_DATA,
+            ParameterType.ONEPASSWORD,
+            ParameterType.AZURE_VAULT_CREDENTIAL,
+            ParameterType.CREDENTIAL,
+            ParameterType.AZURE_SECRET,
+        ]
+
 
 class Parameter(BaseModel, abc.ABC):
     # TODO (kerem): Should we also have organization_id here?


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances `CodeBlock` to support credential parameters with TOTP handling and introduces a `Credential` class for encapsulating credential data.
> 
>   - **Behavior**:
>     - `CodeBlock` in `block.py` now supports credential parameters, including TOTP handling for `Bitwarden`, `OnePassword`, and `AzureVault`.
>     - Introduces `Credential` class to encapsulate credential data.
>   - **Parameter Handling**:
>     - Adds `is_secret_or_credential()` method to `ParameterType` in `parameter.py` to identify secret or credential parameters.
>     - Updates `execute()` in `CodeBlock` to handle credential parameters, including TOTP values.
>   - **Imports**:
>     - Adds imports for `BitwardenConstants`, `AzureVaultConstants`, `OnePasswordConstants`, and `pyotp` in `block.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 961d436b7ef8740e8926ae16bb96d93e2e115fc4. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔐 This PR enhances CodeBlock functionality to support credential parameters with TOTP (Time-based One-Time Password) handling for multiple credential providers including Bitwarden, OnePassword, and Azure Vault.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Credential Support**: Introduces a new `Credential` class using `SimpleNamespace` to encapsulate credential data within code blocks
- **TOTP Integration**: Adds automatic TOTP generation using `pyotp` library for supported credential providers (Bitwarden, OnePassword, Azure Vault)
- **Parameter Type Enhancement**: Adds `is_secret_or_credential()` method to `ParameterType` enum to identify credential and secret parameter types
- **Enhanced Parameter Processing**: Updates `CodeBlock.execute()` method to handle both simple secrets and complex credential dictionaries

### Technical Implementation
```mermaid
flowchart TD
    A[CodeBlock.execute()] --> B{Parameter Type Check}
    B -->|Not Secret/Credential| C[Use Value Directly]
    B -->|Secret/Credential| D{Value Type Check}
    D -->|Dictionary| E[Process Credential Fields]
    D -->|Simple Value| F[Get Secret Value]
    E --> G{Is TOTP?}
    G -->|Yes| H[Generate TOTP Code]
    G -->|No| I[Use Secret Value]
    H --> J[Create Credential Object]
    I --> J
    F --> K[Use Secret or Original Value]
    C --> L[Add to Parameter Values]
    J --> L
    K --> L
```

### Impact
- **Enhanced Security**: Provides structured credential handling with automatic TOTP generation for multi-factor authentication scenarios
- **Provider Flexibility**: Supports multiple credential management systems (Bitwarden, OnePassword, Azure Vault) with unified handling
- **Code Block Capability**: Enables code blocks to securely access and utilize credentials without exposing sensitive data in plain text
- **Backward Compatibility**: Maintains existing functionality for non-credential parameters while extending support for credential types

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added support for structured credential parameters, enabling multi-field credentials to be passed and resolved at runtime.
  * Automatically generates TOTP codes for supported vault-sourced credentials (e.g., Bitwarden, 1Password, Azure Key Vault) when applicable.
  * Falls back gracefully with warnings if required TOTP secrets are missing, preserving placeholder values.
  * Expanded recognition of secret/credential parameter types for more consistent handling across workflows.
  * Introduced a public Credential object to expose resolved credential fields to blocks while keeping sensitive values managed securely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->