### PR TITLE
improve caching reliability by add retries for scrape_page

### DIFF
--- a/skyvern/constants.py
+++ b/skyvern/constants.py
@@ -43,3 +43,6 @@ TEXT_PRESS_MAX_LENGTH = 20
 
 # Script generation constants
 DEFAULT_SCRIPT_RUN_ID = "default"
+
+# SkyvernPage constants
+SKYVERN_PAGE_MAX_SCRAPING_RETRIES = 2

--- a/skyvern/core/script_generations/real_skyvern_page_ai.py
+++ b/skyvern/core/script_generations/real_skyvern_page_ai.py
@@ -9,7 +9,7 @@ from jinja2.sandbox import SandboxedEnvironment
 from playwright.async_api import Page
 
 from skyvern.config import settings
-from skyvern.constants import SPECIAL_FIELD_VERIFICATION_CODE
+from skyvern.constants import SKYVERN_PAGE_MAX_SCRAPING_RETRIES, SPECIAL_FIELD_VERIFICATION_CODE
 from skyvern.core.script_generations.skyvern_page_ai import SkyvernPageAi
 from skyvern.forge import app
 from skyvern.forge.prompts import prompt_engine
@@ -145,7 +145,9 @@ class RealSkyvernPageAi(SkyvernPageAi):
             # Build the element tree of the current page for the prompt
             context = skyvern_context.ensure_context()
             payload_str = _get_context_data(data)
-            refreshed_page = await self.scraped_page.generate_scraped_page_without_screenshots()
+            refreshed_page = await self.scraped_page.generate_scraped_page_without_screenshots(
+                max_retries=SKYVERN_PAGE_MAX_SCRAPING_RETRIES
+            )
             element_tree = refreshed_page.build_element_tree()
 
             organization_id = context.organization_id if context else None
@@ -244,7 +246,9 @@ class RealSkyvernPageAi(SkyvernPageAi):
                         else:
                             data = {SPECIAL_FIELD_VERIFICATION_CODE: verification_code}
 
-                refreshed_page = await self.scraped_page.generate_scraped_page_without_screenshots()
+                refreshed_page = await self.scraped_page.generate_scraped_page_without_screenshots(
+                    max_retries=SKYVERN_PAGE_MAX_SCRAPING_RETRIES
+                )
                 self.scraped_page = refreshed_page
 
                 # Try to get element_id from selector if selector is provided
@@ -348,7 +352,9 @@ class RealSkyvernPageAi(SkyvernPageAi):
                 if files and isinstance(data, dict) and "files" not in data:
                     data["files"] = files
 
-                refreshed_page = await self.scraped_page.generate_scraped_page_without_screenshots()
+                refreshed_page = await self.scraped_page.generate_scraped_page_without_screenshots(
+                    max_retries=SKYVERN_PAGE_MAX_SCRAPING_RETRIES
+                )
                 self.scraped_page = refreshed_page
 
                 # Try to get element_id from selector if selector is provided
@@ -445,7 +451,9 @@ class RealSkyvernPageAi(SkyvernPageAi):
                     if value and isinstance(data, dict) and "value" not in data:
                         data["value"] = value
 
-                    refreshed_page = await self.scraped_page.generate_scraped_page_without_screenshots()
+                    refreshed_page = await self.scraped_page.generate_scraped_page_without_screenshots(
+                        max_retries=SKYVERN_PAGE_MAX_SCRAPING_RETRIES
+                    )
                     self.scraped_page = refreshed_page
                     element_tree = refreshed_page.build_element_tree()
                     merged_goal = SELECT_OPTION_GOAL.format(intention=intention, prompt=prompt)
@@ -501,7 +509,7 @@ class RealSkyvernPageAi(SkyvernPageAi):
     ) -> dict[str, Any] | list | str | None:
         """Extract information from the page using AI."""
 
