### PR TITLE
Support Google Cloud Workload Identity for vertex models

### DIFF
--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -1049,7 +1049,8 @@ if settings.ENABLE_NOVITA:
 # NOTE: If you want to specify a location, make sure the model is available in the target location.
 # If you want to use the global location, you must set the VERTEX_PROJECT_ID environment variable.
 # See documentation: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations#united-states
-if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
+# Support both explicit service account credentials and Google Cloud Workload Identity (metadata server fallback)
+if settings.ENABLE_VERTEX_AI:
     api_base: str | None = None
     if settings.VERTEX_LOCATION == "global" and settings.VERTEX_PROJECT_ID:
         api_base = f"https://aiplatform.googleapis.com/v1/projects/{settings.VERTEX_PROJECT_ID}/locations/global/publishers/google/models"
@@ -1058,18 +1059,18 @@ if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
         "VERTEX_GEMINI_2.5_PRO",
         LLMConfig(
             "vertex_ai/gemini-2.5-pro",
-            ["VERTEX_CREDENTIALS"],
+            [],
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=65535,
             litellm_params=LiteLLMParams(
-                vertex_credentials=settings.VERTEX_CREDENTIALS,
                 api_base=f"{api_base}/gemini-2.5-pro" if api_base else None,
                 vertex_location=settings.VERTEX_LOCATION,
                 thinking={
                     "budget_tokens": settings.GEMINI_THINKING_BUDGET,
                     "type": "enabled" if settings.GEMINI_INCLUDE_THOUGHT else None,
                 },
+                vertex_credentials=settings.VERTEX_CREDENTIALS,
             ),
         ),
     )
@@ -1077,18 +1078,18 @@ if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
         "VERTEX_GEMINI_2.5_PRO_PREVIEW",
         LLMConfig(
             "vertex_ai/gemini-2.5-pro-preview-05-06",
-            ["VERTEX_CREDENTIALS"],
+            [],
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=65535,
             litellm_params=LiteLLMParams(
-                vertex_credentials=settings.VERTEX_CREDENTIALS,
                 api_base=f"{api_base}/gemini-2.5-pro-preview-05-06" if api_base else None,
                 vertex_location=settings.VERTEX_LOCATION,
                 thinking={
                     "budget_tokens": settings.GEMINI_THINKING_BUDGET,
                     "type": "enabled" if settings.GEMINI_INCLUDE_THOUGHT else None,
                 },
+                vertex_credentials=settings.VERTEX_CREDENTIALS,
             ),
         ),
     )
@@ -1096,18 +1097,18 @@ if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
         "VERTEX_GEMINI_2.5_FLASH_DEPRECATED",
         LLMConfig(
             "vertex_ai/gemini-2.5-flash",
-            ["VERTEX_CREDENTIALS"],
+            [],
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=65535,
             litellm_params=LiteLLMParams(
-                vertex_credentials=settings.VERTEX_CREDENTIALS,
                 api_base=f"{api_base}/gemini-2.5-flash" if api_base else None,
                 vertex_location=settings.VERTEX_LOCATION,
                 thinking={
                     "budget_tokens": settings.GEMINI_THINKING_BUDGET,
                     "type": "enabled" if settings.GEMINI_INCLUDE_THOUGHT else None,
                 },
+                vertex_credentials=settings.VERTEX_CREDENTIALS,
             ),
         ),
     )
@@ -1115,18 +1116,18 @@ if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
         "VERTEX_GEMINI_2.5_FLASH_LITE_DEPRECATED",
         LLMConfig(
             "vertex_ai/gemini-2.5-flash-lite",
-            ["VERTEX_CREDENTIALS"],
+            [],
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=65535,
             litellm_params=LiteLLMParams(
-                vertex_credentials=settings.VERTEX_CREDENTIALS,
                 api_base=f"{api_base}/gemini-2.5-flash-lite" if api_base else None,
                 vertex_location=settings.VERTEX_LOCATION,
                 thinking={
                     "budget_tokens": settings.GEMINI_THINKING_BUDGET,
                     "type": "enabled" if settings.GEMINI_INCLUDE_THOUGHT else None,
                 },
+                vertex_credentials=settings.VERTEX_CREDENTIALS,
             ),
         ),
     )
