### PR TITLE
Update API specifications with fern api update

### DIFF
--- a/fern/openapi/skyvern_openapi.json
+++ b/fern/openapi/skyvern_openapi.json
@@ -2963,6 +2963,11 @@
             "title": "Cache Actions",
             "default": false
           },
+          "disable_cache": {
+            "type": "boolean",
+            "title": "Disable Cache",
+            "default": false
+          },
           "complete_verification": {
             "type": "boolean",
             "title": "Complete Verification",
@@ -3127,6 +3132,11 @@
             "type": "boolean",
             "title": "Cache Actions",
             "default": false
+          },
+          "disable_cache": {
+            "type": "boolean",
+            "title": "Disable Cache",
+            "default": false
           }
         },
         "type": "object",
@@ -3162,6 +3172,7 @@
           "reload_page",
           "extract",
           "verification_code",
+          "goto_url",
           "scroll",
           "keypress",
           "move",
@@ -5298,6 +5309,11 @@
             "title": "Cache Actions",
             "default": false
           },
+          "disable_cache": {
+            "type": "boolean",
+            "title": "Disable Cache",
+            "default": false
+          },
           "complete_verification": {
             "type": "boolean",
             "title": "Complete Verification",
@@ -5433,6 +5449,11 @@
           "cache_actions": {
             "type": "boolean",
             "title": "Cache Actions",
+            "default": false
+          },
+          "disable_cache": {
+            "type": "boolean",
+            "title": "Disable Cache",
             "default": false
           }
         },
@@ -5694,6 +5715,11 @@
             "title": "Cache Actions",
             "default": false
           },
+          "disable_cache": {
+            "type": "boolean",
+            "title": "Disable Cache",
+            "default": false
+          },
           "complete_verification": {
             "type": "boolean",
             "title": "Complete Verification",
@@ -5856,6 +5882,11 @@
           "cache_actions": {
             "type": "boolean",
             "title": "Cache Actions",
+            "default": false
+          },
+          "disable_cache": {
+            "type": "boolean",
+            "title": "Disable Cache",
             "default": false
           },
           "download_timeout": {
@@ -7342,6 +7373,11 @@
             "title": "Cache Actions",
             "default": false
           },
+          "disable_cache": {
+            "type": "boolean",
+            "title": "Disable Cache",
+            "default": false
+          },
           "complete_verification": {
             "type": "boolean",
             "title": "Complete Verification",
@@ -7500,6 +7536,11 @@
           "cache_actions": {
             "type": "boolean",
             "title": "Cache Actions",
+            "default": false
+          },
+          "disable_cache": {
+            "type": "boolean",
+            "title": "Disable Cache",
             "default": false
           },
           "complete_criterion": {
@@ -8017,6 +8058,11 @@
             "title": "Cache Actions",
             "default": false
           },
+          "disable_cache": {
+            "type": "boolean",
+            "title": "Disable Cache",
+            "default": false
+          },
           "complete_verification": {
             "type": "boolean",
             "title": "Complete Verification",
@@ -8187,6 +8233,11 @@
             "title": "Cache Actions",
             "default": false
           },
+          "disable_cache": {
+            "type": "boolean",
+            "title": "Disable Cache",
+            "default": false
+          },
           "complete_criterion": {
             "anyOf": [
               {
@@ -8347,6 +8398,14 @@
         ],
         "title": "NonEmptyPasswordCredential",
         "description": "Password credential model that requires non-empty values."
+      },
+      "OTPType": {
+        "type": "string",
+        "enum": [
+          "totp",
+          "magic_link"
+        ],
+        "title": "OTPType"
       },
       "OnePasswordCredentialParameter": {
         "properties": {
@@ -9215,6 +9274,17 @@
             "format": "date-time",
             "title": "Modified At",
             "description": "The timestamp when the TOTP code was modified."
+          },
+          "otp_type": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OTPType"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The type of the OTP code."
           }
         },
         "type": "object",
@@ -9586,6 +9656,11 @@
             "title": "Cache Actions",
             "default": false
           },
+          "disable_cache": {
+            "type": "boolean",
+            "title": "Disable Cache",
+            "default": false
+          },
           "complete_verification": {
             "type": "boolean",
             "title": "Complete Verification",
@@ -9790,6 +9865,11 @@
           "cache_actions": {
             "type": "boolean",
             "title": "Cache Actions",
+            "default": false
+          },
+          "disable_cache": {
+            "type": "boolean",
+            "title": "Disable Cache",
             "default": false
           },
           "complete_criterion": {
@@ -11307,6 +11387,11 @@
             "title": "Cache Actions",
             "default": false
           },
+          "disable_cache": {
+            "type": "boolean",
+            "title": "Disable Cache",
+            "default": false
+          },
           "complete_verification": {
             "type": "boolean",
             "title": "Complete Verification",
@@ -11652,6 +11737,11 @@
           "cache_actions": {
             "type": "boolean",
             "title": "Cache Actions",
+            "default": false
+          },
+          "disable_cache": {
+            "type": "boolean",
+            "title": "Disable Cache",
             "default": false
           },
           "complete_verification": {


### PR DESCRIPTION
Update API specifications by running fern api update.

---

🔄 This PR updates the Skyvern API specifications by adding new cache control functionality and OTP type support across multiple workflow and task endpoints.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Cache Control Enhancement**: Added `disable_cache` boolean parameter (default: false) to 14 different API endpoints across workflow and task operations
- **Action Type Extension**: Added `goto_url` to the list of supported action types in the API specification
- **OTP Type Support**: Introduced new `OTPType` enum with values `totp` and `magic_link`, and added optional `otp_type` field to TOTP code models

### Technical Implementation
```mermaid
flowchart TD
    A[API Specification Update] --> B[Cache Control]
    A --> C[Action Types]
    A --> D[OTP Enhancement]
    
    B --> B1[disable_cache parameter]
    B --> B2[14 endpoints affected]
    B --> B3[Default: false]
    
    C --> C1[goto_url action added]
    
    D --> D1[OTPType enum]
    D --> D2[totp/magic_link values]
    D --> D3[otp_type field in TOTP model]
```

### Impact
- **Enhanced Cache Control**: Developers can now explicitly disable caching on a per-request basis, providing more granular control over data freshness
- **Extended Action Support**: The addition of `goto_url` action type expands the automation capabilities of the platform
- **Improved OTP Handling**: Better categorization and handling of different OTP types (TOTP vs Magic Link) for authentication workflows
- **Backward Compatibility**: All new fields have sensible defaults, ensuring existing integrations continue to work without modification

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update API specifications in `skyvern_openapi.json` with new `disable_cache` property and `OTPType` enum.
> 
>   - **API Specification Updates**:
>     - Add `disable_cache` boolean property with default `false` in multiple sections of `skyvern_openapi.json`.
>     - Introduce `OTPType` enum with values `totp` and `magic_link` in `skyvern_openapi.json`.
>     - Add `otp_type` property referencing `OTPType` in `skyvern_openapi.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 3ff44cdf5e0ec1d4a8fc5d2a9b01e63978463461. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added per-step cache control with a disable_cache option across workflow and task blocks.
  - Introduced a new action type for direct URL navigation.
  - Expanded OTP handling by allowing an otp_type field (TOTP or magic_link) for more precise authentication flows.

- Improvements
  - Public API schemas now reflect the new otp_type and cache control options for clearer, more explicit integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->