### PR TITLE
Update API specifications with fern api update

### DIFF
--- a/fern/openapi/skyvern_openapi.json
+++ b/fern/openapi/skyvern_openapi.json
@@ -2531,6 +2531,17 @@
             ],
             "title": "Tool Call Id"
           },
+          "xpath": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Xpath"
+          },
           "errors": {
             "anyOf": [
               {
@@ -8319,6 +8330,14 @@
             "examples": [
               "JBSWY3DPEHPK3PXP"
             ]
+          },
+          "totp_type": {
+            "$ref": "#/components/schemas/TotpType",
+            "description": "Type of 2FA method used for this credential",
+            "default": "none",
+            "examples": [
+              "authenticator"
+            ]
           }
         },
         "type": "object",
@@ -8656,6 +8675,14 @@
             "description": "The username associated with the credential",
             "examples": [
               "user@example.com"
+            ]
+          },
+          "totp_type": {
+            "$ref": "#/components/schemas/TotpType",
+            "description": "Type of 2FA method used for this credential",
+            "default": "none",
+            "examples": [
+              "authenticator"
             ]
           }
         },
@@ -10926,6 +10953,17 @@
           "failure_describe"
         ],
         "title": "ThoughtType"
+      },
+      "TotpType": {
+        "type": "string",
+        "enum": [
+          "authenticator",
+          "email",
+          "text",
+          "none"
+        ],
+        "title": "TotpType",
+        "description": "Type of 2FA/TOTP method used."
       },
       "UploadToS3Block": {
         "properties": {


### PR DESCRIPTION
Update API specifications by running fern api update.

---

🔧 This PR updates the API specifications by running `fern api update`, adding support for XPath tracking in tool calls and introducing a comprehensive TOTP (Time-based One-Time Password) type system for 2FA authentication methods.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **XPath Support**: Added optional `xpath` field to tool call responses for better element tracking and debugging
- **TOTP Type System**: Introduced `TotpType` enum with four authentication methods: `authenticator`, `email`, `text`, and `none`
- **Credential Enhancement**: Updated credential schemas to include `totp_type` field with proper defaults and examples

### Technical Implementation
```mermaid
flowchart TD
    A[API Specification Update] --> B[Tool Call Enhancement]
    A --> C[Authentication System]
    
    B --> D[Add XPath Field]
    D --> E[Optional String/Null Type]
    
    C --> F[Define TotpType Enum]
    F --> G[authenticator]
    F --> H[email] 
    F --> I[text]
    F --> J[none]
    
    C --> K[Update Credential Schemas]
    K --> L[Add totp_type Field]
    L --> M[Set Default: none]
    L --> N[Add Examples]
```

### Impact
- **Debugging Capability**: XPath field enables better tracking of web elements during automation tasks
- **Security Enhancement**: Structured TOTP support allows for multiple 2FA methods with clear type definitions
- **API Consistency**: Standardized approach to handling different authentication methods across the platform
- **Backward Compatibility**: All new fields are optional with sensible defaults, ensuring no breaking changes

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update API specifications in `skyvern_openapi.json` with new fields and `TotpType` schema.
> 
>   - **API Specification Updates**:
>     - Add `xpath` field to `skyvern_openapi.json` with `string` or `null` type.
>     - Add `totp_type` field to `skyvern_openapi.json` with reference to `TotpType` schema.
>   - **Schema Additions**:
>     - Add `TotpType` schema with `enum` values: `authenticator`, `email`, `text`, `none`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for efb9773008d3422f2b792fe388bc1142a1ba2545. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added support for specifying two-factor method type on credentials and responses, with options: authenticator, email, text, or none (defaults to none).
  * Exposed the two-factor method type in API responses to improve visibility and consistency.
  * Introduced an optional XPath selector on actions to enable more precise element targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->