### PR TITLE
get task v2 block disable_cache value back

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -1089,6 +1089,7 @@ function getWorkflowBlock(node: WorkflowBlockNode): BlockYAML {
         totp_identifier: node.data.totpIdentifier,
         totp_verification_url: node.data.totpVerificationUrl,
         url: node.data.url,
+        disable_cache: node.data.disableCache ?? false,
       };
     }
     case "validation": {
@@ -1894,6 +1895,7 @@ function convertBlocksToBlockYAML(
           max_steps: block.max_steps,
           totp_identifier: block.totp_identifier,
           totp_verification_url: block.totp_verification_url,
+          disable_cache: block.disable_cache ?? false,
         };
         return blockYaml;
       }

--- a/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowYamlTypes.ts
@@ -174,6 +174,7 @@ export type Taskv2BlockYAML = BlockYAMLBase & {
   totp_verification_url: string | null;
   totp_identifier: string | null;
   max_steps: number | null;
+  disable_cache: boolean;
 };
 
 export type ValidationBlockYAML = BlockYAMLBase & {


### PR DESCRIPTION
reverted by mistake: https://github.com/Skyvern-AI/skyvern/pull/3814/files
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `disable_cache` property to `Taskv2BlockYAML` with default `false` in `workflowEditorUtils.ts` and `workflowYamlTypes.ts`.
> 
>   - **Behavior**:
>     - Adds `disable_cache` property to `Taskv2BlockYAML` in `workflowYamlTypes.ts`.
>     - Sets `disable_cache` to `false` by default in `getWorkflowBlock()` and `convertBlocksToBlockYAML()` in `workflowEditorUtils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d7088b9f2b1a7c4a34b7055b601cac01fbbc9999. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cache control for workflow task blocks, enabling users to disable caching on individual tasks during workflow execution. Cache remains enabled by default to maintain backward compatibility with existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->