### PR TITLE
Jon/use new runs urls

### DIFF
--- a/skyvern-frontend/src/hooks/useFirstParam.ts
+++ b/skyvern-frontend/src/hooks/useFirstParam.ts
@@ -11,7 +11,7 @@ const useFirstParam = (...paramNames: string[]) => {
       return value;
     }
   }
-  return null;
+  return undefined;
 };
 
 export { useFirstParam };

--- a/skyvern-frontend/src/routes/history/RunHistory.tsx
+++ b/skyvern-frontend/src/routes/history/RunHistory.tsx
@@ -29,6 +29,7 @@ import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { getClient } from "@/api/AxiosClient";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
+import * as env from "@/util/env";
 
 function isTask(run: Task | WorkflowRunApiResponse): run is Task {
   return "task_id" in run;
@@ -185,7 +186,9 @@ function RunHistory() {
                     onClick={(event) => {
                       handleNavigate(
                         event,
-                        `/workflows/${run.workflow_permanent_id}/${run.workflow_run_id}/overview`,
+                        env.useNewRunsUrl
+                          ? `/runs/${run.workflow_run_id}`
+                          : `/workflows/${run.workflow_permanent_id}/${run.workflow_run_id}/overview`,
                       );
                     }}
                   >

--- a/skyvern-frontend/src/routes/runs/RunRouter.tsx
+++ b/skyvern-frontend/src/routes/runs/RunRouter.tsx
@@ -4,6 +4,7 @@
  */
 
 import { Navigate, Route, Routes, useParams } from "react-router-dom";
+import { useMemo } from "react";
 
 import { PageLayout } from "@/components/PageLayout";
 import { Status404 } from "@/components/Status404";
@@ -22,11 +23,66 @@ import { WorkflowsPageLayout } from "@/routes/workflows/WorkflowsPageLayout";
 import { useTaskV2Query } from "@/routes/runs/useTaskV2Query";
 
 function RunRouter() {
-  let { runId } = useParams();
+  const { runId } = useParams();
 
   const { data: task_v2, isLoading } = useTaskV2Query({
     id: runId?.startsWith("tsk_v2") ? runId : undefined,
   });
+
+  const runType = runId?.startsWith("tsk_v2")
+    ? "redirect"
+    : runId?.startsWith("wr_")
+      ? "workflow"
+      : runId?.startsWith("tsk_")
+        ? "task"
+        : null;
+
+  const routes = useMemo(() => {
+    if (runType === "workflow") {
+      return (
+        <Routes>
+          <Route element={<WorkflowsPageLayout />}>
+            <Route element={<WorkflowRun />}>
+              <Route index element={<Navigate to="overview" replace />} />
+              <Route
+                path="blocks"
+                element={<Navigate to="overview" replace />}
+              />
+              <Route path="overview" element={<WorkflowRunOverview />} />
+              <Route path="output" element={<WorkflowRunOutput />} />
+              <Route
+                path="parameters"
+                element={<WorkflowPostRunParameters />}
+              />
+              <Route path="recording" element={<WorkflowRunRecording />} />
+              <Route
+                path="code"
+                element={<WorkflowRunCode showCacheKeyValueSelector={true} />}
+              />
+            </Route>
+          </Route>
+        </Routes>
+      );
+    }
+
+    if (runType === "task") {
+      return (
+        <Routes>
+          <Route element={<PageLayout />}>
+            <Route element={<TaskDetails />}>
+              <Route index element={<Navigate to="actions" replace />} />
+              <Route path="actions" element={<TaskActions />} />
+              <Route path="recording" element={<TaskRecording />} />
+              <Route path="parameters" element={<TaskParameters />} />
+              <Route path="diagnostics" element={<StepArtifactsLayout />} />
+            </Route>
+          </Route>
+        </Routes>
+      );
+    }
+
+    return <Status404 />;
+  }, [runType]);
 
   if (runId?.startsWith("tsk_v2")) {
     if (isLoading) {
@@ -45,50 +101,10 @@ function RunRouter() {
       return <Status404 />;
     }
 
-    runId = workflowRunId;
-
     return <Navigate to={`/runs/${workflowRunId}`} replace />;
   }
 
-  if (runId?.startsWith("wr_")) {
-    return (
-      <Routes>
-        <Route element={<WorkflowsPageLayout />}>
-          <Route element={<WorkflowRun />}>
-            <Route index element={<Navigate to="overview" replace />} />
-            <Route path="blocks" element={<Navigate to="overview" replace />} />
-            <Route path="overview" element={<WorkflowRunOverview />} />
-            <Route path="output" element={<WorkflowRunOutput />} />
-            <Route path="parameters" element={<WorkflowPostRunParameters />} />
-            <Route path="recording" element={<WorkflowRunRecording />} />
-            <Route
-              path="code"
-              element={<WorkflowRunCode showCacheKeyValueSelector={true} />}
-            />
-          </Route>
-        </Route>
-      </Routes>
-    );
-  }
-
-  if (runId?.startsWith("tsk_")) {
-    return (
-      <Routes>
-        <Route element={<PageLayout />}>
-          <Route element={<TaskDetails />}>
-            <Route index element={<Navigate to="actions" replace />} />
-            <Route path="actions" element={<TaskActions />} />
-            <Route path="recording" element={<TaskRecording />} />
-            <Route path="parameters" element={<TaskParameters />} />
-            <Route path="diagnostics" element={<StepArtifactsLayout />} />
-          </Route>
-        </Route>
-      </Routes>
-    );
-  }
-
-  // Fallback (should not reach here due to earlier check)
-  return <Status404 />;
+  return routes;
 }
 
 export { RunRouter };

--- a/skyvern-frontend/src/routes/tasks/create/retry/RetryTask.tsx
+++ b/skyvern-frontend/src/routes/tasks/create/retry/RetryTask.tsx
@@ -1,9 +1,9 @@
-import { useParams } from "react-router-dom";
 import { useTaskQuery } from "../../detail/hooks/useTaskQuery";
 import { CreateNewTaskForm } from "../CreateNewTaskForm";
+import { useFirstParam } from "@/hooks/useFirstParam";
 
 function RetryTask() {
-  const { taskId } = useParams();
+  const taskId = useFirstParam("taskId", "runId");
   const { data: task, isLoading } = useTaskQuery({ id: taskId });
 
   if (isLoading) {

--- a/skyvern-frontend/src/routes/tasks/detail/TaskDetails.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/TaskDetails.tsx
@@ -40,6 +40,7 @@ import { statusIsFinalized } from "../types";
 import { MAX_STEPS_DEFAULT } from "../constants";
 import { useTaskQuery } from "./hooks/useTaskQuery";
 import { useFirstParam } from "@/hooks/useFirstParam";
+import * as env from "@/util/env";
 
 function createTaskRequestObject(values: TaskApiResponse) {
   return {
@@ -303,7 +304,11 @@ function TaskDetails() {
             workflow &&
             workflowRun && (
               <Link
-                to={`/workflows/${workflow.workflow_permanent_id}/${workflowRun.workflow_run_id}/overview`}
+                to={
+                  env.useNewRunsUrl
+                    ? `/runs/${workflowRun.workflow_run_id}`
+                    : `/workflows/${workflow.workflow_permanent_id}/${workflowRun.workflow_run_id}/overview`
+                }
               >
                 {workflow.title}
               </Link>

--- a/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
+++ b/skyvern-frontend/src/routes/workflows/RunWorkflowForm.tsx
@@ -49,6 +49,7 @@ import { getLabelForWorkflowParameterType } from "./editor/workflowEditorUtils";
 import { WorkflowParameter } from "./types/workflowTypes";
 import { WorkflowParameterInput } from "./WorkflowParameterInput";
 import { TestWebhookDialog } from "@/components/TestWebhookDialog";
+import * as env from "@/util/env";
 
 // Utility function to omit specified keys from an object
 function omit<T extends Record<string, unknown>, K extends keyof T>(
@@ -247,7 +248,9 @@ function RunWorkflowForm({
         queryKey: ["runs"],
       });
       navigate(
-        `/workflows/${workflowPermanentId}/${response.data.workflow_run_id}/overview`,
+        env.useNewRunsUrl
+          ? `/runs/${response.data.workflow_run_id}`
+          : `/workflows/${workflowPermanentId}/${response.data.workflow_run_id}/overview`,
       );
     },
     onError: (error: AxiosError) => {

--- a/skyvern-frontend/src/routes/workflows/WorkflowPage.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowPage.tsx
@@ -49,6 +49,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { RunParametersDialog } from "./workflowRun/RunParametersDialog";
+import * as env from "@/util/env";
 
 function WorkflowPage() {
   const { workflowPermanentId } = useParams();
@@ -186,18 +187,19 @@ function WorkflowPage() {
                     <TableRow
                       key={workflowRun.workflow_run_id}
                       onClick={(event) => {
+                        const url = env.useNewRunsUrl
+                          ? `/runs/${workflowRun.workflow_run_id}`
+                          : `/workflows/${workflowPermanentId}/${workflowRun.workflow_run_id}/overview`;
+
                         if (event.ctrlKey || event.metaKey) {
                           window.open(
-                            window.location.origin +
-                              `/workflows/${workflowPermanentId}/${workflowRun.workflow_run_id}/overview`,
+                            window.location.origin + url,
                             "_blank",
                             "noopener,noreferrer",
                           );
                           return;
                         }
-                        navigate(
-                          `/workflows/${workflowPermanentId}/${workflowRun.workflow_run_id}/overview`,
-                        );
+                        navigate(url);
                       }}
                       className="cursor-pointer"
                     >

--- a/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowRun.tsx
@@ -32,7 +32,7 @@ import {
   ReloadIcon,
 } from "@radix-ui/react-icons";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Link, Outlet, useParams, useSearchParams } from "react-router-dom";
+import { Link, Outlet, useSearchParams } from "react-router-dom";
 import { statusIsFinalized, statusIsRunningOrQueued } from "../tasks/types";
 import { useWorkflowRunWithWorkflowQuery } from "./hooks/useWorkflowRunWithWorkflowQuery";
 import { WorkflowRunTimeline } from "./workflowRun/WorkflowRunTimeline";
@@ -44,6 +44,7 @@ import { cn } from "@/util/utils";
 import { ScrollArea, ScrollAreaViewport } from "@/components/ui/scroll-area";
 import { ApiWebhookActionsMenu } from "@/components/ApiWebhookActionsMenu";
 import { WebhookReplayDialog } from "@/components/WebhookReplayDialog";
+import { useFirstParam } from "@/hooks/useFirstParam";
 import { type ApiCommandOptions } from "@/util/apiCommands";
 import { useBlockScriptsQuery } from "@/routes/workflows/hooks/useBlockScriptsQuery";
 import { constructCacheKeyValue } from "@/routes/workflows/editor/utils";
@@ -55,7 +56,7 @@ function WorkflowRun() {
   const embed = searchParams.get("embed");
   const isEmbedded = embed === "true";
   const active = searchParams.get("active");
-  const { workflowRunId } = useParams();
+  const workflowRunId = useFirstParam("workflowRunId", "runId");
   const credentialGetter = useCredentialGetter();
   const apiCredential = useApiCredential();
   const queryClient = useQueryClient();

--- a/skyvern-frontend/src/routes/workflows/hooks/useWorkflowRunTimelineQuery.ts
+++ b/skyvern-frontend/src/routes/workflows/hooks/useWorkflowRunTimelineQuery.ts
@@ -2,7 +2,6 @@ import { getClient } from "@/api/AxiosClient";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
 import { statusIsNotFinalized } from "@/routes/tasks/types";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
-import { useParams } from "react-router-dom";
 import { WorkflowRunTimelineItem } from "../types/workflowRunTypes";
 import { useWorkflowRunWithWorkflowQuery } from "./useWorkflowRunWithWorkflowQuery";
 import { useGlobalWorkflowsQuery } from "./useGlobalWorkflowsQuery";
@@ -10,13 +9,11 @@ import { useFirstParam } from "@/hooks/useFirstParam";
 
 function useWorkflowRunTimelineQuery() {
   const workflowRunId = useFirstParam("workflowRunId", "runId");
-  const { workflowPermanentId: workflowPermanentIdParam } = useParams();
   const credentialGetter = useCredentialGetter();
   const { data: globalWorkflows } = useGlobalWorkflowsQuery();
   const { data: workflowRun } = useWorkflowRunWithWorkflowQuery();
-
-  const workflowPermanentId =
-    workflowPermanentIdParam ?? workflowRun?.workflow?.workflow_permanent_id;
+  const workflow = workflowRun?.workflow;
+  const workflowPermanentId = workflow?.workflow_permanent_id;
 
   return useQuery<Array<WorkflowRunTimelineItem>>({
     queryKey: ["workflowRunTimeline", workflowPermanentId, workflowRunId],

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunStream.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunStream.tsx
@@ -1,5 +1,5 @@
 import { Status } from "@/api/types";
-import { useWorkflowRunQuery } from "../hooks/useWorkflowRunQuery";
+import { useWorkflowRunWithWorkflowQuery } from "../hooks/useWorkflowRunWithWorkflowQuery";
 import { ZoomableImage } from "@/components/ZoomableImage";
 import { useEffect, useState } from "react";
 import { statusIsNotFinalized } from "@/routes/tasks/types";
@@ -25,12 +25,14 @@ const wssBaseUrl = import.meta.env.VITE_WSS_BASE_URL;
 
 function WorkflowRunStream(props?: Props) {
   const alwaysShowStream = props?.alwaysShowStream ?? false;
-  const { data: workflowRun } = useWorkflowRunQuery();
+  const { data: workflowRun } = useWorkflowRunWithWorkflowQuery();
   const [streamImgSrc, setStreamImgSrc] = useState<string>("");
   const showStream =
     alwaysShowStream || (workflowRun && statusIsNotFinalized(workflowRun));
   const credentialGetter = useCredentialGetter();
-  const { workflowRunId, workflowPermanentId } = useParams();
+  const { workflowRunId } = useParams();
+  const workflow = workflowRun?.workflow;
+  const workflowPermanentId = workflow?.workflow_permanent_id;
   const queryClient = useQueryClient();
 
   useEffect(() => {
@@ -72,6 +74,9 @@ function WorkflowRunStream(props?: Props) {
             });
             queryClient.invalidateQueries({
               queryKey: ["workflowRun", workflowPermanentId, workflowRunId],
+            });
+            queryClient.invalidateQueries({
+              queryKey: ["workflowRun", workflowRunId],
             });
             queryClient.invalidateQueries({
               queryKey: ["workflowTasks", workflowRunId],

--- a/skyvern-frontend/src/util/env.ts
+++ b/skyvern-frontend/src/util/env.ts
@@ -94,6 +94,8 @@ function clearRuntimeApiKey(): void {
   }
 }
 
+const useNewRunsUrl = true as const;
+
 export {
   apiBaseUrl,
   runsApiBaseUrl,
@@ -106,4 +108,5 @@ export {
   getRuntimeApiKey,
   persistRuntimeApiKey,
   clearRuntimeApiKey,
+  useNewRunsUrl,
 };


### PR DESCRIPTION
## What

Follows https://github.com/Skyvern-AI/skyvern-cloud/pull/7124, which was buggy.

- add a flag for quick switching between new/old workflow run URL(s)
- then apply it at pertinent code sites 
- due to dynamic routes added by `RunRouter`, the interplay between click events for react-router's `Link` components and parent elements requires an explicit `stopPropagation`; add those where necessary
- this is what caused the `Diagnostics` button to stop working 
- modify `useFirstParam` to return `undefined` instead of `null`, as that is the more common expectation at site usages
- use `useFirstParam` at more code sites, as required
- `useFirstParam` coalesces different path param names, treating them as the same, e.g. `taskId` and `runId`, or `workflowRunId` and `runId`
- use `useWorkflowRunWithWorkflowQuery` at more code sites, as required
- calls the endpoint added in https://github.com/Skyvern-AI/skyvern-cloud/pull/7109, which returns a _workflow_ along with a _workflow run_; as wpid is (potentially) no longer in the path param, we can grab it from the _workflow_
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> This PR updates the URL structure for workflow runs, introduces a toggle for new/old URL formats, fixes click event propagation, and refines parameter handling.
> 
>   - **Behavior**:
>     - Introduces `useNewRunsUrl` flag in `env.ts` to toggle between new and old URL formats for workflow runs.
>     - Updates navigation logic in `RunHistory.tsx`, `WorkflowPage.tsx`, and `TaskDetails.tsx` to use the new URL format based on the flag.
>     - Fixes click event propagation issue in `WorkflowPage.tsx` to prevent parent navigation on button clicks.
>   - **Hooks**:
>     - Modifies `useFirstParam` in `useFirstParam.ts` to return `undefined` instead of `null` for missing parameters.
>     - Extends usage of `useFirstParam` in `RetryTask.tsx`, `TaskDetails.tsx`, and `WorkflowRun.tsx` for consistent parameter handling.
>   - **Routing**:
>     - Refactors `RunRouter.tsx` to dynamically handle routes based on run ID prefixes (`tsk_`, `wr_`).
>     - Uses `useMemo` for route configuration in `RunRouter.tsx` to optimize rendering.
>   - **Misc**:
>     - Calls new endpoint from previous PR to fetch workflow and workflow run data.
>     - Minor logging and error handling improvements across files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 4f54b6f79d6e45b16df8c2a6b7a81147289cabdd. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new URL format for workflow run navigation with feature flag support. Workflow runs now route to `/runs/{id}` instead of previous paths.

* **Improvements**
  * Enhanced parameter extraction across route components for more reliable data retrieval.
  * Optimized data fetching with consolidated query logic for workflow and run data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔄 This PR introduces a feature flag system for transitioning to new workflow run URLs, fixes event propagation issues that broke the Diagnostics button, and refactors parameter handling and routing logic for better consistency across the application.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **URL Management**: Added `useNewRunsUrl` feature flag in `env.ts` to toggle between old (`/workflows/{id}/{runId}/overview`) and new (`/runs/{runId}`) URL formats
- **Event Handling**: Fixed event propagation issues that prevented the Diagnostics button from working properly due to dynamic routing changes
- **Parameter Extraction**: Enhanced `useFirstParam` hook to return `undefined` instead of `null` and applied it consistently across components for better parameter coalescing
- **Routing Refactor**: Completely restructured `RunRouter.tsx` to handle different run types (task, workflow, redirect) with memoized route generation
- **Query Optimization**: Replaced `useWorkflowRunQuery` with `useWorkflowRunWithWorkflowQuery` to fetch workflow data alongside run data

### Technical Implementation
```mermaid
flowchart TD
    A[RunRouter] --> B{Run Type Detection}
    B -->|tsk_v2| C[Redirect to Workflow Run]
    B -->|wr_| D[Workflow Routes]
    B -->|tsk_| E[Task Routes]
    B -->|unknown| F[404 Page]
    
    G[useNewRunsUrl Flag] --> H{URL Format}
    H -->|true| I[/runs/{runId}]
    H -->|false| J[/workflows/{id}/{runId}/overview]
    
    K[useFirstParam] --> L[Coalesce Parameters]
    L --> M[taskId ↔ runId]
    L --> N[workflowRunId ↔ runId]
```

### Impact
- **User Experience**: Seamless transition between old and new URL formats without breaking existing bookmarks or links
- **Bug Resolution**: Fixed broken Diagnostics button functionality that was caused by event bubbling in the new routing system
- **Code Consistency**: Unified parameter handling across components reduces duplication and potential bugs
- **Performance**: Memoized routing logic and optimized query usage improve rendering performance
- **Maintainability**: Feature flag approach allows for gradual rollout and easy rollback if issues arise

</details>

_Created with [Palmier](https://www.palmier.io)_