### PR TITLE
add browser sessions to oss router/nav

### DIFF
--- a/skyvern-frontend/src/router.tsx
+++ b/skyvern-frontend/src/router.tsx
@@ -1,5 +1,6 @@
 import { Navigate, Outlet, createBrowserRouter } from "react-router-dom";
 import { BrowserSession } from "@/routes/browserSessions/BrowserSession";
+import { BrowserSessions } from "@/routes/browserSessions/BrowserSessions";
 import { PageLayout } from "./components/PageLayout";
 import { DiscoverPage } from "./routes/discover/DiscoverPage";
 import { HistoryPage } from "./routes/history/HistoryPage";
@@ -41,6 +42,10 @@ const router = createBrowserRouter([
       </DebugStoreProvider>
     ),
     children: [
+      {
+        path: "browser-sessions",
+        element: <BrowserSessions />,
+      },
       {
         index: true,
         element: <Navigate to="/discover" />,

--- a/skyvern-frontend/src/routes/root/SideNav.tsx
+++ b/skyvern-frontend/src/routes/root/SideNav.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/util/utils";
 import {
   CounterClockwiseClockIcon,
   GearIcon,
+  GlobeIcon,
   LightningBoltIcon,
 } from "@radix-ui/react-icons";
 import { KeyIcon } from "@/components/icons/KeyIcon.tsx";
@@ -35,6 +36,11 @@ function SideNav() {
             label: "History",
             to: "/history",
             icon: <CounterClockwiseClockIcon className="size-6" />,
+          },
+          {
+            label: "Browsers",
+            to: "/browser-sessions",
+            icon: <GlobeIcon className="size-6" />,
           },
         ]}
       />


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6834/add-browser-sessions-feature-to-oss

---

🌐 This PR adds browser sessions functionality to the OSS (Open Source Software) version by integrating the BrowserSessions component into the main router and navigation menu. The changes enable users to access and manage browser sessions through a new "Browsers" navigation item in the sidebar.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Router Configuration**: Added a new route `/browser-sessions` that renders the `BrowserSessions` component in the main application router
- **Navigation Menu**: Integrated a new "Browsers" menu item in the sidebar navigation with a globe icon, linking to the browser sessions page
- **Component Import**: Added import for the `BrowserSessions` component and `GlobeIcon` from Radix UI icons

### Technical Implementation
```mermaid
flowchart TD
    A[User clicks 'Browsers' in sidebar] --> B[Navigate to /browser-sessions]
    B --> C[Router matches path]
    C --> D[Renders BrowserSessions component]
    D --> E[User can manage browser sessions]
    
    F[SideNav Component] --> G[NavLinkGroup with Browsers item]
    G --> H[GlobeIcon + Link to /browser-sessions]
```

### Impact
- **Feature Parity**: Brings browser session management capabilities to the OSS version, matching enterprise features
- **User Experience**: Provides intuitive access to browser sessions through consistent navigation patterns
- **Code Organization**: Maintains clean separation of concerns by adding the route alongside existing navigation structure without disrupting current functionality

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add browser sessions feature to router and side navigation.
> 
>   - **Routing**:
>     - Adds `BrowserSessions` route to `router.tsx` with path `/browser-sessions`.
>   - **Navigation**:
>     - Adds "Browsers" link to `SideNav.tsx` with path `/browser-sessions` and `GlobeIcon`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ec2bf44ea0a8a609c1dedf77e48d8dacdba545f6. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Browsers" menu option to the Build section of the navigation for easy access to browser sessions management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->