### PR TITLE
prompted workflows: use (nav block, [extract block],) for v1 prompts

### DIFF
--- a/skyvern/forge/sdk/schemas/prompts.py
+++ b/skyvern/forge/sdk/schemas/prompts.py
@@ -1,0 +1,21 @@
+import typing as t
+
+from pydantic import BaseModel, Field
+
+from skyvern.forge.sdk.schemas.task_v2 import TaskV2Request
+from skyvern.forge.sdk.schemas.tasks import PromptedTaskRequest
+
+
+class CreateWorkflowFromPromptRequestV1(BaseModel):
+    task_version: t.Literal["v1"]
+    request: PromptedTaskRequest
+
+
+class CreateWorkflowFromPromptRequestV2(BaseModel):
+    task_version: t.Literal["v2"]
+    request: TaskV2Request
+
+
+CreateFromPromptRequest = t.Annotated[
+    t.Union[CreateWorkflowFromPromptRequestV1, CreateWorkflowFromPromptRequestV2], Field(discriminator="task_version")
+]

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -160,6 +160,29 @@ class TaskRequest(TaskBase):
         return validate_url(url)
 
 
+class PromptedTaskRequest(TaskRequest):
+    ai_fallback: bool | None = Field(
+        default=False,
+        description="Whether to use AI fallback when the task fails.",
+        examples=[True, False],
+    )
+    publish_workflow: bool | None = Field(
+        default=False,
+        description="Whether to publish the workflow created from the prompt.",
+        examples=[True, False],
+    )
+    run_with: str | None = Field(
+        default=None,
+        description="The executor to run the task with.",
+        examples=["code", "agent"],
+    )
+    user_prompt: str = Field(
+        ...,
+        description="The user's prompt for the task.",
+        examples=["Get a quote for car insurance"],
+    )
+
+
 class TaskStatus(StrEnum):
     created = "created"
     queued = "queued"


### PR DESCRIPTION
BE part of https://linear.app/skyvern/issue/SKY-6641/use-v1-blocks-for-v1-prompts

NOTE: branch name is now a misnomer.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for v1 and v2 task versions in `create_workflow_from_prompt` with new request types and conditional logic.
> 
>   - **Behavior**:
>     - `create_workflow_from_prompt` in `agent_protocol.py` now uses `CreateFromPromptRequest` to handle both v1 and v2 task versions.
>     - Adds conditional logic in `create_workflow_from_prompt` to handle v1 and v2 task versions differently in `service.py`.
>   - **Schemas**:
>     - Adds `CreateWorkflowFromPromptRequestV1` and `CreateWorkflowFromPromptRequestV2` in `prompts.py`.
>     - Adds `PromptedTaskRequest` in `tasks.py` for v1 task requests.
>   - **Misc**:
>     - Updates `create_workflow_from_prompt` in `service.py` to use `NavigationBlock` and `ExtractionBlock` for v1, and `TaskV2Block` for v2.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6f8f308d18d10ebe73ed194031d2fdd19d61ab40. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔄 This PR introduces versioned workflow creation from prompts, enabling v1 prompts to use NavigationBlock and ExtractionBlock structures while maintaining v2 compatibility with TaskV2Block. The changes implement a discriminated union approach to handle different task versions through a new schema structure.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Schema Architecture**: Created new `CreateFromPromptRequest` discriminated union type that handles both v1 (`PromptedTaskRequest`) and v2 (`TaskV2Request`) task versions
- **API Endpoint**: Modified `create_workflow_from_prompt` to accept the new schema and extract task version and request data appropriately
- **Workflow Generation Logic**: Added conditional logic in `WorkflowService.create_workflow_from_prompt` to generate different block types based on task version
- **Block Structure**: V1 prompts now generate NavigationBlock + optional ExtractionBlock, while v2 continues using TaskV2Block

### Technical Implementation
```mermaid
flowchart TD
    A[CreateFromPromptRequest] --> B{task_version}
    B -->|v1| C[PromptedTaskRequest]
    B -->|v2| D[TaskV2Request]
    C --> E[Generate Task Prompt]
    E --> F[NavigationBlock + ExtractionBlock]
    D --> G[TaskV2Block]
    F --> H[Workflow Creation]
    G --> H
```

### Impact
- **Backward Compatibility**: Maintains full compatibility with existing v2 workflows while enabling v1 block structures
- **Prompt Processing**: V1 prompts now undergo additional LLM processing to extract navigation and data extraction goals
- **Workflow Structure**: V1 workflows can now have multiple blocks (navigation + extraction) compared to v2's single TaskV2Block approach
- **API Flexibility**: The discriminated union approach provides type safety while supporting multiple workflow generation strategies

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Create workflows directly from a prompt with an expanded request payload (includes user_prompt, run_with, publish_workflow, AI fallback, proxy, extra headers, and scrolling limits).
  - Choose task version (v1 or v2) when generating workflows; v1 builds navigation/extraction blocks, v2 retains existing behavior. Defaults to v2.
  - AI fallback now enabled by default when not specified.
  - Updated request format for permission checks and workflow parameters to ensure consistent handling across public and legacy endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->