### PR TITLE
Rework state management arch for blocks (fix rando max recursion errors, maybe other bugs)

### DIFF
--- a/skyvern-frontend/src/components/ModelSelector.tsx
+++ b/skyvern-frontend/src/components/ModelSelector.tsx
@@ -66,7 +66,6 @@ function ModelSelector({
             const newValue = v === constants.SkyvernOptimized ? null : v;
             const modelName = newValue ? reverseMap[newValue] : null;
             const value = modelName ? { model_name: modelName } : null;
-            console.log({ v, newValue, modelName, value });
             onChange(value);
           }}
         >

--- a/skyvern-frontend/src/components/WorkflowBlockInputTextarea.tsx
+++ b/skyvern-frontend/src/components/WorkflowBlockInputTextarea.tsx
@@ -5,6 +5,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { WorkflowBlockParameterSelect } from "@/routes/workflows/editor/nodes/WorkflowBlockParameterSelect";
 import { useWorkflowTitleStore } from "@/store/WorkflowTitleStore";
 import { useEffect, useRef, useState } from "react";
+import { useDebouncedCallback } from "use-debounce";
 
 type Props = Omit<
   React.ComponentProps<typeof AutoResizingTextarea>,
@@ -29,14 +30,14 @@ function WorkflowBlockInputTextarea(props: Props) {
     setInternalValue(props.value ?? "");
   }, [props.value]);
 
