### PR TITLE
point flash and flash lite to stable

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -395,11 +395,11 @@ class Settings(BaseSettings):
         if self.is_cloud_environment():
             return {
                 "gemini-2.5-pro-preview-05-06": {"llm_key": "VERTEX_GEMINI_2.5_PRO", "label": "Gemini 2.5 Pro"},
-                "gemini-2.5-flash-preview-09-2025": {
+                "gemini-2.5-flash": {
                     "llm_key": "VERTEX_GEMINI_2.5_FLASH",
                     "label": "Gemini 2.5 Flash",
                 },
-                "gemini-2.5-flash-lite-preview-09-2025": {
+                "gemini-2.5-flash-lite": {
                     "llm_key": "VERTEX_GEMINI_2.5_FLASH_LITE",
                     "label": "Gemini 2.5 Flash Lite",
                 },
@@ -431,11 +431,11 @@ class Settings(BaseSettings):
             # TODO: apparently the list for OSS is to be much larger
             return {
                 "gemini-2.5-pro-preview-05-06": {"llm_key": "VERTEX_GEMINI_2.5_PRO", "label": "Gemini 2.5 Pro"},
-                "gemini-2.5-flash-preview-09-2025": {
+                "gemini-2.5-flash": {
                     "llm_key": "VERTEX_GEMINI_2.5_FLASH",
                     "label": "Gemini 2.5 Flash",
                 },
-                "gemini-2.5-flash-lite-preview-09-2025": {
+                "gemini-2.5-flash-lite": {
                     "llm_key": "VERTEX_GEMINI_2.5_FLASH_LITE",
                     "label": "Gemini 2.5 Flash Lite",
                 },

--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -1190,14 +1190,14 @@ if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
     LLMConfigRegistry.register_config(
         "VERTEX_GEMINI_2.5_FLASH",
         LLMConfig(
-            "vertex_ai/gemini-2.5-flash-preview-09-2025",
+            "vertex_ai/gemini-2.5-flash",
             ["VERTEX_CREDENTIALS"],
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=65535,
             litellm_params=LiteLLMParams(
                 vertex_credentials=settings.VERTEX_CREDENTIALS,
-                api_base=f"{api_base}/gemini-2.5-flash-preview-09-2025" if api_base else None,
+                api_base=f"{api_base}/gemini-2.5-flash" if api_base else None,
                 vertex_location=settings.VERTEX_LOCATION,
                 thinking={
                     "budget_tokens": settings.GEMINI_THINKING_BUDGET,
@@ -1209,14 +1209,14 @@ if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
     LLMConfigRegistry.register_config(
         "VERTEX_GEMINI_2.5_FLASH_LITE",
         LLMConfig(
-            "vertex_ai/gemini-2.5-flash-lite-preview-09-2025",
+            "vertex_ai/gemini-2.5-flash-lite",
             ["VERTEX_CREDENTIALS"],
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=65535,
             litellm_params=LiteLLMParams(
                 vertex_credentials=settings.VERTEX_CREDENTIALS,
-                api_base=f"{api_base}/gemini-2.5-flash-lite-preview-09-2025" if api_base else None,
+                api_base=f"{api_base}/gemini-2.5-flash-lite" if api_base else None,
                 vertex_location=settings.VERTEX_LOCATION,
                 thinking={
                     "budget_tokens": settings.GEMINI_THINKING_BUDGET,


### PR DESCRIPTION
	Apparently the 429 errors are for the preview models, shouldn't happen for the stable ones
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Updated Gemini 2.5 Flash and Flash Lite model identifiers to stable versions and maintained backward compatibility with aliases.
> 
>   - **Model Identifiers**:
>     - Updated `gemini-2.5-flash-preview-09-2025` to `gemini-2.5-flash` in `skyvern/config.py` and `config_registry.py`.
>     - Updated `gemini-2.5-flash-lite-preview-09-2025` to `gemini-2.5-flash-lite` in `skyvern/config.py` and `config_registry.py`.
>   - **Backward Compatibility**:
>     - Aliased old preview model names to maintain compatibility in `config_registry.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5a1d742e6257f2d77439e5b89f843ecee6a4d502. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Gemini 2.5 Flash and Gemini 2.5 Flash Lite model identifiers for Vertex AI to use simplified naming conventions, replacing preview suffixes with standard identifiers.
  * Maintained backward compatibility with existing model configurations and aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->