### PR TITLE
backend - add 'paused' as a workflow run status

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1262,6 +1262,7 @@ async def _cancel_workflow_run(workflow_run_id: str, organization_id: str, x_api
             WorkflowRunStatus.running,
             WorkflowRunStatus.created,
             WorkflowRunStatus.queued,
+            WorkflowRunStatus.paused,
         ]:
             continue
         await app.WORKFLOW_SERVICE.mark_workflow_run_as_canceled(child_workflow_run.workflow_run_id)

--- a/skyvern/forge/sdk/routes/streaming_verify.py
+++ b/skyvern/forge/sdk/routes/streaming_verify.py
@@ -179,7 +179,12 @@ async def verify_workflow_run(
 
         return None, None
 
-    if workflow_run.status not in [WorkflowRunStatus.created, WorkflowRunStatus.queued, WorkflowRunStatus.running]:
+    if workflow_run.status not in [
+        WorkflowRunStatus.created,
+        WorkflowRunStatus.queued,
+        WorkflowRunStatus.running,
+        WorkflowRunStatus.paused,
+    ]:
         LOG.info(
             "Workflow run is not running.",
             workflow_run_status=workflow_run.status,

--- a/skyvern/forge/sdk/workflow/models/workflow.py
+++ b/skyvern/forge/sdk/workflow/models/workflow.py
@@ -110,6 +110,7 @@ class WorkflowRunStatus(StrEnum):
     canceled = "canceled"
     timed_out = "timed_out"
     completed = "completed"
+    paused = "paused"
 
     def is_final(self) -> bool:
         return self in [

--- a/skyvern/services/run_service.py
+++ b/skyvern/services/run_service.py
@@ -119,6 +119,7 @@ async def cancel_workflow_run(
             WorkflowRunStatus.running,
             WorkflowRunStatus.created,
             WorkflowRunStatus.queued,
+            WorkflowRunStatus.paused,
         ]:
             continue
         await app.WORKFLOW_SERVICE.mark_workflow_run_as_canceled(child_workflow_run.workflow_run_id)


### PR DESCRIPTION
BE portion of https://linear.app/skyvern/issue/SKY-6857/add-a-new-workflow-run-status-paused
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add 'paused' status to `WorkflowRunStatus` and update cancellation and verification logic to handle it.
> 
>   - **WorkflowRunStatus**:
>     - Add `paused` status to `WorkflowRunStatus` in `workflow.py`.
>     - Update `is_final()` method to exclude `paused` from final statuses.
>   - **Cancellation Logic**:
>     - Update `_cancel_workflow_run()` in `agent_protocol.py` to handle `paused` status.
>     - Update `cancel_workflow_run()` in `run_service.py` to handle `paused` status.
>   - **Verification Logic**:
>     - Update `verify_workflow_run()` in `streaming_verify.py` to include `paused` status in valid statuses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 4fc5056453f66da40ece23b3f203c2eb9cdbd277. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

⏸️ This PR adds a new `paused` status to the workflow run system, enabling workflows to be temporarily suspended while maintaining their ability to be resumed or canceled. The changes update the status enum and modify all relevant workflow handling logic to properly recognize and process paused workflows.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Status Enum Extension**: Added `paused` as a new value to the `WorkflowRunStatus` enum in the workflow models
- **Cancellation Logic**: Updated workflow cancellation functions to include paused workflows as valid candidates for cancellation
- **Verification Process**: Modified workflow run verification to allow paused workflows to continue through the verification pipeline
- **Service Layer**: Enhanced the run service to handle paused workflows consistently across all operations

### Technical Implementation
```mermaid
flowchart TD
    A[Workflow Run] --> B{Current Status}
    B -->|created| C[Can Cancel/Verify]
    B -->|queued| C
    B -->|running| C
    B -->|paused| C
    B -->|completed| D[Cannot Cancel]
    B -->|canceled| D
    B -->|timed_out| D
    
    C --> E[Cancellation Process]
    C --> F[Verification Process]
    
    E --> G[Mark as Canceled]
    F --> H[Continue Processing]
```

### Impact
- **Workflow Control**: Enables better workflow lifecycle management by allowing temporary suspension without termination
- **System Consistency**: Ensures paused workflows are handled uniformly across all system components (cancellation, verification, monitoring)
- **Operational Flexibility**: Provides operators with more granular control over long-running workflows that may need temporary pausing

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added paused workflow run state as a new status in the workflow lifecycle, enabling better workflow state management
* Paused workflow runs can now be canceled when parent workflows are canceled, extending cascade cancellation to previously non-cancelable paused child runs
* Extended workflow verification process to properly support and handle paused workflow run states with appropriate browser session establishment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->