### PR TITLE
various Validation Block buffs

### DIFF
--- a/skyvern-frontend/src/components/NoticeMe.tsx
+++ b/skyvern-frontend/src/components/NoticeMe.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef, useState } from "react";
+
+interface Props {
+  trigger: "render" | "viewport";
+}
+
+function NoticeMe({ children, trigger }: React.PropsWithChildren<Props>) {
+  const [shouldAnimate, setShouldAnimate] = useState(trigger === "render");
+  const [shouldHide, setShouldHide] = useState(false);
+  const elementRef = useRef<HTMLDivElement>(null);
+  const hasExitedRef = useRef(false);
+
+  useEffect(() => {
+    if (trigger !== "viewport") return;
+
+    const element = elementRef.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            // Element is visible in viewport
+            if (hasExitedRef.current) {
+              // Force animation restart by removing then re-adding class
+              setShouldHide(false);
+              setShouldAnimate(false);
+              // Use setTimeout to ensure the class is removed before re-adding
+              setTimeout(() => {
+                setShouldAnimate(true);
+              }, 10);
+              hasExitedRef.current = false;
+            }
+          } else {
+            // Element is NOT visible in viewport (completely outside)
+            setShouldAnimate(false);
+            setShouldHide(true);
+            hasExitedRef.current = true;
+          }
+        });
+      },
+      {
+        threshold: 0,
+        rootMargin: "0px",
+      },
+    );
+
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [trigger]);
+
+  const getAnimationClass = () => {
+    if (shouldHide) return "notice-me-hidden";
+    if (shouldAnimate) return "notice-me-animate";
+    return "";
+  };
+
+  return (
+    <>
+      <div
+        ref={elementRef}
+        className={getAnimationClass()}
+        style={{ display: "flex" }}
+      >
+        {children}
+      </div>
+      <style>{`
+        .notice-me-hidden {
+          opacity: 0;
+        }
+
+        .notice-me-animate {
+          animation: notice-fade-up 0.5s ease-out;
+        }
+
+        @keyframes notice-fade-up {
+          0% {
+            opacity: 0;
+            transform: translateY(20px);
+          }
+          100% {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+      `}</style>
+    </>
+  );
+}
+
+export { NoticeMe };

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/components/MicroDropdown.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/components/MicroDropdown.tsx
@@ -61,7 +61,7 @@ function MicroDropdown({ selections, selected, onChange }: Props) {
     <div ref={dropdownRef} className="relative inline-block">
       <div className="flex items-center gap-1">
         <div
-          className="relative inline-flex p-0 text-xs text-slate-400"
+          className="relative inline-flex p-0 text-xs text-[#00d2ff]"
           onClick={() => {
             if (!isOpen && dropdownRef.current) {
               const rect = dropdownRef.current.getBoundingClientRect();

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { getClient } from "@/api/AxiosClient";
 import { ProxyLocation, Status } from "@/api/types";
+import { NoticeMe } from "@/components/NoticeMe";
 import { StatusBadge } from "@/components/StatusBadge";
 import { toast } from "@/components/ui/use-toast";
 import { useLogging } from "@/hooks/useLogging";
@@ -531,24 +532,26 @@ function NodeHeader({
                 <span className="text-xs text-slate-400">
                   {transmutations.blockTitle}
                 </span>
-                <MicroDropdown
-                  selections={[
-                    transmutations.self,
-                    ...transmutations.others.map((t) => t.label),
-                  ]}
-                  selected={transmutations.self}
-                  onChange={(label) => {
-                    const transmutation = transmutations.others.find(
-                      (t) => t.label === label,
-                    );
+                <NoticeMe trigger="viewport">
+                  <MicroDropdown
+                    selections={[
+                      transmutations.self,
+                      ...transmutations.others.map((t) => t.label),
+                    ]}
+                    selected={transmutations.self}
+                    onChange={(label) => {
+                      const transmutation = transmutations.others.find(
+                        (t) => t.label === label,
+                      );
 
-                    if (!transmutation) {
-                      return;
-                    }
+                      if (!transmutation) {
+                        return;
+                      }
 
-                    transmuteNodeCallback(nodeId, transmutation.nodeName);
-                  }}
-                />
+                      transmuteNodeCallback(nodeId, transmutation.nodeName);
+                    }}
+                  />
+                </NoticeMe>
               </div>
             ) : (
               <span className="text-xs text-slate-400">{blockTitle}</span>

--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
@@ -84,8 +84,8 @@ const nodeLibraryItems: Array<{
         className="size-6"
       />
     ),
-    title: "Validation Block",
-    description: "Validate completion criteria",
+    title: "AI or Human Validation",
+    description: "Have an AI or Human validate the state of the screen",
   },
   /**
    * The Human Interaction block can be had via a transmutation of the


### PR DESCRIPTION
https://linear.app/skyvern/issue/SKY-6985/various-validation-buffs

## What 

- renames Validation block title to "AI or Human Validation"
- changes Validation block description to "Have an AI or Human validate the state of the screen"
- adds animation and color to transmute dropdown (agent -> human, or human -> agent)

https://github.com/user-attachments/assets/4eacd91a-9ab6-4c0e-9a7f-1158ab78284b



<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances validation block UI with animations, renames it to "AI or Human Validation", and updates dropdown styling.
> 
>   - **UI Enhancements**:
>     - Added `NoticeMe` component in `NoticeMe.tsx` for viewport-triggered fade-up animations.
>     - Updated `MicroDropdown.tsx` to change dropdown text color to cyan.
>   - **Validation Block**:
>     - Renamed validation block title to "AI or Human Validation" and updated description in `WorkflowNodeLibraryPanel.tsx`.
>     - Integrated `NoticeMe` for dropdown animations in `NodeHeader.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 7e3a3eb6a6438a7678bfd4233beb7fe6a567bc07. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fade-up animation effects triggered by viewport visibility or component rendering.

* **Style**
  * Updated dropdown trigger color styling in the workflow editor.

* **Chores**
  * Improved labeling for the validation feature in the node library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

✨ This PR enhances the Validation Block UI with improved naming, visual styling, and smooth animations to better communicate its dual AI/Human validation capabilities and make the transmutation dropdown more discoverable.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **New Animation Component**: Added `NoticeMe.tsx` component with viewport-triggered fade-up animations and intersection observer logic
- **UI Text Updates**: Renamed "Validation Block" to "AI or Human Validation" with updated description emphasizing screen state validation
- **Visual Enhancements**: Changed MicroDropdown text color from gray (`text-slate-400`) to cyan (`text-[#00d2ff]`) for better visibility
- **Animation Integration**: Wrapped the transmutation dropdown in NodeHeader with the NoticeMe component for attention-grabbing effects

### Technical Implementation
```mermaid
flowchart TD
    A[NoticeMe Component] --> B{Trigger Type}
    B -->|render| C[Immediate Animation]
    B -->|viewport| D[Intersection Observer]
    D --> E{Element Visible?}
    E -->|Yes| F[Trigger Animation]
    E -->|No| G[Hide Element]
    F --> H[Fade-up Animation]
    G --> I[Set Opacity 0]
    
    J[NodeHeader] --> K[Transmutation Dropdown]
    K --> L[NoticeMe Wrapper]
    L --> M[Animated Dropdown]
```

### Impact
- **User Experience**: The animation draws attention to the transmutation feature (AI ↔ Human switching), making this important functionality more discoverable
- **Clarity**: The renamed title and description better communicate that validation can be performed by either AI or humans
- **Visual Polish**: The cyan color and smooth animations provide a more modern, engaging interface that guides user attention to key interactive elements

</details>

_Created with [Palmier](https://www.palmier.io)_