### PR TITLE
use value of the optiona when the content is empty

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1380,6 +1380,7 @@ function getSelectOptions(element) {
     selectOptions.push({
       optionIndex: option.index,
       text: removeMultipleSpaces(option.textContent),
+      value: removeMultipleSpaces(option.value),
     });
   }
 

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -152,6 +152,8 @@ def json_to_html(element: dict, need_skyvern_attrs: bool = True) -> str:
     # build option HTML
     option_html = "".join(
         f'<option index="{option.get("optionIndex")}">{option.get("text")}</option>'
+        if option.get("text")
+        else f'<option index="{option.get("optionIndex")}" value="{option.get("value")}">{option.get("text")}</option>'
         for option in element.get("options", [])
     )
 

--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -85,6 +85,7 @@ RAW_INPUT_NAME_VALUE = ["name", "email", "username", "password", "phone"]
 class SkyvernOptionType(typing.TypedDict):
     optionIndex: int
     text: str
+    value: str
 
 
 class SkyvernElement:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved select option handling to properly capture and preserve value attributes for dropdown menus during form processing and rendering, enhancing form submission accuracy and overall reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔧 This PR enhances select option handling by capturing both the displayed text and underlying value attributes, ensuring proper form interaction when option text content is empty but values exist.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **DOM Scraping Enhancement**: Modified `getSelectOptions()` in `domUtils.js` to extract both `textContent` and `value` attributes from option elements
- **Type Definition Update**: Added `value: str` field to `SkyvernOptionType` TypedDict in `dom.py` to support the new data structure
- **HTML Generation Logic**: Updated `json_to_html()` in `scraper.py` to conditionally use option values when text content is empty, ensuring proper option rendering

### Technical Implementation
```mermaid
flowchart TD
    A[DOM Option Element] --> B[getSelectOptions JS Function]
    B --> C[Extract textContent]
    B --> D[Extract value attribute]
    C --> E[SkyvernOptionType Object]
    D --> E
    E --> F[json_to_html Python Function]
    F --> G{Text Content Empty?}
    G -->|Yes| H[Use value in HTML]
    G -->|No| I[Use text in HTML]
    H --> J[Generated Option HTML]
    I --> J
```

### Impact
- **Form Interaction Accuracy**: Resolves issues where dropdown options with empty text but valid values would be improperly handled
- **Data Extraction Completeness**: Ensures both visual text and underlying form values are preserved during web scraping operations
- **Backward Compatibility**: Changes are additive and don't break existing functionality, as the text-based logic remains the primary path

</details>

_Created with [Palmier](https://www.palmier.io)_