### PR TITLE
respect workflow and block model overrides

### DIFF
--- a/skyvern/schemas/workflows.py
+++ b/skyvern/schemas/workflows.py
@@ -257,9 +257,6 @@ class CodeBlockYAML(BlockYAML):
     parameter_keys: list[str] | None = None
 
 
-DEFAULT_TEXT_PROMPT_LLM_KEY = settings.SECONDARY_LLM_KEY or settings.LLM_KEY
-
-
 class TextPromptBlockYAML(BlockYAML):
     # There is a mypy bug with Literal. Without the type: ignore, mypy will raise an error:
     # Parameter 1 of Literal[...] cannot be of type "Any"
@@ -267,7 +264,7 @@ class TextPromptBlockYAML(BlockYAML):
     # to infer the type of the parameter_type attribute.
     block_type: Literal[BlockType.TEXT_PROMPT] = BlockType.TEXT_PROMPT  # type: ignore
 
-    llm_key: str = DEFAULT_TEXT_PROMPT_LLM_KEY
+    llm_key: str | None = None
     prompt: str
     parameter_keys: list[str] | None = None
     json_schema: dict[str, Any] | None = None


### PR DESCRIPTION
## Summary
- Remove the hardcoded GPT‑5 mini default from `TextPromptBlock` so the “Skyvern Optimized ✨” option inherits the task/workflow/PostHog handler chain.
- Make `TextPromptBlock` (and its YAML schema) treat `llm_key` as optional and always route through `LLMAPIHandlerFactory.get_override_llm_api_handler`, ensuring block-level model selections override workflow-level picks.
- Add `tests/unit/test_text_prompt_block.py` to verify block-level model overrides win and unset blocks fall back to the default handler.

## Testing
- `pytest tests/unit/test_text_prompt_block.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LLM key configuration is now optional in workflow blocks, enabling workflows to use default LLM handlers when not explicitly specified.
  * Enhanced LLM selection with improved override capabilities for more flexible handler assignment.

* **Refactor**
  * Simplified internal LLM resolution logic for improved code maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance `TextPromptBlock` to support block-level model overrides and add unit tests for verification.
> 
>   - **Behavior**:
>     - Remove hardcoded default LLM key from `TextPromptBlock` to allow inheritance from task/workflow/PostHog handler chain.
>     - Make `llm_key` optional in `TextPromptBlock` and `TextPromptBlockYAML`, routing through `LLMAPIHandlerFactory.get_override_llm_api_handler` for block-level model overrides.
>   - **Testing**:
>     - Add `tests/unit/test_text_prompt_block.py` to verify block-level model overrides and default handler fallback.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 54da6976ea54634db464d4ce26a87234dc30b20e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR refactors the TextPromptBlock to respect workflow and block-level model overrides by making the LLM key optional and removing hardcoded defaults, allowing proper inheritance from the task/workflow/PostHog handler chain.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **LLM Key Management**: Removed hardcoded `DEFAULT_TEXT_PROMPT_LLM_KEY` constants and made `llm_key` optional (`str | None = None`) in both `TextPromptBlock` and `TextPromptBlockYAML`
- **Override Logic**: Updated `send_prompt()` method to use `LLMAPIHandlerFactory.get_override_llm_api_handler()` with proper fallback to `app.LLM_API_HANDLER`
- **Template Formatting**: Added null-check in `format_potential_template_parameters()` to only format `llm_key` when it's not None
- **Schema Consistency**: Applied the same optional pattern to the YAML schema definition

### Technical Implementation
```mermaid
flowchart TD
    A[TextPromptBlock.send_prompt] --> B{llm_key set?}
    B -->|Yes| C[Use block-level llm_key]
    B -->|No| D[Use override_llm_key]
    C --> E[LLMAPIHandlerFactory.get_override_llm_api_handler]
    D --> E
    E --> F{Handler found?}
    F -->|Yes| G[Use specific handler]
    F -->|No| H[Fallback to app.LLM_API_HANDLER]
    G --> I[Execute prompt]
    H --> I
```

### Impact
- **Proper Override Hierarchy**: Block-level model selections now correctly override workflow-level configurations, enabling fine-grained control
- **Default Handler Inheritance**: Blocks without explicit LLM keys inherit from the "Skyvern Optimized ✨" option through the task/workflow/PostHog handler chain
- **Backward Compatibility**: Changes maintain existing functionality while enabling new override capabilities without breaking existing workflows

</details>

_Created with [Palmier](https://www.palmier.io)_