### PR TITLE
Browser streaming: add org token to CDP connection header

### DIFF
--- a/skyvern/forge/sdk/routes/streaming_clients.py
+++ b/skyvern/forge/sdk/routes/streaming_clients.py
@@ -271,6 +271,7 @@ class Streaming:
 
     organization_id: str
     vnc_port: int
+    x_api_key: str
     websocket: WebSocket
 
     # --


### PR DESCRIPTION
	Follows https://github.com/Skyvern-AI/skyvern-cloud/pull/6904
Part of https://linear.app/skyvern/issue/SKY-5695/streaming-browser-feature-seamless-copy-paste
Context: https://skyvern.slack.com/archives/C074UNDSRJM/p1761152959585709?thread_ts=1761090749.638099&cid=C074UNDSRJM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization-level API key authentication support for streaming sessions, enabling secure context-aware operations.
  * Enhanced browser session management with organization-specific download path configuration for improved file handling during automated workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds API key authentication to streaming sessions, modifies `StreamingAgent` and `Streaming` classes, and updates functions to handle API key retrieval and usage.
> 
>   - **Behavior**:
>     - Adds API key authentication to streaming connections via headers in `streaming_agent.py`.
>     - Retrieves organization API tokens in `streaming_vnc.py` using `get_x_api_key()`.
>     - Sets download paths per organization/session in `StreamingAgent.connect()`.
>   - **Classes and Functions**:
>     - `StreamingAgent.__init__()` now requires a `streaming` parameter.
>     - `Streaming` class in `streaming_clients.py` now includes `x_api_key` attribute.
>     - `get_streaming_for_browser_session()`, `get_streaming_for_task()`, and `get_streaming_for_workflow_run()` in `streaming_vnc.py` now include API key retrieval.
>   - **Misc**:
>     - Adds `Constants.MissingXApiKey` in `streaming_vnc.py` for missing API key handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 04bfc79f8351cdbfe40f31e43f30f83137e4dff3. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->