### PR TITLE
ensure stream continues when switching between stream and recordings

### DIFF
--- a/skyvern-frontend/src/components/BrowserStream.tsx
+++ b/skyvern-frontend/src/components/BrowserStream.tsx
@@ -75,6 +75,7 @@ type Props = {
     run: WorkflowRunStatusApiResponse;
   };
   resizeTrigger?: number;
+  isVisible?: boolean;
   // --
   onClose?: () => void;
 };
@@ -86,6 +87,7 @@ function BrowserStream({
   task = undefined,
   workflow = undefined,
   resizeTrigger,
+  isVisible = true,
   // --
   onClose,
 }: Props) {
@@ -622,7 +624,7 @@ function BrowserStream({
       )}
       ref={setCanvasContainerRef}
     >
-      {isReady && (
+      {isReady && isVisible && (
         <div className="overlay z-10 flex items-center justify-center overflow-hidden">
           {showControlButtons && (
             <div className="control-buttons pointer-events-none relative flex h-full w-full items-center justify-center">

--- a/skyvern-frontend/src/routes/browserSessions/BrowserSession.tsx
+++ b/skyvern-frontend/src/routes/browserSessions/BrowserSession.tsx
@@ -23,7 +23,6 @@ import { useCredentialGetter } from "@/hooks/useCredentialGetter";
 import { useCloseBrowserSessionMutation } from "@/routes/browserSessions/hooks/useCloseBrowserSessionMutation";
 import { CopyText } from "@/routes/workflows/editor/Workspace";
 import { type BrowserSession as BrowserSessionType } from "@/routes/workflows/types/browserSessionTypes";
-import { cn } from "@/util/utils";
 
 import { BrowserSessionVideo } from "./BrowserSessionVideo";
 
@@ -183,20 +182,28 @@ function BrowserSession() {
         {/* Tab Content */}
         <div className="relative min-h-0 w-full flex-1 rounded-lg border p-4">
           <div
-            className={cn(
-              "absolute left-0 top-0 z-10 flex h-full w-full items-center justify-center",
-              {
-                hidden: activeTab !== "stream",
-              },
-            )}
+            className="absolute left-0 top-0 z-10 flex h-full w-full items-center justify-center"
+            style={{
+              visibility: activeTab === "stream" ? "visible" : "hidden",
+              pointerEvents: activeTab === "stream" ? "auto" : "none",
+            }}
           >
             <BrowserStream
               browserSessionId={browserSessionId}
               interactive={false}
               showControlButtons={true}
+              isVisible={activeTab === "stream"}
             />
           </div>
-          {activeTab === "videos" && <BrowserSessionVideo />}
+          <div
+            className="h-full w-full"
+            style={{
+              visibility: activeTab === "videos" ? "visible" : "hidden",
+              pointerEvents: activeTab === "videos" ? "auto" : "none",
+            }}
+          >
+            <BrowserSessionVideo />
+          </div>
         </div>
       </div>
       <Toaster />


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6935/stream-stops-when-switching-between-stream-and-recordings
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure stream continuity when switching tabs by adding visibility control to `BrowserStream` and using inline styles in `BrowserSession`.
> 
>   - **Behavior**:
>     - `BrowserStream` component now supports `isVisible` prop to control visibility.
>     - Stream visibility toggled using inline styles in `BrowserSession`.
>   - **Refactor**:
>     - Replaced conditional class-based visibility control with inline styling in `BrowserSession`.
>     - Removed unused import `cn` from `BrowserSession.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e6a74883693341809559aac617d0b1489dc8d8f3. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized browser session tab switching to improve responsiveness when toggling between live stream and recordings views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔄 This PR fixes a critical issue where browser streams would stop when users switched between the stream and recordings tabs by implementing proper visibility control instead of DOM hiding/showing.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **BrowserStream Component**: Added optional `isVisible` prop to control stream rendering without unmounting the component
- **Tab Management**: Replaced CSS class-based hiding (`hidden` class) with inline `visibility` and `pointer-events` styles
- **Stream Continuity**: Stream now persists in the background when switching tabs, preventing interruption
- **Code Cleanup**: Removed unused `cn` utility import from BrowserSession component

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant BrowserSession
    participant BrowserStream
    participant StreamService
    
    User->>BrowserSession: Switch to "videos" tab
    BrowserSession->>BrowserStream: Set isVisible=false
    Note over BrowserStream: Stream continues running<br/>but UI is hidden
    BrowserStream->>StreamService: Maintains connection
    
    User->>BrowserSession: Switch back to "stream" tab
    BrowserSession->>BrowserStream: Set isVisible=true
    BrowserStream->>User: Shows live stream immediately
    Note over User: No reconnection delay
```

### Impact
- **User Experience**: Eliminates stream interruption and reconnection delays when switching between tabs
- **Performance**: Stream maintains connection in background, reducing bandwidth and processing overhead from reconnections
- **Technical Robustness**: Uses CSS visibility instead of DOM manipulation, preventing component unmounting and remounting cycles

</details>

_Created with [Palmier](https://www.palmier.io)_