### PR TITLE
raise exception when non dict response

### DIFF
--- a/skyvern/forge/sdk/api/llm/exceptions.py
+++ b/skyvern/forge/sdk/api/llm/exceptions.py
@@ -24,6 +24,11 @@ class InvalidLLMResponseFormat(BaseLLMError):
         super().__init__(f"LLM response content is not a valid JSON: {response}")
 
 
+class InvalidLLMResponseType(BaseLLMError):
+    def __init__(self, response_type: str) -> None:
+        super().__init__(f"LLM response content is expected to be a dict, but got {response_type}")
+
+
 class DuplicateCustomLLMProviderError(BaseLLMError):
     def __init__(self, llm_key: str) -> None:
         super().__init__(f"Custom LLMProvider {llm_key} is already registered")

--- a/skyvern/forge/sdk/api/llm/utils.py
+++ b/skyvern/forge/sdk/api/llm/utils.py
@@ -10,7 +10,7 @@ import structlog
 
 from skyvern.constants import MAX_IMAGE_MESSAGES
 from skyvern.forge.sdk.api.llm import commentjson
-from skyvern.forge.sdk.api.llm.exceptions import EmptyLLMResponseError, InvalidLLMResponseFormat
+from skyvern.forge.sdk.api.llm.exceptions import EmptyLLMResponseError, InvalidLLMResponseFormat, InvalidLLMResponseType
 
 LOG = structlog.get_logger()
 
@@ -155,13 +155,14 @@ def _coerce_response_to_dict(response: Any) -> dict[str, Any]:
             return first_dict
 
         LOG.warning("List response contained no dict entries; returning empty dict")
-        return {}
+        raise InvalidLLMResponseType("list")
 
     LOG.warning(
         "Parsed LLM response is not a dict; returning empty dict",
         response_type=type(response).__name__,
     )
-    return {}
+
+    raise InvalidLLMResponseType(type(response).__name__)
 
 
 def parse_api_response(response: litellm.ModelResponse, add_assistant_prefix: bool = False) -> dict[str, Any]:


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces `InvalidLLMResponseType` to handle non-dict LLM responses, improving error visibility and updating tests accordingly.
> 
>   - **Behavior**:
>     - Raises `InvalidLLMResponseType` in `_coerce_response_to_dict()` in `utils.py` when LLM response is not a `dict`.
>     - Handles list responses by checking for a `dict` within the list, otherwise raises `InvalidLLMResponseType`.
>   - **Exceptions**:
>     - Adds `InvalidLLMResponseType` in `exceptions.py` to handle non-dict LLM responses.
>   - **Tests**:
>     - Updates test suite to validate exception handling for non-dict LLM responses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for cf26082a28dd1ded99b72e3faca64803f889daa2. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for LLM response validation. The system now explicitly raises exceptions for invalid response types instead of silently returning empty results, making error conditions more visible and easier to debug.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🚨 This PR improves error handling for LLM responses by raising specific exceptions when non-dictionary responses are encountered, replacing the previous behavior of silently returning empty dictionaries. The change enhances debugging capabilities and makes response validation failures more explicit and actionable.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Exception Handling**: Added new `InvalidLLMResponseType` exception class to handle cases where LLM responses are not dictionaries
- **Response Validation**: Modified `_coerce_response_to_dict()` function to raise exceptions instead of returning empty dictionaries for invalid response types
- **Error Visibility**: Replaced silent failures with explicit error reporting for better debugging and monitoring

### Technical Implementation
```mermaid
flowchart TD
    A[LLM Response] --> B{Is Dict?}
    B -->|Yes| C[Return Dict]
    B -->|No| D{Is List?}
    D -->|Yes| E{Contains Dict?}
    E -->|Yes| F[Return First Dict]
    E -->|No| G[Raise InvalidLLMResponseType]
    D -->|No| H[Raise InvalidLLMResponseType]
    
    style G fill:#ff6b6b
    style H fill:#ff6b6b
```

### Impact
- **Error Transparency**: Developers now receive clear error messages when LLM responses don't match expected dictionary format
- **Debugging Enhancement**: Specific exception types make it easier to identify and handle different failure scenarios
- **Breaking Change**: Applications relying on the previous behavior of returning empty dictionaries will need to handle the new exceptions

</details>

_Created with [Palmier](https://www.palmier.io)_