### PR TITLE
move startup and teardown events to forge api_app.py

### DIFF
--- a/skyvern/forge/api_app.py
+++ b/skyvern/forge/api_app.py
@@ -55,7 +55,19 @@ def custom_openapi() -> dict:
 async def lifespan(_: FastAPI) -> AsyncGenerator[None, Any]:
     """Lifespan context manager for FastAPI app startup and shutdown."""
     LOG.info("Server started")
+    if forge_app.api_app_startup_event:
+        LOG.info("Calling api app startup event")
+        try:
+            await forge_app.api_app_startup_event()
+        except Exception:
+            LOG.exception("Failed to execute api app startup event")
     yield
+    if forge_app.api_app_shutdown_event:
+        LOG.info("Calling api app shutdown event")
+        try:
+            await forge_app.api_app_shutdown_event()
+        except Exception:
+            LOG.exception("Failed to execute api app shutdown event")
     LOG.info("Server shutting down")
 
 

--- a/skyvern/forge/app.py
+++ b/skyvern/forge/app.py
@@ -127,6 +127,8 @@ scrape_exclude: ScrapeExcludeFunc | None = None
 authentication_function: Callable[[str], Awaitable[Organization]] | None = None
 authenticate_user_function: Callable[[str], Awaitable[str | None]] | None = None
 setup_api_app: Callable[[FastAPI], None] | None = None
+api_app_startup_event: Callable[[], Awaitable[None]] | None = None
+api_app_shutdown_event: Callable[[], Awaitable[None]] | None = None
 
 agent = ForgeAgent()
 


### PR DESCRIPTION
	This PR fixes the bug introduced by https://github.com/Skyvern-AI/skyvern-cloud/pull/6814

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Moves startup/shutdown event handling to `api_app.py`, making them explicit and allowing external invocation, with no immediate user-facing changes.
> 
>   - **Behavior**:
>     - Moves startup/shutdown event handling to `lifespan()` in `api_app.py`, making them explicit and allowing external invocation.
>     - Persistent session monitoring on startup and conditional lock cleanup on shutdown remain intact.
>     - Routing and rate-limiting behavior unchanged.
>   - **Functions**:
>     - Adds `api_app_startup_event` and `api_app_shutdown_event` to `app.py` for external invocation.
>   - **Misc**:
>     - No immediate user-facing changes; startup/shutdown actions must be invoked via the exposed hooks when used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 3f1bcc4a2a71d5e6c289b7f7eab16468cc0f72eb. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional startup and shutdown hooks that can run during the app lifecycle.

- **Refactor**
  - Startup/shutdown flow made explicit with logging and error handling around those hooks.

- **Impact**
  - No immediate user-facing changes; behavior unchanged unless the new hooks are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->