### PR TITLE
Bump bitwarden timeout to 120s, try fix github action

### DIFF
--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -715,15 +715,19 @@ class BitwardenService:
 
     @staticmethod
     async def _unlock_using_server(master_password: str) -> None:
-        status_response = await aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/status", retry=3, retry_timeout=15)
+        status_response = await aiohttp_get_json(
+            f"{BITWARDEN_SERVER_BASE_URL}/status", retry=3, retry_timeout=30, timeout=120
+        )
         status = status_response["data"]["template"]["status"]
         if status != "unlocked":
-            await aiohttp_post(f"{BITWARDEN_SERVER_BASE_URL}/unlock", data={"password": master_password})
+            await aiohttp_post(
+                f"{BITWARDEN_SERVER_BASE_URL}/unlock", data={"password": master_password}, retry_timeout=30, timeout=120
+            )
 
     @staticmethod
     async def _get_login_item_by_id_using_server(item_id: str) -> PasswordCredential:
         response = await aiohttp_get_json(
-            f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, retry_timeout=30
+            f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, timeout=120, retry_timeout=30
         )
         if not response or response.get("success") is False:
             raise BitwardenGetItemError(f"Failed to get login item by ID: {item_id}")
@@ -746,8 +750,8 @@ class BitwardenService:
         name: str,
         credential: PasswordCredential,
     ) -> str:
-        item_template = await aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/object/template/item")
-        login_template = await aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/object/template/item.login")
+        item_template = await aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/object/template/item", timeout=120)
+        login_template = await aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/object/template/item.login", timeout=120)
 
         item_template = item_template["data"]["template"]
         login_template = login_template["data"]["template"]
@@ -762,7 +766,7 @@ class BitwardenService:
         item_template["collectionIds"] = [collection_id]
         item_template["organizationId"] = bw_organization_id
 
-        response = await aiohttp_post(f"{BITWARDEN_SERVER_BASE_URL}/object/item", data=item_template)
+        response = await aiohttp_post(f"{BITWARDEN_SERVER_BASE_URL}/object/item", data=item_template, timeout=120)
         if not response or response.get("success") is False:
             raise BitwardenCreateLoginItemError("Failed to create login item")
 
@@ -775,8 +779,10 @@ class BitwardenService:
         name: str,
         credential: CreditCardCredential,
     ) -> str:
-        item_template = await aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/object/template/item")
-        credit_card_template = await aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/object/template/item.card")
+        item_template = await aiohttp_get_json(f"{BITWARDEN_SERVER_BASE_URL}/object/template/item", timeout=120)
+        credit_card_template = await aiohttp_get_json(
+            f"{BITWARDEN_SERVER_BASE_URL}/object/template/item.card", timeout=120
+        )
 
         item_template = item_template["data"]["template"]
         credit_card_template = credit_card_template["data"]["template"]
@@ -948,7 +954,10 @@ class BitwardenService:
     @staticmethod
     async def _get_collection_items_using_server(collection_id: str) -> list[CredentialItem]:
         response = await aiohttp_get_json(
-            f"{BITWARDEN_SERVER_BASE_URL}/list/object/items?collectionId={collection_id}", retry=3, retry_timeout=30
+            f"{BITWARDEN_SERVER_BASE_URL}/list/object/items?collectionId={collection_id}",
+            retry=3,
+            retry_timeout=30,
+            timeout=120,
         )
         if not response or response.get("success") is False:
             raise BitwardenGetItemError("Failed to get collection items")
@@ -971,7 +980,7 @@ class BitwardenService:
     @staticmethod
     async def _get_credential_item_by_id_using_server(item_id: str) -> CredentialItem:
         response = await aiohttp_get_json(
-            f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, retry_timeout=30
+            f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", retry=3, timeout=120, retry_timeout=30
         )
         if not response or response.get("success") is False:
             raise BitwardenGetItemError(f"Failed to get credential item by ID: {item_id}")
@@ -1021,4 +1030,4 @@ class BitwardenService:
 
     @staticmethod
     async def _delete_credential_item_using_server(item_id: str) -> None:
-        await aiohttp_delete(f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}")
+        await aiohttp_delete(f"{BITWARDEN_SERVER_BASE_URL}/object/item/{item_id}", timeout=120)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Increased timeout to 120 seconds for Bitwarden API calls in `bitwarden.py` to address timeout issues.
> 
>   - **Timeout Adjustments**:
>     - Increased timeout to 120 seconds for `aiohttp_get_json` and `aiohttp_post` calls in `_unlock_using_server`, `_get_login_item_by_id_using_server`, `_create_login_item_using_server`, `_create_credit_card_item_using_server`, `_get_collection_items_using_server`, and `_get_credential_item_by_id_using_server` in `bitwarden.py`.
>     - Increased timeout to 120 seconds for `aiohttp_delete` call in `_delete_credential_item_using_server` in `bitwarden.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for be92917066236378c65f1f229fb240017676e7eb. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

⏱️ This PR increases timeout values from 15-30 seconds to 120 seconds across all Bitwarden API calls to improve reliability and prevent timeout-related failures. The changes also standardize retry timeout values to 30 seconds for consistency across the service.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Timeout Configuration**: Increased timeout from 15-30 seconds to 120 seconds for all Bitwarden server API calls
- **Retry Timeout Standardization**: Unified retry_timeout to 30 seconds across all functions that previously used 15 seconds
- **API Call Coverage**: Updated 8 different Bitwarden service methods including unlock, item retrieval, creation, and deletion operations

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client as Skyvern Client
    participant BW as Bitwarden Service
    participant Server as Bitwarden Server
    
    Client->>BW: Request credential operation
    BW->>Server: API call (timeout: 120s, retry_timeout: 30s)
    Note over Server: Processing time may vary
    Server-->>BW: Response (within 120s window)
    BW-->>Client: Return result
    
    Note over BW,Server: Previous timeout: 15-30s
    Note over BW,Server: New timeout: 120s
```

### Impact
- **Reliability Improvement**: Reduces timeout-related failures for slower Bitwarden server responses, especially beneficial for GitHub Actions environments
- **Consistency Enhancement**: Standardizes timeout handling across all Bitwarden API interactions
- **Operational Stability**: Provides more generous time allowances for network latency and server processing delays without affecting application logic

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of Bitwarden interactions by increasing timeouts and adding retries across unlock, item retrieval, creation, deletion, and collection listing. Reduces request failures on slow networks or under load. No changes to user workflows or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->