### PR TITLE
Add termination-aware complete verification experiment (SKY-6884)

### DIFF
--- a/skyvern/forge/prompts/skyvern/check-user-goal-with-termination.j2
+++ b/skyvern/forge/prompts/skyvern/check-user-goal-with-termination.j2
@@ -1,0 +1,54 @@
+You are here to help the user determine if the user has completed their goal on the web{{ " according to the complete criterion" if complete_criterion else "" }}. Use the content of the elements parsed from the page,{{ "" if without_screenshots else " the screenshots of the page," }} the user goal and user details to determine the status of the task.
+
+Make sure to ONLY return the JSON object in this format with no additional text before or after it:
+```json
+{
+  "page_info": str, // Think step by step. Describe all the useful information in the page related to the user goal.
+  "thoughts": str, // Think step by step. Explain your reasoning for the status you selected.
+  "status": str // Must be one of three values: "complete", "terminate", or "continue". Use "complete" ONLY if the user goal has been fully achieved{{ " according to the complete criterion" if complete_criterion else "" }}. Use "terminate" ONLY if the goal CANNOT ever be achieved (e.g., a file doesn't exist, an error modal blocks progress permanently, or an explicit termination condition is met in the user goal). Use "continue" if the goal is not yet achieved but more steps could potentially achieve it (this is the most common case - use this when you need to wait, navigate, or try different actions).
+}
+```
+
+Important: Think carefully about the difference between "terminate" and "continue":
+- "terminate" = impossible to achieve, stop trying (e.g., "account does not exist", "file unavailable", permanent error)
+- "continue" = not done yet, but achievable with more steps (e.g., page is loading, need to click something, need to wait)
+
+User Goal:
+```
+{{ navigation_goal }}
+```
+
+User Details:
+```
+{{ navigation_payload }}
+```
+{% if complete_criterion %}
+Complete Criterion:
+```
+{{ complete_criterion }}
+```{% endif %}{% if terminate_criterion %}
+Terminate Criterion:
+```
+{{ terminate_criterion }}
+```{% endif %}
+{% if action_history %}
+Action History:
+```
+{{ action_history }}
+```
+{% endif %}{% if new_elements_ids %}
+IDs for emerging HTML elements
+```
+{{ new_elements_ids }}
+```
+{% endif %}
+Elements on the page:
+```
+{{ elements }}
+```
+
+Current datetime, ISO format:
+```
+{{ local_datetime }}
+```
+


### PR DESCRIPTION
	Add 3-state verification for file download blocks (SKY-6884)

Replace boolean `user_goal_achieved` field with explicit 3-state status for 
file download block verification:
- "complete": Goal achieved successfully
- "terminate": Goal impossible, stop trying
- "continue": Not done yet, keep going

Changes:
- Add VerificationStatus enum (complete/terminate/continue) to CompleteVerifyResult
- Add status field with backward-compatible helper properties (is_complete, is_terminate, is_continue)
- Create check-user-goal-with-termination.j2 prompt returning status field
- Add USE_TERMINATION_AWARE_COMPLETE_VERIFICATION experiment flag
- Scope to FileDownloadBlock only via isinstance check in complete_verify()
- Convert CompleteAction to TerminateAction when status is "terminate"
- Support termination in both sync and parallel verification flows
- Keep legacy fields (user_goal_achieved, should_terminate) for backward compatibility
- Add comprehensive experiment documentation

This fixes SKY-6884 where file download blocks would incorrectly complete when 
they should terminate (e.g., file unavailable, error modal blocking progress). 

The LLM was conflating "task should end" with "goal achieved", setting 
user_goal_achieved: true when it recognized a termination condition. The new 
3-state design gives the LLM explicit vocabulary to distinguish:
- Success (complete)
- Permanent failure (terminate) 
- Temporary state (continue)

Scoped to file download blocks only because:
- File downloads have clear binary outcomes (exists or doesn't)
- Reduces risk of false terminations in complex multi-step workflows
- Can expand to other block types after validation

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces a 3-state verification system for file download blocks, replacing the boolean system, with backward compatibility and experiment flag control.
> 
>   - **Behavior**:
>     - Introduces 3-state verification for file download blocks: `complete`, `terminate`, `continue`.
>     - Replaces `user_goal_achieved` with `VerificationStatus` in `CompleteVerifyResult`.
>     - Adds `check-user-goal-with-termination.j2` prompt for structured JSON verification.
>     - Converts `CompleteAction` to `TerminateAction` when status is `terminate`.
>     - Supports termination in sync and parallel verification flows.
>     - Scoped to `FileDownloadBlock` via `isinstance` check in `complete_verify()`.
>     - Retains legacy fields for backward compatibility.
>   - **Models**:
>     - Adds `VerificationStatus` enum to `actions.py`.
>     - Updates `CompleteVerifyResult` in `actions.py` with new status field and helper properties.
>   - **Misc**:
>     - Adds `USE_TERMINATION_AWARE_COMPLETE_VERIFICATION` experiment flag.
>     - Updates `agent.py` and `handler.py` to handle new verification logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 97f7ffe4efa8a27d5def50285d9b1d8a1661fa5a. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Three-state verification (complete / terminate / continue) and a new structured JSON verification prompt for file-download flows, behind an experiment flag.

* **Behavior**
  * Verification can now explicitly trigger termination vs completion; termination cancels in-progress work, records outcomes, and is surfaced in logs and task status while preserving legacy flows.

* **Documentation**
  * Added experiment, rollout, monitoring, testing, metrics, and rollback docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->