### PR TITLE
support to scrape on the chrome error page

### DIFF
--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -791,7 +791,11 @@ class BrowserState:
         return [
             http_page
             for http_page in self.browser_context.pages
-            if http_page.url == "about:blank" or urlparse(http_page.url).scheme in ["http", "https"]
+            if (
+                http_page.url == "about:blank"
+                or http_page.url == "chrome-error://chromewebdata/"
+                or urlparse(http_page.url).scheme in ["http", "https"]
+            )
         ]
 
     async def validate_browser_context(self, page: Page) -> bool:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for recognizing Chrome error pages in `list_valid_pages` in `browser_factory.py`.
> 
>   - **Behavior**:
>     - `list_valid_pages` in `browser_factory.py` now includes `chrome-error://chromewebdata/` as a valid page URL.
>     - This allows handling of Chrome error pages in the browser context.
>   - **Misc**:
>     - No other files or functions are affected by this change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 54e3936b458c83e57afbb25bf82014c0ff7bfc22. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced browser page recognition to identify additional page types as valid, improving page availability detection and browser context handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->