### PR TITLE
remove skip screenshot annotations experiment

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -1763,43 +1763,6 @@ class ForgeAgent:
 
         return actions
 
-    async def _should_skip_screenshot_annotations(self, task: Task, draw_boxes: bool) -> bool:
-        """
-        Check PostHog feature flag to determine if screenshot annotations should be skipped.
-
-        Args:
-            task: The task being executed
-            draw_boxes: Current value indicating if boxes should be drawn
-
-        Returns:
-            bool: True if annotations should be drawn, False if they should be skipped
-        """
-        if not draw_boxes:  # Only check if we were going to draw boxes
-            return draw_boxes
-
-        try:
-            distinct_id = task.workflow_run_id if task.workflow_run_id else task.task_id
-            skip_annotations = await app.EXPERIMENTATION_PROVIDER.is_feature_enabled_cached(
-                "SKIP_SCREENSHOT_ANNOTATIONS",
-                distinct_id,
-                properties={"organization_id": task.organization_id},
-            )
-            if skip_annotations:
-                LOG.info(
-                    "Skipping screenshot annotations per SKIP_SCREENSHOT_ANNOTATIONS feature flag",
-                    task_id=task.task_id,
-                    workflow_run_id=task.workflow_run_id,
-                )
-                return False
-        except Exception:
-            LOG.warning(
-                "Failed to check SKIP_SCREENSHOT_ANNOTATIONS feature flag, using default behavior",
-                task_id=task.task_id,
-                exc_info=True,
-            )
-
-        return draw_boxes
-
     async def _speculate_next_step_plan(
         self,
         task: Task,
@@ -2305,9 +2268,6 @@ class ForgeAgent:
             max_screenshot_number = 1
             draw_boxes = False
             scroll = False
-
-        # Check PostHog feature flag to skip screenshot annotations
-        draw_boxes = await self._should_skip_screenshot_annotations(task, draw_boxes)
 
         return await scrape_website(
             browser_state,


### PR DESCRIPTION
## Updates
- `skyvern/forge/agent.py`: deleted `_should_skip_screenshot_annotations` and always rely on the existing `draw_boxes` logic so annotations stay enabled except for CUA engines; removed the associated feature-flag call before invoking `scrape_website`.

## Testing
- `pre-commit` (ruff, ruff format, isort, mypy, etc.)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove `_should_skip_screenshot_annotations` and feature-flag check, relying on `draw_boxes` for screenshot annotations in `skyvern/forge/agent.py`.
> 
>   - **Behavior**:
>     - Removes `_should_skip_screenshot_annotations` function from `skyvern/forge/agent.py`.
>     - Always uses `draw_boxes` logic for annotations, except for CUA engines.
>     - Removes feature-flag check for `SKIP_SCREENSHOT_ANNOTATIONS` before `scrape_website()` call.
>   - **Testing**:
>     - Ran `pre-commit` checks including `ruff`, `isort`, and `mypy`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 51b83c74207770d3e2e5c19a601fdbdcc38aa666. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🧹 This PR removes the experimental screenshot annotations feature flag system, simplifying the codebase by eliminating the `_should_skip_screenshot_annotations` method and its associated PostHog feature flag checks. The change ensures screenshot annotations are consistently enabled based on existing `draw_boxes` logic, except for CUA engines.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Feature Flag Removal**: Deleted the `_should_skip_screenshot_annotations` method (37 lines) that checked PostHog's `SKIP_SCREENSHOT_ANNOTATIONS` feature flag
- **Logic Simplification**: Removed the feature flag check call before `scrape_website` invocation in `_scrape_with_type` method
- **Behavior Standardization**: Screenshot annotations now consistently follow the existing `draw_boxes` logic without experimental overrides

### Technical Implementation
```mermaid
flowchart TD
    A[Task Execution] --> B[_scrape_with_type method]
    B --> C{draw_boxes logic}
    C -->|True| D[Enable annotations]
    C -->|False for CUA| E[Disable annotations]
    D --> F[scrape_website with annotations]
    E --> G[scrape_website without annotations]
    
    style A fill:#e1f5fe
    style F fill:#c8e6c9
    style G fill:#ffcdd2
```

### Impact
- **Code Simplification**: Removes 40+ lines of experimental code, reducing complexity and maintenance burden
- **Consistent Behavior**: Eliminates potential confusion from feature flag overrides, ensuring predictable annotation behavior
- **Performance**: Minor improvement by removing feature flag lookup and caching operations during task execution

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined screenshot annotation display logic by removing feature flag-based control mechanisms. Screenshot annotations now follow a simplified, consistent behavior path based solely on existing configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->