### PR TITLE
fix frontend none cdp url

### DIFF
--- a/skyvern-frontend/src/routes/browserSessions/BrowserSessions.tsx
+++ b/skyvern-frontend/src/routes/browserSessions/BrowserSessions.tsx
@@ -204,9 +204,7 @@ function BrowserSessions() {
                   ) : (
                     <span className="opacity-50">never</span>
                   );
-                  const cdpUrl =
-                    browserSession.browser_address ??
-                    "wss://session-staging.skyvern.com/pbs_442960015326262218/devtools/browser/f01f27e1-182b-4a33-9017-4c1146d3eb3e";
+                  const cdpUrl = browserSession.browser_address ?? "-";
 
                   return (
                     <TableRow


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix CDP URL display in `BrowserSessions.tsx` to use a placeholder when unavailable and conditionally render copy action.
> 
>   - **Bug Fix**:
>     - In `BrowserSessions.tsx`, updated CDP URL display to use "-" as a placeholder when `browser_address` is unavailable.
>     - Conditional rendering of `CopyText` component for CDP URL, only shown when a valid URL is present.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e092f7d0d3d99043eca8476789020925d5137fe4. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CDP URL display handling: Now shows "-" when the address is unavailable, with copy functionality disabled for empty values instead of displaying a fallback URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔧 This PR fixes the frontend CDP URL handling by replacing a hardcoded staging URL with a simple placeholder when no browser address is available. The change prevents displaying misleading connection information to users when browser sessions don't have valid CDP endpoints.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **URL Fallback Logic**: Replaced hardcoded staging URL `"wss://session-staging.skyvern.com/pbs_442960015326262218/devtools/browser/f01f27e1-182b-4a33-9017-4c1146d3eb3e"` with simple placeholder `"-"`
- **User Experience**: Eliminates confusion by showing a clear indicator when CDP URL is unavailable instead of a potentially invalid staging endpoint
- **Code Simplification**: Removes dependency on hardcoded staging infrastructure details from the frontend codebase

### Technical Implementation
```mermaid
flowchart TD
    A[Browser Session Data] --> B{browser_address exists?}
    B -->|Yes| C[Display actual CDP URL]
    B -->|No| D[Display "-" placeholder]
    D --> E[User sees clear unavailable indicator]
    C --> F[User can copy valid URL]
```

### Impact
- **User Experience**: Users now see a clear "-" indicator instead of a potentially confusing staging URL when CDP is unavailable
- **Code Maintainability**: Removes hardcoded staging URLs that could become stale or misleading over time
- **Error Prevention**: Prevents users from attempting to connect to invalid or inaccessible staging endpoints

</details>

_Created with [Palmier](https://www.palmier.io)_