### PR TITLE
use explicit vertex credentials for cache manager

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -673,12 +673,6 @@ class LLMAPIHandlerFactory:
             # Add Vertex AI cache reference only for the intended cached prompt
             vertex_cache_attached = False
             cache_resource_name = getattr(context, "vertex_cache_name", None)
-            LOG.info(
-                "Vertex cache attachment check",
-                cache_resource_name=cache_resource_name,
-                prompt_name=prompt_name,
-                use_prompt_caching=getattr(context, "use_prompt_caching", None) if context else None,
-            )
             if (
                 cache_resource_name
                 and prompt_name == EXTRACT_ACTION_PROMPT_NAME


### PR DESCRIPTION
	## Summary
- teach `VertexCacheManager` to parse the existing `VERTEX_CREDENTIALS` secret and mint its own access tokens
- keep a cached service-account credential and fall back to ADC only if the secret is missing
- clean up the redundant “vertex cache attachment check” log

## Testing
- not run (verify via staging cache hits)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow supplying Vertex AI credentials as JSON for cache management; supports parsing, selecting service-account or application-default credentials, lazy initialization, token refresh, and graceful fallback.

* **Chores**
  * Removed an informational log message related to Vertex cache attachment checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->