### PR TITLE
fix: ensure parallel verification runs data extraction

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -3621,6 +3621,14 @@ class ForgeAgent:
                 )
                 return True, last_step, None
 
+            if isinstance(persisted_action, CompleteAction) and task.navigation_goal and task.data_extraction_goal:
+                task = await self._run_data_extraction_after_complete_action(
+                    task=task,
+                    step=step,
+                    scraped_page=scraped_page,
+                    working_page=working_page,
+                )
+
             LOG.info(
                 "Parallel verification: goal achieved, marking task as completed",
                 step_id=step.step_id,
@@ -4360,3 +4368,33 @@ class ForgeAgent:
             return False
 
         return any(action_result.success for action_result in last_action_results)
+
+    async def _run_data_extraction_after_complete_action(
+        self,
+        task: Task,
+        step: Step,
+        scraped_page: ScrapedPage,
+        working_page: Page,
+    ) -> Task:
+        """
+        Run the extraction flow when a task with a data extraction goal completes during parallel verification.
+        """
+        refreshed_task = await app.DATABASE.get_task(task.task_id, task.organization_id)
+        if refreshed_task:
+            task = refreshed_task
+
+        extract_action = await self.create_extract_action(task, step, scraped_page)
+        extract_results = await ActionHandler.handle_action(scraped_page, task, step, working_page, extract_action)
+        await app.AGENT_FUNCTION.post_action_execution(extract_action)
+
+        if step.output is None:
+            step.output = AgentStepOutput(action_results=[], actions_and_results=[], errors=[])
+        if step.output.action_results is None:
+            step.output.action_results = []
+        if step.output.actions_and_results is None:
+            step.output.actions_and_results = []
+
+        step.output.action_results.extend(extract_results)
+        step.output.actions_and_results.append((extract_action, extract_results))
+
+        return task

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -322,8 +322,8 @@ class Task(TaskBase):
         if status.requires_failure_reason() and failure_reason is None:
             raise ValueError(f"status_requires_failure_reason({status},{self.task_id}")
 
-        # if status.requires_extracted_info() and self.data_extraction_goal and extracted_information is None:
-        #     raise ValueError(f"status_requires_extracted_information({status},{self.task_id}")
+        if status.requires_extracted_info() and self.data_extraction_goal and extracted_information is None:
+            raise ValueError(f"status_requires_extracted_information({status},{self.task_id})")
 
         if status.cant_have_extracted_info() and extracted_information is not None:
             raise ValueError(f"status_cant_have_extracted_information({self.task_id})")


### PR DESCRIPTION
	## Summary
- Re-enabled the `Task.validate_update` guard so tasks with a `data_extraction_goal` must supply `extracted_information` before entering `completed`.
- Updated the parallel verification path to mirror the sequential flow: when the verified `CompleteAction` fires for an extraction task, we now run an `ExtractAction`, append its results to the step output, and then mark the task complete.
- Added targeted unit coverage for the new flow and for the validation rule.

## Testing
- `pytest tests/unit/test_parallel_verification.py`
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Re-enable validation for data extraction tasks and update parallel verification to include data extraction, with new unit tests added.
> 
>   - **Behavior**:
>     - Re-enable `Task.validate_update` guard in `tasks.py` to require `extracted_information` for tasks with `data_extraction_goal` before marking as `completed`.
>     - Update `_handle_completed_step_with_parallel_verification()` in `agent.py` to run `ExtractAction` after `CompleteAction` for tasks with data extraction goals.
>   - **Tests**:
>     - Add unit tests for parallel verification and validation rule in `test_parallel_verification.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 00997b0c6fc84dcdf3e97da026bd773e9f33c269. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Data extraction now runs automatically during parallel verification when a step completes, and extraction results are appended to the step and task outputs.

* **Bug Fixes**
  * Validation now requires extracted information when a task status demands it, preventing tasks from completing without required extraction.

* **Reliability**
  * Extraction results and related output fields are now consistently initialized and recorded to improve task/result integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->