### PR TITLE
fix ng selectable detect

### DIFF
--- a/skyvern/webeye/scraper/domUtils.js
+++ b/skyvern/webeye/scraper/domUtils.js
@@ -1186,6 +1186,10 @@ const isAngularDropdown = (element) => {
     return false;
   }
 
+  if (element.type?.toLowerCase() === "search") {
+    return false;
+  }
+
   const tagName = element.tagName.toLowerCase();
   if (tagName === "input" || tagName === "span") {
     const ariaLabel = element.hasAttribute("aria-label")


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where search input fields were incorrectly identified as dropdown elements, which could have caused processing errors during web scraping operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix `isAngularDropdown` in `domUtils.js` to exclude search inputs from dropdown detection.
> 
>   - **Bug Fix**:
>     - Update `isAngularDropdown` in `domUtils.js` to exclude elements with `type="search"` from being detected as dropdowns.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f02486ca9b00cffb0062fcface0150ff2ce6ec92. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes a bug in Angular dropdown detection by preventing search input fields from being incorrectly classified as dropdown menus. The change adds a simple type check to exclude elements with `type="search"` from dropdown detection logic.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Element Type Filtering**: Added a new condition in `isAngularDropdown()` function to return `false` for elements with `type="search"`
- **Early Return Logic**: The check is placed early in the function, before existing tag name and attribute checks
- **Case-Insensitive Comparison**: Uses `toLowerCase()` to ensure robust type matching

### Technical Implementation
```mermaid
flowchart TD
    A[Element passed to isAngularDropdown] --> B{Element exists?}
    B -->|No| C[Return false]
    B -->|Yes| D{Type is 'search'?}
    D -->|Yes| E[Return false - NEW CHECK]
    D -->|No| F{Tag is input/span?}
    F -->|Yes| G[Check aria-label and other attributes]
    F -->|No| H[Continue with other checks]
    G --> I[Return dropdown detection result]
    H --> I
```

### Impact
- **Improved Accuracy**: Prevents search input fields from being misidentified as Angular dropdowns during web scraping
- **Better Web Interaction**: Enhances the reliability of automated web interactions by correctly classifying UI elements
- **Minimal Risk**: The change is a simple early return that doesn't affect existing dropdown detection logic for other element types

</details>

_Created with [Palmier](https://www.palmier.io)_