@@ -1134,18 +1135,18 @@ if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
         "VERTEX_GEMINI_2.5_FLASH_PREVIEW",
         LLMConfig(
             "vertex_ai/gemini-2.5-flash-preview-05-20",
-            ["VERTEX_CREDENTIALS"],
+            [],
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=65535,
             litellm_params=LiteLLMParams(
-                vertex_credentials=settings.VERTEX_CREDENTIALS,
                 api_base=f"{api_base}/gemini-2.5-flash-preview-05-20" if api_base else None,
                 vertex_location=settings.VERTEX_LOCATION,
                 thinking={
                     "budget_tokens": settings.GEMINI_THINKING_BUDGET,
                     "type": "enabled" if settings.GEMINI_INCLUDE_THOUGHT else None,
                 },
+                vertex_credentials=settings.VERTEX_CREDENTIALS,
             ),
         ),
     )
@@ -1153,18 +1154,18 @@ if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
         "VERTEX_GEMINI_2.5_FLASH_PREVIEW_04_17",
         LLMConfig(
             "vertex_ai/gemini-2.5-flash-preview-04-17",
-            ["VERTEX_CREDENTIALS"],
+            [],
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=65535,
             litellm_params=LiteLLMParams(
-                vertex_credentials=settings.VERTEX_CREDENTIALS,
                 api_base=f"{api_base}/gemini-2.5-flash-preview-04-17" if api_base else None,
                 vertex_location=settings.VERTEX_LOCATION,
                 thinking={
                     "budget_tokens": settings.GEMINI_THINKING_BUDGET,
                     "type": "enabled" if settings.GEMINI_INCLUDE_THOUGHT else None,
                 },
+                vertex_credentials=settings.VERTEX_CREDENTIALS,
             ),
         ),
     )
@@ -1172,18 +1173,18 @@ if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
         "VERTEX_GEMINI_2.5_FLASH_PREVIEW_05_20",
         LLMConfig(
             "vertex_ai/gemini-2.5-flash-preview-05-20",
-            ["VERTEX_CREDENTIALS"],
+            [],
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=65535,
             litellm_params=LiteLLMParams(
-                vertex_credentials=settings.VERTEX_CREDENTIALS,
                 api_base=f"{api_base}/gemini-2.5-flash-preview-05-20" if api_base else None,
                 vertex_location=settings.VERTEX_LOCATION,
                 thinking={
                     "budget_tokens": settings.GEMINI_THINKING_BUDGET,
                     "type": "enabled" if settings.GEMINI_INCLUDE_THOUGHT else None,
                 },
+                vertex_credentials=settings.VERTEX_CREDENTIALS,
             ),
         ),
     )
@@ -1191,18 +1192,18 @@ if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
         "VERTEX_GEMINI_2.5_FLASH",
         LLMConfig(
             "vertex_ai/gemini-2.5-flash",
-            ["VERTEX_CREDENTIALS"],
+            [],
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=65535,
             litellm_params=LiteLLMParams(
-                vertex_credentials=settings.VERTEX_CREDENTIALS,
                 api_base=f"{api_base}/gemini-2.5-flash" if api_base else None,
                 vertex_location=settings.VERTEX_LOCATION,
                 thinking={
                     "budget_tokens": settings.GEMINI_THINKING_BUDGET,
                     "type": "enabled" if settings.GEMINI_INCLUDE_THOUGHT else None,
                 },
+                vertex_credentials=settings.VERTEX_CREDENTIALS,
             ),
         ),
     )
