### PR TITLE
Enable code generation when a single block is run in the debugger

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -416,6 +416,18 @@ function Workspace({
   }, []);
 
   useEffect(() => {
+    if (isFinalized) {
+      queryClient.invalidateQueries({
+        queryKey: ["block-scripts"],
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: ["cache-key-values"],
+      });
+    }
+  }, [isFinalized, queryClient, workflowRun]);
+
+  useEffect(() => {
     blockScriptStore.setScripts(blockScriptsPublished ?? {});
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [blockScriptsPublished]);

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
@@ -17,6 +17,7 @@ import { useNodeLabelChangeHandler } from "@/routes/workflows/hooks/useLabelChan
 import { useDeleteNodeCallback } from "@/routes/workflows/hooks/useDeleteNodeCallback";
 import { useToggleScriptForNodeCallback } from "@/routes/workflows/hooks/useToggleScriptForNodeCallback";
 import { useDebugSessionQuery } from "@/routes/workflows/hooks/useDebugSessionQuery";
+import { useWorkflowQuery } from "@/routes/workflows/hooks/useWorkflowQuery";
 import { useWorkflowRunQuery } from "@/routes/workflows/hooks/useWorkflowRunQuery";
 import {
   debuggableWorkflowBlockTypes,
@@ -67,6 +68,7 @@ type Payload = Record<string, unknown> & {
   totp_url: string | null;
   webhook_url: string | null;
   workflow_id: string;
+  code_gen: boolean | null;
 };
 
 const getPayload = (opts: {
@@ -169,6 +171,9 @@ function NodeHeader({
   const workflowRunIsRunningOrQueued =
     workflowRun && statusIsRunningOrQueued(workflowRun);
   const { data: debugSession } = useDebugSessionQuery({
+    workflowPermanentId,
+  });
+  const { data: workflow } = useWorkflowQuery({
     workflowPermanentId,
   });
   const saveWorkflow = useWorkflowSave();
@@ -458,7 +463,10 @@ function NodeHeader({
   });
 
   const handleOnPlay = () => {
-    runBlock.mutate({ codeGen: false });
+    const numBlocksInWorkflow = (workflow?.workflow_definition.blocks ?? [])
+      .length;
+
+    runBlock.mutate({ codeGen: numBlocksInWorkflow === 1 });
   };
 
   const handleOnCancel = () => {


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6634/single-block-script-generation
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable code generation for single-block workflows from node header and refresh data post-finalization in `Workspace.tsx` and `NodeHeader.tsx`.
> 
>   - **Behavior**:
>     - Code generation is enabled for single-block workflows when initiated from a node header in `NodeHeader.tsx`.
>     - After a workflow run is finalized, `block-scripts` and `cache-key-values` queries are invalidated in `Workspace.tsx` to refresh data.
>   - **Functions**:
>     - `handleOnPlay()` in `NodeHeader.tsx` now checks the number of blocks and sets `codeGen` accordingly.
>     - `useEffect` in `Workspace.tsx` invalidates queries when `isFinalized` is true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for fb4f736bd02e27a73c487596682d244aa7d28e54. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically refreshes block scripts and cache values after workflow finalization to show the latest results without manual reloads.
  * Play action now uses current workflow data to enable code generation only for single-block workflows, improving clarity and control.

* **Bug Fixes**
  * Prevents unintended code generation on multi-block workflows by gating the feature to single-block cases.
  * Ensures up-to-date information is displayed immediately after finalizing a workflow via automatic cache refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔧 This PR enables automatic code generation when running single-block workflows in the debugger and ensures data freshness by invalidating queries after workflow finalization. The changes improve the debugging experience by automatically enabling code generation for simple workflows while maintaining data consistency.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Smart Code Generation**: Modified `NodeHeader.tsx` to automatically enable code generation (`codeGen: true`) when running workflows that contain only a single block
- **Data Invalidation**: Added a `useEffect` hook in `Workspace.tsx` to invalidate `block-scripts` and `cache-key-values` queries when a workflow run is finalized
- **Type Enhancement**: Extended the `Payload` type to include a `code_gen` boolean field for better type safety

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant NodeHeader
    participant Workflow
    participant QueryClient
    
    User->>NodeHeader: Click Play Button
    NodeHeader->>Workflow: Get workflow definition
    Workflow-->>NodeHeader: Return blocks array
    NodeHeader->>NodeHeader: Check if numBlocks === 1
    NodeHeader->>NodeHeader: Set codeGen = (numBlocks === 1)
    NodeHeader->>NodeHeader: Execute runBlock.mutate({codeGen})
    
    Note over QueryClient: When workflow finalizes
    QueryClient->>QueryClient: Invalidate block-scripts queries
    QueryClient->>QueryClient: Invalidate cache-key-values queries
```

### Impact
- **Enhanced User Experience**: Single-block workflows automatically benefit from code generation without manual configuration
- **Data Consistency**: Query invalidation ensures users see fresh data after workflow completion, preventing stale information
- **Debugging Efficiency**: Streamlines the debugging process by intelligently determining when code generation would be most beneficial

</details>

_Created with [Palmier](https://www.palmier.io)_