### PR TITLE
raise occupied exception before creating workflow

### DIFF
--- a/skyvern/exceptions.py
+++ b/skyvern/exceptions.py
@@ -777,8 +777,8 @@ class LLMCallerNotFoundError(SkyvernException):
 
 
 class BrowserSessionAlreadyOccupiedError(SkyvernHTTPException):
-    def __init__(self, browser_session_id: str) -> None:
-        super().__init__(f"Browser session {browser_session_id} is already occupied")
+    def __init__(self, browser_session_id: str, runnable_id: str) -> None:
+        super().__init__(f"Browser session {browser_session_id} is already occupied by {runnable_id}")
 
 
 class BrowserSessionNotRenewable(SkyvernException):


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for browser session conflicts by including details about which workflow occupies the session
  * Added validation checks before starting workflow runs to ensure browser sessions are available and not currently in use, preventing workflows from starting with invalid session states

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes bug by raising `BrowserSessionAlreadyOccupiedError` with detailed message and improves error handling for unavailable browser sessions in `service.py`.
> 
>   - **Behavior**:
>     - Raises `BrowserSessionAlreadyOccupiedError` in `setup_workflow_run()` in `service.py` if a browser session is already occupied, including the `runnable_id` in the error message.
>     - Logs a warning and raises `BrowserSessionNotFound` if the requested browser session cannot be found.
>   - **Exceptions**:
>     - Updates `BrowserSessionAlreadyOccupiedError` to include `runnable_id` in the error message.
>   - **Logging**:
>     - Adds logging for warnings when a browser session is not found or is already occupied in `setup_workflow_run()` in `service.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 48c8def5d883e02ea85b827680d586a1fa315bed. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🛡️ This PR prevents workflow runs from using browser sessions that are already occupied by other workflows, improving resource management and error handling. It adds validation checks before workflow creation and enhances error messages to include which runnable is currently using the session.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Exception Enhancement**: Updated `BrowserSessionAlreadyOccupiedError` to include the `runnable_id` parameter, making error messages more informative by showing which process is currently using the session
- **Workflow Setup Validation**: Added pre-creation validation in `setup_workflow_run()` to check if a requested browser session exists and is available before creating the workflow run
- **Error Handling**: Improved error handling with specific warnings and exceptions for browser session conflicts, preventing resource contention

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant WorkflowService
    participant Database
    participant BrowserSession
    
    Client->>WorkflowService: Request workflow with browser_session_id
    WorkflowService->>Database: get_persistent_browser_session()
    alt Session not found
        Database-->>WorkflowService: None
        WorkflowService-->>Client: BrowserSessionNotFound
    else Session occupied
        Database-->>WorkflowService: session with runnable_id
        WorkflowService-->>Client: BrowserSessionAlreadyOccupiedError(session_id, runnable_id)
    else Session available
        Database-->>WorkflowService: session without runnable_id
        WorkflowService->>WorkflowService: create_workflow_run()
        WorkflowService-->>Client: Success
    end
```

### Impact
- **Resource Protection**: Prevents multiple workflows from attempting to use the same browser session simultaneously, avoiding conflicts and potential data corruption
- **Better Error Messages**: Users now receive clear information about which process is using a requested browser session, improving debugging and troubleshooting
- **Early Validation**: Catches browser session conflicts before workflow creation, saving resources and providing faster feedback to users

</details>

_Created with [Palmier](https://www.palmier.io)_