### PR TITLE
execute_task_webhook uses the latest non canceled step

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -3138,12 +3138,11 @@ class ForgeAgent:
         await app.ARTIFACT_MANAGER.wait_for_upload_aiotasks([task.task_id])
 
         if need_call_webhook:
-            await self.execute_task_webhook(task=task, last_step=last_step, api_key=api_key)
+            await self.execute_task_webhook(task=task, api_key=api_key)
 
     async def execute_task_webhook(
         self,
         task: Task,
-        last_step: Step | None,
         api_key: str | None,
     ) -> None:
         if not api_key:
@@ -3159,6 +3158,7 @@ class ForgeAgent:
                 task_id=task.task_id,
             )
             return
+        last_step = await app.DATABASE.get_latest_step(task.task_id, organization_id=task.organization_id)
 
         task_response = await self.build_task_response(task=task, last_step=last_step)
         # try to build the new TaskRunResponse for backward compatibility

--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -532,6 +532,7 @@ class AgentDB:
                         select(StepModel)
                         .filter_by(task_id=task_id)
                         .filter_by(organization_id=organization_id)
+                        .filter(StepModel.status != StepStatus.canceled)
                         .order_by(StepModel.order.desc())
                         .order_by(StepModel.retry_index.desc())
                     )

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1644,10 +1644,8 @@ async def cancel_task(
             detail=f"Task not found {task_id}",
         )
     task = await app.agent.update_task(task_obj, status=TaskStatus.canceled)
-    # get latest step
-    latest_step = await app.DATABASE.get_latest_step(task_id, organization_id=current_org.organization_id)
     # retry the webhook
-    await app.agent.execute_task_webhook(task=task, last_step=latest_step, api_key=x_api_key)
+    await app.agent.execute_task_webhook(task=task, api_key=x_api_key)
 
 
 async def _cancel_workflow_run(workflow_run_id: str, organization_id: str, x_api_key: str | None = None) -> None:
@@ -1778,7 +1776,7 @@ async def retry_webhook(
         return await app.agent.build_task_response(task=task_obj)
 
     # retry the webhook
-    await app.agent.execute_task_webhook(task=task_obj, last_step=latest_step, api_key=x_api_key)
+    await app.agent.execute_task_webhook(task=task_obj, api_key=x_api_key)
 
     return await app.agent.build_task_response(task=task_obj, last_step=latest_step)
 

--- a/skyvern/services/run_service.py
+++ b/skyvern/services/run_service.py
@@ -86,8 +86,7 @@ async def cancel_task_v1(task_id: str, organization_id: str | None = None, api_k
     if not task:
         raise TaskNotFound(task_id=task_id)
     task = await app.agent.update_task(task, status=TaskStatus.canceled)
-    latest_step = await app.DATABASE.get_latest_step(task_id, organization_id=organization_id)
-    await app.agent.execute_task_webhook(task=task, last_step=latest_step, api_key=api_key)
+    await app.agent.execute_task_webhook(task=task, api_key=api_key)
 
 
 async def cancel_task_v2(task_id: str, organization_id: str | None = None) -> None:
@@ -164,7 +163,7 @@ async def retry_run_webhook(run_id: str, organization_id: str | None = None, api
             raise TaskNotFound(task_id=run_id)
         latest_step = await app.DATABASE.get_latest_step(run_id, organization_id=organization_id)
         if latest_step:
-            await app.agent.execute_task_webhook(task=task, last_step=latest_step, api_key=api_key)
+            await app.agent.execute_task_webhook(task=task, api_key=api_key)
     elif run.task_run_type == RunType.task_v2:
         task_v2 = await app.DATABASE.get_task_v2(run_id, organization_id=organization_id)
         if not task_v2:


### PR DESCRIPTION
---

🔄 This PR refactors the webhook execution logic to automatically fetch the latest non-canceled step instead of passing it as a parameter, ensuring webhooks always use the most recent valid step data.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Method Signature Simplification**: Removed `last_step` parameter from `execute_task_webhook()` method across all call sites
- **Database Query Enhancement**: Modified `get_latest_step()` to filter out canceled steps using `StepModel.status != StepStatus.canceled`
- **Internal Step Retrieval**: The webhook method now internally fetches the latest non-canceled step using `app.DATABASE.get_latest_step()`
- **Call Site Updates**: Updated all invocations in `agent.py`, `agent_protocol.py`, and `run_service.py` to remove the `last_step` parameter

### Technical Implementation
```mermaid
sequenceDiagram
    participant Caller as Service/Route
    participant Agent as Agent.execute_task_webhook()
    participant DB as Database
    participant Webhook as External Webhook

    Caller->>Agent: execute_task_webhook(task, api_key)
    Note over Caller,Agent: No longer passes last_step parameter
    Agent->>DB: get_latest_step(task_id, org_id)
    Note over DB: Filters out canceled steps
    DB-->>Agent: latest_non_canceled_step
    Agent->>Agent: build_task_response(task, last_step)
    Agent->>Webhook: Send webhook with latest step data
```

### Impact
- **Data Consistency**: Ensures webhooks always receive the most current non-canceled step information
- **Code Simplification**: Reduces parameter passing complexity and eliminates the need for callers to fetch step data
- **Reliability Improvement**: Prevents webhooks from being triggered with stale or canceled step data
- **Maintainability**: Centralizes step retrieval logic within the webhook execution method

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `execute_task_webhook` now fetches the latest non-canceled step automatically, simplifying function calls and excluding canceled steps from the database query.
> 
>   - **Behavior**:
>     - `execute_task_webhook` in `agent.py` now automatically fetches the latest non-canceled step from the database, removing the need for `last_step` parameter.
>     - Calls to `execute_task_webhook` in `agent.py`, `agent_protocol.py`, and `run_service.py` updated to remove `last_step` argument.
>   - **Database**:
>     - `get_latest_step` in `client.py` updated to exclude steps with `StepStatus.canceled`.
>   - **Misc**:
>     - Removed `last_step` parameter from `execute_task_webhook` function signature in `agent.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 29a4680fd51814a175e2a1f5f52582e527251bda. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook execution to exclude canceled steps when determining the latest task step for callback operations.

* **Refactor**
  * Unified webhook invocation across task retry, cancellation, and completion flows for more consistent behavior and improved reliability in task lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->