### PR TITLE
Warn 'Authentication failed'

### DIFF
--- a/skyvern/forge/sdk/routes/streaming/messages.py
+++ b/skyvern/forge/sdk/routes/streaming/messages.py
@@ -69,7 +69,7 @@ async def messages(
     organization_id = await auth(apikey=apikey, token=token, websocket=websocket)
 
     if not organization_id:
-        LOG.error(
+        LOG.warning(
             "Authentication failed.",
             browser_session_id=browser_session_id,
             workflow_run_id=workflow_run_id,

--- a/skyvern/forge/sdk/routes/streaming/vnc.py
+++ b/skyvern/forge/sdk/routes/streaming/vnc.py
@@ -89,7 +89,7 @@ async def stream(
     organization_id = await auth(apikey=apikey, token=token, websocket=websocket)
 
     if not organization_id:
-        LOG.error("Authentication failed.", task_id=task_id, workflow_run_id=workflow_run_id)
+        LOG.warning("Authentication failed.", task_id=task_id, workflow_run_id=workflow_run_id)
         return
 
     vnc_channel: VncChannel


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted authentication failure logging severity in streaming routes to improve log classification and reduce alert fatigue from expected authentication scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Change logging level from error to warning for authentication failures in `messages.py` and `vnc.py`.
> 
>   - **Logging**:
>     - Change logging level from error to warning for authentication failures in `messages()` in `messages.py` and `stream()` in `vnc.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9ecbe6827883177bcea10f81d88444c08bfccce3. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR downgrades authentication failure logging from error to warning level in streaming handlers for messages and VNC endpoints. The change improves log clarity by treating authentication failures as expected operational events rather than system errors.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Logging Level Adjustment**: Changed `LOG.error` to `LOG.warning` for authentication failures in two streaming endpoints
- **Messages Handler**: Updated authentication failure logging in `skyvern/forge/sdk/routes/streaming/messages.py`
- **VNC Handler**: Updated authentication failure logging in `skyvern/forge/sdk/routes/streaming/vnc.py`

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant StreamingHandler
    participant AuthService
    participant Logger
    
    Client->>StreamingHandler: WebSocket connection request
    StreamingHandler->>AuthService: Validate credentials
    AuthService-->>StreamingHandler: Authentication failed
    StreamingHandler->>Logger: LOG.warning("Authentication failed")
    StreamingHandler-->>Client: Connection terminated
```

### Impact
- **Log Clarity**: Authentication failures are now properly categorized as warnings rather than errors, reducing noise in error monitoring
- **Operational Monitoring**: Helps distinguish between actual system errors and expected authentication rejections
- **No Functional Changes**: The control flow remains identical - handlers still terminate early on authentication failure

</details>

_Created with [Palmier](https://www.palmier.io)_