-  const doOnChange = (value: string) => {
+  const doOnChange = useDebouncedCallback((value: string) => {
     onChange(value);
 
     if (canWriteTitle) {
       maybeWriteTitle(value);
       maybeAcceptTitle();
     }
-  };
+  }, 300);
 
   const handleTextareaSelect = () => {
     if (textareaRef.current) {
@@ -76,12 +77,13 @@ function WorkflowBlockInputTextarea(props: Props) {
         {...textAreaProps}
         value={internalValue}
         ref={textareaRef}
-        onBlur={(event) => {
-          doOnChange(event.target.value);
+        onBlur={() => {
+          doOnChange.flush();
         }}
         onChange={(event) => {
           setInternalValue(event.target.value);
           handleTextareaSelect();
+          doOnChange(event.target.value);
         }}
         onClick={handleTextareaSelect}
         onKeyUp={handleTextareaSelect}

--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -83,8 +83,6 @@ import { getWorkflowErrors } from "./workflowEditorUtils";
 import { toast } from "@/components/ui/use-toast";
 import { useAutoPan } from "./useAutoPan";
 
-const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0));
-
 function convertToParametersYAML(
   parameters: ParametersState,
 ): Array<
@@ -278,7 +276,6 @@ function FlowRenderer({
   const parameters = useWorkflowParametersStore((state) => state.parameters);
   const nodesInitialized = useNodesInitialized();
   const [shouldConstrainPan, setShouldConstrainPan] = useState(false);
-  const onNodesChangeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const flowIsConstrained = debugStore.isDebugMode;
 
   useEffect(() => {
@@ -672,6 +669,7 @@ function FlowRenderer({
                 }
               }
             });
+
             if (dimensionChanges.length > 0) {
               doLayout(tempNodes, edges);
             }
@@ -687,20 +685,23 @@ function FlowRenderer({
               workflowChangesStore.setHasChanges(true);
             }
 
-            // only allow one update in _this_ render cycle
-            if (onNodesChangeTimeoutRef.current === null) {
-              onNodesChange(changes);
-              onNodesChangeTimeoutRef.current = setTimeout(() => {
-                onNodesChangeTimeoutRef.current = null;
-              }, 0);
-            } else {
-              // if we have an update in this render cycle already, then to
-              // prevent max recursion errors, defer the update to next render
-              // cycle
-              nextTick().then(() => {
-                onNodesChange(changes);
-              });
-            }
+            onNodesChange(changes);
+
+            // NOTE: should no longer be needed (woot!) - delete if true (want real-world testing first)
+            // // only allow one update in _this_ render cycle
+            // if (onNodesChangeTimeoutRef.current === null) {
+            //   onNodesChange(changes);
+            //   onNodesChangeTimeoutRef.current = setTimeout(() => {
+            //     onNodesChangeTimeoutRef.current = null;
+            //   }, 0);
+            // } else {
+            //   // if we have an update in this render cycle already, then to
+            //   // prevent max recursion errors, defer the update to next render
+            //   // cycle
+            //   nextTick().then(() => {
+            //     onNodesChange(changes);
+            //   });
+            // }
           }}
           onEdgesChange={onEdgesChange}
           nodeTypes={nodeTypes}

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/CodeBlockNode/CodeBlockNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/CodeBlockNode/CodeBlockNode.tsx
@@ -1,18 +1,19 @@
+import { useParams } from "react-router-dom";
+import { Handle, NodeProps, Position } from "@xyflow/react";
+
 import { Label } from "@/components/ui/label";
 import { WorkflowBlockInputSet } from "@/components/WorkflowBlockInputSet";
 import { CodeEditor } from "@/routes/workflows/components/CodeEditor";
-import { Handle, NodeProps, Position, useReactFlow } from "@xyflow/react";
-import { useState } from "react";
-import type { CodeBlockNode } from "./types";
-import { cn } from "@/util/utils";
-import { NodeHeader } from "../components/NodeHeader";
-import { useParams } from "react-router-dom";
 import { statusIsRunningOrQueued } from "@/routes/tasks/types";
 import { useWorkflowRunQuery } from "@/routes/workflows/hooks/useWorkflowRunQuery";
+import { useUpdate } from "@/routes/workflows/editor/useUpdate";
 import { deepEqualStringArrays } from "@/util/equality";
+import { cn } from "@/util/utils";
+
+import type { CodeBlockNode } from "./types";
+import { NodeHeader } from "../components/NodeHeader";
 
 function CodeBlockNode({ id, data }: NodeProps<CodeBlockNode>) {
-  const { updateNodeData } = useReactFlow();
   const { editable, label } = data;
   const { blockLabel: urlBlockLabel } = useParams();
   const { data: workflowRun } = useWorkflowRunQuery();
@@ -22,10 +23,7 @@ function CodeBlockNode({ id, data }: NodeProps<CodeBlockNode>) {
     urlBlockLabel !== undefined && urlBlockLabel === label;
   const thisBlockIsPlaying =
     workflowRunIsRunningOrQueued && thisBlockIsTargetted;
-  const [inputs, setInputs] = useState({
-    code: data.code,
-    parameterKeys: data.parameterKeys,
-  });
+  const update = useUpdate<CodeBlockNode["data"]>({ id, editable });
 
   return (
     <div>
@@ -65,36 +63,23 @@ function CodeBlockNode({ id, data }: NodeProps<CodeBlockNode>) {
           <WorkflowBlockInputSet
             nodeId={id}
             onChange={(parameterKeys) => {
-              const differs = !deepEqualStringArrays(
-                inputs.parameterKeys,
-                Array.from(parameterKeys),
-              );
-
-              if (!differs) {
-                return;
+              const newParameterKeys = Array.from(parameterKeys);
+              if (
+                !deepEqualStringArrays(data.parameterKeys, newParameterKeys)
+              ) {
+                update({ parameterKeys: newParameterKeys });
               }
-
-              setInputs({
-                ...inputs,
-                parameterKeys: Array.from(parameterKeys),
-              });
-
-              updateNodeData(id, { parameterKeys: Array.from(parameterKeys) });
             }}
-            values={new Set(inputs.parameterKeys ?? [])}
+            values={new Set(data.parameterKeys ?? [])}
           />
         </div>
         <div className="space-y-2">
           <Label className="text-xs text-slate-300">Code Input</Label>
           <CodeEditor
             language="python"
-            value={inputs.code}
+            value={data.code}
             onChange={(value) => {
-              if (!data.editable) {
-                return;
-              }
-              setInputs({ ...inputs, code: value });
-              updateNodeData(id, { code: value });
+              update({ code: value });
             }}
             className="nopan"
             fontSize={8}

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/ExtractionNode/ExtractionNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/ExtractionNode/ExtractionNode.tsx
@@ -11,14 +11,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
-import {
-  Handle,
-  NodeProps,
-  Position,
-  useEdges,
-  useNodes,
-  useReactFlow,
-} from "@xyflow/react";
+import { Handle, NodeProps, Position, useEdges, useNodes } from "@xyflow/react";
 import { useState } from "react";
 import { dataSchemaExampleValue } from "../types";
 import type { ExtractionNode } from "./types";
@@ -40,12 +33,12 @@ import { NodeTabs } from "../components/NodeTabs";
 import { useParams } from "react-router-dom";
 import { statusIsRunningOrQueued } from "@/routes/tasks/types";
 import { useWorkflowRunQuery } from "@/routes/workflows/hooks/useWorkflowRunQuery";
+import { useUpdate } from "@/routes/workflows/editor/useUpdate";
 import { useRerender } from "@/hooks/useRerender";
 
 import { DisableCache } from "../DisableCache";
 
 function ExtractionNode({ id, data, type }: NodeProps<ExtractionNode>) {
-  const { updateNodeData } = useReactFlow();
   const [facing, setFacing] = useState<"front" | "back">("front");
   const blockScriptStore = useBlockScriptStore();
   const { editable, label } = data;
@@ -58,31 +51,12 @@ function ExtractionNode({ id, data, type }: NodeProps<ExtractionNode>) {
     urlBlockLabel !== undefined && urlBlockLabel === label;
   const thisBlockIsPlaying =
     workflowRunIsRunningOrQueued && thisBlockIsTargetted;
-  const [inputs, setInputs] = useState({
-    url: data.url,
-    dataExtractionGoal: data.dataExtractionGoal,
-    dataSchema: data.dataSchema,
-    maxStepsOverride: data.maxStepsOverride,
-    continueOnFailure: data.continueOnFailure,
-    cacheActions: data.cacheActions,
-    disableCache: data.disableCache,
-    engine: data.engine,
-    model: data.model,
-  });
   const nodes = useNodes<AppNode>();
   const edges = useEdges();
   const outputParameterKeys = getAvailableOutputParameterKeys(nodes, edges, id);
   const rerender = useRerender({ prefix: "accordian" });
-
   const isFirstWorkflowBlock = useIsFirstBlockInWorkflow({ id });
-
-  function handleChange(key: string, value: unknown) {
-    if (!editable) {
-      return;
-    }
-    setInputs({ ...inputs, [key]: value });
-    updateNodeData(id, { [key]: value });
-  }
+  const update = useUpdate<ExtractionNode["data"]>({ id, editable });
 
   useEffect(() => {
     setFacing(data.showCode ? "back" : "front");
@@ -144,22 +118,22 @@ function ExtractionNode({ id, data, type }: NodeProps<ExtractionNode>) {
                 if (!editable) {
                   return;
                 }
-                handleChange("dataExtractionGoal", value);
+                update({ dataExtractionGoal: value });
               }}
-              value={inputs.dataExtractionGoal}
+              value={data.dataExtractionGoal}
               placeholder={placeholders["extraction"]["dataExtractionGoal"]}
               className="nopan text-xs"
             />
           </div>
           <WorkflowDataSchemaInputGroup
-            value={inputs.dataSchema}
+            value={data.dataSchema}
             onChange={(value) => {
-              handleChange("dataSchema", value);
+              update({ dataSchema: value });
             }}
             exampleValue={dataSchemaExampleValue}
             suggestionContext={{
-              data_extraction_goal: inputs.dataExtractionGoal,
-              current_schema: inputs.dataSchema,
+              data_extraction_goal: data.dataExtractionGoal,
+              current_schema: data.dataSchema,
             }}
           />
           <Separator />
@@ -177,16 +151,16 @@ function ExtractionNode({ id, data, type }: NodeProps<ExtractionNode>) {
                   <div className="space-y-2">
                     <ModelSelector
                       className="nopan w-52 text-xs"
-                      value={inputs.model}
+                      value={data.model}
                       onChange={(value) => {
-                        handleChange("model", value);
+                        update({ model: value });
                       }}
                     />
                     <ParametersMultiSelect
                       availableOutputParameters={outputParameterKeys}
                       parameters={data.parameterKeys}
                       onParametersChange={(parameterKeys) => {
-                        updateNodeData(id, { parameterKeys });
+                        update({ parameterKeys });
                       }}
                     />
                   </div>
@@ -197,9 +171,9 @@ function ExtractionNode({ id, data, type }: NodeProps<ExtractionNode>) {
                       </Label>
                     </div>
                     <RunEngineSelector
-                      value={inputs.engine}
+                      value={data.engine}
                       onChange={(value) => {
-                        handleChange("engine", value);
+                        update({ engine: value });
                       }}
                       className="nopan w-52 text-xs"
                     />
@@ -220,7 +194,7 @@ function ExtractionNode({ id, data, type }: NodeProps<ExtractionNode>) {
                       }
                       className="nopan w-52 text-xs"
                       min="0"
-                      value={inputs.maxStepsOverride ?? ""}
+                      value={data.maxStepsOverride ?? ""}
                       onChange={(event) => {
                         if (!editable) {
                           return;
@@ -229,7 +203,7 @@ function ExtractionNode({ id, data, type }: NodeProps<ExtractionNode>) {
                           event.target.value === ""
                             ? null
                             : Number(event.target.value);
-                        handleChange("maxStepsOverride", value);
+                        update({ maxStepsOverride: value });
                       }}
                     />
                   </div>
@@ -247,25 +221,25 @@ function ExtractionNode({ id, data, type }: NodeProps<ExtractionNode>) {
                     </div>
                     <div className="w-52">
                       <Switch
-                        checked={inputs.continueOnFailure}
+                        checked={data.continueOnFailure}
                         onCheckedChange={(checked) => {
                           if (!editable) {
                             return;
                           }
-                          handleChange("continueOnFailure", checked);
+                          update({ continueOnFailure: checked });
                         }}
                       />
                     </div>
                   </div>
                   <DisableCache
-                    cacheActions={inputs.cacheActions}
-                    disableCache={inputs.disableCache}
+                    cacheActions={data.cacheActions}
+                    disableCache={data.disableCache}
                     editable={editable}
                     onCacheActionsChange={(cacheActions) => {
-                      handleChange("cacheActions", cacheActions);
+                      update({ cacheActions });
                     }}
                     onDisableCacheChange={(disableCache) => {
-                      handleChange("disableCache", disableCache);
+                      update({ disableCache });
                     }}
                   />
                 </div>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/FileParserNode/FileParserNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/FileParserNode/FileParserNode.tsx
@@ -1,7 +1,6 @@
 import { HelpTooltip } from "@/components/HelpTooltip";
 import { Label } from "@/components/ui/label";
-import { Handle, NodeProps, Position, useReactFlow } from "@xyflow/react";
-import { useState } from "react";
+import { Handle, NodeProps, Position } from "@xyflow/react";
 import { helpTooltips } from "../../helpContent";
 import { type FileParserNode } from "./types";
 import { WorkflowBlockInput } from "@/components/WorkflowBlockInput";
@@ -13,10 +12,10 @@ import { WorkflowDataSchemaInputGroup } from "@/components/DataSchemaInputGroup/
 import { dataSchemaExampleForFileExtraction } from "../types";
 import { statusIsRunningOrQueued } from "@/routes/tasks/types";
 import { useWorkflowRunQuery } from "@/routes/workflows/hooks/useWorkflowRunQuery";
+import { useUpdate } from "@/routes/workflows/editor/useUpdate";
 import { ModelSelector } from "@/components/ModelSelector";
 
 function FileParserNode({ id, data }: NodeProps<FileParserNode>) {
-  const { updateNodeData } = useReactFlow();
   const { editable, label } = data;
   const { blockLabel: urlBlockLabel } = useParams();
   const { data: workflowRun } = useWorkflowRunQuery();
@@ -26,21 +25,8 @@ function FileParserNode({ id, data }: NodeProps<FileParserNode>) {
     urlBlockLabel !== undefined && urlBlockLabel === label;
   const thisBlockIsPlaying =
     workflowRunIsRunningOrQueued && thisBlockIsTargetted;
-  const [inputs, setInputs] = useState({
-    fileUrl: data.fileUrl,
-    jsonSchema: data.jsonSchema,
-    model: data.model,
-  });
-
-  function handleChange(key: string, value: unknown) {
-    if (!data.editable) {
-      return;
-    }
-    setInputs({ ...inputs, [key]: value });
-    updateNodeData(id, { [key]: value });
-  }
-
   const isFirstWorkflowBlock = useIsFirstBlockInWorkflow({ id });
+  const update = useUpdate<FileParserNode["data"]>({ id, editable });
 
   return (
     <div>
@@ -90,26 +76,26 @@ function FileParserNode({ id, data }: NodeProps<FileParserNode>) {
 
             <WorkflowBlockInput
               nodeId={id}
-              value={inputs.fileUrl}
+              value={data.fileUrl}
               onChange={(value) => {
-                handleChange("fileUrl", value);
+                update({ fileUrl: value });
               }}
               className="nopan text-xs"
             />
           </div>
           <WorkflowDataSchemaInputGroup
             exampleValue={dataSchemaExampleForFileExtraction}
-            value={inputs.jsonSchema}
+            value={data.jsonSchema}
             onChange={(value) => {
-              handleChange("jsonSchema", value);
+              update({ jsonSchema: value });
             }}
             suggestionContext={{}}
           />
           <ModelSelector
             className="nopan w-52 text-xs"
-            value={inputs.model}
+            value={data.model}
             onChange={(value) => {
-              handleChange("model", value);
+              update({ model: value });
             }}
           />
         </div>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/FileUploadNode/FileUploadNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/FileUploadNode/FileUploadNode.tsx
@@ -1,11 +1,10 @@
 import { HelpTooltip } from "@/components/HelpTooltip";
 import { Label } from "@/components/ui/label";
-import { Handle, NodeProps, Position, useReactFlow } from "@xyflow/react";
+import { Handle, NodeProps, Position } from "@xyflow/react";
 import { helpTooltips } from "../../helpContent";
 import { type FileUploadNode } from "./types";
 import { WorkflowBlockInputTextarea } from "@/components/WorkflowBlockInputTextarea";
 import { WorkflowBlockInput } from "@/components/WorkflowBlockInput";
-import { useState } from "react";
 import { cn } from "@/util/utils";
 import { NodeHeader } from "../components/NodeHeader";
 import { useParams } from "react-router-dom";
@@ -18,9 +17,9 @@ import {
 } from "@/components/ui/select";
 import { statusIsRunningOrQueued } from "@/routes/tasks/types";
 import { useWorkflowRunQuery } from "@/routes/workflows/hooks/useWorkflowRunQuery";
+import { useUpdate } from "@/routes/workflows/editor/useUpdate";
 
 function FileUploadNode({ id, data }: NodeProps<FileUploadNode>) {
-  const { updateNodeData } = useReactFlow();
   const { editable, label } = data;
   const { blockLabel: urlBlockLabel } = useParams();
   const { data: workflowRun } = useWorkflowRunQuery();
@@ -30,26 +29,7 @@ function FileUploadNode({ id, data }: NodeProps<FileUploadNode>) {
     urlBlockLabel !== undefined && urlBlockLabel === label;
   const thisBlockIsPlaying =
     workflowRunIsRunningOrQueued && thisBlockIsTargetted;
-
-  const [inputs, setInputs] = useState({
-    storageType: data.storageType,
-    awsAccessKeyId: data.awsAccessKeyId ?? "",
-    awsSecretAccessKey: data.awsSecretAccessKey ?? "",
-    s3Bucket: data.s3Bucket ?? "",
-    regionName: data.regionName ?? "",
-    path: data.path ?? "",
-    azureStorageAccountName: data.azureStorageAccountName ?? "",
-    azureStorageAccountKey: data.azureStorageAccountKey ?? "",
-    azureBlobContainerName: data.azureBlobContainerName ?? "",
-  });
-
-  function handleChange(key: string, value: unknown) {
-    if (!data.editable) {
-      return;
-    }
-    setInputs({ ...inputs, [key]: value });
-    updateNodeData(id, { [key]: value });
-  }
+  const update = useUpdate<FileUploadNode["data"]>({ id, editable });
 
   return (
     <div>
@@ -92,8 +72,10 @@ function FileUploadNode({ id, data }: NodeProps<FileUploadNode>) {
               />
             </div>
             <Select
-              value={inputs.storageType}
-              onValueChange={(value) => handleChange("storageType", value)}
+              value={data.storageType}
+              onValueChange={(value) =>
+                value && update({ storageType: value as "s3" | "azure" })
+              }
               disabled={!editable}
             >
               <SelectTrigger className="nopan text-xs">
@@ -106,7 +88,7 @@ function FileUploadNode({ id, data }: NodeProps<FileUploadNode>) {
             </Select>
           </div>
 
-          {inputs.storageType === "s3" && (
+          {data.storageType === "s3" && (
             <>
               <div className="space-y-2">
                 <div className="flex items-center gap-2">
@@ -120,9 +102,9 @@ function FileUploadNode({ id, data }: NodeProps<FileUploadNode>) {
                 <WorkflowBlockInputTextarea
                   nodeId={id}
                   onChange={(value) => {
-                    handleChange("awsAccessKeyId", value);
+                    update({ awsAccessKeyId: value });
                   }}
-                  value={inputs.awsAccessKeyId as string}
+                  value={data.awsAccessKeyId as string}
                   className="nopan text-xs"
                 />
               </div>
@@ -140,10 +122,10 @@ function FileUploadNode({ id, data }: NodeProps<FileUploadNode>) {
                 <WorkflowBlockInput
                   nodeId={id}
                   type="password"
-                  value={inputs.awsSecretAccessKey as string}
+                  value={data.awsSecretAccessKey as string}
                   className="nopan text-xs"
                   onChange={(value) => {
-                    handleChange("awsSecretAccessKey", value);
+                    update({ awsSecretAccessKey: value });
                   }}
                 />
               </div>
@@ -157,9 +139,9 @@ function FileUploadNode({ id, data }: NodeProps<FileUploadNode>) {
                 <WorkflowBlockInputTextarea
                   nodeId={id}
                   onChange={(value) => {
-                    handleChange("s3Bucket", value);
+                    update({ s3Bucket: value });
                   }}
-                  value={inputs.s3Bucket as string}
+                  value={data.s3Bucket as string}
                   className="nopan text-xs"
                 />
               </div>
@@ -173,9 +155,9 @@ function FileUploadNode({ id, data }: NodeProps<FileUploadNode>) {
                 <WorkflowBlockInputTextarea
                   nodeId={id}
                   onChange={(value) => {
-                    handleChange("regionName", value);
+                    update({ regionName: value });
                   }}
-                  value={inputs.regionName as string}
+                  value={data.regionName as string}
                   className="nopan text-xs"
                 />
               </div>
@@ -189,16 +171,16 @@ function FileUploadNode({ id, data }: NodeProps<FileUploadNode>) {
                 <WorkflowBlockInputTextarea
                   nodeId={id}
                   onChange={(value) => {
-                    handleChange("path", value);
+                    update({ path: value });
                   }}
-                  value={inputs.path as string}
+                  value={data.path as string}
                   className="nopan text-xs"
                 />
               </div>
             </>
           )}
 
-          {inputs.storageType === "azure" && (
+          {data.storageType === "azure" && (
             <>
               <div className="space-y-2">
                 <div className="flex items-center gap-2">
@@ -214,9 +196,9 @@ function FileUploadNode({ id, data }: NodeProps<FileUploadNode>) {
                 <WorkflowBlockInputTextarea
                   nodeId={id}
                   onChange={(value) => {
-                    handleChange("azureStorageAccountName", value);
+                    update({ azureStorageAccountName: value });
                   }}
-                  value={inputs.azureStorageAccountName as string}
+                  value={data.azureStorageAccountName as string}
                   className="nopan text-xs"
                 />
               </div>
@@ -234,10 +216,10 @@ function FileUploadNode({ id, data }: NodeProps<FileUploadNode>) {
                 <WorkflowBlockInput
                   nodeId={id}
                   type="password"
-                  value={inputs.azureStorageAccountKey as string}
+                  value={data.azureStorageAccountKey as string}
                   className="nopan text-xs"
                   onChange={(value) => {
-                    handleChange("azureStorageAccountKey", value);
+                    update({ azureStorageAccountKey: value });
                   }}
                 />
               </div>
@@ -255,9 +237,9 @@ function FileUploadNode({ id, data }: NodeProps<FileUploadNode>) {
                 <WorkflowBlockInputTextarea
                   nodeId={id}
                   onChange={(value) => {
-                    handleChange("azureBlobContainerName", value);
+                    update({ azureBlobContainerName: value });
                   }}
-                  value={inputs.azureBlobContainerName as string}
+                  value={data.azureBlobContainerName as string}
                   className="nopan text-xs"
                 />
               </div>
@@ -271,9 +253,9 @@ function FileUploadNode({ id, data }: NodeProps<FileUploadNode>) {
                 <WorkflowBlockInputTextarea
                   nodeId={id}
                   onChange={(value) => {
-                    handleChange("path", value);
+                    update({ path: value });
                   }}
-                  value={inputs.path as string}
+                  value={data.path as string}
                   className="nopan text-xs"
                 />
               </div>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/LoopNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/LoopNode/types.ts
@@ -6,6 +6,7 @@ export type LoopNodeData = NodeBaseData & {
   loopValue: string;
   loopVariableReference: string;
   completeIfEmpty: boolean;
+  continueOnFailure: boolean;
 };
 
 export type LoopNode = Node<LoopNodeData, "loop">;

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/PDFParserNode/PDFParserNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/PDFParserNode/PDFParserNode.tsx
@@ -1,8 +1,7 @@
 import { HelpTooltip } from "@/components/HelpTooltip";
 import { Label } from "@/components/ui/label";
 import { WorkflowBlockInput } from "@/components/WorkflowBlockInput";
-import { Handle, NodeProps, Position, useReactFlow } from "@xyflow/react";
-import { useState } from "react";
+import { Handle, NodeProps, Position } from "@xyflow/react";
 import { helpTooltips } from "../../helpContent";
 import { dataSchemaExampleForFileExtraction } from "../types";
 import { type PDFParserNode } from "./types";
@@ -13,10 +12,10 @@ import { NodeHeader } from "../components/NodeHeader";
 import { useParams } from "react-router-dom";
 import { statusIsRunningOrQueued } from "@/routes/tasks/types";
 import { useWorkflowRunQuery } from "@/routes/workflows/hooks/useWorkflowRunQuery";
+import { useUpdate } from "@/routes/workflows/editor/useUpdate";
 import { ModelSelector } from "@/components/ModelSelector";
 
 function PDFParserNode({ id, data }: NodeProps<PDFParserNode>) {
-  const { updateNodeData } = useReactFlow();
   const { editable, label } = data;
   const { blockLabel: urlBlockLabel } = useParams();
   const { data: workflowRun } = useWorkflowRunQuery();
@@ -26,21 +25,8 @@ function PDFParserNode({ id, data }: NodeProps<PDFParserNode>) {
     urlBlockLabel !== undefined && urlBlockLabel === label;
   const thisBlockIsPlaying =
     workflowRunIsRunningOrQueued && thisBlockIsTargetted;
-  const [inputs, setInputs] = useState({
-    fileUrl: data.fileUrl,
-    jsonSchema: data.jsonSchema,
-    model: data.model,
-  });
-
-  function handleChange(key: string, value: unknown) {
-    if (!data.editable) {
-      return;
-    }
-    setInputs({ ...inputs, [key]: value });
-    updateNodeData(id, { [key]: value });
-  }
-
   const isFirstWorkflowBlock = useIsFirstBlockInWorkflow({ id });
+  const update = useUpdate<PDFParserNode["data"]>({ id, editable });
 
   return (
     <div>
@@ -89,26 +75,26 @@ function PDFParserNode({ id, data }: NodeProps<PDFParserNode>) {
             </div>
             <WorkflowBlockInput
               nodeId={id}
-              value={inputs.fileUrl}
+              value={data.fileUrl}
               onChange={(value) => {
-                handleChange("fileUrl", value);
+                update({ fileUrl: value });
               }}
               className="nopan text-xs"
             />
           </div>
           <WorkflowDataSchemaInputGroup
             exampleValue={dataSchemaExampleForFileExtraction}
-            value={inputs.jsonSchema}
+            value={data.jsonSchema}
             onChange={(value) => {
-              handleChange("jsonSchema", value);
+              update({ jsonSchema: value });
             }}
             suggestionContext={{}}
           />
           <ModelSelector
             className="nopan w-52 text-xs"
-            value={inputs.model}
+            value={data.model}
             onChange={(value) => {
-              handleChange("model", value);
+              update({ model: value });
             }}
           />
         </div>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/SendEmailNode/SendEmailNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/SendEmailNode/SendEmailNode.tsx
@@ -1,8 +1,7 @@
 import { HelpTooltip } from "@/components/HelpTooltip";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
-import { Handle, NodeProps, Position, useReactFlow } from "@xyflow/react";
-import { useState } from "react";
+import { Handle, NodeProps, Position } from "@xyflow/react";
 import { helpTooltips } from "../../helpContent";
 import { type SendEmailNode } from "./types";
 import { WorkflowBlockInput } from "@/components/WorkflowBlockInput";
@@ -13,9 +12,9 @@ import { NodeHeader } from "../components/NodeHeader";
 import { useParams } from "react-router-dom";
 import { statusIsRunningOrQueued } from "@/routes/tasks/types";
 import { useWorkflowRunQuery } from "@/routes/workflows/hooks/useWorkflowRunQuery";
+import { useUpdate } from "@/routes/workflows/editor/useUpdate";
 
 function SendEmailNode({ id, data }: NodeProps<SendEmailNode>) {
-  const { updateNodeData } = useReactFlow();
   const { editable, label } = data;
   const { blockLabel: urlBlockLabel } = useParams();
   const { data: workflowRun } = useWorkflowRunQuery();
@@ -25,22 +24,8 @@ function SendEmailNode({ id, data }: NodeProps<SendEmailNode>) {
     urlBlockLabel !== undefined && urlBlockLabel === label;
   const thisBlockIsPlaying =
     workflowRunIsRunningOrQueued && thisBlockIsTargetted;
-  const [inputs, setInputs] = useState({
-    recipients: data.recipients,
-    subject: data.subject,
-    body: data.body,
-    fileAttachments: data.fileAttachments,
-  });
-
-  function handleChange(key: string, value: unknown) {
-    if (!data.editable) {
-      return;
-    }
-    setInputs({ ...inputs, [key]: value });
-    updateNodeData(id, { [key]: value });
-  }
-
   const isFirstWorkflowBlock = useIsFirstBlockInWorkflow({ id });
+  const update = useUpdate<SendEmailNode["data"]>({ id, editable });
 
   return (
     <div>
@@ -86,9 +71,9 @@ function SendEmailNode({ id, data }: NodeProps<SendEmailNode>) {
           <WorkflowBlockInput
             nodeId={id}
             onChange={(value) => {
-              handleChange("recipients", value);
+              update({ recipients: value });
             }}
-            value={inputs.recipients}
+            value={data.recipients}
             placeholder="example@gmail.com, example2@gmail.com..."
             className="nopan text-xs"
           />
@@ -99,9 +84,9 @@ function SendEmailNode({ id, data }: NodeProps<SendEmailNode>) {
           <WorkflowBlockInput
             nodeId={id}
             onChange={(value) => {
-              handleChange("subject", value);
+              update({ subject: value });
             }}
-            value={inputs.subject}
+            value={data.subject}
             placeholder="What is the gist?"
             className="nopan text-xs"
           />
@@ -111,9 +96,9 @@ function SendEmailNode({ id, data }: NodeProps<SendEmailNode>) {
           <WorkflowBlockInputTextarea
             nodeId={id}
             onChange={(value) => {
-              handleChange("body", value);
+              update({ body: value });
             }}
-            value={inputs.body}
+            value={data.body}
             placeholder="What would you like to say?"
             className="nopan text-xs"
           />
@@ -128,9 +113,9 @@ function SendEmailNode({ id, data }: NodeProps<SendEmailNode>) {
           </div>
           <WorkflowBlockInput
             nodeId={id}
-            value={inputs.fileAttachments}
+            value={data.fileAttachments}
             onChange={(value) => {
-              handleChange("fileAttachments", value);
+              update({ fileAttachments: value });
             }}
             disabled
             className="nopan text-xs"

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/types.ts
@@ -10,7 +10,7 @@ export type WorkflowStartNodeData = {
   persistBrowserSession: boolean;
   model: WorkflowModel | null;
   maxScreenshotScrolls: number | null;
-  extraHttpHeaders: string | null;
+  extraHttpHeaders: string | Record<string, unknown> | null;
   editable: boolean;
   runWith: string | null;
   scriptCacheKey: string | null;

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/TaskNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/TaskNode.tsx
@@ -17,14 +17,7 @@ import { WorkflowBlockInputTextarea } from "@/components/WorkflowBlockInputTexta
 import { BlockCodeEditor } from "@/routes/workflows/components/BlockCodeEditor";
 import { CodeEditor } from "@/routes/workflows/components/CodeEditor";
 import { useBlockScriptStore } from "@/store/BlockScriptStore";
-import {
-  Handle,
-  NodeProps,
-  Position,
-  useEdges,
-  useNodes,
-  useReactFlow,
-} from "@xyflow/react";
+import { Handle, NodeProps, Position, useEdges, useNodes } from "@xyflow/react";
 import { useState } from "react";
 import { AppNode } from "..";
 import { helpTooltips, placeholders } from "../../helpContent";
@@ -41,12 +34,12 @@ import { NodeHeader } from "../components/NodeHeader";
 import { useParams } from "react-router-dom";
 import { statusIsRunningOrQueued } from "@/routes/tasks/types";
 import { useWorkflowRunQuery } from "@/routes/workflows/hooks/useWorkflowRunQuery";
+import { useUpdate } from "@/routes/workflows/editor/useUpdate";
 import { useRerender } from "@/hooks/useRerender";
 
 import { DisableCache } from "../DisableCache";
 
 function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
-  const { updateNodeData } = useReactFlow();
   const [facing, setFacing] = useState<"front" | "back">("front");
   const blockScriptStore = useBlockScriptStore();
   const { editable, label } = data;
@@ -59,41 +52,12 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
     urlBlockLabel !== undefined && urlBlockLabel === label;
   const thisBlockIsPlaying =
     workflowRunIsRunningOrQueued && thisBlockIsTargetted;
-
   const rerender = useRerender({ prefix: "accordian" });
   const nodes = useNodes<AppNode>();
   const edges = useEdges();
   const outputParameterKeys = getAvailableOutputParameterKeys(nodes, edges, id);
   const isFirstWorkflowBlock = useIsFirstBlockInWorkflow({ id });
-
-  const [inputs, setInputs] = useState({
-    url: data.url,
-    navigationGoal: data.navigationGoal,
-    dataExtractionGoal: data.dataExtractionGoal,
-    completeCriterion: data.completeCriterion,
-    terminateCriterion: data.terminateCriterion,
-    dataSchema: data.dataSchema,
-    maxStepsOverride: data.maxStepsOverride,
-    allowDownloads: data.allowDownloads,
-    continueOnFailure: data.continueOnFailure,
-    cacheActions: data.cacheActions,
-    disableCache: data.disableCache,
-    downloadSuffix: data.downloadSuffix,
-    errorCodeMapping: data.errorCodeMapping,
-    totpVerificationUrl: data.totpVerificationUrl,
-    totpIdentifier: data.totpIdentifier,
-    includeActionHistoryInVerification: data.includeActionHistoryInVerification,
-    engine: data.engine,
-    model: data.model,
-  });
-
-  function handleChange(key: string, value: unknown) {
-    if (!editable) {
-      return;
-    }
-    setInputs({ ...inputs, [key]: value });
-    updateNodeData(id, { [key]: value });
-  }
+  const update = useUpdate<TaskNode["data"]>({ id, editable });
 
   useEffect(() => {
     setFacing(data.showCode ? "back" : "front");
@@ -129,8 +93,8 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
             blockLabel={label}
             editable={editable}
             nodeId={id}
-            totpIdentifier={inputs.totpIdentifier}
-            totpUrl={inputs.totpVerificationUrl}
+            totpIdentifier={data.totpIdentifier}
+            totpUrl={data.totpVerificationUrl}
             type={type}
           />
           <Accordion
@@ -158,9 +122,9 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
                       canWriteTitle={true}
                       nodeId={id}
                       onChange={(value) => {
-                        handleChange("url", value);
+                        update({ url: value });
                       }}
-                      value={inputs.url}
+                      value={data.url}
                       placeholder={placeholders["task"]["url"]}
                       className="nopan text-xs"
                     />
@@ -175,9 +139,9 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
                     <WorkflowBlockInputTextarea
                       nodeId={id}
                       onChange={(value) => {
-                        handleChange("navigationGoal", value);
+                        update({ navigationGoal: value });
                       }}
-                      value={inputs.navigationGoal}
+                      value={data.navigationGoal}
                       placeholder={placeholders["task"]["navigationGoal"]}
                       className="nopan text-xs"
                     />
@@ -187,7 +151,7 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
                       availableOutputParameters={outputParameterKeys}
                       parameters={data.parameterKeys}
                       onParametersChange={(parameterKeys) => {
-                        updateNodeData(id, { parameterKeys });
+                        update({ parameterKeys });
                       }}
                     />
                   </div>
@@ -210,9 +174,9 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
                     <WorkflowBlockInputTextarea
                       nodeId={id}
                       onChange={(value) => {
-                        handleChange("dataExtractionGoal", value);
+                        update({ dataExtractionGoal: value });
                       }}
-                      value={inputs.dataExtractionGoal}
+                      value={data.dataExtractionGoal}
                       placeholder={placeholders["task"]["dataExtractionGoal"]}
                       className="nopan text-xs"
                     />
@@ -220,13 +184,13 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
                   <WorkflowDataSchemaInputGroup
                     exampleValue={dataSchemaExampleValue}
                     onChange={(value) => {
-                      handleChange("dataSchema", value);
+                      update({ dataSchema: value });
                     }}
-                    value={inputs.dataSchema}
+                    value={data.dataSchema}
                     suggestionContext={{
-                      data_extraction_goal: inputs.dataExtractionGoal,
-                      current_schema: inputs.dataSchema,
-                      navigation_goal: inputs.navigationGoal,
+                      data_extraction_goal: data.dataExtractionGoal,
+                      current_schema: data.dataSchema,
+                      navigation_goal: data.navigationGoal,
                     }}
                   />
                 </div>
@@ -243,18 +207,18 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
                     <WorkflowBlockInputTextarea
                       nodeId={id}
                       onChange={(value) => {
-                        handleChange("completeCriterion", value);
+                        update({ completeCriterion: value });
                       }}
-                      value={inputs.completeCriterion}
+                      value={data.completeCriterion}
                       className="nopan text-xs"
                     />
                   </div>
                   <Separator />
                   <ModelSelector
                     className="nopan w-52 text-xs"
-                    value={inputs.model}
+                    value={data.model}
                     onChange={(value) => {
-                      handleChange("model", value);
+                      update({ model: value });
                     }}
                   />
                   <div className="flex items-center justify-between">
@@ -264,9 +228,9 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
                       </Label>
                     </div>
                     <RunEngineSelector
-                      value={inputs.engine}
+                      value={data.engine}
                       onChange={(value) => {
-                        handleChange("engine", value);
+                        update({ engine: value });
                       }}
                       className="nopan w-52 text-xs"
                     />
@@ -285,13 +249,13 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
                       placeholder={placeholders["task"]["maxStepsOverride"]}
                       className="nopan w-52 text-xs"
                       min="0"
-                      value={inputs.maxStepsOverride ?? ""}
+                      value={data.maxStepsOverride ?? ""}
                       onChange={(event) => {
                         const value =
                           event.target.value === ""
                             ? null
                             : Number(event.target.value);
-                        handleChange("maxStepsOverride", value);
+                        update({ maxStepsOverride: value });
                       }}
                     />
                   </div>
@@ -306,29 +270,28 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
                         />
                       </div>
                       <Checkbox
-                        checked={inputs.errorCodeMapping !== "null"}
+                        checked={data.errorCodeMapping !== "null"}
                         disabled={!editable}
                         onCheckedChange={(checked) => {
-                          handleChange(
-                            "errorCodeMapping",
-                            checked
+                          update({
+                            errorCodeMapping: checked
                               ? JSON.stringify(
                                   errorMappingExampleValue,
                                   null,
                                   2,
                                 )
                               : "null",
-                          );
+                          });
                         }}
                       />
                     </div>
-                    {inputs.errorCodeMapping !== "null" && (
+                    {data.errorCodeMapping !== "null" && (
                       <div>
                         <CodeEditor
                           language="json"
-                          value={inputs.errorCodeMapping}
+                          value={data.errorCodeMapping}
                           onChange={(value) => {
-                            handleChange("errorCodeMapping", value);
+                            update({ errorCodeMapping: value });
                           }}
                           className="nopan"
                           fontSize={8}
@@ -352,12 +315,11 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
                     </div>
                     <div className="w-52">
                       <Switch
-                        checked={inputs.includeActionHistoryInVerification}
+                        checked={data.includeActionHistoryInVerification}
                         onCheckedChange={(checked) => {
-                          handleChange(
-                            "includeActionHistoryInVerification",
-                            checked,
-                          );
+                          update({
+                            includeActionHistoryInVerification: checked,
+                          });
                         }}
                       />
                     </div>
@@ -373,22 +335,22 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
                     </div>
                     <div className="w-52">
                       <Switch
-                        checked={inputs.continueOnFailure}
+                        checked={data.continueOnFailure}
                         onCheckedChange={(checked) => {
-                          handleChange("continueOnFailure", checked);
+                          update({ continueOnFailure: checked });
                         }}
                       />
                     </div>
                   </div>
                   <DisableCache
-                    cacheActions={inputs.cacheActions}
-                    disableCache={inputs.disableCache}
+                    cacheActions={data.cacheActions}
+                    disableCache={data.disableCache}
                     editable={editable}
                     onCacheActionsChange={(cacheActions) => {
-                      handleChange("cacheActions", cacheActions);
+                      update({ cacheActions });
                     }}
                     onDisableCacheChange={(disableCache) => {
-                      handleChange("disableCache", disableCache);
+                      update({ disableCache });
                     }}
                   />
                   <Separator />
@@ -403,9 +365,9 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
                     </div>
                     <div className="w-52">
                       <Switch
-                        checked={inputs.allowDownloads}
+                        checked={data.allowDownloads}
                         onCheckedChange={(checked) => {
-                          handleChange("allowDownloads", checked);
+                          update({ allowDownloads: checked });
                         }}
                       />
                     </div>
@@ -424,9 +386,9 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
                       type="text"
                       placeholder={placeholders["task"]["downloadSuffix"]}
                       className="nopan w-52 text-xs"
-                      value={inputs.downloadSuffix ?? ""}
+                      value={data.downloadSuffix ?? ""}
                       onChange={(value) => {
-                        handleChange("downloadSuffix", value);
+                        update({ downloadSuffix: value });
                       }}
                     />
                   </div>
@@ -443,9 +405,9 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
                     <WorkflowBlockInputTextarea
                       nodeId={id}
                       onChange={(value) => {
-                        handleChange("totpIdentifier", value);
+                        update({ totpIdentifier: value });
                       }}
-                      value={inputs.totpIdentifier ?? ""}
+                      value={data.totpIdentifier ?? ""}
                       placeholder={placeholders["task"]["totpIdentifier"]}
                       className="nopan text-xs"
                     />
@@ -462,9 +424,9 @@ function TaskNode({ id, data, type }: NodeProps<TaskNode>) {
                     <WorkflowBlockInputTextarea
                       nodeId={id}
                       onChange={(value) => {
-                        handleChange("totpVerificationUrl", value);
+                        update({ totpVerificationUrl: value });
                       }}
-                      value={inputs.totpVerificationUrl ?? ""}
+                      value={data.totpVerificationUrl ?? ""}
                       placeholder={placeholders["task"]["totpVerificationUrl"]}
                       className="nopan text-xs"
                     />

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/Taskv2Node/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/Taskv2Node/types.ts
@@ -11,6 +11,7 @@ export type Taskv2NodeData = NodeBaseData & {
   totpVerificationUrl: string | null;
   totpIdentifier: string | null;
   maxSteps: number | null;
+  cacheActions: boolean;
   disableCache: boolean;
   maxScreenshotScrolls: number | null;
 };
@@ -27,6 +28,7 @@ export const taskv2NodeDefaultData: Taskv2NodeData = {
   totpIdentifier: null,
   totpVerificationUrl: null,
   maxSteps: MAX_STEPS_DEFAULT,
+  cacheActions: false,
   disableCache: false,
   model: null,
   maxScreenshotScrolls: null,

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TextPromptNode/TextPromptNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TextPromptNode/TextPromptNode.tsx
@@ -1,8 +1,7 @@
 import { HelpTooltip } from "@/components/HelpTooltip";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
-import { Handle, NodeProps, Position, useReactFlow } from "@xyflow/react";
-import { useState } from "react";
+import { Handle, NodeProps, Position } from "@xyflow/react";
 import { helpTooltips } from "../../helpContent";
 import { type TextPromptNode } from "./types";
 import { WorkflowBlockInputTextarea } from "@/components/WorkflowBlockInputTextarea";
@@ -15,9 +14,9 @@ import { NodeHeader } from "../components/NodeHeader";
 import { useParams } from "react-router-dom";
 import { statusIsRunningOrQueued } from "@/routes/tasks/types";
 import { useWorkflowRunQuery } from "@/routes/workflows/hooks/useWorkflowRunQuery";
+import { useUpdate } from "@/routes/workflows/editor/useUpdate";
 
 function TextPromptNode({ id, data }: NodeProps<TextPromptNode>) {
-  const { updateNodeData } = useReactFlow();
   const { editable, label } = data;
   const { blockLabel: urlBlockLabel } = useParams();
   const { data: workflowRun } = useWorkflowRunQuery();
@@ -27,21 +26,8 @@ function TextPromptNode({ id, data }: NodeProps<TextPromptNode>) {
     urlBlockLabel !== undefined && urlBlockLabel === label;
   const thisBlockIsPlaying =
     workflowRunIsRunningOrQueued && thisBlockIsTargetted;
-  const [inputs, setInputs] = useState({
-    prompt: data.prompt,
-    jsonSchema: data.jsonSchema,
-    model: data.model,
-  });
-
-  function handleChange(key: string, value: unknown) {
-    if (!editable) {
-      return;
-    }
-    setInputs({ ...inputs, [key]: value });
-    updateNodeData(id, { [key]: value });
-  }
-
   const isFirstWorkflowBlock = useIsFirstBlockInWorkflow({ id });
+  const update = useUpdate<TextPromptNode["data"]>({ id, editable });
 
   return (
     <div>
@@ -91,9 +77,9 @@ function TextPromptNode({ id, data }: NodeProps<TextPromptNode>) {
           <WorkflowBlockInputTextarea
             nodeId={id}
             onChange={(value) => {
-              handleChange("prompt", value);
+              update({ prompt: value });
             }}
-            value={inputs.prompt}
+            value={data.prompt}
             placeholder="What do you want to generate?"
             className="nopan text-xs"
           />
@@ -101,16 +87,16 @@ function TextPromptNode({ id, data }: NodeProps<TextPromptNode>) {
         <Separator />
         <ModelSelector
           className="nopan w-52 text-xs"
-          value={inputs.model}
+          value={data.model}
           onChange={(value) => {
-            handleChange("model", value);
+            update({ model: value });
           }}
         />
         <WorkflowDataSchemaInputGroup
           exampleValue={dataSchemaExampleValue}
-          value={inputs.jsonSchema}
+          value={data.jsonSchema}
           onChange={(value) => {
-            handleChange("jsonSchema", value);
+            update({ jsonSchema: value });
           }}
           suggestionContext={{}}
         />

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/URLNode/URLNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/URLNode/URLNode.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { Flippable } from "@/components/Flippable";
-import { Handle, NodeProps, Position, useReactFlow } from "@xyflow/react";
+import { Handle, NodeProps, Position } from "@xyflow/react";
 import type { URLNode } from "./types";
 import { useIsFirstBlockInWorkflow } from "../../hooks/useIsFirstNodeInWorkflow";
 import { useState } from "react";
@@ -14,9 +14,9 @@ import { NodeHeader } from "../components/NodeHeader";
 import { useParams } from "react-router-dom";
 import { statusIsRunningOrQueued } from "@/routes/tasks/types";
 import { useWorkflowRunQuery } from "@/routes/workflows/hooks/useWorkflowRunQuery";
+import { useUpdate } from "@/routes/workflows/editor/useUpdate";
 
 function URLNode({ id, data, type }: NodeProps<URLNode>) {
-  const { updateNodeData } = useReactFlow();
   const [facing, setFacing] = useState<"front" | "back">("front");
   const blockScriptStore = useBlockScriptStore();
   const { editable, label } = data;
@@ -30,18 +30,7 @@ function URLNode({ id, data, type }: NodeProps<URLNode>) {
   const thisBlockIsPlaying =
     workflowRunIsRunningOrQueued && thisBlockIsTargetted;
   const isFirstWorkflowBlock = useIsFirstBlockInWorkflow({ id });
-
-  const [inputs, setInputs] = useState({
-    url: data.url,
-  });
-
-  function handleChange(key: string, value: unknown) {
-    if (!editable) {
-      return;
-    }
-    setInputs({ ...inputs, [key]: value });
-    updateNodeData(id, { [key]: value });
-  }
+  const update = useUpdate<URLNode["data"]>({ id, editable });
 
   useEffect(() => {
     setFacing(data.showCode ? "back" : "front");
@@ -94,9 +83,9 @@ function URLNode({ id, data, type }: NodeProps<URLNode>) {
                 canWriteTitle={true}
                 nodeId={id}
                 onChange={(value) => {
-                  handleChange("url", value);
+                  update({ url: value });
                 }}
-                value={inputs.url}
+                value={data.url}
                 placeholder={placeholders[type]["url"]}
                 className="nopan text-xs"
               />

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/ValidationNode/ValidationNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/ValidationNode/ValidationNode.tsx
@@ -15,14 +15,7 @@ import { WorkflowBlockInputTextarea } from "@/components/WorkflowBlockInputTexta
 import { BlockCodeEditor } from "@/routes/workflows/components/BlockCodeEditor";
 import { CodeEditor } from "@/routes/workflows/components/CodeEditor";
 import { useBlockScriptStore } from "@/store/BlockScriptStore";
-import {
-  Handle,
-  NodeProps,
-  Position,
-  useEdges,
-  useNodes,
-  useReactFlow,
-} from "@xyflow/react";
+import { Handle, NodeProps, Position, useEdges, useNodes } from "@xyflow/react";
 import { useState } from "react";
 import { helpTooltips } from "../../helpContent";
 import { errorMappingExampleValue } from "../types";
@@ -37,12 +30,12 @@ import { NodeHeader } from "../components/NodeHeader";
 import { useParams } from "react-router-dom";
 import { statusIsRunningOrQueued } from "@/routes/tasks/types";
 import { useWorkflowRunQuery } from "@/routes/workflows/hooks/useWorkflowRunQuery";
+import { useUpdate } from "@/routes/workflows/editor/useUpdate";
 import { useRerender } from "@/hooks/useRerender";
 
 import { DisableCache } from "../DisableCache";
 
 function ValidationNode({ id, data, type }: NodeProps<ValidationNode>) {
-  const { updateNodeData } = useReactFlow();
   const [facing, setFacing] = useState<"front" | "back">("front");
   const blockScriptStore = useBlockScriptStore();
   const { editable, label } = data;
@@ -55,28 +48,12 @@ function ValidationNode({ id, data, type }: NodeProps<ValidationNode>) {
     urlBlockLabel !== undefined && urlBlockLabel === label;
   const thisBlockIsPlaying =
     workflowRunIsRunningOrQueued && thisBlockIsTargetted;
-  const [inputs, setInputs] = useState({
-    completeCriterion: data.completeCriterion,
-    terminateCriterion: data.terminateCriterion,
-    errorCodeMapping: data.errorCodeMapping,
-    model: data.model,
-    disableCache: data.disableCache,
-  });
-
   const rerender = useRerender({ prefix: "accordian" });
   const nodes = useNodes<AppNode>();
   const edges = useEdges();
   const outputParameterKeys = getAvailableOutputParameterKeys(nodes, edges, id);
-
-  function handleChange(key: string, value: unknown) {
-    if (!editable) {
-      return;
-    }
-    setInputs({ ...inputs, [key]: value });
-    updateNodeData(id, { [key]: value });
-  }
-
   const isFirstWorkflowBlock = useIsFirstBlockInWorkflow({ id });
+  const update = useUpdate<ValidationNode["data"]>({ id, editable });
 
   useEffect(() => {
     setFacing(data.showCode ? "back" : "front");
@@ -128,9 +105,9 @@ function ValidationNode({ id, data, type }: NodeProps<ValidationNode>) {
             <WorkflowBlockInputTextarea
               nodeId={id}
               onChange={(value) => {
-                handleChange("completeCriterion", value);
+                update({ completeCriterion: value });
               }}
-              value={inputs.completeCriterion}
+              value={data.completeCriterion}
               className="nopan text-xs"
             />
           </div>
@@ -139,9 +116,9 @@ function ValidationNode({ id, data, type }: NodeProps<ValidationNode>) {
             <WorkflowBlockInputTextarea
               nodeId={id}
               onChange={(value) => {
-                handleChange("terminateCriterion", value);
+                update({ terminateCriterion: value });
               }}
-              value={inputs.terminateCriterion}
+              value={data.terminateCriterion}
               className="nopan text-xs"
             />
           </div>
@@ -160,16 +137,16 @@ function ValidationNode({ id, data, type }: NodeProps<ValidationNode>) {
                   <div className="space-y-2">
                     <ModelSelector
                       className="nopan mr-[1px] w-52 text-xs"
-                      value={inputs.model}
+                      value={data.model}
                       onChange={(value) => {
-                        handleChange("model", value);
+                        update({ model: value });
                       }}
                     />
                     <ParametersMultiSelect
                       availableOutputParameters={outputParameterKeys}
                       parameters={data.parameterKeys}
                       onParametersChange={(parameterKeys) => {
-                        updateNodeData(id, { parameterKeys });
+                        update({ parameterKeys });
                       }}
                     />
                   </div>
@@ -186,35 +163,34 @@ function ValidationNode({ id, data, type }: NodeProps<ValidationNode>) {
                         />
                       </div>
                       <Checkbox
-                        checked={inputs.errorCodeMapping !== "null"}
+                        checked={data.errorCodeMapping !== "null"}
                         disabled={!editable}
                         onCheckedChange={(checked) => {
                           if (!editable) {
                             return;
                           }
-                          handleChange(
-                            "errorCodeMapping",
-                            checked
+                          update({
+                            errorCodeMapping: checked
                               ? JSON.stringify(
                                   errorMappingExampleValue,
                                   null,
                                   2,
                                 )
                               : "null",
-                          );
+                          });
                         }}
                       />
                     </div>
-                    {inputs.errorCodeMapping !== "null" && (
+                    {data.errorCodeMapping !== "null" && (
                       <div>
                         <CodeEditor
                           language="json"
-                          value={inputs.errorCodeMapping}
+                          value={data.errorCodeMapping}
                           onChange={(value) => {
                             if (!editable) {
                               return;
                             }
-                            handleChange("errorCodeMapping", value);
+                            update({ errorCodeMapping: value });
                           }}
                           className="nopan"
                           fontSize={8}
@@ -241,19 +217,19 @@ function ValidationNode({ id, data, type }: NodeProps<ValidationNode>) {
                           if (!editable) {
                             return;
                           }
-                          updateNodeData(id, { continueOnFailure: checked });
+                          update({ continueOnFailure: checked });
                         }}
                       />
                     </div>
                   </div>
                   <DisableCache
-                    disableCache={inputs.disableCache}
+                    disableCache={data.disableCache}
                     editable={editable}
                     onCacheActionsChange={(cacheActions) => {
-                      handleChange("cacheActions", cacheActions);
+                      update({ cacheActions });
                     }}
                     onDisableCacheChange={(disableCache) => {
-                      handleChange("disableCache", disableCache);
+                      update({ disableCache });
                     }}
                   />
                 </div>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/ValidationNode/types.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/ValidationNode/types.ts
@@ -6,6 +6,7 @@ export type ValidationNodeData = NodeBaseData & {
   terminateCriterion: string;
   errorCodeMapping: string;
   parameterKeys: Array<string>;
+  cacheActions?: boolean;
   disableCache: boolean;
 };
 
@@ -20,6 +21,7 @@ export const validationNodeDefaultData: ValidationNodeData = {
   continueOnFailure: false,
   editable: true,
   parameterKeys: [],
+  cacheActions: false,
   disableCache: false,
   model: null,
 };

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/WaitNode/WaitNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/WaitNode/WaitNode.tsx
@@ -1,7 +1,6 @@
 import { HelpTooltip } from "@/components/HelpTooltip";
 import { Label } from "@/components/ui/label";
-import { Handle, NodeProps, Position, useReactFlow } from "@xyflow/react";
-import { useState } from "react";
+import { Handle, NodeProps, Position } from "@xyflow/react";
 import { helpTooltips } from "../../helpContent";
 import type { WaitNode } from "./types";
 import { useIsFirstBlockInWorkflow } from "../../hooks/useIsFirstNodeInWorkflow";
@@ -11,9 +10,9 @@ import { NodeHeader } from "../components/NodeHeader";
 import { useParams } from "react-router-dom";
 import { statusIsRunningOrQueued } from "@/routes/tasks/types";
 import { useWorkflowRunQuery } from "@/routes/workflows/hooks/useWorkflowRunQuery";
+import { useUpdate } from "@/routes/workflows/editor/useUpdate";
 
 function WaitNode({ id, data, type }: NodeProps<WaitNode>) {
-  const { updateNodeData } = useReactFlow();
   const { editable, label } = data;
   const { blockLabel: urlBlockLabel } = useParams();
   const { data: workflowRun } = useWorkflowRunQuery();
@@ -23,19 +22,9 @@ function WaitNode({ id, data, type }: NodeProps<WaitNode>) {
     urlBlockLabel !== undefined && urlBlockLabel === label;
   const thisBlockIsPlaying =
     workflowRunIsRunningOrQueued && thisBlockIsTargetted;
-  const [inputs, setInputs] = useState({
-    waitInSeconds: data.waitInSeconds,
-  });
-
-  function handleChange(key: string, value: unknown) {
-    if (!editable) {
-      return;
-    }
-    setInputs({ ...inputs, [key]: value });
-    updateNodeData(id, { [key]: value });
-  }
-
   const isFirstWorkflowBlock = useIsFirstBlockInWorkflow({ id });
+
+  const update = useUpdate<WaitNode["data"]>({ id, editable });
 
   return (
     <div>
@@ -84,9 +73,9 @@ function WaitNode({ id, data, type }: NodeProps<WaitNode>) {
             ) : null}
           </div>
           <Input
-            value={inputs.waitInSeconds}
+            value={data.waitInSeconds}
             onChange={(event) => {
-              handleChange("waitInSeconds", event.target.value);
+              update({ waitInSeconds: event.target.value });
             }}
             className="nopan text-xs"
           />

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
@@ -91,7 +91,9 @@ const getPayload = (opts: {
     extraHttpHeaders =
       opts.workflowSettings.extraHttpHeaders === null
         ? null
-        : JSON.parse(opts.workflowSettings.extraHttpHeaders);
+        : typeof opts.workflowSettings.extraHttpHeaders === "object"
+          ? opts.workflowSettings.extraHttpHeaders
+          : JSON.parse(opts.workflowSettings.extraHttpHeaders);
   } catch (e: unknown) {
     toast({
       variant: "warning",

--- a/skyvern-frontend/src/routes/workflows/editor/useUpdate.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/useUpdate.ts
@@ -1,0 +1,38 @@
+import { useReactFlow } from "@xyflow/react";
+import { useCallback } from "react";
+
+type UseUpdateOptions = {
+  id: string;
+  editable: boolean;
+};
+
+/**
+ * A reusable hook for updating node data in React Flow.
+ *
+ * @template T - The root data type that extends Record<string, unknown>
+ * @param options - Configuration object containing node id and editable flag
+ * @returns An update function that accepts partial updates of type T
+ *
+ * @example
+ * ```tsx
+ * const update = useUpdate<WaitNode["data"]>({ id, editable });
+ * update({ waitInSeconds: "5" });
+ * ```
+ */
+export function useUpdate<T extends Record<string, unknown>>({
+  id,
+  editable,
+}: UseUpdateOptions) {
+  const { updateNodeData } = useReactFlow();
+
+  const update = useCallback(
+    (updates: Partial<T>) => {
+      if (!editable) return;
+
+      updateNodeData(id, updates);
+    },
+    [id, editable, updateNodeData],
+  );
+
+  return update;
+}

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -264,6 +264,7 @@ function convertToNode(
           prompt: block.prompt,
           url: block.url ?? "",
           maxSteps: block.max_steps,
+          cacheActions: block.cache_actions ?? false,
           disableCache: block.disable_cache ?? false,
           totpIdentifier: block.totp_identifier,
           totpVerificationUrl: block.totp_verification_url,
@@ -1457,7 +1458,10 @@ function getWorkflowSettings(nodes: Array<AppNode>): WorkflowSettings {
       webhookCallbackUrl: data.webhookCallbackUrl,
       model: data.model,
       maxScreenshotScrolls: data.maxScreenshotScrolls,
-      extraHttpHeaders: data.extraHttpHeaders,
+      extraHttpHeaders:
+        data.extraHttpHeaders && typeof data.extraHttpHeaders === "object"
+          ? JSON.stringify(data.extraHttpHeaders)
+          : data.extraHttpHeaders,
       runWith: data.runWith,
       scriptCacheKey: data.scriptCacheKey,
       aiFallback: data.aiFallback,

--- a/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
@@ -318,6 +318,7 @@ export type Taskv2Block = WorkflowBlockBase & {
   totp_verification_url: string | null;
   totp_identifier: string | null;
   max_steps: number | null;
+  cache_actions?: boolean;
   disable_cache: boolean;
 };
 

--- a/skyvern-frontend/src/store/WorkflowSettingsStore.ts
+++ b/skyvern-frontend/src/store/WorkflowSettingsStore.ts
@@ -11,9 +11,14 @@ export interface WorkflowSettingsState {
   persistBrowserSession: boolean;
   model: WorkflowModel | null;
   maxScreenshotScrollingTimes: number | null;
-  extraHttpHeaders: string | null;
+  extraHttpHeaders: string | Record<string, unknown> | null;
   setWorkflowSettings: (
-    settings: Partial<Omit<WorkflowSettingsState, "setWorkflowSettings">>,
+    settings: Partial<
+      Omit<
+        WorkflowSettingsState,
+        "setWorkflowSettings" | "resetWorkflowSettings"
+      >
+    >,
   ) => void;
   resetWorkflowSettings: () => void;
 }


### PR DESCRIPTION
Rework state management arch for blocks (fix max recursion; maybe other bugs).

re: https://linear.app/skyvern/issue/SKY-6737/long-press-on-delete-key-crashes-the-ui

But this is a long-standing issue. It pre-dates moi. Multiple (quickie) attempts have been made to fix this. Here's one:

https://linear.app/skyvern/issue/SKY-5868/max-recursion-error-in-app

This PR removes the multiple-sources of truth _every_ block was using to maintain state. Turns out that [SSOT](https://en.wikipedia.org/wiki/Single_source_of_truth) is still a great honking idea. Two sources of truth were:
- internal, `useState` inside each block
- the node (block) data inside react-flow

Here, we go for letting react-flow be the SSOT.

Additionally, we debounce the change emissions of two textual inputs:
- `CodeEditor`
- `WorkflowBlockInputTextarea`

This change was attempted a while back, but proved brittle in the face of multiple sources of truth.

---

That said, this PR may introduce new bugs that we'll want to squash immediately. The surface area here is kinda' large, and TANT (There Are No Tests).


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor state management for workflow blocks using React Flow as the single source of truth, introducing debouncing and centralizing updates with a new `useUpdate` hook.
> 
>   - **State Management**:
>     - Centralizes state management using React Flow as the single source of truth, removing internal `useState` from blocks.
>     - Introduces `useUpdate` hook in `useUpdate.ts` for updating node data.
>   - **Debouncing**:
>     - Adds debouncing to `CodeEditor` and `WorkflowBlockInputTextarea` to reduce rapid state updates.
>   - **Node Updates**:
>     - Refactors state updates in nodes like `TaskNode`, `StartNode`, `ValidationNode`, and others to use the new `useUpdate` hook.
>     - Removes redundant state management logic from nodes.
>   - **Miscellaneous**:
>     - Fixes stray debug logging in `ModelSelector.tsx`.
>     - Adjusts `getPayload` in `NodeHeader.tsx` to handle complex HTTP headers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for daa2d15a28079b7fa681dcd52f915c3a5e51d351. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cache actions toggle for task nodes to control behavior caching
  * Added continue-on-failure option for loop nodes
  * Enhanced HTTP headers configuration to support structured data

* **Performance Improvements**
  * Implemented debounced text input handlers (300ms) to reduce unnecessary updates during typing
  * Optimized workflow node state management for better responsiveness

* **Updates**
  * Improved overall state synchronization across workflow editor nodes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔄 This PR refactors the state management architecture for workflow blocks to eliminate dual state sources and fix maximum recursion errors caused by rapid input changes. It consolidates state management to use React Flow as the single source of truth while introducing debouncing for text inputs.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **State Management Consolidation**: Removed internal `useState` hooks from all workflow node components (ActionNode, ExtractionNode, LoginNode, etc.) and made React Flow the single source of truth for node data
- **Debouncing Implementation**: Added 300ms debouncing to `CodeEditor` and `WorkflowBlockInputTextarea` components to prevent rapid state updates that caused recursion errors
- **New useUpdate Hook**: Created a centralized `useUpdate` hook that provides a consistent interface for updating node data across all components
- **Flow Renderer Optimization**: Simplified the node change handling logic by removing the timeout-based deferred update mechanism that was causing recursion issues

### Technical Implementation
```mermaid
flowchart TD
    A[User Input] --> B[Debounced Handler 300ms]
    B --> C[useUpdate Hook]
    C --> D{Editable Check}
    D -->|Yes| E[updateNodeData React Flow]
    D -->|No| F[No Action]
    E --> G[React Flow State Update]
    G --> H[Component Re-render]
    H --> I[UI Updated]
    
    J[Old Architecture] --> K[useState Internal State]
    K --> L[React Flow State]
    L --> M[Potential Sync Issues]
    M --> N[Max Recursion Errors]
```

### Impact
- **Bug Resolution**: Fixes the long-standing maximum recursion error that occurred during rapid input changes, particularly when holding down the delete key
- **Performance Improvement**: Debouncing reduces the frequency of state updates, improving overall editor performance and preventing UI crashes
- **Code Maintainability**: Eliminates dual state management complexity across 20+ node components, making the codebase more maintainable and less error-prone
- **Consistency**: Provides a unified update pattern across all workflow blocks through the `useUpdate` hook, reducing code duplication and potential inconsistencies

</details>

_Created with [Palmier](https://www.palmier.io)_