### PR TITLE
set workflow status to 'published' when a user saves a workflow

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -291,7 +291,7 @@ function FlowRenderer({
   const workflowChangesStore = useWorkflowHasChangesStore();
   const setGetSaveDataRef = useRef(workflowChangesStore.setGetSaveData);
   setGetSaveDataRef.current = workflowChangesStore.setGetSaveData;
-  const saveWorkflow = useWorkflowSave();
+  const saveWorkflow = useWorkflowSave({ status: "published" });
   useShouldNotifyWhenClosingTab(workflowChangesStore.hasChanges);
   const blocker = useBlocker(({ currentLocation, nextLocation }) => {
     return (

--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -213,7 +213,7 @@ function Workspace({
     useWorkflowPanelStore();
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
-  const saveWorkflow = useWorkflowSave();
+  const saveWorkflow = useWorkflowSave({ status: "published" });
 
   const { data: workflowRun } = useWorkflowRunQuery();
   const isFinalized = workflowRun ? statusIsFinalized(workflowRun) : false;

--- a/skyvern-frontend/src/store/WorkflowHasChangesStore.ts
+++ b/skyvern-frontend/src/store/WorkflowHasChangesStore.ts
@@ -37,6 +37,10 @@ type WorkflowHasChangesStore = {
   setShowConfirmCodeCacheDeletion: (show: boolean) => void;
 };
 
+interface WorkflowSaveOpts {
+  status?: string;
+}
+
 const useWorkflowHasChangesStore = create<WorkflowHasChangesStore>((set) => {
   return {
     hasChanges: false,
@@ -62,7 +66,7 @@ const useWorkflowHasChangesStore = create<WorkflowHasChangesStore>((set) => {
   };
 });
 
-const useWorkflowSave = () => {
+const useWorkflowSave = (opts?: WorkflowSaveOpts) => {
   const credentialGetter = useCredentialGetter();
   const queryClient = useQueryClient();
   const {
@@ -139,7 +143,7 @@ const useWorkflowSave = () => {
           blocks: saveData.blocks,
         },
         is_saved_task: saveData.workflow.is_saved_task,
-        status: saveData.workflow.status,
+        status: opts?.status ?? saveData.workflow.status,
         run_sequentially: saveData.settings.runSequentially,
         sequential_key: saveData.settings.sequentialKey,
       };


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6869/bug-workflow-not-saving-after-running-from-main-prompt-box

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated workflow save behavior to automatically assign a "published" status when saving workflows in the editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Sets workflow status to 'published' by default when saving, with optional status parameter support in `useWorkflowSave`.
> 
>   - **Behavior**:
>     - Sets workflow status to 'published' by default when saving in `FlowRenderer` and `Workspace`.
>     - `useWorkflowSave` function now accepts an optional `status` parameter to specify workflow state.
>   - **Functions**:
>     - Updates `useWorkflowSave` in `WorkflowHasChangesStore.ts` to handle optional `status` parameter.
>   - **Components**:
>     - Modifies `FlowRenderer.tsx` and `Workspace.tsx` to use `useWorkflowSave` with `status: "published"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 51fe820107fc87b169539e215721a70427932892. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔄 This PR fixes a bug where workflows were not being properly saved with "published" status, ensuring that when users save a workflow it is consistently marked as published rather than remaining in draft state.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Workflow Save Hook**: Modified `useWorkflowSave` to accept an optional `WorkflowSaveOpts` parameter with status field
- **FlowRenderer Component**: Updated to pass `{ status: "published" }` when calling `useWorkflowSave()`
- **Workspace Component**: Updated to pass `{ status: "published" }` when calling `useWorkflowSave()`
- **Store Interface**: Added `WorkflowSaveOpts` interface to define the optional status parameter structure

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant FlowRenderer
    participant Workspace
    participant useWorkflowSave
    participant API
    
    User->>FlowRenderer: Save workflow
    FlowRenderer->>useWorkflowSave: saveWorkflow({ status: "published" })
    useWorkflowSave->>API: Save with status: "published"
    
    User->>Workspace: Save workflow
    Workspace->>useWorkflowSave: saveWorkflow({ status: "published" })
    useWorkflowSave->>API: Save with status: "published"
    
    Note over useWorkflowSave: Uses opts?.status ?? saveData.workflow.status
```

### Impact
- **Bug Resolution**: Fixes the issue where workflows remained in draft state after saving from the main prompt box
- **Consistent Behavior**: Ensures all workflow saves result in published status, providing predictable user experience
- **Flexible Architecture**: The optional parameter design allows future customization of workflow status during save operations
- **Backward Compatibility**: Changes are non-breaking as the status parameter is optional with fallback to existing behavior

</details>

_Created with [Palmier](https://www.palmier.io)_