### PR TITLE
fix diagnostics button clicks

### DIFF
--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineBlockItem.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineBlockItem.tsx
@@ -144,7 +144,10 @@ function WorkflowRunTimelineBlockItem({
             <div className="flex flex-col items-end gap-[1px]">
               <div className="flex gap-1 self-start rounded bg-slate-elevation5 px-2 py-1">
                 {showDiagnosticLink ? (
-                  <Link to={`/tasks/${block.task_id}/diagnostics`}>
+                  <Link
+                    to={`/tasks/${block.task_id}/diagnostics`}
+                    onClick={(event) => event.stopPropagation()}
+                  >
                     <div className="flex gap-1">
                       <ExternalLinkIcon className="size-4" />
                       <span className="text-xs">Diagnostics</span>

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineItemInfoSection.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineItemInfoSection.tsx
@@ -90,6 +90,7 @@ function WorkflowRunTimelineItemInfoSection({ activeItem }: Props) {
                 <Link
                   to={`/tasks/${item.task_id}/diagnostics`}
                   title="Go to diagnostics"
+                  onClick={(event) => event.stopPropagation()}
                 >
                   <div className="flex items-center gap-2 px-3 py-1 text-sm font-medium">
                     <ExternalLinkIcon />


### PR DESCRIPTION
Fix for bug introduced via: https://github.com/Skyvern-AI/skyvern-cloud/pull/7124

Follow up for https://github.com/Skyvern-AI/skyvern-cloud/pull/7124 is https://github.com/Skyvern-AI/skyvern-cloud/pull/7129, which also contains this fix.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes diagnostics button click behavior by adding `event.stopPropagation()` in `WorkflowRunTimelineBlockItem` and `WorkflowRunTimelineItemInfoSection`.
> 
>   - **Behavior**:
>     - Fixes diagnostics button click behavior in `WorkflowRunTimelineBlockItem` and `WorkflowRunTimelineItemInfoSection` by adding `event.stopPropagation()` to prevent event bubbling.
>   - **Files Affected**:
>     - `WorkflowRunTimelineBlockItem.tsx`: Adds `onClick` handler to `<Link>` for diagnostics.
>     - `WorkflowRunTimelineItemInfoSection.tsx`: Adds `onClick` handler to `<Link>` for diagnostics.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1f31e5022e9e2acb92c94337a42b18a3533b992d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes a UI bug where clicking on diagnostics buttons was triggering unintended parent element click events by adding event propagation stoppers to two workflow timeline components.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Event Handling**: Added `onClick={(event) => event.stopPropagation()}` to diagnostics Link components in `WorkflowRunTimelineBlockItem.tsx` and `WorkflowRunTimelineItemInfoSection.tsx`
- **Bug Fix**: Prevents diagnostics button clicks from bubbling up to parent elements that may have their own click handlers
- **User Experience**: Ensures that clicking the diagnostics button only navigates to the diagnostics page without triggering other UI interactions

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant DiagnosticsButton
    participant ParentElement
    participant Router
    
    User->>DiagnosticsButton: Click
    DiagnosticsButton->>DiagnosticsButton: stopPropagation()
    DiagnosticsButton->>Router: Navigate to /tasks/{id}/diagnostics
    Note over ParentElement: Click event does not bubble up
```

### Impact
- **User Interface**: Eliminates unexpected behavior when users click diagnostics buttons, providing a more predictable interaction
- **Event Management**: Properly isolates click events to prevent interference between nested interactive elements
- **Navigation**: Ensures clean navigation to diagnostics pages without side effects from parent component event handlers

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Diagnostics link interactions in the workflow run timeline. Fixed an issue where clicking the Diagnostics link would unintentionally trigger parent element actions. The link now operates with proper event isolation, ensuring clicks navigate only to Diagnostics without affecting surrounding UI elements or triggering unrelated parent handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->