### PR TITLE
Allow Testing of Webhook URLs in create flow

### DIFF
--- a/skyvern-frontend/src/components/TestWebhookDialog.tsx
+++ b/skyvern-frontend/src/components/TestWebhookDialog.tsx
@@ -1,0 +1,308 @@
+import { useEffect, useState } from "react";
+import { ReloadIcon, CopyIcon, CheckIcon } from "@radix-ui/react-icons";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { CodeEditor } from "@/routes/workflows/components/CodeEditor";
+import { getClient } from "@/api/AxiosClient";
+import { useCredentialGetter } from "@/hooks/useCredentialGetter";
+import { toast } from "@/components/ui/use-toast";
+
+type TestWebhookRequest = {
+  webhook_url: string;
+  run_type: "task" | "workflow_run";
+  run_id: string | null;
+};
+
+type TestWebhookResponse = {
+  status_code: number | null;
+  latency_ms: number;
+  response_body: string;
+  headers_sent: Record<string, string>;
+  error: string | null;
+};
+
+type TestWebhookDialogProps = {
+  runType: "task" | "workflow_run";
+  runId?: string | null;
+  initialWebhookUrl?: string;
+  trigger?: React.ReactNode;
+};
+
+function TestWebhookDialog({
+  runType,
+  runId,
+  initialWebhookUrl,
+  trigger,
+}: TestWebhookDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [targetUrl, setTargetUrl] = useState(initialWebhookUrl || "");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<TestWebhookResponse | null>(null);
+  const [signatureOpen, setSignatureOpen] = useState(false);
+  const [responseOpen, setResponseOpen] = useState(false);
+  const [copiedResponse, setCopiedResponse] = useState(false);
+  const credentialGetter = useCredentialGetter();
+
+  const runTest = async (url: string) => {
+    setTargetUrl(url);
+    if (!url.trim()) {
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description: "Enter a webhook URL before testing.",
+      });
+      setOpen(false);
+      return;
+    }
+
+    setLoading(true);
+    setResult(null);
+    setSignatureOpen(false);
+    setResponseOpen(false);
+    setCopiedResponse(false);
+
+    try {
+      const client = await getClient(credentialGetter);
+      const response = await client.post<TestWebhookResponse>(
+        "/internal/test-webhook",
+        {
+          webhook_url: url,
+          run_type: runType,
+          run_id: runId ?? null,
+        } satisfies TestWebhookRequest,
+      );
+
+      setResult(response.data);
+
+      if (response.data.error) {
+        toast({
+          variant: "destructive",
+          title: "Webhook Test Failed",
+          description: response.data.error,
+        });
+      } else if (
+        response.data.status_code &&
+        response.data.status_code >= 200 &&
+        response.data.status_code < 300
+      ) {
+        toast({
+          variant: "success",
+          title: "Webhook Test Successful",
+          description: `Received ${response.data.status_code} response in ${response.data.latency_ms}ms`,
+        });
+      } else if (response.data.status_code) {
+        toast({
+          variant: "destructive",
+          title: "Webhook Test Failed",
+          description: `Received ${response.data.status_code} response`,
+        });
+      }
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Error",
+        description:
+          error instanceof Error ? error.message : "Failed to test webhook",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const nextUrl = initialWebhookUrl || "";
+    setTargetUrl(nextUrl);
+    void runTest(nextUrl);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, initialWebhookUrl]);
+
+  const handleCopyResponse = async () => {
+    if (!result?.response_body) {
+      return;
+    }
+    await navigator.clipboard.writeText(result.response_body);
+    setCopiedResponse(true);
+    setTimeout(() => setCopiedResponse(false), 2000);
+  };
+
+  const getStatusBadgeClass = (statusCode: number | null) => {
+    if (!statusCode) return "bg-slate-500";
+    if (statusCode >= 200 && statusCode < 300) return "bg-green-600";
+    if (statusCode >= 400 && statusCode < 500) return "bg-orange-600";
+    if (statusCode >= 500) return "bg-red-600";
+    return "bg-blue-600";
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {trigger || (
+          <Button type="button" variant="secondary">
+            Test Webhook
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Test Webhook URL</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="test-webhook-url">Testing URL</Label>
+            <Input
+              id="test-webhook-url"
+              value={targetUrl}
+              onChange={(event) => setTargetUrl(event.target.value)}
+              placeholder="https://your-endpoint.com/webhook"
+            />
+          </div>
+
+          {loading && !result ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <ReloadIcon className="h-4 w-4 animate-spin" />
+              Sending test webhook…
+            </div>
+          ) : null}
+
+          {result && (
+            <div className="space-y-4 border-t pt-4">
+              {result.error ? (
+                <div className="rounded-md border border-red-600 bg-red-50 p-4 dark:bg-red-950">
+                  <p className="text-sm font-medium text-red-900 dark:text-red-100">
+                    Error
+                  </p>
+                  <p className="mt-1 text-sm text-red-700 dark:text-red-200">
+                    {result.error}
+                  </p>
+                </div>
+              ) : (
+                <>
+                  <div className="flex items-center gap-4">
+                    <div>
+                      <Label className="text-xs text-muted-foreground">
+                        Status
+                      </Label>
+                      <div className="mt-1 flex items-center gap-2">
+                        <span
+                          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium text-white ${getStatusBadgeClass(result.status_code)}`}
+                        >
+                          {result.status_code || "N/A"}
+                        </span>
+                      </div>
+                    </div>
+                    <div>
+                      <Label className="text-xs text-muted-foreground">
+                        Latency
+                      </Label>
+                      <p className="mt-1 text-sm font-medium">
+                        {result.latency_ms}ms
+                      </p>
+                    </div>
+                  </div>
+
+                  <Collapsible
+                    open={responseOpen}
+                    onOpenChange={setResponseOpen}
+                  >
+                    <CollapsibleTrigger asChild>
+                      <Button variant="outline" className="w-full">
+                        {responseOpen
+                          ? "Hide Response Body"
+                          : "Show Response Body"}
+                      </Button>
+                    </CollapsibleTrigger>
+                    <CollapsibleContent className="mt-4 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <Label>Response Body</Label>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={handleCopyResponse}
+                        >
+                          {copiedResponse ? (
+                            <CheckIcon className="h-4 w-4" />
+                          ) : (
+                            <CopyIcon className="h-4 w-4" />
+                          )}
+                        </Button>
+                      </div>
+                      <CodeEditor
+                        language="json"
+                        value={result.response_body || "Empty response"}
+                        readOnly
+                        minHeight="100px"
+                        maxHeight="300px"
+                        className="w-full"
+                      />
+                    </CollapsibleContent>
+                  </Collapsible>
+
+                  <Collapsible
+                    open={signatureOpen}
+                    onOpenChange={setSignatureOpen}
+                  >
+                    <CollapsibleTrigger asChild>
+                      <Button variant="outline" className="w-full">
+                        {signatureOpen
+                          ? "Hide Headers Sent"
+                          : "Show Headers Sent"}
+                      </Button>
+                    </CollapsibleTrigger>
+                    <CollapsibleContent className="mt-4 space-y-4">
+                      <div className="space-y-2">
+                        <Label>Headers Sent</Label>
+                        <div className="space-y-1 rounded-md border bg-slate-50 p-3 font-mono text-sm dark:bg-slate-950">
+                          {Object.entries(result.headers_sent).map(
+                            ([key, value]) => (
+                              <div key={key}>
+                                <span className="text-slate-600 dark:text-slate-400">
+                                  {key}:
+                                </span>{" "}
+                                {value}
+                              </div>
+                            ),
+                          )}
+                        </div>
+                      </div>
+                    </CollapsibleContent>
+                  </Collapsible>
+                </>
+              )}
+
+              <Button
+                type="button"
+                onClick={() => void runTest(targetUrl)}
+                disabled={loading || !targetUrl}
+                variant="secondary"
+                size="sm"
+                className="self-start"
+              >
+                Retest
+              </Button>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export { TestWebhookDialog };

--- a/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/CreateNewTaskForm.tsx
@@ -41,6 +41,7 @@ import {
 import { ProxySelector } from "@/components/ProxySelector";
 import { Switch } from "@/components/ui/switch";
 import { MAX_SCREENSHOT_SCROLLS_DEFAULT } from "@/routes/workflows/editor/nodes/Taskv2Node/types";
+import { TestWebhookDialog } from "@/components/TestWebhookDialog";
 type Props = {
   initialValues: CreateNewTaskFormValues;
 };
@@ -527,11 +528,31 @@ function CreateNewTaskForm({ initialValues }: Props) {
                         </FormLabel>
                         <div className="w-full">
                           <FormControl>
-                            <Input
-                              {...field}
-                              placeholder="https://"
-                              value={field.value === null ? "" : field.value}
-                            />
+                            <div className="flex flex-col gap-2">
+                              <Input
+                                className="w-full"
+                                {...field}
+                                placeholder="https://"
+                                value={field.value === null ? "" : field.value}
+                              />
+                              <TestWebhookDialog
+                                runType="task"
+                                runId={null}
+                                initialWebhookUrl={
+                                  field.value === null ? undefined : field.value
+                                }
+                                trigger={
+                                  <Button
+                                    type="button"
+                                    variant="secondary"
+                                    className="self-start"
+                                    disabled={!field.value}
+                                  >
+                                    Test Webhook
+                                  </Button>
+                                }
+                              />
+                            </div>
                           </FormControl>
                           <FormMessage />
                         </div>

--- a/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/PromptBox.tsx
@@ -8,6 +8,7 @@ import { InboxIcon } from "@/components/icons/InboxIcon";
 import { MessageIcon } from "@/components/icons/MessageIcon";
 import { TrophyIcon } from "@/components/icons/TrophyIcon";
 import { ProxySelector } from "@/components/ProxySelector";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { KeyValueInput } from "@/components/KeyValueInput";
 import {
@@ -45,6 +46,7 @@ import {
   MAX_STEPS_DEFAULT,
 } from "@/routes/workflows/editor/nodes/Taskv2Node/types";
 import { useAutoplayStore } from "@/store/useAutoplayStore";
+import { TestWebhookDialog } from "@/components/TestWebhookDialog";
 
 const exampleCases = [
   {
@@ -352,12 +354,30 @@ function PromptBox() {
                         information
                       </div>
                     </div>
-                    <Input
-                      value={webhookCallbackUrl ?? ""}
-                      onChange={(event) => {
-                        setWebhookCallbackUrl(event.target.value);
-                      }}
-                    />
+                    <div className="flex flex-col gap-2">
+                      <Input
+                        className="w-full"
+                        value={webhookCallbackUrl ?? ""}
+                        onChange={(event) => {
+                          setWebhookCallbackUrl(event.target.value);
+                        }}
+                      />
+                      <TestWebhookDialog
+                        runType="task"
+                        runId={null}
+                        initialWebhookUrl={webhookCallbackUrl ?? undefined}
+                        trigger={
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            className="self-start"
+                            disabled={!webhookCallbackUrl}
+                          >
+                            Test Webhook
+                          </Button>
+                        }
+                      />
+                    </div>
                   </div>
                   <div className="flex gap-16">
                     <div className="w-48 shrink-0">

--- a/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/SavedTaskForm.tsx
@@ -33,6 +33,7 @@ import { TaskFormSection } from "./TaskFormSection";
 import { savedTaskFormSchema, SavedTaskFormValues } from "./taskFormTypes";
 import { OrganizationApiResponse, ProxyLocation } from "@/api/types";
 import { ProxySelector } from "@/components/ProxySelector";
+import { TestWebhookDialog } from "@/components/TestWebhookDialog";
 
 type Props = {
   initialValues: SavedTaskFormValues;
@@ -627,11 +628,31 @@ function SavedTaskForm({ initialValues }: Props) {
                         </FormLabel>
                         <div className="w-full">
                           <FormControl>
-                            <Input
-                              {...field}
-                              placeholder="https://"
-                              value={field.value === null ? "" : field.value}
-                            />
+                            <div className="flex flex-col gap-2">
+                              <Input
+                                className="w-full"
+                                {...field}
+                                placeholder="https://"
+                                value={field.value === null ? "" : field.value}
+                              />
+                              <TestWebhookDialog
+                                runType="task"
+                                runId={null}
+                                initialWebhookUrl={
+                                  field.value === null ? undefined : field.value
+                                }
+                                trigger={
+                                  <Button
+                                    type="button"
+                                    variant="secondary"
+                                    className="self-start"
+                                    disabled={!field.value}
+                                  >
+                                    Test Webhook
+                                  </Button>
+                                }
+                              />
+                            </div>
                           </FormControl>
                           <FormMessage />
                         </div>

--- a/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
+++ b/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
@@ -48,6 +48,7 @@ import { MAX_SCREENSHOT_SCROLLS_DEFAULT } from "./editor/nodes/Taskv2Node/types"
 import { getLabelForWorkflowParameterType } from "./editor/workflowEditorUtils";
 import { WorkflowParameter } from "./types/workflowTypes";
 import { WorkflowParameterInput } from "./WorkflowParameterInput";
+import { TestWebhookDialog } from "@/components/TestWebhookDialog";
 
 // Utility function to omit specified keys from an object
 function omit<T extends Record<string, unknown>, K extends keyof T>(
@@ -461,13 +462,37 @@ function RunWorkflowForm({
                     </FormLabel>
                     <div className="w-full space-y-2">
                       <FormControl>
-                        <Input
-                          {...field}
-                          placeholder="https://"
-                          value={
-                            field.value === null ? "" : (field.value as string)
-                          }
-                        />
+                        <div className="flex flex-col gap-2">
+                          <Input
+                            className="w-full"
+                            {...field}
+                            placeholder="https://"
+                            value={
+                              field.value === null
+                                ? ""
+                                : (field.value as string)
+                            }
+                          />
+                          <TestWebhookDialog
+                            runType="workflow_run"
+                            runId={null}
+                            initialWebhookUrl={
+                              field.value === null
+                                ? undefined
+                                : (field.value as string)
+                            }
+                            trigger={
+                              <Button
+                                type="button"
+                                variant="secondary"
+                                className="self-start"
+                                disabled={!field.value}
+                              >
+                                Test Webhook
+                              </Button>
+                            }
+                          />
+                        </div>
                       </FormControl>
                       <FormMessage />
                     </div>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/StartNode/StartNode.tsx
@@ -39,6 +39,8 @@ import { useBlockScriptStore } from "@/store/BlockScriptStore";
 import { BlockCodeEditor } from "@/routes/workflows/components/BlockCodeEditor";
 import { useUpdate } from "@/routes/workflows/editor/useUpdate";
 import { cn } from "@/util/utils";
+import { Button } from "@/components/ui/button";
+import { TestWebhookDialog } from "@/components/TestWebhookDialog";
 
 interface StartSettings {
   webhookCallbackUrl: string;
@@ -170,15 +172,35 @@ function StartNode({ id, data }: NodeProps<StartNode>) {
                           <Label>Webhook Callback URL</Label>
                           <HelpTooltip content="The URL of a webhook endpoint to send the workflow results" />
                         </div>
-                        <Input
-                          value={data.webhookCallbackUrl}
-                          placeholder="https://"
-                          onChange={(event) => {
-                            update({
-                              webhookCallbackUrl: event.target.value,
-                            });
-                          }}
-                        />
+                        <div className="flex flex-col gap-2">
+                          <Input
+                            className="w-full"
+                            value={data.webhookCallbackUrl}
+                            placeholder="https://"
+                            onChange={(event) => {
+                              update({
+                                webhookCallbackUrl: event.target.value,
+                              });
+                            }}
+                          />
+                          <TestWebhookDialog
+                            runType="workflow_run"
+                            runId={null}
+                            initialWebhookUrl={
+                              data.webhookCallbackUrl || undefined
+                            }
+                            trigger={
+                              <Button
+                                type="button"
+                                variant="secondary"
+                                className="self-start"
+                                disabled={!data.webhookCallbackUrl}
+                              >
+                                Test Webhook
+                              </Button>
+                            }
+                          />
+                        </div>
                       </div>
                       <div className="space-y-2">
                         <div className="flex gap-2">

--- a/skyvern/forge/sdk/routes/__init__.py
+++ b/skyvern/forge/sdk/routes/__init__.py
@@ -8,3 +8,4 @@ from skyvern.forge.sdk.routes import scripts  # noqa: F401
 from skyvern.forge.sdk.routes import streaming  # noqa: F401
 from skyvern.forge.sdk.routes import streaming_commands  # noqa: F401
 from skyvern.forge.sdk.routes import streaming_vnc  # noqa: F401
+from skyvern.forge.sdk.routes import webhooks  # noqa: F401

--- a/skyvern/forge/sdk/routes/webhooks.py
+++ b/skyvern/forge/sdk/routes/webhooks.py
@@ -1,0 +1,173 @@
+from time import perf_counter
+
+import httpx
+import structlog
+from fastapi import Depends
+
+from skyvern.exceptions import BlockedHost, SkyvernHTTPException
+from skyvern.forge import app
+from skyvern.forge.sdk.core.security import generate_skyvern_webhook_headers
+from skyvern.forge.sdk.db.enums import OrganizationAuthTokenType
+from skyvern.forge.sdk.routes.routers import base_router, legacy_base_router
+from skyvern.forge.sdk.schemas.organizations import Organization
+from skyvern.forge.sdk.services import org_auth_service
+from skyvern.schemas.webhooks import TestWebhookRequest, TestWebhookResponse
+from skyvern.services.webhook_service import build_sample_task_payload, build_sample_workflow_run_payload
+from skyvern.utils.url_validators import validate_url
+
+LOG = structlog.get_logger()
+
+
+@legacy_base_router.post(
+    "/internal/test-webhook",
+    tags=["Internal"],
+    description="Test a webhook endpoint by sending a sample payload",
+    summary="Test webhook endpoint",
+)
+@base_router.post(
+    "/internal/test-webhook",
+    tags=["Internal"],
+    description="Test a webhook endpoint by sending a sample payload",
+    summary="Test webhook endpoint",
+)
+async def test_webhook(
+    request: TestWebhookRequest,
+    current_org: Organization = Depends(org_auth_service.get_current_org),
+) -> TestWebhookResponse:
+    """
+    Test a webhook endpoint by sending a sample signed payload.
+
+    This endpoint allows users to:
+    - Validate their webhook receiver can be reached
+    - Test HMAC signature verification
+    - See the exact headers and payload format Skyvern sends
+
+    The endpoint respects SSRF protection (BLOCKED_HOSTS, private IPs) and will return
+    a helpful error message if the URL is blocked.
+    """
+    start_time = perf_counter()
+
+    # Validate the URL (raises BlockedHost or SkyvernHTTPException for invalid URLs)
+    try:
+        validated_url = validate_url(request.webhook_url)
+        if not validated_url:
+            return TestWebhookResponse(
+                status_code=None,
+                latency_ms=0,
+                response_body="",
+                headers_sent={},
+                error="Invalid webhook URL",
+            )
+    except BlockedHost as exc:
+        return TestWebhookResponse(
+            status_code=None,
+            latency_ms=0,
+            response_body="",
+            headers_sent={},
+            error=(
+                f"This URL is blocked by SSRF protection (host: {exc.host}). "
+                "Add the host to ALLOWED_HOSTS to test internal endpoints or use an external receiver "
+                "such as webhook.site or requestbin.com."
+            ),
+        )
+    except SkyvernHTTPException as exc:
+        error_message = getattr(exc, "message", None) or "Invalid webhook URL. Use http(s) and a valid host."
+        return TestWebhookResponse(
+            status_code=None,
+            latency_ms=0,
+            response_body="",
+            headers_sent={},
+            error=error_message,
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard
+        LOG.error("Error validating webhook URL", error=str(exc), webhook_url=request.webhook_url)
+        return TestWebhookResponse(
+            status_code=None,
+            latency_ms=0,
+            response_body="",
+            headers_sent={},
+            error="Unexpected error while validating the webhook URL.",
+        )
+
+    # Build the sample payload based on run type
+    try:
+        if request.run_type == "task":
+            payload = build_sample_task_payload(run_id=request.run_id)
+        else:  # workflow_run
+            payload = build_sample_workflow_run_payload(run_id=request.run_id)
+    except Exception as e:
+        LOG.error("Error building sample payload", error=str(e), run_type=request.run_type)
+        return TestWebhookResponse(
+            status_code=None,
+            latency_ms=0,
+            response_body="",
+            headers_sent={},
+            error=f"Failed to build sample payload: {str(e)}",
+        )
+
+    # Get the organization's API key to sign the webhook
+    # For testing, we use a placeholder if no API key is available
+    api_key_obj = await app.DATABASE.get_valid_org_auth_token(
+        current_org.organization_id,
+        OrganizationAuthTokenType.api.value,
+    )
+    api_key = api_key_obj.token if api_key_obj else "test_api_key_placeholder"
+
+    headers = generate_skyvern_webhook_headers(payload=payload, api_key=api_key)
+
+    # Send the webhook request
+    status_code = None
+    response_body = ""
+    error = None
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                validated_url,
+                content=payload,
+                headers=headers,
+                timeout=httpx.Timeout(10.0),
+            )
+            status_code = response.status_code
+
+            # Capture first 2KB of response body
+            response_text = response.text
+            if len(response_text) > 2048:
+                response_body = response_text[:2048] + "\n... (truncated)"
+            else:
+                response_body = response_text
+
+    except httpx.TimeoutException:
+        error = "Request timed out after 10 seconds."
+        LOG.warning(
+            "Test webhook timeout",
+            organization_id=current_org.organization_id,
+            webhook_url=validated_url,
+        )
+    except httpx.NetworkError as exc:
+        error = f"Could not reach URL: {exc}"
+        LOG.warning(
+            "Test webhook network error",
+            organization_id=current_org.organization_id,
+            webhook_url=validated_url,
+            error=str(exc),
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard
+        error = f"Unexpected error: {exc}"
+        LOG.error(
+            "Test webhook unexpected error",
+            organization_id=current_org.organization_id,
+            webhook_url=validated_url,
+            error=str(exc),
+            exc_info=True,
+        )
+
+    latency_ms = int((perf_counter() - start_time) * 1000)
+
+    return TestWebhookResponse(
+        status_code=status_code,
+        latency_ms=latency_ms,
+        response_body=response_body,
+        headers_sent=headers,
+        error=error,
+    )

--- a/skyvern/schemas/webhooks.py
+++ b/skyvern/schemas/webhooks.py
@@ -1,0 +1,17 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class TestWebhookRequest(BaseModel):
+    webhook_url: str = Field(..., description="The webhook URL to test")
+    run_type: Literal["task", "workflow_run"] = Field(..., description="Type of run to simulate")
+    run_id: str | None = Field(None, description="Optional run ID to include in the sample payload")
+
+
+class TestWebhookResponse(BaseModel):
+    status_code: int | None = Field(None, description="HTTP status code from the webhook receiver")
+    latency_ms: int = Field(..., description="Round-trip time in milliseconds")
+    response_body: str = Field(..., description="First 2KB of the response body")
+    headers_sent: dict[str, str] = Field(..., description="Headers sent with the webhook request")
+    error: str | None = Field(None, description="Error message if the request failed")

--- a/skyvern/services/webhook_service.py
+++ b/skyvern/services/webhook_service.py
@@ -1,0 +1,165 @@
+import json
+from datetime import datetime, timezone
+
+from skyvern.forge.sdk.schemas.tasks import TaskRequest, TaskResponse, TaskStatus
+from skyvern.forge.sdk.workflow.models.workflow import WorkflowRunResponseBase, WorkflowRunStatus
+from skyvern.schemas.runs import (
+    ProxyLocation,
+    RunStatus,
+    RunType,
+    TaskRunRequest,
+    TaskRunResponse,
+    WorkflowRunRequest,
+    WorkflowRunResponse,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def build_sample_task_payload(run_id: str | None = None) -> str:
+    """
+    Build a sample task webhook payload using the real TaskResponse + TaskRunResponse models
+    so schema changes are reflected automatically.
+    """
+    task_id = run_id or "tsk_sample_123456789"
+    now = _now()
+
+    task_request = TaskRequest(
+        url="https://example.com/start",
+        webhook_callback_url="https://webhook.example.com/receive",
+        navigation_goal="Visit the sample site and capture details",
+        data_extraction_goal="Collect sample output data",
+        navigation_payload={"sample_field": "sample_value"},
+        proxy_location=ProxyLocation.RESIDENTIAL,
+        extra_http_headers={"x-sample-header": "value"},
+    )
+
+    task_response = TaskResponse(
+        request=task_request,
+        task_id=task_id,
+        status=TaskStatus.completed,
+        created_at=now,
+        modified_at=now,
+        queued_at=now,
+        started_at=now,
+        finished_at=now,
+        extracted_information={
+            "sample_field": "sample_value",
+            "example_data": "This is sample extracted data from the task",
+        },
+        action_screenshot_urls=[
+            "https://example.com/screenshots/task-action-1.png",
+            "https://example.com/screenshots/task-action-2.png",
+        ],
+        screenshot_url="https://example.com/screenshots/task-final.png",
+        recording_url="https://example.com/recordings/task.mp4",
+        downloaded_files=[],
+        downloaded_file_urls=[],
+        errors=[],
+        max_steps_per_run=10,
+    )
+
+    payload_dict = json.loads(task_response.model_dump_json(exclude={"request"}))
+
+    task_run_response = TaskRunResponse(
+        run_id=task_id,
+        run_type=RunType.task_v1,
+        status=RunStatus.completed,
+        output=payload_dict.get("extracted_information"),
+        downloaded_files=None,
+        recording_url=payload_dict.get("recording_url"),
+        screenshot_urls=payload_dict.get("action_screenshot_urls"),
+        failure_reason=payload_dict.get("failure_reason"),
+        created_at=now,
+        modified_at=now,
+        queued_at=now,
+        started_at=now,
+        finished_at=now,
+        app_url=f"https://app.skyvern.com/tasks/{task_id}",
+        browser_session_id="pbs_sample_123456",
+        max_screenshot_scrolls=payload_dict.get("max_screenshot_scrolls"),
+        script_run=None,
+        errors=payload_dict.get("errors"),
+        run_request=TaskRunRequest(
+            prompt="Visit the sample site and collect information",
+            url=task_request.url,
+            webhook_url=task_request.webhook_callback_url,
+            data_extraction_schema=task_request.extracted_information_schema,
+            error_code_mapping=task_request.error_code_mapping,
+            proxy_location=task_request.proxy_location,
+            extra_http_headers=task_request.extra_http_headers,
+            browser_session_id=None,
+        ),
+    )
+
+    payload_dict.update(json.loads(task_run_response.model_dump_json(exclude_unset=True)))
+    return json.dumps(payload_dict, separators=(",", ":"), ensure_ascii=False)
+
+
+def build_sample_workflow_run_payload(run_id: str | None = None) -> str:
+    """
+    Build a sample workflow webhook payload using the real WorkflowRunResponseBase + WorkflowRunResponse models
+    so schema changes are reflected automatically.
+    """
+    workflow_run_id = run_id or "wr_sample_123456789"
+    workflow_id = "wpid_sample_123"
+    now = _now()
+
+    workflow_base = WorkflowRunResponseBase(
+        workflow_id=workflow_id,
+        workflow_run_id=workflow_run_id,
+        status=WorkflowRunStatus.completed,
+        proxy_location=ProxyLocation.RESIDENTIAL,
+        webhook_callback_url="https://webhook.example.com/receive",
+        queued_at=now,
+        started_at=now,
+        finished_at=now,
+        created_at=now,
+        modified_at=now,
+        parameters={"sample_param": "sample_value"},
+        screenshot_urls=["https://example.com/screenshots/workflow-step.png"],
+        recording_url="https://example.com/recordings/workflow.mp4",
+        downloaded_files=[],
+        downloaded_file_urls=[],
+        outputs={"result": "success", "data": "Sample workflow output"},
+        total_steps=5,
+        total_cost=0.05,
+        workflow_title="Sample Workflow",
+        browser_session_id="pbs_sample_123456",
+        errors=[],
+    )
+
+    payload_dict = json.loads(workflow_base.model_dump_json())
+
+    workflow_run_response = WorkflowRunResponse(
+        run_id=workflow_run_id,
+        run_type=RunType.workflow_run,
+        status=RunStatus.completed,
+        output=payload_dict.get("outputs"),
+        downloaded_files=None,
+        recording_url=payload_dict.get("recording_url"),
+        screenshot_urls=payload_dict.get("screenshot_urls"),
+        failure_reason=payload_dict.get("failure_reason"),
+        created_at=now,
+        modified_at=now,
+        queued_at=payload_dict.get("queued_at"),
+        started_at=payload_dict.get("started_at"),
+        finished_at=payload_dict.get("finished_at"),
+        app_url=f"https://app.skyvern.com/workflows/{workflow_id}/{workflow_run_id}",
+        browser_session_id=payload_dict.get("browser_session_id"),
+        max_screenshot_scrolls=payload_dict.get("max_screenshot_scrolls"),
+        script_run=None,
+        errors=payload_dict.get("errors"),
+        run_request=WorkflowRunRequest(
+            workflow_id=workflow_id,
+            title=payload_dict.get("workflow_title"),
+            parameters=payload_dict.get("parameters"),
+            proxy_location=ProxyLocation.RESIDENTIAL,
+            webhook_url=payload_dict.get("webhook_callback_url"),
+        ),
+    )
+
+    payload_dict.update(json.loads(workflow_run_response.model_dump_json(exclude_unset=True)))
+    return json.dumps(payload_dict, separators=(",", ":"), ensure_ascii=False)


### PR DESCRIPTION
---

🔗 This PR adds webhook testing functionality to the Skyvern frontend, allowing users to test webhook URLs directly from task and workflow creation forms with real-time validation, sample payload delivery, and response analysis.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Frontend Component**: New `TestWebhookDialog` component with comprehensive webhook testing UI including status codes, latency metrics, response body viewer, and headers inspection
- **Backend API**: New `/internal/test-webhook` endpoint that validates URLs, generates sample payloads, and sends signed webhook requests with SSRF protection
- **Integration Points**: Webhook testing buttons added to all webhook input fields across task creation forms, workflow forms, and workflow editor nodes
- **Sample Data Generation**: New service for creating realistic sample payloads for both task and workflow run webhooks using actual response models

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant Frontend
    participant Backend
    participant WebhookURL
    
    User->>Frontend: Click "Test Webhook"
    Frontend->>Backend: POST /internal/test-webhook
    Backend->>Backend: Validate URL (SSRF protection)
    Backend->>Backend: Generate sample payload
    Backend->>Backend: Sign with HMAC
    Backend->>WebhookURL: POST webhook with payload
    WebhookURL->>Backend: HTTP response
    Backend->>Frontend: Test results (status, latency, body)
    Frontend->>User: Display results with collapsible sections
```

### Impact
- **Developer Experience**: Users can now validate webhook endpoints before deploying, reducing integration debugging time
- **Security**: SSRF protection prevents testing against internal/blocked hosts while providing helpful error messages
- **Reliability**: Real payload structure testing ensures webhook receivers handle actual Skyvern data formats correctly
- **UI/UX**: Consistent testing interface across all webhook input locations with detailed response inspection capabilities

</details>

_Created with [Palmier](https://www.palmier.io)_