### PR TITLE
no need to sanitize cache_key

### DIFF
--- a/skyvern/core/script_generations/generate_script.py
+++ b/skyvern/core/script_generations/generate_script.py
@@ -441,6 +441,7 @@ def _action_to_stmt(act: dict[str, Any], task: dict[str, Any], assign_to_output:
 
 def _build_block_fn(block: dict[str, Any], actions: list[dict[str, Any]]) -> FunctionDef:
     name = _safe_name(block.get("label") or block.get("title") or f"block_{block.get('workflow_run_block_id')}")
+    cache_key = block.get("label") or block.get("title") or f"block_{block.get('workflow_run_block_id')}"
     body_stmts: list[cst.BaseStatement] = []
     is_extraction_block = block.get("block_type") == "extraction"
 
@@ -473,7 +474,7 @@ def _build_block_fn(block: dict[str, Any], actions: list[dict[str, Any]]) -> Fun
                 Param(name=Name("context"), annotation=cst.Annotation(cst.Name("RunContext"))),
             ]
         ),
-        decorators=[_make_decorator(name, block)],
+        decorators=[_make_decorator(cache_key, block)],
         body=cst.IndentedBlock(body_stmts),
         returns=None,
         asynchronous=cst.Asynchronous(),
@@ -482,6 +483,7 @@ def _build_block_fn(block: dict[str, Any], actions: list[dict[str, Any]]) -> Fun
 
 def _build_task_v2_block_fn(block: dict[str, Any], child_blocks: list[dict[str, Any]]) -> FunctionDef:
     """Build a cached function for task_v2 blocks that calls child workflow sub-tasks."""
+    cache_key = block.get("label") or block.get("title") or f"block_{block.get('workflow_run_block_id')}"
     name = _safe_name(block.get("label") or block.get("title") or f"block_{block.get('workflow_run_block_id')}")
     body_stmts: list[cst.BaseStatement] = []
 
@@ -501,7 +503,7 @@ def _build_task_v2_block_fn(block: dict[str, Any], child_blocks: list[dict[str, 
                 Param(name=Name("context"), annotation=cst.Annotation(cst.Name("RunContext"))),
             ]
         ),
-        decorators=[_make_decorator(name, block)],
+        decorators=[_make_decorator(cache_key, block)],
         body=cst.IndentedBlock(body_stmts),
         returns=None,
         asynchronous=cst.Asynchronous(),


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove cache key sanitization by using block's label or title directly in `generate_script.py`.
> 
>   - **Behavior**:
>     - Use block's `label`, `title`, or `workflow_run_block_id` directly as `cache_key` in `_build_block_fn` and `_build_task_v2_block_fn`.
>     - Removes the need to sanitize `cache_key` before using it in decorators.
>   - **Functions**:
>     - `_build_block_fn`: Uses `cache_key` directly for decorator.
>     - `_build_task_v2_block_fn`: Uses `cache_key` directly for decorator.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2d122a3d5c1451ea03e67023f8bb6ff9bd4bfe9c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR removes unnecessary sanitization of cache keys in script generation by using raw block attributes directly instead of sanitized function names for decorator cache keys.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Cache Key Handling**: Introduced separate `cache_key` variable that uses raw block attributes (label, title, or block ID) without sanitization
- **Function Naming**: Maintained sanitized `name` variable for function names while using unsanitized `cache_key` for decorators
- **Decorator Parameters**: Updated `_make_decorator` calls in both `_build_block_fn` and `_build_task_v2_block_fn` to use `cache_key` instead of sanitized `name`

### Technical Implementation
```mermaid
flowchart TD
    A[Block Data] --> B[Extract label/title/ID]
    B --> C[Create cache_key - Raw]
    B --> D[Create name - Sanitized via _safe_name]
    C --> E[Pass to _make_decorator]
    D --> F[Use for function name]
    E --> G[Decorator with original cache key]
    F --> H[Function with safe name]
    G --> I[Better cache behavior]
    H --> I
```

### Impact
- **Cache Efficiency**: Cache keys now preserve original block identifiers, potentially improving cache hit rates and consistency
- **Code Clarity**: Separates concerns between function naming (which needs sanitization for valid Python identifiers) and cache identification (which benefits from original values)
- **Backward Compatibility**: No breaking changes as this only affects internal caching behavior, not external APIs

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved caching granularity for blocks and tasks using block metadata, enabling more precise cache hits and faster repeat executions.
* **Bug Fixes**
  * Reduced risk of cache collisions between similarly labeled blocks/tasks, improving consistency and reliability across reruns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->