-        scraped_page_refreshed = await self.scraped_page.refresh()
+        scraped_page_refreshed = await self.scraped_page.refresh(max_retries=SKYVERN_PAGE_MAX_SCRAPING_RETRIES)
         context = skyvern_context.current()
         tz_info = datetime.now(tz=timezone.utc).tzinfo
         if context and context.tz_info:
@@ -598,7 +606,9 @@ class RealSkyvernPageAi(SkyvernPageAi):
             reasoning=action_info.get("reasoning"),
         )
 
-        refreshed_page = await self.scraped_page.generate_scraped_page_without_screenshots()
+        refreshed_page = await self.scraped_page.generate_scraped_page_without_screenshots(
+            max_retries=SKYVERN_PAGE_MAX_SCRAPING_RETRIES
+        )
         self.scraped_page = refreshed_page
         element_tree = refreshed_page.build_element_tree()
 

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -366,11 +366,12 @@ class ScrapedPage(BaseModel, ElementTreeBuilder):
             element["children"] = new_children
         return element
 
-    async def refresh(self, draw_boxes: bool = True, scroll: bool = True) -> Self:
+    async def refresh(self, draw_boxes: bool = True, scroll: bool = True, max_retries: int = 0) -> Self:
         refreshed_page = await scrape_website(
             browser_state=self._browser_state,
             url=self.url,
             cleanup_element_tree=self._clean_up_func,
+            max_retries=max_retries,
             scrape_exclude=self._scrape_exclude,
             draw_boxes=draw_boxes,
             scroll=scroll,
@@ -390,20 +391,25 @@ class ScrapedPage(BaseModel, ElementTreeBuilder):
         return self
 
     async def generate_scraped_page(
-        self, draw_boxes: bool = True, scroll: bool = True, take_screenshots: bool = True
+        self,
+        draw_boxes: bool = True,
+        scroll: bool = True,
+        take_screenshots: bool = True,
+        max_retries: int = 0,
     ) -> Self:
         return await scrape_website(
             browser_state=self._browser_state,
             url=self.url,
             cleanup_element_tree=self._clean_up_func,
+            max_retries=max_retries,
             scrape_exclude=self._scrape_exclude,
             take_screenshots=take_screenshots,
             draw_boxes=draw_boxes,
             scroll=scroll,
         )
 
-    async def generate_scraped_page_without_screenshots(self) -> Self:
-        return await self.generate_scraped_page(take_screenshots=False)
+    async def generate_scraped_page_without_screenshots(self, max_retries: int = 0) -> Self:
+        return await self.generate_scraped_page(take_screenshots=False, max_retries=max_retries)
 
 
 @TraceManager.traced_async(ignore_input=True)
@@ -412,6 +418,7 @@ async def scrape_website(
     url: str,
     cleanup_element_tree: CleanupElementTreeFunc,
     num_retry: int = 0,
+    max_retries: int = settings.MAX_SCRAPING_RETRIES,
     scrape_exclude: ScrapeExcludeFunc | None = None,
     take_screenshots: bool = True,
     draw_boxes: bool = True,
@@ -460,10 +467,11 @@ async def scrape_website(
         raise
     except Exception as e:
         # NOTE: MAX_SCRAPING_RETRIES is set to 0 in both staging and production
-        if num_retry > settings.MAX_SCRAPING_RETRIES:
+        if num_retry > max_retries:
             LOG.error(
                 "Scraping failed after max retries, aborting.",
-                max_retries=settings.MAX_SCRAPING_RETRIES,
+                max_retries=max_retries,
+                num_retry=num_retry,
                 url=url,
                 exc_info=True,
             )
@@ -471,12 +479,14 @@ async def scrape_website(
                 raise e
             else:
                 raise ScrapingFailed() from e
-        LOG.info("Scraping failed, will retry", num_retry=num_retry, url=url)
+        LOG.info("Scraping failed, will retry", max_retries=max_retries, num_retry=num_retry, url=url, wait_seconds=0.5)
+        await asyncio.sleep(0.5)
         return await scrape_website(
             browser_state,
             url,
             cleanup_element_tree,
             num_retry=num_retry,
+            max_retries=max_retries,
             scrape_exclude=scrape_exclude,
             take_screenshots=take_screenshots,
             draw_boxes=draw_boxes,


### PR DESCRIPTION
Running into bugs when caching code runs too fast:
before page is fully loaded after page.goto, we do a scrape and playwright fails:
```
2025-11-21T05:43:09.054140Z [error    ] [scraper.py                    :465 ] Scraping failed after max retries, aborting. max_retries=0 url=about:blank
...
...
...
  raise rewrite_error(error, f"{parsed_st['apiName']}: {error}") from None
playwright._impl._errors.Error: Page.evaluate: Execution context was destroyed, most likely because of a navigation
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved page scraping reliability with configurable retry limits, allowing up to 2 automatic retry attempts when scraping fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔄 This PR improves caching reliability by adding configurable retry logic to page scraping operations, addressing race conditions where scraping attempts fail due to pages not being fully loaded after navigation.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Constants Addition**: Added `SKYVERN_PAGE_MAX_SCRAPING_RETRIES = 2` constant to centralize retry configuration
- **Scraper Enhancement**: Modified `scrape_website()` function to accept a `max_retries` parameter with proper retry logic and 0.5-second delays
- **API Updates**: Updated all scraping methods (`refresh()`, `generate_scraped_page()`, `generate_scraped_page_without_screenshots()`) to accept and pass through the `max_retries` parameter
- **AI Integration**: Applied retry logic across all AI operations (click, input, upload, select, extract, act) that perform page scraping

### Technical Implementation
```mermaid
sequenceDiagram
    participant AI as AI Operation
    participant SP as ScrapedPage
    participant SW as scrape_website
    participant PW as Playwright
    
    AI->>SP: generate_scraped_page_without_screenshots(max_retries=2)
    SP->>SW: scrape_website(max_retries=2)
    SW->>PW: page.evaluate()
    
    alt Success
        PW-->>SW: DOM data
        SW-->>SP: ScrapedPage
        SP-->>AI: Updated page
    else Failure (retry < max_retries)
        PW-->>SW: Error: Execution context destroyed
        SW->>SW: sleep(0.5)
        SW->>PW: page.evaluate() [retry]
    else Max retries exceeded
        SW-->>SP: ScrapingFailed exception
    end
```

### Impact
- **Reliability Improvement**: Resolves race conditions where scraping fails due to "Execution context was destroyed" errors during page navigation
- **Configurable Resilience**: Provides centralized control over retry behavior with a reasonable default of 2 retries
- **Performance Optimization**: Adds minimal 0.5-second delays between retries to allow pages to stabilize without excessive waiting
- **Backward Compatibility**: All changes are additive with sensible defaults, maintaining existing API contracts

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds retry logic to improve scraping reliability with configurable retries, defaulting to 2, across various scraping functions.
> 
>   - **Behavior**:
>     - Introduces retry logic for scraping operations with a default of 2 retries, configurable via `SKYVERN_PAGE_MAX_SCRAPING_RETRIES` in `constants.py`.
>     - Updates `refresh()` and `generate_scraped_page_without_screenshots()` in `scraper.py` to accept `max_retries` parameter.
>     - Implements retry logic in `scrape_website()` with a 0.5-second wait between retries.
>   - **Functions**:
>     - Modifies `ai_click()`, `ai_input_text()`, `ai_upload_file()`, `ai_select_option()`, `ai_extract()`, and `ai_act()` in `real_skyvern_page_ai.py` to use the new retry logic.
>     - Updates `scrape_website()` and `scrape_web_unsafe()` in `scraper.py` to handle retries.
>   - **Constants**:
>     - Adds `SKYVERN_PAGE_MAX_SCRAPING_RETRIES` to `constants.py` with a default value of 2.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a3329308703eb6d1c7416bb8698461f0f8ed0739. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->