### PR TITLE
removing totp_type from context

### DIFF
--- a/skyvern/forge/sdk/workflow/context_manager.py
+++ b/skyvern/forge/sdk/workflow/context_manager.py
@@ -304,6 +304,9 @@ class WorkflowRunContext:
             }
             credential_dict = credential.model_dump()
             for key, value in credential_dict.items():
+                # Exclude totp_type from navigation payload as it's metadata, not input data
+                if key == "totp_type":
+                    continue
                 if value is None:
                     continue
                 random_secret_id = self.generate_random_secret_id()
@@ -353,6 +356,9 @@ class WorkflowRunContext:
         }
         credential_dict = credential.model_dump()
         for key, value in credential_dict.items():
+            # Exclude totp_type from navigation payload as it's metadata, not input data
+            if key == "totp_type":
+                continue
             random_secret_id = self.generate_random_secret_id()
             secret_id = f"{random_secret_id}_{key}"
             self.secrets[secret_id] = value


### PR DESCRIPTION
## Fix: Remove totp_type from Login block prompts to prevent 2FA failures

### Problem
The `totp_type` field was being included in navigation payloads sent to the LLM, causing it to incorrectly select the TOTP type instead of the password during login attempts, leading to 2FA failures.

### Solution
Modified `register_credential_parameter_value()` in `WorkflowRunContext` to exclude `totp_type` from credential placeholder generation. The `totp_type` field is metadata that shouldn't be available as input to the LLM.

### Changes
- Added filtering logic to skip `totp_type` when creating credential placeholders for navigation payloads
- `totp_type` remains available elsewhere in the system for its intended metadata purpose

### Impact
- Fixes 2FA failures in Login blocks
- LLM now only sees relevant input fields (`username`, `password`, `totp`) 
- No breaking changes to existing functionality
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Exclude `totp_type` from navigation payloads in `WorkflowRunContext` to fix 2FA failures.
> 
>   - **Behavior**:
>     - Excludes `totp_type` from navigation payloads in `register_credential_parameter_value()` and `register_secret_workflow_parameter_value()` in `context_manager.py`.
>     - Ensures `totp_type` is treated as metadata, not input data.
>   - **Impact**:
>     - Fixes 2FA failures in Login blocks by preventing incorrect TOTP type selection.
>     - LLM now only processes relevant input fields (`username`, `password`, `totp`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 8b6884f99774a48986ad547f2d62821cdb6e04eb. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the TOTP type field from being captured as a secret or credential value.
  - Ensures only actual credential data is stored and mapped, reducing noise and potential misclassification.
  - No changes to user-facing interfaces or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->