### PR TITLE
For code deletion via workflow save, only ask to delete published code (not pending)

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -4510,6 +4510,8 @@ class AgentDB:
         self,
         organization_id: str,
         workflow_permanent_id: str,
+        statuses: list[ScriptStatus] | None = None,
+        script_ids: list[str] | None = None,
     ) -> int:
         """
         Soft delete all published workflow scripts for a workflow permanent id by setting deleted_at timestamp.
@@ -4530,6 +4532,12 @@ class AgentDB:
                     .values(deleted_at=datetime.now(timezone.utc))
                 )
 
+                if statuses:
+                    stmt = stmt.where(WorkflowScriptModel.status.in_([s.value for s in statuses]))
+
+                if script_ids:
+                    stmt = stmt.where(WorkflowScriptModel.script_id.in_(script_ids))
+
                 result = await session.execute(stmt)
                 await session.commit()
 
@@ -4545,6 +4553,7 @@ class AgentDB:
         self,
         organization_id: str,
         workflow_permanent_id: str,
+        statuses: list[ScriptStatus] | None = None,
     ) -> list[WorkflowScriptModel]:
         try:
             async with self.Session() as session:
@@ -4554,6 +4563,9 @@ class AgentDB:
                     .filter_by(workflow_permanent_id=workflow_permanent_id)
                     .filter_by(deleted_at=None)
                 )
+
+                if statuses:
+                    query = query.filter(WorkflowScriptModel.status.in_([s.value for s in statuses]))
 
                 return (await session.scalars(query)).all()
         except SQLAlchemyError:


### PR DESCRIPTION
	https://linear.app/skyvern/issue/SKY-6702/shall-we-only-delete-published-scripts

Has been updated to:
- when user saves a workflow
- only ask for confirmation if published code may be deleted
- always delete non-published code

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update workflow script deletion logic to only confirm deletion for published scripts and automatically delete non-published scripts.
> 
>   - **Behavior**:
>     - `maybe_delete_cached_code()` in `service.py` now only asks for confirmation if published scripts may be deleted, and always deletes non-published scripts.
>   - **Database Operations**:
>     - `delete_workflow_scripts_by_permanent_id()` in `client.py` now accepts `statuses` and `script_ids` to filter which scripts to delete.
>     - `get_workflow_scripts_by_permanent_id()` in `client.py` now accepts `statuses` to filter scripts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6ca39fcc51538e164d297d3eab3aa52caefae25e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional filters when listing or removing workflow scripts by status and specific IDs for more targeted actions.
  - Introduced a safeguard for deleting published scripts that requires explicit approval, with clearer messaging when deletion is blocked.
  - Enhanced deletion behavior to limit scope to selected items, reducing the risk of accidental removals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->