### PR TITLE
Backend: implement InteractionBlock

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -95,6 +95,12 @@ class Settings(BaseSettings):
     SKYVERN_TELEMETRY: bool = True
     ANALYTICS_ID: str = "anonymous"
 
+    # email settings
+    SMTP_HOST: str = "localhost"
+    SMTP_PORT: int = 25
+    SMTP_USERNAME: str = "username"
+    SMTP_PASSWORD: str = "password"
+
     # browser settings
     BROWSER_LOCALE: str = "en-US"
     BROWSER_TIMEZONE: str = "America/New_York"

--- a/skyvern/core/script_generations/generate_script.py
+++ b/skyvern/core/script_generations/generate_script.py
@@ -872,6 +872,13 @@ def _build_validate_statement(
     return cst.SimpleStatementLine([cst.Expr(cst.Await(call))])
 
 
+def _build_human_interaction_statement(
+    block: dict[str, Any],
+) -> cst.SimpleStatementLine:
+    LOG.warning("Human interaction code generation is not yet implemented.", block=block)
+    return cst.SimpleStatementLine([cst.Expr(cst.Comment("# TODO: Implement human interaction logic"))])
+
+
 def _build_wait_statement(block: dict[str, Any]) -> cst.SimpleStatementLine:
     """Build a skyvern.wait statement."""
     args = [
@@ -1577,6 +1584,8 @@ def _build_block_statement(block: dict[str, Any], data_variable_name: str | None
             stmt = _build_navigate_statement(block_title, block, data_variable_name)
     elif block_type == "validation":
         stmt = _build_validate_statement(block_title, block, data_variable_name)
+    elif block_type == "human_interaction":
+        stmt = _build_human_interaction_statement(block)
     elif block_type == "task_v2":
         stmt = _build_run_task_statement(block_title, block, data_variable_name)
     elif block_type == "send_email":

--- a/skyvern/forge/sdk/api/email.py
+++ b/skyvern/forge/sdk/api/email.py
@@ -1,0 +1,77 @@
+import smtplib
+from email.message import EmailMessage
+
+import structlog
+from email_validator import EmailNotValidError, validate_email
+
+from skyvern.config import settings
+
+LOG = structlog.get_logger()
+
+
+async def _send(*, message: EmailMessage) -> bool:
+    try:
+        smtp_host = smtplib.SMTP(settings.SMTP_HOST, settings.SMTP_PORT)
+
+        LOG.info("email: Connected to SMTP server")
+
+        smtp_host.starttls()
+        smtp_host.login(settings.SMTP_USERNAME, settings.SMTP_PASSWORD)
+
+        LOG.info("email: Logged in to SMTP server")
+
+        smtp_host.send_message(message)
+
+        LOG.info("email: Email sent")
+    except Exception as e:
+        LOG.error("email: Failed to send email", error=str(e))
+        raise e
+
+    return True
+
+
+def validate_recipients(recipients: list[str]) -> None:
+    for recipient in recipients:
+        try:
+            validate_email(recipient)
+        except EmailNotValidError:
+            raise Exception(
+                f"invalid email address: {recipient}",
+            )
+
+
+async def build_message(
+    *,
+    body: str | None = None,
+    recipients: list[str],
+    sender: str,
+    subject: str,
+) -> EmailMessage:
+    to = ", ".join(recipients)
+    msg = EmailMessage()
+    msg["BCC"] = sender  # BCC the sender so there is a record of the email being sent
+    msg["From"] = sender
+    msg["Subject"] = subject
+    msg["To"] = to
+    msg.set_content(body)
+
+    return msg
+
+
+async def send(
+    *,
+    sender: str,
+    subject: str,
+    recipients: list[str],
+    body: str | None = None,
+) -> bool:
+    validate_recipients(recipients)
+
+    message = await build_message(
+        body=body,
+        recipients=recipients,
+        sender=sender,
+        subject=subject,
+    )
+
+    return await _send(message=message)

--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -1975,7 +1975,11 @@ class AgentDB:
             raise
 
     async def get_workflow_run(
-        self, workflow_run_id: str, organization_id: str | None = None, job_id: str | None = None
+        self,
+        workflow_run_id: str,
+        organization_id: str | None = None,
+        job_id: str | None = None,
+        status: WorkflowRunStatus | None = None,
     ) -> WorkflowRun | None:
         try:
             async with self.Session() as session:
@@ -1984,6 +1988,8 @@ class AgentDB:
                     get_workflow_run_query = get_workflow_run_query.filter_by(organization_id=organization_id)
                 if job_id:
                     get_workflow_run_query = get_workflow_run_query.filter_by(job_id=job_id)
+                if status:
+                    get_workflow_run_query = get_workflow_run_query.filter_by(status=status.value)
                 if workflow_run := (await session.scalars(get_workflow_run_query)).first():
                     return convert_to_workflow_run(workflow_run)
                 return None

--- a/skyvern/schemas/workflows.py
+++ b/skyvern/schemas/workflows.py
@@ -37,6 +37,7 @@ class BlockType(StrEnum):
     GOTO_URL = "goto_url"
     PDF_PARSER = "pdf_parser"
     HTTP_REQUEST = "http_request"
+    HUMAN_INTERACTION = "human_interaction"
 
 
 class BlockStatus(StrEnum):
@@ -429,6 +430,20 @@ class WaitBlockYAML(BlockYAML):
     wait_sec: int = 0
 
 
+class HumanInteractionBlockYAML(BlockYAML):
+    block_type: Literal[BlockType.HUMAN_INTERACTION] = BlockType.HUMAN_INTERACTION  # type: ignore
+
+    instructions: str = "Please review and approve or reject to continue the workflow."
+    positive_descriptor: str = "Approve"
+    negative_descriptor: str = "Reject"
+    timeout_seconds: int
+
+    sender: str
+    recipients: list[str]
+    subject: str
+    body: str
+
+
 class FileDownloadBlockYAML(BlockYAML):
     block_type: Literal[BlockType.FILE_DOWNLOAD] = BlockType.FILE_DOWNLOAD  # type: ignore
 
@@ -511,6 +526,7 @@ BLOCK_YAML_SUBCLASSES = (
     | ExtractionBlockYAML
     | LoginBlockYAML
     | WaitBlockYAML
+    | HumanInteractionBlockYAML
     | FileDownloadBlockYAML
     | UrlBlockYAML
     | PDFParserBlockYAML


### PR DESCRIPTION
	## What

- adds new `HumanInteractionBlock`
- auto-creates new browser session for workflows that have 1 or more `InteractionBlock`s, _and_ the run request did not have a pbs id
- automatically browser sessions that have been auto-created
- refactors existing email code from SendEmailBlock into module

From the debugger UI, I tested that:
- the block runs
- the email is sent
- the block times out (honouring its timeout option)

## Why 

context: https://skyvern.slack.com/archives/C07B3K5FCKH/p1761092644375069
context: https://www.notion.so/Need-it-next-week-Support-a-Pause-workflow-block-that-allows-users-to-continue-Human-in-the-lo-11b426c42cd4807aa345ce7ea6f5bcd8
https://linear.app/skyvern/issue/SKY-6845/implement-new-hitl-block-type-on-the-backend-name-tbd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added email configuration settings (SMTP host, port, username, password credentials) to enable email delivery capabilities.
* Introduced Human Interaction workflow blocks that send approval requests via email and handle user responses automatically.
* Added ability to pause and resume workflow execution mid-process.
* Automatic persistent browser session creation for workflows containing human interaction approval blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces `HumanInteractionBlock` for human input in workflows, with email notifications and timeout handling, and refactors email logic.
> 
>   - **New Features**:
>     - Adds `HumanInteractionBlock` in `block.py` for workflows to pause for human input, with email notifications and timeout handling.
>     - Updates `service.py` to auto-create browser sessions for workflows with `HumanInteractionBlock`.
>     - Adds `continue_workflow_run` endpoint in `agent_protocol.py` to resume paused workflows.
>   - **Refactoring**:
>     - Moves email sending logic to `email.py`.
>   - **Configuration**:
>     - Adds SMTP configuration fields to `config.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 40e6aa79c01fb93fffc74c0166ebe5f9f1a9cfd6. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->