### PR TITLE
make cacheActions optional in DisableCache component; add disable cache toggle to Validation and V2Task blocks

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/DisableCache.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/DisableCache.tsx
@@ -12,7 +12,7 @@ function DisableCache({
   onCacheActionsChange,
   onDisableCacheChange,
 }: {
-  cacheActions: boolean;
+  cacheActions?: boolean;
   disableCache: boolean;
   editable: boolean;
   // --

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/Taskv2Node/Taskv2Node.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/Taskv2Node/Taskv2Node.tsx
@@ -26,6 +26,8 @@ import { useRerender } from "@/hooks/useRerender";
 import { BlockCodeEditor } from "@/routes/workflows/components/BlockCodeEditor";
 import { useBlockScriptStore } from "@/store/BlockScriptStore";
 
+import { DisableCache } from "../DisableCache";
+
 function Taskv2Node({ id, data, type }: NodeProps<Taskv2Node>) {
   const { editable, label } = data;
   const { blockLabel: urlBlockLabel } = useParams();
@@ -49,6 +51,7 @@ function Taskv2Node({ id, data, type }: NodeProps<Taskv2Node>) {
     totpVerificationUrl: data.totpVerificationUrl,
     totpIdentifier: data.totpIdentifier,
     maxSteps: data.maxSteps,
+    disableCache: data.disableCache,
     model: data.model,
   });
 
@@ -167,6 +170,18 @@ function Taskv2Node({ id, data, type }: NodeProps<Taskv2Node>) {
                       }}
                     />
                   </div>
+                  <Separator />
+                  <DisableCache
+                    disableCache={inputs.disableCache}
+                    editable={editable}
+                    onCacheActionsChange={(cacheActions) => {
+                      handleChange("cacheActions", cacheActions);
+                    }}
+                    onDisableCacheChange={(disableCache) => {
+                      handleChange("disableCache", disableCache);
+                    }}
+                  />
+                  <Separator />
                   <div className="space-y-2">
                     <div className="flex gap-2">
                       <Label className="text-xs text-slate-300">

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/Taskv2Node/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/Taskv2Node/types.ts
@@ -11,6 +11,7 @@ export type Taskv2NodeData = NodeBaseData & {
   totpVerificationUrl: string | null;
   totpIdentifier: string | null;
   maxSteps: number | null;
+  disableCache: boolean;
   maxScreenshotScrolls: number | null;
 };
 
@@ -26,6 +27,7 @@ export const taskv2NodeDefaultData: Taskv2NodeData = {
   totpIdentifier: null,
   totpVerificationUrl: null,
   maxSteps: MAX_STEPS_DEFAULT,
+  disableCache: false,
   model: null,
   maxScreenshotScrolls: null,
 };

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/ValidationNode/ValidationNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/ValidationNode/ValidationNode.tsx
@@ -39,6 +39,8 @@ import { statusIsRunningOrQueued } from "@/routes/tasks/types";
 import { useWorkflowRunQuery } from "@/routes/workflows/hooks/useWorkflowRunQuery";
 import { useRerender } from "@/hooks/useRerender";
 
+import { DisableCache } from "../DisableCache";
+
 function ValidationNode({ id, data, type }: NodeProps<ValidationNode>) {
   const { updateNodeData } = useReactFlow();
   const [facing, setFacing] = useState<"front" | "back">("front");
@@ -58,6 +60,7 @@ function ValidationNode({ id, data, type }: NodeProps<ValidationNode>) {
     terminateCriterion: data.terminateCriterion,
     errorCodeMapping: data.errorCodeMapping,
     model: data.model,
+    disableCache: data.disableCache,
   });
 
   const rerender = useRerender({ prefix: "accordian" });
@@ -243,6 +246,16 @@ function ValidationNode({ id, data, type }: NodeProps<ValidationNode>) {
                       />
                     </div>
                   </div>
+                  <DisableCache
+                    disableCache={inputs.disableCache}
+                    editable={editable}
+                    onCacheActionsChange={(cacheActions) => {
+                      handleChange("cacheActions", cacheActions);
+                    }}
+                    onDisableCacheChange={(disableCache) => {
+                      handleChange("disableCache", disableCache);
+                    }}
+                  />
                 </div>
               </AccordionContent>
             </AccordionItem>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/ValidationNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/ValidationNode/types.ts
@@ -6,6 +6,7 @@ export type ValidationNodeData = NodeBaseData & {
   terminateCriterion: string;
   errorCodeMapping: string;
   parameterKeys: Array<string>;
+  disableCache: boolean;
 };
 
 export type ValidationNode = Node<ValidationNodeData, "validation">;
@@ -19,6 +20,7 @@ export const validationNodeDefaultData: ValidationNodeData = {
   continueOnFailure: false,
   editable: true,
   parameterKeys: [],
+  disableCache: false,
   model: null,
 };
 

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -264,6 +264,7 @@ function convertToNode(
           prompt: block.prompt,
           url: block.url ?? "",
           maxSteps: block.max_steps,
+          disableCache: block.disable_cache ?? false,
           totpIdentifier: block.totp_identifier,
           totpVerificationUrl: block.totp_verification_url,
           maxScreenshotScrolls: null,
@@ -281,6 +282,7 @@ function convertToNode(
           completeCriterion: block.complete_criterion ?? "",
           terminateCriterion: block.terminate_criterion ?? "",
           parameterKeys: block.parameters.map((p) => p.key),
+          disableCache: block.disable_cache ?? false,
         },
       };
     }

--- a/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
@@ -318,6 +318,7 @@ export type Taskv2Block = WorkflowBlockBase & {
   totp_verification_url: string | null;
   totp_identifier: string | null;
   max_steps: number | null;
+  disable_cache: boolean;
 };
 
 export type ForLoopBlock = WorkflowBlockBase & {
@@ -391,6 +392,7 @@ export type ValidationBlock = WorkflowBlockBase & {
   terminate_criterion: string | null;
   error_code_mapping: Record<string, string> | null;
   parameters: Array<WorkflowParameter>;
+  disable_cache?: boolean;
 };
 
 export type ActionBlock = WorkflowBlockBase & {


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6787/add-disable-cache-toggle-to-validation-and-task-v2-blocks
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Make `cacheActions` optional in `DisableCache` and add `disableCache` toggle to `ValidationNode` and `Taskv2Node`.
> 
>   - **Behavior**:
>     - `cacheActions` is now optional in `DisableCache` component.
>     - Added `disableCache` toggle to `ValidationNode` and `Taskv2Node` components.
>   - **Data Handling**:
>     - Updated `Taskv2NodeData` and `ValidationNodeData` types to include `disableCache`.
>     - Default `disableCache` set to `false` in `taskv2NodeDefaultData` and `validationNodeDefaultData`.
>   - **Node Conversion**:
>     - `convertToNode()` in `workflowEditorUtils.ts` updated to handle `disableCache` for `task_v2` and `validation` blocks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 58d1980163f4067fede6b09eb7b8370121b845cd. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

⚙️ This PR enhances the workflow editor by making the `cacheActions` parameter optional in the `DisableCache` component and adds disable cache toggle functionality to both Validation and Task V2 blocks. The changes improve the flexibility of cache management across different workflow node types.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Component Interface**: Made `cacheActions` parameter optional in `DisableCache` component by changing from `cacheActions: boolean` to `cacheActions?: boolean`
- **Node Enhancement**: Added `DisableCache` component integration to both `Taskv2Node` and `ValidationNode` components with proper event handlers
- **Type System**: Extended `Taskv2NodeData` and `ValidationNodeData` types to include `disableCache: boolean` property with default value of `false`
- **Data Conversion**: Updated `convertToNode()` utility function to handle `disable_cache` field mapping from backend block data to frontend node data

### Technical Implementation
```mermaid
flowchart TD
    A[DisableCache Component] --> B[Made cacheActions Optional]
    C[Taskv2Node] --> D[Added DisableCache Toggle]
    E[ValidationNode] --> F[Added DisableCache Toggle]
    G[Type Definitions] --> H[Added disableCache Property]
    I[Workflow Utils] --> J[Updated convertToNode Function]
    
    D --> K[handleChange for disableCache]
    F --> L[handleChange for disableCache]
    H --> M[Default Value: false]
    J --> N[Maps disable_cache from Backend]
```

### Impact
- **Enhanced Flexibility**: The optional `cacheActions` parameter allows the `DisableCache` component to be used in contexts where cache actions aren't applicable
- **Improved User Experience**: Users can now control cache behavior directly from Validation and Task V2 blocks through a consistent UI toggle
- **Backward Compatibility**: All changes maintain backward compatibility by providing sensible defaults (`false` for `disableCache`) and making previously required parameters optional
- **Consistent Architecture**: The implementation follows existing patterns for node data handling and state management across the workflow editor

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Disable Cache” option in Advanced Settings for Task v2 and Validation nodes, letting you bypass cached results when needed.
  * The cache actions control now hides automatically when not applicable.
  * Workflows now load and save the “Disable Cache” setting.
  * Default is off for existing and new workflows; behavior remains unchanged unless enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->