@@ -1210,18 +1211,18 @@ if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
         "VERTEX_GEMINI_2.5_FLASH_LITE",
         LLMConfig(
             "vertex_ai/gemini-2.5-flash-lite",
-            ["VERTEX_CREDENTIALS"],
+            [],
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=65535,
             litellm_params=LiteLLMParams(
-                vertex_credentials=settings.VERTEX_CREDENTIALS,
                 api_base=f"{api_base}/gemini-2.5-flash-lite" if api_base else None,
                 vertex_location=settings.VERTEX_LOCATION,
                 thinking={
                     "budget_tokens": settings.GEMINI_THINKING_BUDGET,
                     "type": "enabled" if settings.GEMINI_INCLUDE_THOUGHT else None,
                 },
+                vertex_credentials=settings.VERTEX_CREDENTIALS,
             ),
         ),
     )
@@ -1230,18 +1231,18 @@ if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
         "VERTEX_GEMINI_2.5_FLASH_PREVIEW_09_2025",
         LLMConfig(
             "vertex_ai/gemini-2.5-flash-preview-09-2025",
-            ["VERTEX_CREDENTIALS"],
+            [],
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=65535,
             litellm_params=LiteLLMParams(
-                vertex_credentials=settings.VERTEX_CREDENTIALS,
                 api_base=f"{api_base}/gemini-2.5-flash-preview-09-2025" if api_base else None,
                 vertex_location=settings.VERTEX_LOCATION,
                 thinking={
                     "budget_tokens": settings.GEMINI_THINKING_BUDGET,
                     "type": "enabled" if settings.GEMINI_INCLUDE_THOUGHT else None,
                 },
+                vertex_credentials=settings.VERTEX_CREDENTIALS,
             ),
         ),
     )
@@ -1249,18 +1250,18 @@ if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
         "VERTEX_GEMINI_2.5_FLASH_LITE_PREVIEW_09_2025",
         LLMConfig(
             "vertex_ai/gemini-2.5-flash-lite-preview-09-2025",
-            ["VERTEX_CREDENTIALS"],
+            [],
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=65535,
             litellm_params=LiteLLMParams(
-                vertex_credentials=settings.VERTEX_CREDENTIALS,
                 api_base=f"{api_base}/gemini-2.5-flash-lite-preview-09-2025" if api_base else None,
                 vertex_location=settings.VERTEX_LOCATION,
                 thinking={
                     "budget_tokens": settings.GEMINI_THINKING_BUDGET,
                     "type": "enabled" if settings.GEMINI_INCLUDE_THOUGHT else None,
                 },
+                vertex_credentials=settings.VERTEX_CREDENTIALS,
             ),
         ),
     )
@@ -1268,14 +1269,14 @@ if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
         "VERTEX_GEMINI_FLASH_2_0",
         LLMConfig(
             "vertex_ai/gemini-2.0-flash-001",
-            ["VERTEX_CREDENTIALS"],
+            [],
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=8192,
             litellm_params=LiteLLMParams(
                 api_base=f"{api_base}/gemini-2.0-flash-001" if api_base else None,
-                vertex_credentials=settings.VERTEX_CREDENTIALS,
                 vertex_location=settings.VERTEX_LOCATION,
+                vertex_credentials=settings.VERTEX_CREDENTIALS,
             ),
         ),
     )
@@ -1283,13 +1284,13 @@ if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
         "VERTEX_GEMINI_PRO",
         LLMConfig(
             "vertex_ai/gemini-1.5-pro",
-            ["VERTEX_CREDENTIALS"],
+            [],
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=8192,
             litellm_params=LiteLLMParams(
-                vertex_credentials=settings.VERTEX_CREDENTIALS,
                 vertex_location=settings.VERTEX_LOCATION,  # WARN: this model don't support global
+                vertex_credentials=settings.VERTEX_CREDENTIALS,
             ),
         ),
     )
