### PR TITLE
fix codeblock skyvern credential

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -1581,7 +1581,12 @@ async def wrapper():
         parameter_values = {}
         for parameter in self.parameters:
             value = workflow_run_context.get_value(parameter.key)
-            if not parameter.parameter_type.is_secret_or_credential():
+            if not parameter.parameter_type.is_secret_or_credential() and not (
+                # NOTE: skyvern credential is a 'credential_id' workflow parameter type
+                parameter.parameter_type == ParameterType.WORKFLOW
+                and parameter.workflow_parameter_type is not None
+                and parameter.workflow_parameter_type.is_credential_type()
+            ):
                 parameter_values[parameter.key] = value
                 continue
             if isinstance(value, dict):

--- a/skyvern/forge/sdk/workflow/models/parameter.py
+++ b/skyvern/forge/sdk/workflow/models/parameter.py
@@ -199,6 +199,9 @@ class WorkflowParameterType(StrEnum):
     FILE_URL = "file_url"
     CREDENTIAL_ID = "credential_id"
 
+    def is_credential_type(self) -> bool:
+        return self == WorkflowParameterType.CREDENTIAL_ID
+
     def convert_value(self, value: Any) -> str | int | float | bool | dict | list | None:
         if value is None:
             return None


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix handling of `credential_id` workflow parameter type as a credential in `block.py` and `parameter.py`.
> 
>   - **Behavior**:
>     - Update `execute()` in `block.py` to handle `credential_id` as a credential type, ensuring it is processed correctly in workflow parameters.
>   - **Models**:
>     - Add `is_credential_type()` method to `WorkflowParameterType` in `parameter.py` to identify `CREDENTIAL_ID` as a credential type.
>   - **Misc**:
>     - Add comments in `block.py` to clarify the handling of `credential_id` as a workflow parameter type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 28e5a7fe9d23e10b09e35874b7aa451617a92e9c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔐 This PR fixes credential handling in Skyvern workflows by properly treating `credential_id` parameters as credential types, ensuring they are handled securely during code block execution.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Parameter Classification**: Added `is_credential_type()` method to `WorkflowParameterType` enum to identify `CREDENTIAL_ID` as a credential type
- **Execution Logic**: Enhanced the `execute()` method in `block.py` to properly handle workflow parameters that contain credential IDs
- **Security Enhancement**: Extended credential detection logic to include workflow parameters with credential types, not just direct secret/credential parameter types

### Technical Implementation
```mermaid
flowchart TD
    A[Parameter Processing] --> B{Is Secret/Credential Type?}
    B -->|Yes| C[Handle as Credential]
    B -->|No| D{Is Workflow Parameter?}
    D -->|Yes| E{Is Credential Type?}
    D -->|No| F[Add to Parameter Values]
    E -->|Yes| C
    E -->|No| F
    C --> G[Process Credential Securely]
    F --> H[Continue Normal Processing]
```

### Impact
- **Security Improvement**: Ensures credential IDs in workflow parameters are properly identified and handled securely
- **Bug Resolution**: Fixes the issue where `credential_id` workflow parameters were not being treated as credentials
- **Code Clarity**: Adds explicit method to determine credential types, improving code maintainability and reducing ambiguity

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Credential-type workflow parameters are now consistently treated as secrets. This prevents accidental exposure and aligns behavior with other credential inputs during execution and logging. No API changes; existing workflows continue to run as before, with improved security for parameters designated as credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->