### PR TITLE
map gemini workflow models to fallback llm keys

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -396,13 +396,16 @@ class Settings(BaseSettings):
 
         if self.is_cloud_environment():
             return {
-                "gemini-2.5-pro-preview-05-06": {"llm_key": "VERTEX_GEMINI_2.5_PRO", "label": "Gemini 2.5 Pro"},
+                "gemini-2.5-pro-preview-05-06": {
+                    "llm_key": "GEMINI_2_5_PRO_WITH_FALLBACK",
+                    "label": "Gemini 2.5 Pro",
+                },
                 "gemini-2.5-flash": {
-                    "llm_key": "VERTEX_GEMINI_2.5_FLASH",
+                    "llm_key": "GEMINI_2_5_FLASH_WITH_FALLBACK",
                     "label": "Gemini 2.5 Flash",
                 },
                 "gemini-2.5-flash-lite": {
-                    "llm_key": "VERTEX_GEMINI_2.5_FLASH_LITE",
+                    "llm_key": "GEMINI_2_5_FLASH_LITE_WITH_FALLBACK",
                     "label": "Gemini 2.5 Flash Lite",
                 },
                 "azure/gpt-4.1": {"llm_key": "AZURE_OPENAI_GPT4_1", "label": "GPT 4.1"},
@@ -432,13 +435,16 @@ class Settings(BaseSettings):
         else:
             # TODO: apparently the list for OSS is to be much larger
             return {
-                "gemini-2.5-pro-preview-05-06": {"llm_key": "VERTEX_GEMINI_2.5_PRO", "label": "Gemini 2.5 Pro"},
+                "gemini-2.5-pro-preview-05-06": {
+                    "llm_key": "GEMINI_2_5_PRO_WITH_FALLBACK",
+                    "label": "Gemini 2.5 Pro",
+                },
                 "gemini-2.5-flash": {
-                    "llm_key": "VERTEX_GEMINI_2.5_FLASH",
+                    "llm_key": "GEMINI_2_5_FLASH_WITH_FALLBACK",
                     "label": "Gemini 2.5 Flash",
                 },
                 "gemini-2.5-flash-lite": {
-                    "llm_key": "VERTEX_GEMINI_2.5_FLASH_LITE",
+                    "llm_key": "GEMINI_2_5_FLASH_LITE_WITH_FALLBACK",
                     "label": "Gemini 2.5 Flash Lite",
                 },
                 "azure/gpt-4.1": {"llm_key": "AZURE_OPENAI_GPT4_1", "label": "GPT 4.1"},


### PR DESCRIPTION
	Context: https://skyvern.slack.com/archives/C0992QT40BT/p1763044593789979?thread_ts=1761662961.580479&cid=C0992QT40BT

### PR Description

- Update the workflow model mapping so that the Gemini entries from the UI now resolve to `GEMINI_2_5_*_WITH_FALLBACK` keys, ensuring every Gemini selection automatically activates the GPT‑5 fallback router.
- Force `LLMRouterConfig` for the Gemini fallback routers to pass `temperature=None` so router defaults don’t stomp on the GPT‑5 requirement of `temperature=1`.
- Add logging in the workflow runner helpers to show the raw override payload that comes down from the DB, making it easy to confirm which model the frontend requested.

Because our settings layer defaults to `temperature=0.0`, the router object inherited that value and pushed it down to every model in its list. LiteLLM was then sending `temperature=0.0` to GPT‑5, which hard-fails with 429s. Explicitly setting `temperature=None` on the router lets the fallback model’s own `litellm_params` reapply `temperature=1`, satisfying GPT‑5’s contract.


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update Gemini model mappings to use fallback keys and set temperature to None for compatibility with GPT-5.
> 
>   - **Behavior**:
>     - Update Gemini model mappings in `get_model_name_to_llm_key()` to use `GEMINI_2_5_*_WITH_FALLBACK` keys.
>     - Force `LLMRouterConfig` to set `temperature=None` for Gemini fallback routers to ensure `temperature=1` for GPT-5.
>   - **Logging**:
>     - Add logging in workflow runner helpers to display raw override payloads from the DB.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 676eb70c883e340467a629bbd741ee33895d9280. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Gemini 2.5 model configuration mappings to include fallback support.
  * Other model configurations remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->