### PR TITLE
making gpt5 models have temp 1

### DIFF
--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -80,7 +80,7 @@ if settings.ENABLE_OPENAI:
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=128000,
-            temperature=None,
+            temperature=1,  # GPT-5 only supports temperature=1
             reasoning_effort=settings.GPT5_REASONING_EFFORT,
         ),
     )
@@ -92,7 +92,7 @@ if settings.ENABLE_OPENAI:
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=128000,
-            temperature=None,
+            temperature=1,  # GPT-5 only supports temperature=1
             reasoning_effort=settings.GPT5_REASONING_EFFORT,
         ),
     )
@@ -104,7 +104,7 @@ if settings.ENABLE_OPENAI:
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=128000,
-            temperature=None,
+            temperature=1,  # GPT-5 only supports temperature=1
             reasoning_effort=settings.GPT5_REASONING_EFFORT,
         ),
     )
@@ -606,7 +606,7 @@ if settings.ENABLE_AZURE_GPT5:
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=128000,
-            temperature=None,
+            temperature=1,  # GPT-5 only supports temperature=1
             reasoning_effort=settings.GPT5_REASONING_EFFORT,
         ),
     )
@@ -631,7 +631,7 @@ if settings.ENABLE_AZURE_GPT5_MINI:
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=128000,
-            temperature=None,
+            temperature=1,  # GPT-5 only supports temperature=1
             reasoning_effort=settings.GPT5_REASONING_EFFORT,
         ),
     )
@@ -656,7 +656,7 @@ if settings.ENABLE_AZURE_GPT5_NANO:
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=128000,
-            temperature=None,
+            temperature=1,  # GPT-5 only supports temperature=1
             reasoning_effort=settings.GPT5_REASONING_EFFORT,
         ),
     )


### PR DESCRIPTION
Otherwise we get:

```
Error doing the fallback: litellm.UnsupportedParamsError: gpt-5 models (including gpt-5-codex) don't support temperature=0.0. Only temperature=1 is supported. To drop unsupported params set `litellm.drop_params = True`
```
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Set `temperature=1` for all GPT-5 models in `config_registry.py` to prevent `UnsupportedParamsError`.
> 
>   - **Behavior**:
>     - Set `temperature=1` for all GPT-5 models in `config_registry.py` to avoid `UnsupportedParamsError`.
>     - Affects `OPENAI_GPT5`, `OPENAI_GPT5_MINI`, `OPENAI_GPT5_NANO`, `AZURE_OPENAI_GPT5`, `AZURE_OPENAI_GPT5_MINI`, and `AZURE_OPENAI_GPT5_NANO` configurations.
>   - **Misc**:
>     - Add comments indicating GPT-5 only supports `temperature=1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 365fc4fc7d24ae16311bb1eae57a6ee6f3d56304. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Updated temperature settings for GPT-5 models across all supported providers to ensure consistent and reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔧 This PR fixes a compatibility issue with GPT-5 models by setting their temperature parameter to 1, which is the only supported value for these models. The change prevents `UnsupportedParamsError` exceptions that were occurring when the temperature was set to `None` (defaulting to 0.0).

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Model Configuration**: Updated temperature parameter from `None` to `1` for all GPT-5 model variants in the config registry
- **Error Prevention**: Added explanatory comments indicating that GPT-5 models only support temperature=1
- **Scope**: Affects 6 different GPT-5 model configurations including OpenAI and Azure OpenAI variants (standard, mini, nano)

### Technical Implementation
```mermaid
flowchart TD
    A[GPT-5 Model Request] --> B{Temperature Parameter}
    B -->|temperature=None/0.0| C[UnsupportedParamsError]
    B -->|temperature=1| D[Successful API Call]
    C --> E[Request Fails]
    D --> F[Model Response Generated]
    
    style C fill:#ffcccc
    style D fill:#ccffcc
```

### Impact
- **Error Resolution**: Eliminates `litellm.UnsupportedParamsError` exceptions when using GPT-5 models
- **API Compatibility**: Ensures proper integration with OpenAI's GPT-5 API requirements
- **System Stability**: Prevents fallback errors that could disrupt model inference workflows
- **Backward Compatibility**: No breaking changes as this only affects GPT-5 models specifically

</details>

_Created with [Palmier](https://www.palmier.io)_