### PR TITLE
Update API specifications with fern api update

### DIFF
--- a/fern/openapi/skyvern_openapi.json
+++ b/fern/openapi/skyvern_openapi.json
@@ -2531,6 +2531,17 @@
             ],
             "title": "Tool Call Id"
           },
+          "xpath": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Xpath"
+          },
           "errors": {
             "anyOf": [
               {
@@ -8319,6 +8330,14 @@
             "examples": [
               "JBSWY3DPEHPK3PXP"
             ]
+          },
+          "totp_type": {
+            "$ref": "#/components/schemas/TotpType",
+            "description": "Type of 2FA method used for this credential",
+            "default": "none",
+            "examples": [
+              "authenticator"
+            ]
           }
         },
         "type": "object",
@@ -8656,6 +8675,14 @@
             "description": "The username associated with the credential",
             "examples": [
               "user@example.com"
+            ]
+          },
+          "totp_type": {
+            "$ref": "#/components/schemas/TotpType",
+            "description": "Type of 2FA method used for this credential",
+            "default": "none",
+            "examples": [
+              "authenticator"
             ]
           }
         },
@@ -10926,6 +10953,17 @@
           "failure_describe"
         ],
         "title": "ThoughtType"
+      },
+      "TotpType": {
+        "type": "string",
+        "enum": [
+          "authenticator",
+          "email",
+          "text",
+          "none"
+        ],
+        "title": "TotpType",
+        "description": "Type of 2FA/TOTP method used."
       },
       "UploadToS3Block": {
         "properties": {


### PR DESCRIPTION
Update API specifications by running fern api update.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `skyvern_openapi.json` to include new `xpath` and `totp_type` properties and `TotpType` schema.
> 
>   - **API Specification Updates**:
>     - Adds `xpath` property to `skyvern_openapi.json` with `string` or `null` type.
>     - Adds `totp_type` property to `skyvern_openapi.json` with reference to `TotpType` schema.
>     - Introduces `TotpType` schema with `enum` values: `authenticator`, `email`, `text`, `none`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 90890fe1896c0e7998311dea058e3dc0530fc3c2. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a totp_type field for credential requests and responses to specify the 2FA method (authenticator, email, text, or none; defaults to none).
  - Added an xpath attribute to actions within artifacts to support more precise element targeting.

- Documentation
  - Updated API schema documentation to include the TotpType enum and its usage across relevant credential types.
  - Documented the new xpath field for actions, including accepted values and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->