### PR TITLE
backend changes for magic wand button

### DIFF
--- a/skyvern/forge/sdk/routes/prompts.py
+++ b/skyvern/forge/sdk/routes/prompts.py
@@ -24,6 +24,26 @@ class Constants:
     }
 
 
+def resolve_template_name(use_case: str) -> str:
+    """
+    Map a use-case to the template the LLM should receive.
+
+    Defaults to the generic template so new use-cases can be added from the UI
+    without requiring backend changes.
+    """
+    template_name = Constants.IMPROVE_PROMPT_USE_CASE_TO_TEMPLATE_MAP.get(use_case)
+    if template_name:
+        return template_name
+
+    LOG.info(
+        "Unknown improve prompt use case, falling back to default template",
+        use_case=use_case,
+        template_name=Constants.DEFAULT_TEMPLATE_NAME,
+    )
+
+    return Constants.DEFAULT_TEMPLATE_NAME
+
+
 @base_router.post(
     "/prompts/improve",
     tags=["Prompts"],
@@ -38,10 +58,7 @@ async def improve_prompt(
     """
     Improve a prompt based on a specific use-case.
     """
-    template_name = Constants.IMPROVE_PROMPT_USE_CASE_TO_TEMPLATE_MAP.get(
-        use_case,
-        Constants.DEFAULT_TEMPLATE_NAME,
-    )
+    template_name = resolve_template_name(use_case)
 
     llm_prompt = prompt_engine.load_prompt(
         context=request.context,


### PR DESCRIPTION
### Summary

This change enables `/prompts/improve` to accept any `use-case` by defaulting to the generic browser-agent template whenever the provided key isn’t explicitly mapped.

- the default `improve-prompt-for-ai-browser-agent` template works for all current frontend prompts because we pass block/field context along with the raw prompt
- added `resolve_template_name()` to look up known use-cases and fall back (with logging) when new ones arrive  
- kept the legacy map so we can still override specific use-cases if we ever need a custom template  
- ensured full backward compatibility—the endpoint behaves the same for existing keys and gracefully handles new ones  

[Ticket link](https://linear.app/skyvern/issue/SKY-7059/add-magic-wand-button-to-improve-prompts-in-all-blocks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal code organization and maintainability by centralizing template resolution logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->