### PR TITLE
Browser session - add delay before sending webhook to wait for cookies to flush

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -2342,6 +2342,14 @@ class WorkflowService:
             )
             return
 
+        if workflow_run.browser_session_id:
+            LOG.info(
+                "Waiting for browser cookies to flush before webhook",
+                workflow_run_id=workflow_run.workflow_run_id,
+                browser_session_id=workflow_run.browser_session_id,
+            )
+            await asyncio.sleep(15)
+
         # build new schema for backward compatible webhook payload
         app_url = f"{settings.SKYVERN_APP_URL.rstrip('/')}/runs/{workflow_run.workflow_run_id}"
 


### PR DESCRIPTION
This is based on behavior we are seeing from client testing a feature. They have a successful login run to save the browser session. Then our new browser profile is created based on that session (via api call)

<img width="1389" height="572" alt="Screenshot 2025-11-11 at 5 38 57 PM" src="https://github.com/user-attachments/assets/fadc6056-c963-48f1-a963-e3e31ea2f4cd" />

Then, the browser profile is used in a separate workflow run (new feature from https://github.com/Skyvern-AI/skyvern-cloud/pull/7135

However, the cookies are not loaded. Verified customer tried what should work [here](https://skyvern.slack.com/archives/C09NZ6KM2AD/p1762896174522479), but it did [not](https://skyvern.slack.com/archives/C09NZ6KM2AD/p1762907117464669).

Looked at the timestamps of the logs and [found](https://skyvern.slack.com/archives/C09NZ6KM2AD/p1762910844307999?thread_ts=1762907117.464669&cid=C09NZ6KM2AD) that the completion webhook of the browser session login task was sending before the cookies were written to s3

```
(1) 00:03:16 - Login task completes, cleanup starts
(2) 00:03:25 - 9 seconds into cleanup, webhook sent (too early)
(3) 00:03:26 - Search Party received webhook, starts creating profile
(4) 00:03:26-00:03:34 - zipping/uploading profile (8 seconds)
(5) 00:03:34 - Cleanup finishes, cookies fully flushed
```

So proposal here is adding a 15 second delay before sending the webhook. This would only apply if someone is supplying a `browser_session_id` in the workflow login block. Workflows that start with a fresh browser profile, use a browser profile ID, or rely on the ephemeral session skip the delay
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a 15-second delay in `execute_workflow_webhook()` to ensure cookies are flushed before sending a webhook when `browser_session_id` is present.
> 
>   - **Behavior**:
>     - Adds a 15-second delay in `execute_workflow_webhook()` in `service.py` before sending a webhook if `browser_session_id` is present.
>     - Delay ensures cookies are flushed to S3 before webhook is sent.
>     - Delay is skipped for workflows using a fresh browser profile, browser profile ID, or ephemeral session.
>   - **Logging**:
>     - Logs informational message about waiting for cookies to flush when `browser_session_id` is used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 461cfd3ffd871d2b93cf7c090e4c86c9da715697. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of workflow execution with browser sessions by ensuring proper synchronization of browser state before processing webhook payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

⏱️ This PR adds a 15-second delay before sending webhooks when browser sessions are used, ensuring cookies are properly flushed to S3 before downstream processes attempt to create browser profiles. The fix addresses a race condition where webhooks were being sent before cookie cleanup completed, causing browser profile creation to fail due to missing session data.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Webhook Timing**: Added conditional 15-second delay in `execute_workflow_webhook()` function when `browser_session_id` is present
- **Logging Enhancement**: Added informative logging to track when the delay is applied for debugging purposes
- **Conditional Logic**: Delay only applies to workflows using browser sessions, not fresh profiles or ephemeral sessions

### Technical Implementation
```mermaid
sequenceDiagram
    participant WF as Workflow
    participant WH as Webhook Service
    participant S3 as S3 Storage
    participant Client as Client System
    
    WF->>WH: Login task completes
    WH->>WH: Check browser_session_id exists
    alt Browser Session Present
        WH->>WH: Log delay message
        WH->>WH: Wait 15 seconds
        Note over WH,S3: Cookies flush to S3
    end
    WH->>Client: Send webhook
    Client->>S3: Request browser profile
    S3-->>Client: Complete profile with cookies
```

### Impact
- **Race Condition Fix**: Eliminates timing issues where webhooks were sent before cookie cleanup completed (9 seconds vs 18 seconds total cleanup time)
- **Improved Reliability**: Ensures browser profiles created from sessions contain all necessary cookie data for subsequent workflow runs
- **Minimal Performance Impact**: 15-second delay only affects workflows using browser sessions, not standard workflows or fresh profiles

</details>

_Created with [Palmier](https://www.palmier.io)_