### PR TITLE
Fix dirty-checking for workflows that use a Code Block

### DIFF
--- a/skyvern-frontend/src/components/DataSchemaInputGroup/WorkflowDataSchemaInputGroup.tsx
+++ b/skyvern-frontend/src/components/DataSchemaInputGroup/WorkflowDataSchemaInputGroup.tsx
@@ -42,8 +42,6 @@ function WorkflowDataSchemaInputGroup({
     return TSON.parse(value);
   }, [value]);
 
-  console.log({ tsonResult });
-
   const getDataSchemaSuggestionMutation = useMutation({
     mutationFn: async () => {
       const client = await getClient(credentialGetter);

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/CodeBlockNode/CodeBlockNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/CodeBlockNode/CodeBlockNode.tsx
@@ -9,6 +9,7 @@ import { NodeHeader } from "../components/NodeHeader";
 import { useParams } from "react-router-dom";
 import { statusIsRunningOrQueued } from "@/routes/tasks/types";
 import { useWorkflowRunQuery } from "@/routes/workflows/hooks/useWorkflowRunQuery";
+import { deepEqualStringArrays } from "@/util/equality";
 
 function CodeBlockNode({ id, data }: NodeProps<CodeBlockNode>) {
   const { updateNodeData } = useReactFlow();
@@ -64,10 +65,20 @@ function CodeBlockNode({ id, data }: NodeProps<CodeBlockNode>) {
           <WorkflowBlockInputSet
             nodeId={id}
             onChange={(parameterKeys) => {
+              const differs = !deepEqualStringArrays(
+                inputs.parameterKeys,
+                Array.from(parameterKeys),
+              );
+
+              if (!differs) {
+                return;
+              }
+
               setInputs({
                 ...inputs,
                 parameterKeys: Array.from(parameterKeys),
               });
+
               updateNodeData(id, { parameterKeys: Array.from(parameterKeys) });
             }}
             values={new Set(inputs.parameterKeys ?? [])}

--- a/skyvern-frontend/src/util/equality.test.ts
+++ b/skyvern-frontend/src/util/equality.test.ts
@@ -1,0 +1,39 @@
+import { deepEqualStringArrays } from "./equality";
+import { describe, test, expect } from "vitest";
+
+describe("deepEqualStringArrays", () => {
+  test("both undefined", () => {
+    expect(deepEqualStringArrays(undefined, undefined)).toBe(true);
+  });
+
+  test("one undefined, one defined", () => {
+    expect(deepEqualStringArrays(undefined, ["a"])).toBe(false);
+    expect(deepEqualStringArrays(["a"], undefined)).toBe(false);
+  });
+
+  test("both null", () => {
+    expect(deepEqualStringArrays(null, null)).toBe(true);
+  });
+
+  test("one null, one defined", () => {
+    expect(deepEqualStringArrays(null, ["a"])).toBe(false);
+    expect(deepEqualStringArrays(["a"], null)).toBe(false);
+  });
+
+  test("different lengths", () => {
+    expect(deepEqualStringArrays(["a"], ["a", "b"])).toBe(false);
+    expect(deepEqualStringArrays(["a", "b"], ["a"])).toBe(false);
+  });
+
+  test("same elements, same order", () => {
+    expect(deepEqualStringArrays(["a", "b", "c"], ["a", "b", "c"])).toBe(true);
+  });
+
+  test("same elements, different order", () => {
+    expect(deepEqualStringArrays(["a", "b", "c"], ["c", "b", "a"])).toBe(false);
+  });
+
+  test("different elements", () => {
+    expect(deepEqualStringArrays(["a", "b", "c"], ["a", "b", "d"])).toBe(false);
+  });
+});

--- a/skyvern-frontend/src/util/equality.ts
+++ b/skyvern-frontend/src/util/equality.ts
@@ -1,0 +1,13 @@
+function deepEqualStringArrays(
+  a: string[] | null | undefined,
+  b: string[] | null | undefined,
+): boolean {
+  if (a === undefined && b === undefined) return true;
+  if (a === undefined || b === undefined) return false;
+  if (a === null && b === null) return true;
+  if (a === null || b === null) return false;
+  if (a.length !== b.length) return false;
+  return a.every((val, i) => val === b[i]);
+}
+
+export { deepEqualStringArrays };


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6696/is-dirty-function-is-making-every-edit-mode-visit-require-you-to-save
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes dirty-checking in `CodeBlockNode.tsx` by using `deepEqualStringArrays` to compare input parameters, ensuring updates only on actual changes.
> 
>   - **Behavior**:
>     - Fixes dirty-checking in `CodeBlockNode.tsx` by using `deepEqualStringArrays` to compare `parameterKeys` before updating state.
>   - **Utilities**:
>     - Adds `deepEqualStringArrays` in `equality.ts` to compare string arrays, handling `null` and `undefined` cases.
>     - Includes tests for `deepEqualStringArrays` in `equality.test.ts`.
>   - **Misc**:
>     - Removes console log in `WorkflowDataSchemaInputGroup.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 79f1aebb15b31a7f8138a500f250fb6c06db92c6. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes dirty-checking issues in workflow editors by preventing unnecessary node data updates when parameter keys haven't actually changed, resolving the problem where users were forced to save on every edit mode visit.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **CodeBlockNode Component**: Added deep equality checking before updating node data to prevent unnecessary state changes
- **Utility Functions**: Created `deepEqualStringArrays` function to properly compare string arrays with null/undefined handling
- **Test Coverage**: Added comprehensive unit tests covering edge cases like null, undefined, different lengths, and order sensitivity
- **Code Cleanup**: Removed debug console.log statement from WorkflowDataSchemaInputGroup

### Technical Implementation
```mermaid
flowchart TD
    A[User modifies parameter keys] --> B[onChange callback triggered]
    B --> C[deepEqualStringArrays comparison]
    C --> D{Arrays equal?}
    D -->|Yes| E[Early return - no update]
    D -->|No| F[Update local state]
    F --> G[Update node data]
    E --> H[Prevents dirty state]
    G --> I[Triggers dirty state]
```

### Impact
- **User Experience**: Eliminates false positive dirty states that forced unnecessary saves in workflow editor
- **Performance**: Reduces redundant state updates and re-renders by avoiding unnecessary node data changes
- **Code Quality**: Introduces proper deep equality checking with comprehensive test coverage for edge cases
- **Maintainability**: Creates reusable utility function that can be used across other components with similar needs

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow editor performance by preventing unnecessary updates when editing code block parameters, resulting in smoother interactions.

* **Tests**
  * Added unit tests to validate equality checks for parameter lists, improving reliability.

* **Chores**
  * Removed a stray debug log from the data schema input group to clean up console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->