### PR TITLE
prevent cached_content leak to non-extract prompts

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -2,7 +2,7 @@ import dataclasses
 import json
 import time
 from asyncio import CancelledError
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Protocol, runtime_checkable
 
 import litellm
 import structlog
@@ -38,6 +38,19 @@ from skyvern.utils.image_resizer import Resolution, get_resize_target_dimension,
 LOG = structlog.get_logger()
 
 EXTRACT_ACTION_PROMPT_NAME = "extract-actions"
+
+
+@runtime_checkable
+class RouterWithModelList(Protocol):
+    model_list: list[dict[str, Any]]
+
+
+def _get_primary_model_dict(router: Any, main_model_group: str) -> dict[str, Any] | None:
+    if isinstance(router, RouterWithModelList):
+        for model_dict in router.model_list:
+            if model_dict.get("model_name") == main_model_group:
+                return model_dict
+    return None
 
 
 class LLMCallStats(BaseModel):
@@ -366,6 +379,8 @@ class LLMAPIHandlerFactory:
 
             vertex_cache_attached = False
             cache_resource_name = getattr(context, "vertex_cache_name", None)
+            primary_model_dict = _get_primary_model_dict(router, main_model_group)
+
             # Add cached_content to primary model's litellm_params (not global parameters)
             # This ensures it's only passed to the Gemini primary, not to fallback models.
             # By setting it in the model-specific litellm_params, LiteLLM will only include it
@@ -376,23 +391,24 @@ class LLMAPIHandlerFactory:
                 and prompt_name == EXTRACT_ACTION_PROMPT_NAME
                 and getattr(context, "use_prompt_caching", False)
                 and "gemini" in main_model_group.lower()
+                and primary_model_dict is not None
             ):
-                # Modify the router's model_list to add cached_content only to the primary model
-                # The router is created per-handler-instance, so this modification is safe
-                # and idempotent (setting the same value multiple times is fine)
-                for model_dict in router.model_list:
-                    if model_dict.get("model_name") == main_model_group:
-                        if "litellm_params" not in model_dict:
-                            model_dict["litellm_params"] = {}
-                        model_dict["litellm_params"]["cached_content"] = cache_resource_name
-                        vertex_cache_attached = True
-                        LOG.info(
-                            "Adding Vertex AI cache reference to primary model in router",
-                            prompt_name=prompt_name,
-                            primary_model=main_model_group,
-                            fallback_model=llm_config.fallback_model_group,
-                        )
-                        break
+                litellm_params = primary_model_dict.setdefault("litellm_params", {})
+                litellm_params["cached_content"] = cache_resource_name
+                vertex_cache_attached = True
+                LOG.info(
+                    "Adding Vertex AI cache reference to primary model in router",
+                    prompt_name=prompt_name,
+                    primary_model=main_model_group,
+                    fallback_model=llm_config.fallback_model_group,
+                )
+            elif primary_model_dict and "litellm_params" in primary_model_dict:
+                if primary_model_dict["litellm_params"].pop("cached_content", None):
+                    LOG.info(
+                        "Removed Vertex AI cache reference from primary model in router",
+                        prompt_name=prompt_name,
+                        primary_model=main_model_group,
+                    )
 
             llm_request_payload = {
                 "model": llm_key,
@@ -728,6 +744,14 @@ class LLMAPIHandlerFactory:
                     prompt_name=prompt_name,
                     cache_attached=True,
                 )
+            elif "cached_content" in active_parameters:
+                removed_cache = active_parameters.pop("cached_content", None)
+                if removed_cache:
+                    LOG.info(
+                        "Removed Vertex AI cache reference from request",
+                        prompt_name=prompt_name,
+                        cache_was_attached=True,
+                    )
 
             llm_request_payload = {
                 "model": model_name,


### PR DESCRIPTION
Updated both LLM handler paths so `cached_content` is only ever attached to `extract-actions` requests (and stripped in all other cases, including speculative runs), preventing the Vertex cache from leaking into verification prompts. Added a regression unit test that reproduces the original leak by reusing the same Gemini handler/context and confirms non-extract prompts no longer carry cached content. Tests: `uv run pytest tests/unit/test_api_handler_cached_content_fix.py`.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix `cached_content` leak by ensuring it is only attached to `extract-actions` requests in LLM handlers and removed otherwise.
> 
>   - **Behavior**:
>     - Ensure `cached_content` is only attached to `extract-actions` requests in `llm_api_handler_with_router_and_fallback` and `llm_api_handler`.
>     - Remove `cached_content` in non-extract and speculative prompts.
>   - **Functions**:
>     - Modify `llm_api_handler_with_router_and_fallback` to check and attach `cached_content` only for `extract-actions`.
>     - Modify `llm_api_handler` to remove `cached_content` if not `extract-actions`.
>   - **Tests**:
>     - Add regression test in `test_api_handler_cached_content_fix.py` to verify `cached_content` behavior across different prompt scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 926bb499e98a1af50c047b67442c13cdd54945e3. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * LLM call statistics now track reasoning tokens

* **Improvements**
  * Enhanced model routing and Vertex AI cache management for improved performance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔒 This PR fixes a critical bug where Vertex AI cached content was leaking from extract-action prompts to other prompt types, ensuring cache isolation and preventing unintended behavior in verification and other non-extract operations.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Cache Isolation Logic**: Added explicit removal of `cached_content` from non-extract prompts in both router-based and direct LLM handler paths
- **Type Safety**: Introduced `RouterWithModelList` protocol with runtime checking to safely access router model lists
- **Helper Function**: Created `_get_primary_model_dict()` to safely retrieve primary model configuration from router
- **Enhanced Logging**: Added comprehensive logging for both cache attachment and removal operations

### Technical Implementation
```mermaid
flowchart TD
    A[LLM Request] --> B{Is extract-actions prompt?}
    B -->|Yes| C{Is Gemini + Cache Enabled?}
    B -->|No| D[Remove cached_content if present]
    C -->|Yes| E[Attach cached_content to primary model]
    C -->|No| F[Continue without cache]
    D --> G[Log cache removal]
    E --> H[Log cache attachment]
    F --> I[Process request]
    G --> I
    H --> I
```

### Impact
- **Bug Resolution**: Eliminates cached content leakage that could cause incorrect behavior in verification prompts
- **Performance Optimization**: Ensures Vertex AI caching is only applied where intended (extract-actions), preventing unnecessary cache overhead
- **Code Safety**: Improved type checking and null safety when accessing router model configurations
- **Observability**: Enhanced logging provides clear visibility into cache attachment/removal decisions

</details>

_Created with [Palmier](https://www.palmier.io)_