### PR TITLE
make templating strictness easy to switch between

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -114,6 +114,7 @@ class Settings(BaseSettings):
 
     # Workflow constant parameters
     WORKFLOW_DOWNLOAD_DIRECTORY_PARAMETER_KEY: str = "SKYVERN_DOWNLOAD_DIRECTORY"
+    WORKFLOW_TEMPLATING_STRICTNESS: str = "strict"  # options: "strict", "lax"
     WORKFLOW_WAIT_BLOCK_MAX_SEC: int = 30 * 60
 
     # Saved browser session settings


### PR DESCRIPTION
## What 

Adds `settings.WORKFLOW_TEMPLATING_STRICTNESS`, either `lax` or `strict`. Default to `strict`.

## Why 

https://github.com/Skyvern-AI/skyvern-cloud/pull/6987 made templating more strict for blocks. It hasn't been deployed yet. I want to deploy it.

This PR will make it easy to switch templating back to lax, in the case where issues arise with first deploy.

---

⚙️ This PR introduces a configurable templating strictness setting for workflow blocks, allowing easy switching between strict and lax Jinja template validation modes. The change adds a new configuration parameter `WORKFLOW_TEMPLATING_STRICTNESS` that defaults to "strict" but can be set to "lax" for more permissive template handling during deployments.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Configuration Addition**: Added `WORKFLOW_TEMPLATING_STRICTNESS` setting in `skyvern/config.py` with options "strict" (default) or "lax"
- **Template Environment**: Modified Jinja sandbox environment initialization to conditionally use `StrictUndefined` based on the strictness setting
- **Error Handling**: Made missing variable validation conditional - only enforced in strict mode, allowing templates with undefined variables in lax mode

### Technical Implementation
```mermaid
flowchart TD
    A[Workflow Block Processing] --> B{Check WORKFLOW_TEMPLATING_STRICTNESS}
    B -->|strict| C[Use StrictUndefined Environment]
    B -->|lax| D[Use Default Environment]
    C --> E[Validate Missing Variables]
    D --> F[Skip Variable Validation]
    E --> G{Missing Variables?}
    G -->|Yes| H[Raise MissingJinjaVariables Exception]
    G -->|No| I[Render Template]
    F --> I
    I --> J[Return Rendered Result]
```

### Impact
- **Deployment Safety**: Provides a quick rollback mechanism if strict templating causes issues in production
- **Backward Compatibility**: Maintains existing behavior when set to "lax" mode, ensuring no breaking changes for existing workflows
- **Operational Flexibility**: Allows teams to gradually migrate to stricter templating validation without immediate disruption to existing workflows

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `WORKFLOW_TEMPLATING_STRICTNESS` setting to control Jinja template strictness in workflows.
> 
>   - **Settings**:
>     - Add `WORKFLOW_TEMPLATING_STRICTNESS` to `Settings` in `config.py`, defaulting to `strict`.
>   - **Jinja Environment**:
>     - In `block.py`, use `WORKFLOW_TEMPLATING_STRICTNESS` to choose between `StrictUndefined` and default Jinja environment.
>   - **Error Handling**:
>     - In `format_block_parameter_template_from_workflow_run_context()` in `block.py`, conditionally raise `MissingJinjaVariables` based on `WORKFLOW_TEMPLATING_STRICTNESS`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1b6bad9789a901231c1a14b36d90283e061bc6a0. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow template validation strictness setting with "strict" and "lax" modes, controlling how missing variables are handled during template processing. Defaults to "strict" mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->