### PR TITLE
use new run URLs, attempt iii

### DIFF
--- a/skyvern-frontend/src/routes/workflows/hooks/useWorkflowRunQuery.ts
+++ b/skyvern-frontend/src/routes/workflows/hooks/useWorkflowRunQuery.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@/api/AxiosClient";
 import { WorkflowRunStatusApiResponse } from "@/api/types";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
+import { useFirstParam } from "@/hooks/useFirstParam";
 import {
   statusIsNotFinalized,
   statusIsRunningOrQueued,
@@ -10,7 +11,8 @@ import { useParams } from "react-router-dom";
 import { useGlobalWorkflowsQuery } from "./useGlobalWorkflowsQuery";
 
 function useWorkflowRunQuery() {
-  const { workflowRunId, workflowPermanentId } = useParams();
+  const workflowRunId = useFirstParam("workflowRunId", "runId");
+  const { workflowPermanentId } = useParams();
   const credentialGetter = useCredentialGetter();
   const { data: globalWorkflows } = useGlobalWorkflowsQuery();
 

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunStream.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunStream.tsx
@@ -4,7 +4,7 @@ import { ZoomableImage } from "@/components/ZoomableImage";
 import { useEffect, useState } from "react";
 import { statusIsNotFinalized } from "@/routes/tasks/types";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
-import { useParams } from "react-router-dom";
+import { useFirstParam } from "@/hooks/useFirstParam";
 import { getRuntimeApiKey } from "@/util/env";
 import { toast } from "@/components/ui/use-toast";
 import { useQueryClient } from "@tanstack/react-query";
@@ -25,12 +25,12 @@ const wssBaseUrl = import.meta.env.VITE_WSS_BASE_URL;
 
 function WorkflowRunStream(props?: Props) {
   const alwaysShowStream = props?.alwaysShowStream ?? false;
+  const workflowRunId = useFirstParam("workflowRunId", "runId");
   const { data: workflowRun } = useWorkflowRunWithWorkflowQuery();
   const [streamImgSrc, setStreamImgSrc] = useState<string>("");
   const showStream =
     alwaysShowStream || (workflowRun && statusIsNotFinalized(workflowRun));
   const credentialGetter = useCredentialGetter();
-  const { workflowRunId } = useParams();
   const workflow = workflowRun?.workflow;
   const workflowPermanentId = workflow?.workflow_permanent_id;
   const queryClient = useQueryClient();

--- a/skyvern-frontend/src/util/env.ts
+++ b/skyvern-frontend/src/util/env.ts
@@ -94,7 +94,7 @@ function clearRuntimeApiKey(): void {
   }
 }
 
-const useNewRunsUrl = false as const;
+const useNewRunsUrl = true as const;
 
 export {
   apiBaseUrl,


### PR DESCRIPTION
Trail of crumbs starts here: https://github.com/Skyvern-AI/skyvern-cloud/pull/7129

https://linear.app/skyvern/issue/SKY-6511/update-all-run-urls-to-conform-to-this-url-format-dont-break-backwards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activated new workflow runs URL format for improved routing and navigation

* **Refactor**
  * Enhanced workflow run parameter retrieval to support flexible run identification across multiple route patterns and components
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable new Runs URL routing and refactor parameter retrieval in `useWorkflowRunQuery.ts` and `WorkflowRunStream.tsx`.
> 
>   - **Behavior**:
>     - Enable new Runs URL routing by setting `useNewRunsUrl` to `true` in `env.ts`.
>     - Update `useWorkflowRunQuery` in `useWorkflowRunQuery.ts` to use `useFirstParam` for `workflowRunId`.
>     - Update `WorkflowRunStream` in `WorkflowRunStream.tsx` to use `useFirstParam` for `workflowRunId`.
>   - **Refactor**:
>     - Replace `useParams` with `useFirstParam` for `workflowRunId` in `useWorkflowRunQuery.ts` and `WorkflowRunStream.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d53b4e0d378412f049f990dcb7ced19ddb4ca488. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔄 This PR enables new run URL routing functionality by switching from direct URL parameter extraction to a flexible parameter resolution system that supports both legacy and new URL formats for workflow runs.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Parameter Resolution**: Replaced direct `useParams()` calls with `useFirstParam("workflowRunId", "runId")` to support both old and new URL parameter names
- **URL Routing Toggle**: Enabled new run URLs by setting `useNewRunsUrl` to `true` in the environment configuration
- **Component Updates**: Modified `useWorkflowRunQuery` hook and `WorkflowRunStream` component to use the new parameter resolution method

### Technical Implementation
```mermaid
flowchart TD
    A[URL Request] --> B{useFirstParam}
    B --> C[Check 'workflowRunId' param]
    C --> D{Found?}
    D -->|Yes| E[Return workflowRunId]
    D -->|No| F[Check 'runId' param]
    F --> G{Found?}
    G -->|Yes| H[Return runId]
    G -->|No| I[Return undefined]
    E --> J[Continue with workflow logic]
    H --> J
    I --> J
```

### Impact
- **Backward Compatibility**: Maintains support for existing URLs using `workflowRunId` parameter while enabling new URLs with `runId` parameter
- **Flexible Routing**: Allows gradual migration to new URL format without breaking existing bookmarks or integrations
- **Consistent Experience**: Ensures WebSocket connections and workflow queries work seamlessly regardless of URL format used

</details>

_Created with [Palmier](https://www.palmier.io)_