### PR TITLE
auto close when page number exceeds

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -119,6 +119,7 @@ class Settings(BaseSettings):
     BROWSER_HEIGHT: int = 1080
     BROWSER_POLICY_FILE: str = "/etc/chromium/policies/managed/policies.json"
     BROWSER_LOGS_ENABLED: bool = True
+    BROWSER_MAX_PAGES_NUMBER: int = 10
 
     # Add extension folders name here to load extension in your browser
     EXTENSIONS_BASE_PATH: str = "./extensions"


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds a feature to automatically close oldest browser pages when the number of open pages exceeds a configurable limit, with a default of 10 pages.
> 
>   - **Behavior**:
>     - Adds `BROWSER_MAX_PAGES_NUMBER` setting in `skyvern/config.py` to limit open browser pages (default: 10).
>     - Modifies `list_valid_pages()` in `browser_factory.py` to close oldest pages when limit is exceeded, logging a warning.
>   - **Misc**:
>     - Updates initialization process for test notebooks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 13be71153222b0285d063ea2aee9022acbf07edf. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser now supports configurable page management with a default maximum of 10 pages. Older pages are automatically closed when the limit is exceeded.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔒 This PR implements automatic browser page management by introducing a configurable limit on the number of open pages and automatically closing the oldest pages when the limit is exceeded. The feature adds memory management capabilities to prevent resource exhaustion during long-running browser automation sessions.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Configuration**: Added `BROWSER_MAX_PAGES_NUMBER` setting in `config.py` with a default value of 10 pages
- **Page Management**: Modified `list_valid_pages()` method in `browser_factory.py` to accept a `max_pages` parameter and implement automatic page closing logic
- **Logging**: Added warning logs when pages are automatically closed due to exceeding the limit, with a note about potential video recording impact

### Technical Implementation
```mermaid
flowchart TD
    A[list_valid_pages called] --> B[Get all valid pages]
    B --> C{Pages count > max_pages?}
    C -->|No| D[Return all pages]
    C -->|Yes| E[Keep last max_pages pages]
    E --> F[Close oldest pages]
    F --> G[Log warning about closures]
    G --> H[Return reserved pages]
```

### Impact
- **Memory Management**: Prevents unlimited accumulation of browser pages that could lead to memory exhaustion
- **Resource Control**: Provides configurable limits for different deployment scenarios and resource constraints
- **Operational Visibility**: Warning logs help operators understand when automatic cleanup occurs and potential impacts on video recording functionality
- **Backward Compatibility**: The change is non-breaking as it uses a default parameter value and maintains existing behavior when page count is within limits

</details>

_Created with [Palmier](https://www.palmier.io)_