### PR TITLE
FE: allow workflow run UI to show browser stream if workflow run has one

### DIFF
--- a/skyvern-frontend/src/components/BrowserStream.tsx
+++ b/skyvern-frontend/src/components/BrowserStream.tsx
@@ -476,6 +476,11 @@ function BrowserStream({
     }
   }, [task, workflow]);
 
+  useEffect(() => {
+    if (!interactive) {
+      setUserIsControlling(false);
+    }
+  }, [interactive]);
   /**
    * TODO(jdo): could use zod or smth similar
    */


### PR DESCRIPTION
Frontend part of [SKY-6903/hil-autonomous-run-ui-supporting-take-control](https://linear.app/skyvern/issue/SKY-6903/hil-autonomous-run-ui-supporting-take-control)

Follows https://github.com/Skyvern-AI/skyvern-cloud/pull/6989

- show browser live stream in workflow run UI if there is a browser session, and
- if the workflow run is paused, show take-control/stop-controlling buttons on the live stream

<img width="1107" height="795" alt="image" src="https://github.com/user-attachments/assets/d9c231b3-b754-4c54-927c-ef5f3004eb7c" />

Can no longer interact after approval (because the agent is running the show now):

<img width="1068" height="729" alt="image" src="https://github.com/user-attachments/assets/98112384-c84d-41b1-b9c1-f06d4aa2b814" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed control state handling to properly reset when interactive mode is disabled, preventing stale control states.

* **Improvements**
  * Enhanced streaming browser view logic for clearer separation between interactive streaming and static view modes.
  * Optimized workflow run data handling and refresh mechanisms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🖥️ This PR enhances the workflow run UI to display live browser streams when a workflow has an active browser session, with interactive controls when the workflow is paused for human intervention.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Browser Stream Component**: Added useEffect hook to properly reset user control state when interactive mode is disabled
- **Workflow Run Overview**: Refactored streaming logic to conditionally show browser stream based on browser session availability and workflow status
- **Interactive Controls**: Added support for showing take-control/stop-controlling buttons when workflow is paused for human interaction
- **State Management**: Improved query invalidation logic by extracting workflowRunId for better dependency tracking

### Technical Implementation
```mermaid
flowchart TD
    A[Workflow Run UI] --> B{Has Browser Session?}
    B -->|Yes| C{Is Workflow Paused?}
    B -->|No| D[Show Workflow Run Stream]
    C -->|Yes| E[Show Interactive Browser Stream]
    C -->|No| F[Show Read-only Browser Stream]
    E --> G[Display Control Buttons]
    F --> H[Hide Control Buttons]
    G --> I[User Can Take Control]
    H --> J[View Only Mode]
```

### Impact
- **User Experience**: Users can now view live browser sessions during workflow execution and take control when workflows are paused for human intervention
- **Human-in-the-Loop Workflows**: Enables seamless transition between autonomous execution and human control during workflow runs
- **State Consistency**: Improved state management ensures UI controls are properly synchronized with workflow status changes

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances workflow run UI to show browser stream and control buttons based on run status in `BrowserStream.tsx` and `WorkflowRunOverview.tsx`.
> 
>   - **UI Enhancements**:
>     - `BrowserStream.tsx`: Adds `interactive` and `showControlButtons` props to manage control buttons visibility based on workflow run status.
>     - `WorkflowRunOverview.tsx`: Determines when to show `BrowserStream` or `WorkflowRunStream` based on `workflowRun` status and selection.
>   - **Behavior**:
>     - Shows browser live stream if `browser_session_id` is present and workflow run is not finalized.
>     - Displays control buttons when workflow run is paused, allowing users to take or stop control.
>   - **Misc**:
>     - Refactors query invalidation logic in `WorkflowRunOverview.tsx` for better efficiency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 8ccb270e8293c53493aeefab874a8f8715695930. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->