### PR TITLE
Coalesce the Validation Block and the new Human Interaction Block

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/HumanInteractionNode/HumanInteractionNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/HumanInteractionNode/HumanInteractionNode.tsx
@@ -77,6 +77,17 @@ function HumanInteractionNode({
           nodeId={id}
           totpIdentifier={null}
           totpUrl={null}
+          transmutations={{
+            blockTitle: "Validation",
+            self: "human",
+            others: [
+              {
+                label: "agent",
+                reason: "Convert to automated agent validation",
+                nodeName: "validation",
+              },
+            ],
+          }}
           type={type}
         />
         <div

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/ValidationNode/ValidationNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/ValidationNode/ValidationNode.tsx
@@ -91,6 +91,17 @@ function ValidationNode({ id, data, type }: NodeProps<ValidationNode>) {
             nodeId={id}
             totpIdentifier={null}
             totpUrl={null}
+            transmutations={{
+              blockTitle: "Validation",
+              self: "agent",
+              others: [
+                {
+                  label: "human",
+                  reason: "Convert to human validation",
+                  nodeName: "human_interaction",
+                },
+              ],
+            }}
             type={type}
           />
           <div className="space-y-2">

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/components/MicroDropdown.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/components/MicroDropdown.tsx
@@ -1,0 +1,132 @@
+import { ChevronDownIcon, ChevronUpIcon } from "@radix-ui/react-icons";
+import { useEffect, useRef, useState } from "react";
+
+import { cn } from "@/util/utils";
+
+interface Props {
+  selections: string[];
+  selected: string;
+  // --
+  onChange: (selection: string) => void;
+}
+
+function MicroDropdown({ selections, selected, onChange }: Props) {
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [openUpwards, setOpenUpwards] = useState(false);
+
+  function handleOnChange(selection: string) {
+    setIsOpen(false);
+    onChange(selection);
+  }
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside, true);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside, true);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    function handleEscKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener("keydown", handleEscKey);
+    return () => {
+      document.removeEventListener("keydown", handleEscKey);
+    };
+  }, [isOpen]);
+
+  return (
+    <div ref={dropdownRef} className="relative inline-block">
+      <div className="flex items-center gap-1">
+        <div
+          className="relative inline-flex p-0 text-xs text-slate-400"
+          onClick={() => {
+            if (!isOpen && dropdownRef.current) {
+              const rect = dropdownRef.current.getBoundingClientRect();
+              const viewportHeight = window.innerHeight;
+              const componentMiddle = rect.top + rect.height / 2;
+              setOpenUpwards(componentMiddle > viewportHeight * 0.5);
+            }
+            setIsOpen(!isOpen);
+          }}
+        >
+          [{selected}]
+          {isOpen ? (
+            <ChevronUpIcon className="ml-1 h-4 w-4" />
+          ) : (
+            <ChevronDownIcon className="ml-1 h-4 w-4" />
+          )}
+          {isOpen && (
+            <div
+              className={cn(
+                "absolute right-0 z-10 rounded-md bg-background text-xs text-slate-400",
+                "duration-200 animate-in fade-in-0 zoom-in-95",
+                openUpwards
+                  ? "bottom-full mb-2 slide-in-from-bottom-2"
+                  : "top-full mt-2 slide-in-from-top-2",
+              )}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="space-y-1 p-2">
+                {selections.map((s, index) => (
+                  <div
+                    key={s}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-1 rounded-md p-1 hover:bg-slate-800",
+                      "animate-in fade-in-0 slide-in-from-left-2",
+                      {
+                        "pointer-events-none cursor-default opacity-50":
+                          s === selected,
+                      },
+                    )}
+                    style={{
+                      animationDelay: `${(index + 1) * 80}ms`,
+                      animationDuration: "200ms",
+                      animationFillMode: "backwards",
+                    }}
+                  >
+                    <div
+                      onClick={() => {
+                        if (s === selected) {
+                          return;
+                        }
+
+                        handleOnChange(s);
+                      }}
+                    >
+                      {s === selected ? `[${s}]` : s}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { MicroDropdown };

--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
@@ -87,17 +87,21 @@ const nodeLibraryItems: Array<{
     title: "Validation Block",
     description: "Validate completion criteria",
   },
-  {
-    nodeType: "human_interaction",
-    icon: (
-      <WorkflowBlockIcon
-        workflowBlockType={WorkflowBlockTypes.HumanInteraction}
-        className="size-6"
-      />
-    ),
-    title: "Human Interaction Block",
-    description: "Validate via human interaction",
-  },
+  /**
+   * The Human Interaction block can be had via a transmutation of the
+   * Validation block.
+   */
+  // {
+  //   nodeType: "human_interaction",
+  //   icon: (
+  //     <WorkflowBlockIcon
+  //       workflowBlockType={WorkflowBlockTypes.HumanInteraction}
+  //       className="size-6"
+  //     />
+  //   ),
+  //   title: "Human Interaction Block",
+  //   description: "Validate via human interaction",
+  // },
   // {
   //   nodeType: "task",
   //   icon: (

--- a/skyvern-frontend/src/routes/workflows/editor/reactFlowOverrideStyles.css
+++ b/skyvern-frontend/src/routes/workflows/editor/reactFlowOverrideStyles.css
@@ -14,6 +14,22 @@
   @apply bg-slate-elevation3;
 }
 
+/* Smooth transitions for node position and size changes */
+.react-flow__node {
+  transition: transform 0.3s ease-in-out;
+}
+
+/* Smooth transitions for edge position updates */
+.react-flow__edge path,
+.react-flow__edge-path {
+  transition: d 0.3s ease-in-out;
+}
+
+.react-flow__edge text,
+.react-flow__edge-text {
+  transition: transform 0.3s ease-in-out;
+}
+
 .react-flow__handle-top {
   top: 3px;
 }

--- a/skyvern-frontend/src/routes/workflows/hooks/useTransmuteNodeCallback.ts
+++ b/skyvern-frontend/src/routes/workflows/hooks/useTransmuteNodeCallback.ts
@@ -1,0 +1,17 @@
+import { BlockActionContext } from "@/store/BlockActionContext";
+import { useContext } from "react";
+
+function useTransmuteNodeCallback() {
+  const transmuteNodeCallback =
+    useContext(BlockActionContext)?.transmuteNodeCallback;
+
+  if (!transmuteNodeCallback) {
+    throw new Error(
+      "useTransmuteNodeCallback must be used within a BlockActionContextProvider",
+    );
+  }
+
+  return transmuteNodeCallback;
+}
+
+export { useTransmuteNodeCallback };

--- a/skyvern-frontend/src/store/BlockActionContext.ts
+++ b/skyvern-frontend/src/store/BlockActionContext.ts
@@ -1,6 +1,7 @@
 import { createContext } from "react";
 
 type DeleteNodeCallback = (id: string) => void;
+type TransmuteNodeCallback = (id: string, nodeName: string) => void;
 type ToggleScriptForNodeCallback = (opts: {
   id?: string;
   label?: string;
@@ -10,6 +11,7 @@ type ToggleScriptForNodeCallback = (opts: {
 const BlockActionContext = createContext<
   | {
       deleteNodeCallback: DeleteNodeCallback;
+      transmuteNodeCallback: TransmuteNodeCallback;
       toggleScriptForNodeCallback?: ToggleScriptForNodeCallback;
     }
   | undefined


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6847/coalesce-validation-block-with-new-hitl-block-for-toggling-in-situ

## What 

In earlier PRs, a Human Interaction Block was introduced. It is conceptually similar to the existing Validation Block. So, rather than have two blocks in the block library, there is now just one: the  Validation Block.

This block now shows as "Validation [agent]". It can be toggled to "Validation [human]".

- "Validation [agent]" --> Validation Block
- "Validation [human]" --> Human Interaction Block

<img width="531" height="355" alt="Screenshot 2025-10-30 at 9 41 55 PM" src="https://github.com/user-attachments/assets/68b6311e-adfd-49a3-8bc0-087bad150c59" />

<img width="549" height="346" alt="Screenshot 2025-10-30 at 9 42 07 PM" src="https://github.com/user-attachments/assets/5e520465-74ef-4a0f-a485-bc070d8e79e9" />

<img width="528" height="537" alt="Screenshot 2025-10-30 at 9 42 22 PM" src="https://github.com/user-attachments/assets/50e916d6-3003-4ac7-97f1-443e96f6b889" />

## Also

Driveby: add transition effects to the workflow layout mechanism. Currently layout is sudden and jarring. The transitioning helps to make it less so.


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Consolidates Human Interaction Block into Validation Block with toggle functionality and adds node type conversion dropdown and smooth transitions.
> 
>   - **Behavior**:
>     - Consolidates Human Interaction Block into Validation Block, allowing toggle between "Validation [agent]" and "Validation [human]".
>     - Adds `transmuteNode()` in `FlowRenderer.tsx` for node type conversion.
>     - Removes Human Interaction Block from node library in `WorkflowNodeLibraryPanel.tsx`.
>   - **UI Components**:
>     - Introduces `MicroDropdown` for node type selection in `NodeHeader.tsx`.
>     - Updates `NodeHeader.tsx` to use `MicroDropdown` for transmutation options.
>   - **Styles**:
>     - Adds smooth transition animations for nodes and edges in `reactFlowOverrideStyles.css`.
>   - **Context and Hooks**:
>     - Adds `useTransmuteNodeCallback` hook for node transmutation.
>     - Updates `BlockActionContext.ts` to include `transmuteNodeCallback`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 4d914c774467946135516254293c9951478c884d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to convert workflow nodes between different types using an inline dropdown selector.

* **Improvements**
  * Enhanced workflow editor with smooth animations for nodes and edges during updates, providing improved visual feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔄 This PR consolidates the Human Interaction Block and Validation Block into a single unified block with toggle functionality, allowing users to switch between automated agent validation and human validation modes directly in the workflow editor. The change simplifies the block library while maintaining full functionality through an innovative node transmutation system.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Node Consolidation**: Removes Human Interaction Block from the block library and integrates its functionality into the Validation Block
- **Transmutation System**: Introduces a new `transmuteNode` function that allows converting between node types while preserving node identity and connections
- **UI Enhancement**: Adds a `MicroDropdown` component in node headers showing "Validation [agent]" or "Validation [human]" with seamless switching
- **Animation Improvements**: Implements smooth CSS transitions for node and edge movements during layout changes
- **Context Extension**: Extends `BlockActionContext` with `transmuteNodeCallback` for reliable node type conversion

### Technical Implementation
```mermaid
flowchart TD
    A[Validation Block] --> B{User Clicks Dropdown}
    B --> C[MicroDropdown Shows Options]
    C --> D[User Selects 'human']
    D --> E[transmuteNodeCallback Triggered]
    E --> F[transmuteNode Function Called]
    F --> G[Creates New Node with Same ID]
    G --> H[Updates Node Array]
    H --> I[Triggers Layout with Animation]
    I --> J[Human Interaction Block Active]
    
    J --> K[User Can Switch Back to 'agent']
    K --> L[Process Repeats in Reverse]
```

### Impact
- **User Experience**: Streamlines workflow creation by reducing block library complexity while maintaining full functionality
- **Development Efficiency**: Eliminates duplicate code paths and simplifies maintenance of validation-related features  
- **Visual Polish**: Smooth transitions make the workflow editor feel more responsive and professional during node transformations
- **Backward Compatibility**: Maintains existing functionality while providing a more intuitive interface for switching between validation modes

</details>

_Created with [Palmier](https://www.palmier.io)_