### PR TITLE
ensure dialog closes after positive cache deletion confirmation

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -855,6 +855,7 @@ function Workspace({
               onClick={async () => {
                 workflowChangesStore.setSaidOkToCodeCacheDeletion(true);
                 await handleOnSave();
+                workflowChangesStore.setShowConfirmCodeCacheDeletion(false);
               }}
             >
               Yes


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6691/worklfow-safve-bug-after-clicking-yes-to-confirm-the-deletion-of
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure confirmation dialog closes after code cache deletion confirmation in `Workspace.tsx`.
> 
>   - **Behavior**:
>     - In `Workspace.tsx`, after confirming code cache deletion, the confirmation dialog now closes automatically by setting `workflowChangesStore.setShowConfirmCodeCacheDeletion(false)`.
>   - **Misc**:
>     - No other changes or refactors were made.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 36b2adaf4073e0b4e125573d3e71a3f6fe751f5e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes a UI bug where the confirmation dialog for code cache deletion would remain open after the user clicked "Yes" to confirm the deletion in the workflow editor.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Dialog State Management**: Added `workflowChangesStore.setShowConfirmCodeCacheDeletion(false)` to properly close the confirmation dialog after user confirms cache deletion
- **User Experience Fix**: Resolves the issue where users would see a stuck dialog after confirming their action
- **Minimal Code Change**: Single line addition that addresses the root cause without affecting other functionality

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant Dialog
    participant Store
    participant SaveHandler
    
    User->>Dialog: Click "Yes" to confirm cache deletion
    Dialog->>Store: setSaidOkToCodeCacheDeletion(true)
    Dialog->>SaveHandler: await handleOnSave()
    Dialog->>Store: setShowConfirmCodeCacheDeletion(false)
    Store->>Dialog: Dialog closes
```

### Impact
- **User Experience**: Eliminates the frustrating bug where confirmation dialogs would remain visible after user action
- **Workflow Continuity**: Users can now proceed with their workflow editing without being blocked by a stuck dialog
- **Code Reliability**: Ensures proper state management for dialog visibility in the workflow editor

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The code-cache deletion confirmation dialog now closes automatically after a successful save, preventing it from lingering.
  * Reduces extra clicks and clarifies that the save action completed, improving the workflow experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->