### PR TITLE
add log context for No browser state found when creating workflow_run_block

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -367,7 +367,13 @@ class Block(BaseModel, abc.ABC):
             # create a screenshot
             browser_state = app.BROWSER_MANAGER.get_for_workflow_run(workflow_run_id)
             if not browser_state:
-                LOG.warning("No browser state found when creating workflow_run_block", workflow_run_id=workflow_run_id)
+                LOG.warning(
+                    "No browser state found when creating workflow_run_block",
+                    workflow_run_id=workflow_run_id,
+                    workflow_run_block_id=workflow_run_block_id,
+                    browser_session_id=browser_session_id,
+                    block_label=self.label,
+                )
             else:
                 try:
                     screenshot = await browser_state.take_fullpage_screenshot(


### PR DESCRIPTION
---

🔍 This PR enhances logging context for debugging browser state issues by adding additional contextual information to a warning log message when no browser state is found during workflow run block creation.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Logging Enhancement**: Expanded the warning log message in `skyvern/forge/sdk/workflow/models/block.py` to include more contextual information
- **Debug Information**: Added `workflow_run_block_id`, `browser_session_id`, and `block_label` to the existing log that already contained `workflow_run_id`
- **Code Formatting**: Restructured the log call from a single line to a multi-line format for better readability

### Technical Implementation
```mermaid
flowchart TD
    A[execute_safe method called] --> B[Get browser state for workflow_run_id]
    B --> C{Browser state exists?}
    C -->|No| D[Log warning with enhanced context]
    C -->|Yes| E[Take screenshot and continue]
    D --> F[Include workflow_run_id, workflow_run_block_id, browser_session_id, block_label]
    F --> G[Continue execution without screenshot]
```

### Impact
- **Improved Debugging**: Developers will have more context when investigating browser state issues, making it easier to trace problems across workflow runs and blocks
- **Better Observability**: The additional fields (block_label, browser_session_id, workflow_run_block_id) provide a clearer picture of the execution context when failures occur
- **No Functional Changes**: This is purely a logging enhancement with no impact on application behavior, performance, or backward compatibility

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhanced logging in `execute_safe()` in `block.py` to include additional context when no browser state is found.
> 
>   - **Logging**:
>     - Enhanced logging in `execute_safe()` in `block.py` to include `workflow_run_block_id`, `browser_session_id`, and `block_label` when no browser state is found.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ed415b11cf7d14c205ccb1703bc53ee88ea40d31. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced diagnostic logging to include additional context details (workflow run block ID, browser session ID, and block label) when troubleshooting missing browser state scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->