### PR TITLE
allow webhook-generated 2fa to display on 2fa creds - for customers with many creds

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -3311,14 +3311,9 @@ class AgentDB:
         - totp_identifier
         - workflow_run_id (optional)
         2. make sure created_at is within the valid lifespan
-        3. sort by task_id/workflow_id/workflow_run_id nullslast and created_at desc
+        3. sort by created_at desc
         4. apply an optional limit at the DB layer
         """
-        all_null = and_(
-            TOTPCodeModel.task_id.is_(None),
-            TOTPCodeModel.workflow_id.is_(None),
-            TOTPCodeModel.workflow_run_id.is_(None),
-        )
         async with self.Session() as session:
             query = (
                 select(TOTPCodeModel)
@@ -3330,7 +3325,7 @@ class AgentDB:
                 query = query.filter(TOTPCodeModel.otp_type == otp_type)
             if workflow_run_id is not None:
                 query = query.filter(TOTPCodeModel.workflow_run_id == workflow_run_id)
-            query = query.order_by(asc(all_null), TOTPCodeModel.created_at.desc())
+            query = query.order_by(TOTPCodeModel.created_at.desc())
             if limit is not None:
                 query = query.limit(limit)
             totp_code = (await session.scalars(query)).all()
@@ -3348,11 +3343,6 @@ class AgentDB:
         Return recent otp codes for an organization ordered by newest first with optional
         workflow_run_id filtering.
         """
-        all_null = and_(
-            TOTPCodeModel.task_id.is_(None),
-            TOTPCodeModel.workflow_id.is_(None),
-            TOTPCodeModel.workflow_run_id.is_(None),
-        )
         async with self.Session() as session:
             query = select(TOTPCodeModel).filter_by(organization_id=organization_id)
 
@@ -3365,7 +3355,7 @@ class AgentDB:
                 query = query.filter(TOTPCodeModel.otp_type == otp_type)
             if workflow_run_id is not None:
                 query = query.filter(TOTPCodeModel.workflow_run_id == workflow_run_id)
-            query = query.order_by(asc(all_null), TOTPCodeModel.created_at.desc()).limit(limit)
+            query = query.order_by(TOTPCodeModel.created_at.desc()).limit(limit)
             totp_codes = (await session.scalars(query)).all()
             return [TOTPCode.model_validate(totp_code) for totp_code in totp_codes]
 


### PR DESCRIPTION
Issue:
2FA codes received via webhook (orphaned, lacking task_id/workflow_run_id) were often hidden from the Credentials UI. The database query prioritized records with workflow context (order_by(asc(all_null))), causing newer webhook codes to be pushed to the bottom of the list and truncated by the query limit (default 50) when many task-linked codes existed.

Fix:
Updated get_recent_otp_codes and get_otp_codes in AgentDB to remove the sort bias. The query now strictly orders results by created_at DESC, ensuring the most recent codes always appear at the top regardless of their source or context.

Verification:
Manually verified using a script that floods 100 linked codes followed by 1 webhook code. Confirmed that the webhook code now correctly appears at the top of the list in the UI, whereas it was previously hidden.
<img width="1650" height="621" alt="Screenshot 2025-11-19 at 1 02 11 PM" src="https://github.com/user-attachments/assets/a7046835-1546-4fe7-a3d5-9945afdbf4d2" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes sorting issue in `client.py` to ensure webhook-generated 2FA codes are displayed by ordering by `created_at DESC`.
> 
>   - **Behavior**:
>     - Fixes sorting issue in `get_otp_codes` and `get_recent_otp_codes` in `client.py` to ensure webhook-generated 2FA codes are displayed in the UI.
>     - Changes query to order by `created_at DESC` instead of prioritizing task-linked codes.
>   - **Verification**:
>     - Manually verified with a script flooding 100 linked codes followed by 1 webhook code, confirming the webhook code appears at the top of the list.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e412ee63a02f9eb7aff6090ffcdae5cd2d7a76e6. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes a critical sorting issue in 2FA code retrieval that was hiding webhook-generated codes from customers with many credentials. The change removes biased sorting logic that prioritized task-linked codes over orphaned webhook codes, ensuring the most recent codes always appear first in the UI.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Database Query Logic**: Removed the `all_null` sorting bias from `get_otp_codes()` and `get_recent_otp_codes()` methods
- **Sort Order Simplification**: Changed from `order_by(asc(all_null), TOTPCodeModel.created_at.desc())` to simple `order_by(TOTPCodeModel.created_at.desc())`
- **Code Cleanup**: Eliminated redundant `all_null` variable definitions that checked for null task_id, workflow_id, and workflow_run_id

### Technical Implementation
```mermaid
sequenceDiagram
    participant UI as Credentials UI
    participant DB as Database Query
    participant Codes as TOTP Codes
    
    Note over DB: Before Fix
    DB->>Codes: ORDER BY asc(all_null), created_at DESC
    Note over Codes: Task-linked codes prioritized<br/>Webhook codes pushed down<br/>Limited by query limit (50)
    Codes->>UI: Webhook codes hidden
    
    Note over DB: After Fix
    DB->>Codes: ORDER BY created_at DESC only
    Note over Codes: All codes sorted by recency<br/>No bias toward task-linked codes
    Codes->>UI: Most recent codes visible
```

### Impact
- **User Experience**: Webhook-generated 2FA codes now consistently appear at the top of the credentials list for customers with many codes
- **Data Visibility**: Eliminates the issue where recent webhook codes were truncated due to query limits when many task-linked codes existed
- **Query Performance**: Simplified sorting logic reduces query complexity while maintaining chronological ordering

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified OTP code retrieval sorting to consistently order results by creation timestamp, removing special handling for records with null references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->