### PR TITLE
BE: allow workflow run UI to show browser stream if workflow run has one

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -1878,6 +1878,7 @@ class AgentDB:
         sequential_key: str | None = None,
         ai_fallback: bool | None = None,
         depends_on_workflow_run_id: str | None = None,
+        browser_session_id: str | None = None,
     ) -> WorkflowRun:
         async with self.Session() as session:
             workflow_run = (
@@ -1908,6 +1909,8 @@ class AgentDB:
                     workflow_run.ai_fallback = ai_fallback
                 if depends_on_workflow_run_id:
                     workflow_run.depends_on_workflow_run_id = depends_on_workflow_run_id
+                if browser_session_id:
+                    workflow_run.browser_session_id = browser_session_id
                 await session.commit()
                 await session.refresh(workflow_run)
                 await save_workflow_run_logs(workflow_run_id)

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -465,6 +465,10 @@ class WorkflowService:
         if browser_session:
             browser_session_id = browser_session.persistent_browser_session_id
             close_browser_on_completion = True
+            await app.DATABASE.update_workflow_run(
+                workflow_run_id=workflow_run.workflow_run_id,
+                browser_session_id=browser_session_id,
+            )
 
         # Check if there's a related workflow script that should be used instead
         workflow_script, _ = await workflow_script_service.get_workflow_script(workflow, workflow_run, block_labels)


### PR DESCRIPTION
Backend part of [SKY-6903/hil-autonomous-run-ui-supporting-take-control](https://linear.app/skyvern/issue/SKY-6903/hil-autonomous-run-ui-supporting-take-control)

Precedes https://github.com/Skyvern-AI/skyvern-cloud/pull/6988

Change: update a workflow run's browser session id if it has a browser session.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update backend to allow updating a workflow run's browser session ID if it has a browser session.
> 
>   - **Behavior**:
>     - Update `update_workflow_run` in `client.py` to accept `browser_session_id` and update the workflow run's browser session ID if provided.
>     - Modify `execute_workflow` in `service.py` to update the workflow run's browser session ID when a browser session is created.
>   - **Functions**:
>     - Add `browser_session_id` parameter to `update_workflow_run()` in `client.py`.
>     - Call `update_workflow_run()` with `browser_session_id` in `execute_workflow()` in `service.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 79b44118a8698e66cfff6712b6a5a916ac4d551c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔗 This PR enables workflow runs to display browser streams in the UI by linking workflow runs with their associated browser sessions through database updates.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Database Layer**: Added `browser_session_id` parameter to `update_workflow_run()` method in `client.py` to store browser session references
- **Workflow Service**: Modified `execute_workflow()` in `service.py` to automatically update workflow runs with browser session IDs when sessions are created
- **UI Integration**: Establishes the backend foundation for displaying browser streams in the workflow run UI

### Technical Implementation
```mermaid
sequenceDiagram
    participant WS as Workflow Service
    participant DB as Database Client
    participant WR as Workflow Run
    participant BS as Browser Session
    
    WS->>BS: Create browser session
    BS-->>WS: Return session with ID
    WS->>DB: update_workflow_run(browser_session_id)
    DB->>WR: Set browser_session_id field
    WR-->>DB: Updated workflow run
    Note over WR: Now linked to browser session for UI streaming
```

### Impact
- **UI Enhancement**: Enables the frontend to access and display live browser streams for workflow runs
- **Data Consistency**: Maintains proper relationships between workflow runs and their browser sessions
- **User Experience**: Supports the "take control" feature mentioned in the Linear issue, allowing users to interact with running workflows
- **Backward Compatibility**: Changes are additive with optional parameters, ensuring existing functionality remains intact

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow runs now automatically track and persist browser session associations during execution, improving session continuity and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->