### PR TITLE
Delete Azure Vault secrets async

### DIFF
--- a/skyvern/forge/api_app.py
+++ b/skyvern/forge/api_app.py
@@ -1,7 +1,6 @@
 import uuid
-from contextlib import asynccontextmanager
 from datetime import datetime
-from typing import Any, AsyncGenerator, Awaitable, Callable
+from typing import Awaitable, Callable
 
 import structlog
 from fastapi import FastAPI, Response, status
@@ -51,20 +50,12 @@ def custom_openapi() -> dict:
     return app.openapi_schema
 
 
-@asynccontextmanager
-async def lifespan(_: FastAPI) -> AsyncGenerator[None, Any]:
-    """Lifespan context manager for FastAPI app startup and shutdown."""
-    LOG.info("Server started")
-    yield
-    LOG.info("Server shutting down")
-
-
 def get_agent_app() -> FastAPI:
     """
     Start the agent server.
     """
 
-    app = FastAPI(lifespan=lifespan)
+    app = FastAPI()
 
     # Add CORS middleware
     app.add_middleware(

--- a/skyvern/forge/sdk/api/azure.py
+++ b/skyvern/forge/sdk/api/azure.py
@@ -33,7 +33,7 @@ class AsyncAzureVaultClient:
         finally:
             await secret_client.close()
 
-    async def create_secret(self, secret_name: str, secret_value: str, vault_name: str) -> str:
+    async def create_or_update_secret(self, secret_name: str, secret_value: str, vault_name: str) -> str:
         secret_client = await self._get_secret_client(vault_name)
         try:
             secret = await secret_client.set_secret(secret_name, secret_value)

--- a/skyvern/forge/sdk/routes/credentials.py
+++ b/skyvern/forge/sdk/routes/credentials.py
@@ -205,6 +205,7 @@ async def create_credential(
     include_in_schema=False,
 )
 async def delete_credential(
+    background_tasks: BackgroundTasks,
     credential_id: str = Path(
         ...,
         description="The unique identifier of the credential to delete",
@@ -225,6 +226,9 @@ async def delete_credential(
         raise HTTPException(status_code=400, detail="Unsupported credential storage type")
 
     await credential_service.delete_credential(credential)
+
+    # Schedule background cleanup if the service implements it
+    background_tasks.add_task(credential_service.post_delete_credential_item, credential.item_id)
 
     return None
 

--- a/skyvern/forge/sdk/services/credential/credential_vault_service.py
+++ b/skyvern/forge/sdk/services/credential/credential_vault_service.py
@@ -26,6 +26,12 @@ class CredentialVaultService(ABC):
     async def delete_credential(self, credential: Credential) -> None:
         """Delete a credential from the vault and database."""
 
+    async def post_delete_credential_item(self, item_id: str) -> None:
+        """
+        Optional hook for scheduling background cleanup tasks after credential deletion.
+        Default implementation does nothing. Override in subclasses as needed.
+        """
+
     @abstractmethod
     async def get_credential(self, organization_id: str, credential_id: str) -> CredentialResponse:
         """Retrieve a credential with masked sensitive data."""


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Implement asynchronous Azure Vault secret deletion and add post-deletion cleanup hook, with refactoring for clarity.
> 
>   - **Behavior**:
>     - Asynchronous background cleanup for credential deletions in `delete_credential()` in `credentials.py`.
>     - New `post_delete_credential_item()` in `azure_credential_vault_service.py` for async Azure Key Vault deletion.
>     - Missing credential retrieval in `get_credential()` in `azure_credential_vault_service.py` returns 404.
>   - **Refactor**:
>     - Rename `create_secret()` to `create_or_update_secret()` in `azure.py` and `azure_credential_vault_service.py`.
>   - **Misc**:
>     - Remove unused `lifespan` context manager in `api_app.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d7e52ba0962e05ef09f685b8615845ea5679038c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Credential deletions now trigger background cleanup for faster responses.
  - Secret management supports create-or-update (upsert) behavior.

- Bug Fixes
  - Fetching a non-existent credential now returns a 404 error.

- Refactor
  - Simplified application startup/shutdown by removing custom lifecycle hooks.
  - Standardized secret operation naming to reflect upsert behavior.
  - Introduced structured logging in credential services.

- Chores
  - Expanded credential service interface with an optional post-delete hook for background cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

⚡ This PR implements asynchronous deletion of Azure Key Vault secrets to improve API response times by immediately clearing secret values and scheduling the actual deletion as a background task. The changes prevent users from waiting for slow Azure Key Vault deletion operations while ensuring credentials are immediately invalidated.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Azure Credential Service**: Modified `delete_credential` to immediately clear secret values with empty strings and schedule background deletion via `post_delete_credential_item`
- **API Routes**: Added `BackgroundTasks` parameter to credential deletion endpoint to handle asynchronous cleanup
- **Base Service Interface**: Added optional `post_delete_credential_item` hook for background cleanup tasks
- **Azure Client**: Renamed `create_secret` to `create_or_update_secret` to better reflect its functionality
- **FastAPI App**: Removed unused lifespan context manager and related imports

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant API
    participant DB
    participant Azure
    participant Background
    
    Client->>API: DELETE /credential/{id}
    API->>DB: delete_credential()
    API->>Azure: create_or_update_secret("", value)
    Note over Azure: Secret immediately cleared
    API->>Background: schedule post_delete_credential_item()
    API-->>Client: 200 OK (fast response)
    Background->>Azure: delete_secret()
    Note over Background: Actual deletion happens async
```

### Impact
- **Performance**: API responses are now immediate instead of waiting for Azure Key Vault deletion operations (which can take several seconds)
- **Security**: Credentials are immediately invalidated by clearing their values, even before background deletion completes
- **Reliability**: Background task includes comprehensive error logging and graceful failure handling
- **User Experience**: Users no longer experience delays when deleting credentials through the API

</details>

_Created with [Palmier](https://www.palmier.io)_