### PR TITLE
abort scraping when too many elements

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1533,9 +1533,13 @@ async function buildTreeFromBody(
   ) {
     window.GlobalSkyvernFrameIndex = frame_index;
   }
+  const maxElementNumber = 15000;
   const elementsAndResultArray = await buildElementTree(
     document.documentElement,
     frame,
+    false,
+    undefined,
+    maxElementNumber,
   );
   DomUtils.elementListCache = elementsAndResultArray[0];
   return elementsAndResultArray;
@@ -1546,6 +1550,7 @@ async function buildElementTree(
   frame,
   full_tree = false,
   hoverStylesMap = undefined,
+  maxElementNumber = 0,
 ) {
   // Generate hover styles map at the start
   if (hoverStylesMap === undefined) {
@@ -1583,6 +1588,13 @@ async function buildElementTree(
     // skip processing option element as they are already added to the select.options
     if (tagName === "option") {
       return;
+    }
+
+    if (maxElementNumber > 0 && elements.length >= maxElementNumber) {
+      _jsConsoleWarn(
+        "Max element number reached, aborting the element tree building",
+      );
+      return [elements, resultArray];
     }
 
     let current_xpath = null;


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces a maximum element limit in `domUtils.js` to abort DOM tree building when too many elements are processed.
> 
>   - **Behavior**:
>     - Introduces a maximum element limit of 15000 in `buildTreeFromBody()` and `buildElementTree()` in `domUtils.js`.
>     - Aborts element tree building if `maxElementNumber` is reached, logging a warning.
>   - **Functions**:
>     - Adds `maxElementNumber` parameter to `buildElementTree()` to control element processing limit.
>     - Updates `buildTreeFromBody()` to pass `maxElementNumber` to `buildElementTree()`.
>   - **Logging**:
>     - Logs a warning message when the maximum element number is reached in `buildElementTree()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2a086c6d686d6ef5cddc19ee1fafc08375f4ad67. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🛡️ This PR implements a safety mechanism to prevent excessive memory usage and performance degradation by limiting DOM element tree building to 15,000 elements. When the limit is reached, the scraping process gracefully aborts with a warning message, protecting the application from processing overly complex web pages.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Element Limit Implementation**: Added a `maxElementNumber` parameter (default 15,000) to control the maximum number of DOM elements processed during tree building
- **Graceful Abort Mechanism**: Introduced early termination logic that stops processing and returns collected elements when the limit is exceeded
- **Enhanced Logging**: Added warning message to inform users when the element limit is reached during scraping operations
- **Function Signature Updates**: Modified `buildElementTree()` to accept the new `maxElementNumber` parameter and updated `buildTreeFromBody()` to pass this limit

### Technical Implementation
```mermaid
flowchart TD
    A[buildTreeFromBody] --> B[Set maxElementNumber = 15000]
    B --> C[Call buildElementTree with limit]
    C --> D{Elements count >= maxElementNumber?}
    D -->|Yes| E[Log warning message]
    E --> F[Return current elements and resultArray]
    D -->|No| G[Continue processing elements]
    G --> H[Add element to collection]
    H --> D
    F --> I[Complete with partial results]
    G --> J[Complete with full results]
```

### Impact
- **Performance Protection**: Prevents browser crashes and excessive memory consumption when scraping complex pages with thousands of DOM elements
- **Graceful Degradation**: Instead of failing completely, the system returns partial results up to the limit, maintaining functionality
- **Debugging Support**: Warning messages help developers identify when pages exceed processing limits, enabling better error handling and optimization
- **Backward Compatibility**: The change is non-breaking as the limit parameter has a default value and existing functionality remains intact

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a safeguard that caps the number of elements processed when building page structure, preventing runaway traversal on very large or complex pages.
  * Improves stability and responsiveness by reducing timeouts, memory spikes, and potential freezes; logs a warning and returns partial results when the cap is reached.
  * Uses a sensible default limit with no impact on typical pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->