### PR TITLE
make run_with and ai_fallback work in the public API

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -341,6 +341,8 @@ async def run_workflow(
         max_screenshot_scrolls=workflow_run_request.max_screenshot_scrolls,
         extra_http_headers=workflow_run_request.extra_http_headers,
         browser_address=workflow_run_request.browser_address,
+        run_with=workflow_run_request.run_with,
+        ai_fallback=workflow_run_request.ai_fallback,
     )
 
     try:
@@ -371,6 +373,8 @@ async def run_workflow(
         downloaded_files=None,
         recording_url=None,
         app_url=f"{settings.SKYVERN_APP_URL.rstrip('/')}/workflows/{workflow_run.workflow_permanent_id}/{workflow_run.workflow_run_id}",
+        run_with=workflow_run.run_with,
+        ai_fallback=workflow_run.ai_fallback,
     )
 
 

--- a/skyvern/schemas/runs.py
+++ b/skyvern/schemas/runs.py
@@ -502,6 +502,15 @@ class TaskRunResponse(BaseRunResponse):
 
 class WorkflowRunResponse(BaseRunResponse):
     run_type: Literal[RunType.workflow_run] = Field(description="Type of run - always workflow_run for workflow runs")
+    run_with: str | None = Field(
+        default=None,
+        description="Whether the workflow run was executed with agent or code",
+        examples=["agent", "code"],
+    )
+    ai_fallback: bool | None = Field(
+        default=None,
+        description="Whether to fallback to AI if code run fails.",
+    )
     run_request: WorkflowRunRequest | None = Field(
         default=None, description="The original request parameters used to start this workflow run"
     )


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `run_with` and `ai_fallback` parameters to workflow run requests and responses in the public API.
> 
>   - **Behavior**:
>     - Adds `run_with` and `ai_fallback` parameters to `run_workflow()` in `agent_protocol.py` to support execution method and AI fallback.
>     - Updates `WorkflowRunResponse` in `runs.py` to include `run_with` and `ai_fallback` fields.
>   - **Models**:
>     - Adds `run_with` and `ai_fallback` to `WorkflowRunRequest` in `runs.py`.
>     - Updates `WorkflowRunResponse` in `runs.py` to include `run_with` and `ai_fallback` fields.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6edb3d6beb08ee1615294444626232a0970bd4c5. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR exposes the `run_with` and `ai_fallback` parameters in the public API for workflow runs, allowing users to specify execution method (agent vs code) and AI fallback behavior. The changes ensure these configuration options are properly passed through the API layer and returned in responses for better workflow control and transparency.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **API Parameter Passing**: Added `run_with` and `ai_fallback` parameters to the `run_workflow()` function in `agent_protocol.py` to properly forward these options from the request to the workflow execution
- **Response Schema Enhancement**: Extended `WorkflowRunResponse` class in `runs.py` to include `run_with` and `ai_fallback` fields, making these execution details visible to API consumers
- **Public API Completeness**: Bridged the gap between internal workflow capabilities and public API exposure, ensuring all workflow configuration options are accessible

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant API as agent_protocol.py
    participant Workflow as Workflow Engine
    participant Response as WorkflowRunResponse

    Client->>API: POST /workflow/run with run_with & ai_fallback
    API->>Workflow: create_workflow_run() with parameters
    Workflow->>Workflow: Execute with specified method
    Workflow->>Response: Create response with execution details
    Response->>Client: Return workflow run info including run_with & ai_fallback
```

### Impact
- **Enhanced Control**: Users can now specify whether workflows should run with agent or code execution method through the public API
- **Improved Transparency**: API responses now include execution method and fallback configuration, providing better visibility into how workflows were executed
- **Better Integration**: External systems can now fully configure and monitor workflow execution behavior without needing internal access to implementation details

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workflow run results now include execution mode information (agent or code) and AI fallback status, providing greater visibility into how each run was processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->