@@ -1297,13 +1298,13 @@ if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:
         "VERTEX_GEMINI_FLASH",
         LLMConfig(
             "vertex_ai/gemini-1.5-flash",
-            ["VERTEX_CREDENTIALS"],
+            [],
             supports_vision=True,
             add_assistant_prefix=False,
             max_completion_tokens=8192,
             litellm_params=LiteLLMParams(
-                vertex_credentials=settings.VERTEX_CREDENTIALS,
                 vertex_location=settings.VERTEX_LOCATION,  # WARN: this model don't support global
+                vertex_credentials=settings.VERTEX_CREDENTIALS,
             ),
         ),
     )


### PR DESCRIPTION
Problem
The current condition if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS: requires both flags, preventing Workload Identity from being used. LiteLLM's implementation falls back to Workload Identity when vertex_credentials is not provided, but our code never enters the block without credentials set.

Slack
https://skyvern.slack.com/archives/C098558BU79/p1762804950681239?thread_ts=1762527975.202379&cid=C098558BU79

Linear
https://linear.app/skyvern/issue/SKY-7048/modify-conditions-to-allow-workload-identity-usage-with-vertex-ai
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Support Google Cloud Workload Identity for Vertex AI by removing explicit credential requirement and refactoring credential handling in `config_registry.py`.
> 
>   - **Behavior**:
>     - Modified condition in `config_registry.py` to enable Vertex AI without requiring `VERTEX_CREDENTIALS`, allowing Google Cloud Workload Identity usage.
>     - Removed `VERTEX_CREDENTIALS` from public config declarations in `config_registry.py`.
>   - **Refactor**:
>     - Unified Vertex AI credential handling by consistently using `vertex_credentials` in `LiteLLMParams` across all Vertex models in `config_registry.py`.
>     - Simplified gating by relying solely on `ENABLE_VERTEX_AI` flag for registrations in `config_registry.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 504ed26800ed0dd045e10020911501d98ea3c02d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Vertex AI models now support Google Cloud Workload Identity authentication, enabling more flexible credential management alongside traditional service account credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔐 This PR enables Google Cloud Workload Identity support for Vertex AI models by removing the hard requirement for explicit service account credentials. The change allows the system to fall back to Workload Identity authentication when `VERTEX_CREDENTIALS` is not provided, while maintaining backward compatibility with explicit credentials.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Authentication Logic**: Modified the condition from `if settings.ENABLE_VERTEX_AI and settings.VERTEX_CREDENTIALS:` to `if settings.ENABLE_VERTEX_AI:` to allow Workload Identity fallback
- **Configuration Cleanup**: Removed `["VERTEX_CREDENTIALS"]` from the required environment variables list for all 14 Vertex AI model configurations
- **Parameter Restructuring**: Moved `vertex_credentials=settings.VERTEX_CREDENTIALS` to the end of `LiteLLMParams` for consistency across all model configurations

### Technical Implementation
```mermaid
flowchart TD
    A[ENABLE_VERTEX_AI=true] --> B{VERTEX_CREDENTIALS provided?}
    B -->|Yes| C[Use explicit service account credentials]
    B -->|No| D[Fall back to Workload Identity via metadata server]
    C --> E[Initialize Vertex AI models]
    D --> E
    F[Old Logic: ENABLE_VERTEX_AI AND VERTEX_CREDENTIALS] --> G[❌ Blocks Workload Identity]
    
    style A fill:#e1f5fe
    style E fill:#c8e6c9
    style G fill:#ffcdd2
```

### Impact
- **Enhanced Deployment Flexibility**: Enables seamless deployment in Google Cloud environments using Workload Identity without requiring explicit credential management
- **Backward Compatibility**: Maintains full compatibility with existing deployments that use explicit service account credentials
- **Security Improvement**: Reduces the need to manage and store service account keys, following Google Cloud security best practices for credential-less authentication

</details>

_Created with [Palmier](https://www.palmier.io)_