### PR TITLE
add disable_cache to Validation and TaskV2

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -2666,6 +2666,7 @@ class WorkflowService:
                 continue_on_failure=block_yaml.continue_on_failure,
                 # Should only need one step for validation block, but we allow 2 in case the LLM has an unexpected failure and we need to retry.
                 max_steps_per_run=2,
+                disable_cache=block_yaml.disable_cache,
                 model=block_yaml.model,
             )
 
@@ -2834,6 +2835,7 @@ class WorkflowService:
                 totp_identifier=block_yaml.totp_identifier,
                 max_iterations=block_yaml.max_iterations,
                 max_steps=block_yaml.max_steps,
+                disable_cache=block_yaml.disable_cache,
                 model=block_yaml.model,
                 output_parameter=output_parameter,
             )

--- a/skyvern/schemas/workflows.py
+++ b/skyvern/schemas/workflows.py
@@ -341,6 +341,7 @@ class ValidationBlockYAML(BlockYAML):
     terminate_criterion: str | None = None
     error_code_mapping: dict[str, str] | None = None
     parameter_keys: list[str] | None = None
+    disable_cache: bool = False
 
 
 class ActionBlockYAML(BlockYAML):
@@ -462,6 +463,7 @@ class TaskV2BlockYAML(BlockYAML):
     totp_identifier: str | None = None
     max_iterations: int = settings.MAX_ITERATIONS_PER_TASK_V2
     max_steps: int = settings.MAX_STEPS_PER_TASK_V2
+    disable_cache: bool = False
 
 
 class HttpRequestBlockYAML(BlockYAML):


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6787/add-disable-cache-toggle-to-validation-and-task-v2-blocks
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `disable_cache` option to `ValidationBlockYAML` and `TaskV2BlockYAML` for per-block caching control in workflows.
> 
>   - **New Feature**:
>     - Add `disable_cache` option to `ValidationBlockYAML` and `TaskV2BlockYAML` classes in `workflows.py`.
>     - Propagate `disable_cache` through `block_yaml_to_block()` in `service.py` to affect runtime behavior.
>   - **Behavior**:
>     - `disable_cache` defaults to `False`, maintaining existing caching behavior unless explicitly set to `True`.
>     - Allows per-block control over caching in workflow definitions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 77d9e27cd4ba8475159baf5b9a39689e68d1e7ee. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional disable_cache setting in workflow YAML for Validation, Action, and Task (v2) blocks.
  * When enabled, these blocks bypass cached data for fresh execution results.
  * Provides finer control over caching behavior to reduce stale outputs and improve determinism where needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

⚙️ This PR adds a `disable_cache` configuration option to Validation and TaskV2 workflow blocks, allowing users to selectively bypass caching on a per-block basis. The feature defaults to `False` to maintain backward compatibility while providing granular control over caching behavior in workflow definitions.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Schema Updates**: Added `disable_cache: bool = False` field to both `ValidationBlockYAML` and `TaskV2BlockYAML` classes in `workflows.py`
- **Service Integration**: Updated `block_yaml_to_block` function in `service.py` to pass the `disable_cache` parameter when creating ValidationBlock and TaskV2Block instances
- **Backward Compatibility**: Default value of `False` ensures existing workflows continue to work without modification

### Technical Implementation
```mermaid
flowchart TD
    A[YAML Workflow Definition] --> B[ValidationBlockYAML/TaskV2BlockYAML]
    B --> C[disable_cache: bool = False]
    C --> D[block_yaml_to_block function]
    D --> E[ValidationBlock/TaskV2Block creation]
    E --> F[Cache behavior controlled by disable_cache flag]
```

### Impact
- **Enhanced Control**: Users can now disable caching for specific validation and task blocks where fresh execution is required
- **Workflow Flexibility**: Enables more sophisticated workflow configurations where some blocks need to bypass cache while others can benefit from it
- **Zero Breaking Changes**: Default `False` value maintains existing behavior for all current workflows, ensuring seamless deployment

</details>

_Created with [Palmier](https://www.palmier.io)_