### PR TITLE
Update API specifications with fern api update

### DIFF
--- a/fern/openapi/skyvern_openapi.json
+++ b/fern/openapi/skyvern_openapi.json
@@ -3162,6 +3162,7 @@
           "reload_page",
           "extract",
           "verification_code",
+          "goto_url",
           "scroll",
           "keypress",
           "move",
@@ -8348,6 +8349,14 @@
         "title": "NonEmptyPasswordCredential",
         "description": "Password credential model that requires non-empty values."
       },
+      "OTPType": {
+        "type": "string",
+        "enum": [
+          "totp",
+          "magic_link"
+        ],
+        "title": "OTPType"
+      },
       "OnePasswordCredentialParameter": {
         "properties": {
           "parameter_type": {
@@ -9215,6 +9224,17 @@
             "format": "date-time",
             "title": "Modified At",
             "description": "The timestamp when the TOTP code was modified."
+          },
+          "otp_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OTPType"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The type of the OTP code."
           }
         },
         "type": "object",


### PR DESCRIPTION
Update API specifications by running fern api update.

---

🔄 This PR updates the API specifications by running `fern api update`, adding support for a new "goto_url" action type and introducing OTP (One-Time Password) type classification with support for TOTP and magic link authentication methods.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Action Types**: Added "goto_url" to the enumerated list of available action types, expanding navigation capabilities
- **OTP Classification**: Introduced new `OTPType` enum with support for "totp" and "magic_link" authentication methods
- **TOTP Schema Enhancement**: Extended the TOTP code schema to include an optional `otp_type` field for better categorization

### Technical Implementation
```mermaid
flowchart TD
    A[API Specification Update] --> B[Action Types Enhancement]
    A --> C[OTP Type System]
    
    B --> D[goto_url Action Added]
    
    C --> E[OTPType Enum]
    E --> F[totp]
    E --> G[magic_link]
    
    C --> H[TOTP Schema Update]
    H --> I[otp_type Field Added]
    I --> J[Optional/Nullable]
```

### Impact
- **Enhanced Navigation**: The "goto_url" action type provides more explicit URL navigation capabilities for automation workflows
- **Improved Authentication**: OTP type classification enables better handling of different authentication methods (TOTP vs magic links)
- **Backward Compatibility**: All changes are additive - the `otp_type` field is optional/nullable, ensuring existing integrations continue to work

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `skyvern_openapi.json` with new action `goto_url`, `OTPType` schema, and `otp_type` field.
> 
>   - **API Specification Updates**:
>     - Add `goto_url` to action list in `skyvern_openapi.json`.
>     - Introduce `OTPType` schema with `totp` and `magic_link` enums in `skyvern_openapi.json`.
>     - Add `otp_type` field to an existing schema, referencing `OTPType`, in `skyvern_openapi.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 2a30d19056dc9c2cb50c892357804d754b1012c6. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new “goto_url” action type.
  * Introduced explicit OTP types, improving validation and clarity for OTP-related operations.
  * TOTP codes now accept an optional otp_type to specify the OTP variant.

* **Documentation**
  * Updated API specification to include the new action type, OTP types enum, and the otp_type field in TOTPCode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->