### PR TITLE
fix all dict.get fallbacks instances in create-from-prompt endpoint

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -774,8 +774,8 @@ class WorkflowService:
             organization_id=organization.organization_id,
         )
 
-        block_label: str = metadata_response.get("block_label", DEFAULT_FIRST_BLOCK_LABEL)
-        title: str = metadata_response.get("title", DEFAULT_WORKFLOW_TITLE)
+        block_label: str = metadata_response.get("block_label", None) or DEFAULT_FIRST_BLOCK_LABEL
+        title: str = metadata_response.get("title", None) or DEFAULT_WORKFLOW_TITLE
 
         if task_version == "v1":
             task_prompt = prompt_engine.load_prompt(
@@ -790,8 +790,8 @@ class WorkflowService:
             )
 
             data_extraction_goal: str | None = task_response.get("data_extraction_goal")
-            navigation_goal: str = task_response.get("navigation_goal", user_prompt)
-            url: str = task_response.get("url", "")
+            navigation_goal: str = task_response.get("navigation_goal", None) or user_prompt
+            url: str = task_response.get("url", None) or ""
 
             blocks = [
                 NavigationBlock(


### PR DESCRIPTION
	https://linear.app/skyvern/issue/SKY-6769/fix-all-dictget-fallbacks-in-create-from-prompt-endpoint
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `dict.get()` fallbacks in `create_workflow_from_prompt()` in `service.py` to ensure default values are used when keys are missing.
> 
>   - **Bug Fixes**:
>     - In `create_workflow_from_prompt()` in `service.py`, replace `dict.get()` fallbacks with `or` to ensure default values are used when keys are missing.
>     - Specifically, `block_label` and `title` default to `DEFAULT_FIRST_BLOCK_LABEL` and `DEFAULT_WORKFLOW_TITLE` respectively.
>     - `navigation_goal` defaults to `user_prompt` and `url` defaults to an empty string when not specified.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 604ffaececd7f745c6a0d5011705b94c2c2b7abf. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback behavior when generating workflows from prompts: titles and first block labels now reliably use sensible defaults if missing or blank.
  * Navigation goals now default to the original prompt when not provided, ensuring clearer guidance.
  * URLs fall back to an empty value when absent, preventing malformed links.
  * Overall, metadata handling is more consistent and resilient to incomplete responses, reducing confusing or empty fields in newly created workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->