### PR TITLE
fix caching logs (add run_with to workflow run logs)

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -469,7 +469,8 @@ class WorkflowService:
                 LOG.info(
                     "Workflow run is already timed_out, canceled, failed, or terminated, not marking as completed",
                     workflow_run_id=workflow_run_id,
-                    workflow_run_status=workflow_run.status if workflow_run else None,
+                    workflow_run_status=workflow_run.status,
+                    run_with=workflow_run.run_with,
                 )
         await self.clean_up_workflow(
             workflow=workflow,
@@ -2991,6 +2992,7 @@ class WorkflowService:
                 cache_key_value=rendered_cache_key_value,
                 script_id=existing_script.script_id,
                 script_revision_id=existing_script.script_revision_id,
+                run_with=workflow_run.run_with,
             )
             return
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `run_with` field to logging in `execute_workflow()` and `generate_script_if_needed()` for better context.
> 
>   - **Logging Enhancements**:
>     - Added `run_with` field to logging in `execute_workflow()` to provide more context about the workflow run.
>     - Added `run_with` field to logging in `generate_script_if_needed()` to provide more context about the workflow run.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 7754c129b768b6e943442570a0156820ba5e2464. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR enhances logging capabilities by adding the `run_with` field to workflow execution and script generation log messages, providing better context for debugging and monitoring workflow runs.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Workflow Execution Logging**: Added `run_with` field to the log message in `execute_workflow()` when a workflow run is already in a terminal state (timed_out, canceled, failed, or terminated)
- **Script Generation Logging**: Included `run_with` field in the log message within `generate_script_if_needed()` when using cached scripts
- **Code Safety**: Removed unnecessary null check for `workflow_run.status` since the workflow_run object is guaranteed to exist at that point

### Technical Implementation
```mermaid
sequenceDiagram
    participant WS as Workflow Service
    participant LOG as Logger
    participant WR as Workflow Run
    
    WS->>WR: Check workflow run status
    alt Workflow in terminal state
        WS->>LOG: Log with workflow_run_status + run_with
    end
    
    WS->>WS: generate_script_if_needed()
    alt Using cached script
        WS->>LOG: Log with cache info + run_with
    end
```

### Impact
- **Improved Debugging**: The `run_with` field provides crucial context about the execution environment, making it easier to trace and debug workflow issues
- **Better Observability**: Enhanced log messages help operators understand which execution context (e.g., API, UI, scheduled) triggered specific workflow behaviors
- **Consistent Logging**: Standardizes the inclusion of execution context across different workflow operations for better log correlation

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal logging for workflow execution and script generation to include additional diagnostic information, improving system monitoring and troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->