### PR TITLE
abort scraping when too many elements

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1533,9 +1533,13 @@ async function buildTreeFromBody(
   ) {
     window.GlobalSkyvernFrameIndex = frame_index;
   }
+  const maxElementNumber = 15000;
   const elementsAndResultArray = await buildElementTree(
     document.documentElement,
     frame,
+    false,
+    undefined,
+    maxElementNumber,
   );
   DomUtils.elementListCache = elementsAndResultArray[0];
   return elementsAndResultArray;
@@ -1546,6 +1550,7 @@ async function buildElementTree(
   frame,
   full_tree = false,
   hoverStylesMap = undefined,
+  maxElementNumber = 0,
 ) {
   // Generate hover styles map at the start
   if (hoverStylesMap === undefined) {
@@ -1567,6 +1572,13 @@ async function buildElementTree(
   ) {
     if (element === null) {
       _jsConsoleLog("get a null element");
+      return;
+    }
+
+    if (maxElementNumber > 0 && elements.length >= maxElementNumber) {
+      _jsConsoleWarn(
+        "Max element number reached, aborting the element tree building",
+      );
       return;
     }
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add a limit to the number of elements processed in `buildElementTree()` to abort scraping when too many elements are encountered.
> 
>   - **Behavior**:
>     - Introduces `maxElementNumber` parameter in `buildElementTree()` to limit the number of elements processed.
>     - Logs a warning and aborts element tree building if `maxElementNumber` is exceeded.
>   - **Functions**:
>     - Updates `buildTreeFromBody()` to pass `maxElementNumber` to `buildElementTree()`.
>     - Adds check in `buildElementTree()` to compare `elements.length` with `maxElementNumber`.
>   - **Misc**:
>     - Sets `maxElementNumber` to 15000 in `buildTreeFromBody()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5e62d8941182e86e82cb315de7adae67238f255c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

⚡ This PR introduces a performance safeguard by implementing a maximum element limit of 15,000 during DOM tree building operations. When the limit is exceeded, the scraping process aborts gracefully with a warning message, preventing potential memory issues and timeouts on pages with excessive DOM elements.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Element Limit Implementation**: Added `maxElementNumber` parameter (default 15,000) to `buildTreeFromBody()` and `buildElementTree()` functions
- **Abort Mechanism**: Introduced early termination logic that stops DOM tree building when element count exceeds the threshold
- **Warning System**: Added console warning message when the maximum element limit is reached during processing

### Technical Implementation
```mermaid
flowchart TD
    A[buildTreeFromBody starts] --> B[Set maxElementNumber = 15000]
    B --> C[Call buildElementTree with limit]
    C --> D[Process each DOM element]
    D --> E{Element count >= maxElementNumber?}
    E -->|Yes| F[Log warning & abort]
    E -->|No| G[Continue processing]
    G --> D
    F --> H[Return partial results]
    G --> I[Complete tree building]
```

### Impact
- **Performance Protection**: Prevents browser crashes and excessive memory usage on pages with massive DOM structures
- **Graceful Degradation**: Allows partial scraping results rather than complete failure when encountering complex pages
- **Resource Management**: Helps maintain stable operation by setting clear boundaries on processing scope

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an optional cap on the number of page elements processed to improve handling of very large pages.
  - Emits a warning and stops processing when the cap is reached.
  - Default behavior remains unchanged unless a limit is specified.

- Reliability
  - Prevents excessive processing on complex pages, reducing the risk of slowdowns or timeouts.

- Chores
  - Updated internal calls to pass through the new processing limit parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->