### PR TITLE
terminate self and reclaim when claim failed

### DIFF
--- a/skyvern/forge/sdk/schemas/persistent_browser_sessions.py
+++ b/skyvern/forge/sdk/schemas/persistent_browser_sessions.py
@@ -1,10 +1,25 @@
 from datetime import datetime
+from enum import StrEnum
 
 from pydantic import BaseModel, ConfigDict
 
 from skyvern.schemas.runs import ProxyLocation
 
-FINAL_STATUSES = ("completed", "failed")
+
+class PersistentBrowserSessionStatus(StrEnum):
+    created = "created"
+    running = "running"
+    failed = "failed"
+    completed = "completed"
+    timeout = "timeout"
+    retry = "retry"
+
+
+FINAL_STATUSES = (
+    PersistentBrowserSessionStatus.completed,
+    PersistentBrowserSessionStatus.failed,
+    PersistentBrowserSessionStatus.timeout,
+)
 
 
 def is_final_status(status: str | None) -> bool:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactors session management with a new status enum, updates renewal logic, and adds logging for status changes.
> 
>   - **Behavior**:
>     - Introduces `PersistentBrowserSessionStatus` enum in `persistent_browser_sessions.py` for session statuses.
>     - Updates `validate_session_for_renewal()` in `persistent_sessions_manager.py` to handle `retry` and `running` statuses.
>     - Adds logging for status updates in `update_status()` in `persistent_sessions_manager.py`.
>   - **Refactor**:
>     - Refactors session status handling to use `PersistentBrowserSessionStatus` enum.
>     - Introduces `AddressablePersistentBrowserSession` requiring a `browser_address`.
>   - **Misc**:
>     - Simplifies connection attempts to a single try in `persistent_sessions_manager.py`.
>     - Adds status-change logging in `persistent_sessions_manager.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 271082fe8fcbb62f85429e85f9a4baa9b12ec95e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced comprehensive status tracking for persistent browser sessions with six distinct states: created, running, failed, completed, timeout, and retry.
  * Expanded session renewal capabilities to support multiple session states.
  * Enhanced logging of session status transitions for improved visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔄 This PR improves browser session management by introducing standardized status enums, enhancing session renewal validation, and adding better logging for status transitions. The changes focus on making the persistent browser session lifecycle more robust and predictable.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Status Standardization**: Introduced `PersistentBrowserSessionStatus` enum with explicit states (created, running, failed, completed, timeout, retry) replacing string literals
- **Session Validation**: Enhanced `validate_session_for_renewal()` to accept sessions in created, retry, or running states instead of just created
- **Final Status Definition**: Updated `FINAL_STATUSES` to include timeout status alongside completed and failed
- **Logging Enhancement**: Added comprehensive logging for browser session status updates

### Technical Implementation
```mermaid
flowchart TD
    A[Browser Session Created] --> B{Session Status}
    B -->|created| C[Can Renew]
    B -->|retry| C
    B -->|running| C
    B -->|failed| D[Cannot Renew]
    B -->|completed| D
    B -->|timeout| D
    C --> E[Update Status with Logging]
    D --> F[Raise BrowserSessionNotRenewable]
    E --> G[Continue Session Management]
```

### Impact
- **Improved Reliability**: Enum-based status management reduces string-based errors and provides type safety
- **Enhanced Flexibility**: Sessions can now be renewed from multiple valid states (created, retry, running) instead of just created
- **Better Observability**: Added detailed logging for status changes helps with debugging and monitoring session lifecycle
- **Backward Compatibility**: Changes maintain existing functionality while improving the internal structure

</details>

_Created with [Palmier](https://www.palmier.io)_