### PR TITLE
fix claude output tokens

### DIFF
--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -288,7 +288,7 @@ if settings.ENABLE_ANTHROPIC:
             ["ANTHROPIC_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=True,
-            max_completion_tokens=8192,
+            max_completion_tokens=64000,
         ),
     )
     LLMConfigRegistry.register_config(
@@ -308,7 +308,7 @@ if settings.ENABLE_ANTHROPIC:
             ["ANTHROPIC_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=True,
-            max_completion_tokens=8192,
+            max_completion_tokens=32000,
         ),
     )
     LLMConfigRegistry.register_config(
@@ -318,7 +318,7 @@ if settings.ENABLE_ANTHROPIC:
             ["ANTHROPIC_API_KEY"],
             supports_vision=True,
             add_assistant_prefix=True,
-            max_completion_tokens=8192,
+            max_completion_tokens=64000,
         ),
     )
 


### PR DESCRIPTION
- claude 3.7 sonnet: 8192 → 64000
- claude 4 opus: 8192 → 32000
- claude 4 sonnet: 8192 → 64000

---

🔧 This PR updates the maximum completion token limits for Claude AI models to align with their actual capabilities, significantly increasing the output capacity for Claude 3.5 Sonnet and Claude 3 Sonnet from 8,192 to 64,000 tokens, and Claude 3 Opus from 8,192 to 32,000 tokens.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Claude 3.5 Sonnet**: Increased `max_completion_tokens` from 8,192 to 64,000 tokens
- **Claude 3 Opus**: Increased `max_completion_tokens` from 8,192 to 32,000 tokens  
- **Claude 3 Sonnet**: Increased `max_completion_tokens` from 8,192 to 64,000 tokens
- **Configuration Registry**: Updated LLM model configurations in the centralized registry

### Technical Implementation
```mermaid
flowchart TD
    A[LLMConfigRegistry] --> B[Claude 3.5 Sonnet Config]
    A --> C[Claude 3 Opus Config]
    A --> D[Claude 3 Sonnet Config]
    
    B --> B1[max_completion_tokens: 8192 → 64000]
    C --> C1[max_completion_tokens: 8192 → 32000]
    D --> D1[max_completion_tokens: 8192 → 64000]
    
    B1 --> E[Enhanced Output Capacity]
    C1 --> E
    D1 --> E
```

### Impact
- **Enhanced Capability**: Applications can now generate much longer responses from Claude models, enabling more comprehensive outputs for complex tasks
- **Better Resource Utilization**: Aligns configuration with actual model capabilities, preventing artificial limitations on response length
- **Improved User Experience**: Users can receive more detailed and complete responses without hitting token limits prematurely
- **No Breaking Changes**: This is a configuration update that only expands capabilities without affecting existing functionality

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase `max_completion_tokens` for specific Claude models in `config_registry.py` to enhance output capacity.
> 
>   - **Behavior**:
>     - Updated `max_completion_tokens` for `ANTHROPIC_CLAUDE3.7_SONNET` from 8192 to 64000 in `config_registry.py`.
>     - Updated `max_completion_tokens` for `ANTHROPIC_CLAUDE4_OPUS` from 8192 to 32000 in `config_registry.py`.
>     - Updated `max_completion_tokens` for `ANTHROPIC_CLAUDE4_SONNET` from 8192 to 64000 in `config_registry.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 36bd9e63d826dfb13420a6a6c8a3fca6e2f9c3a4. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded maximum AI response length for select Anthropic Claude models, raising limits up to 64k tokens. This enables longer outputs and reduces truncation for extensive tasks such as detailed analyses, multi-step reasoning, large document generation, and end-to-end workflows that previously exceeded limits. Users can compose and receive substantially longer messages without manual splitting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->