### PR TITLE
scroll into view before click

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -724,6 +724,14 @@ async def handle_click_action(
         )
         return [ActionFailure(InteractWithDisabledElement(skyvern_element.get_id()))]
 
+    try:
+        await skyvern_element.scroll_into_view()
+    except Exception:
+        LOG.info(
+            "Failed to scroll into view, ignore it and continue executing",
+            element_id=skyvern_element.get_id(),
+        )
+
     if action.download:
         results = await handle_click_to_download_file_action(action, page, scraped_page, task, step)
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved click action reliability by automatically attempting to scroll target elements into view before interaction, with graceful error handling ensuring actions proceed even when scrolling encounters obstacles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves click reliability in `handle_click_action()` by scrolling elements into view before clicking, with non-fatal logging of scroll failures.
> 
>   - **Behavior**:
>     - In `handle_click_action()` in `handler.py`, added a step to scroll the target element into view before clicking.
>     - Scroll failures are logged but do not prevent the click action from proceeding.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for bbbd0e766035b4a922eece1b6ab18aaba52bbdf3. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🎯 This PR improves click action reliability by automatically scrolling target elements into view before attempting to click them, ensuring better interaction success rates in web automation scenarios.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Click Handler Enhancement**: Added `scroll_into_view()` call before executing click actions in `handle_click_action` function
- **Error Handling**: Implemented graceful failure handling that logs scroll failures but continues with the click operation
- **Non-Breaking Implementation**: The scroll operation is optional and won't interrupt the main click workflow if it fails

### Technical Implementation
```mermaid
sequenceDiagram
    participant Handler as Click Handler
    participant Element as Skyvern Element
    participant Page as Web Page
    participant Logger as Logger

    Handler->>Element: Check if element is disabled
    alt Element is enabled
        Handler->>Element: scroll_into_view()
        alt Scroll succeeds
            Element->>Page: Element scrolled into viewport
        else Scroll fails
            Element->>Logger: Log failure (info level)
            Note over Logger: "Failed to scroll into view, ignore it and continue executing"
        end
        Handler->>Element: Proceed with click action
    else Element is disabled
        Handler->>Handler: Return ActionFailure
    end
```

### Impact
- **Improved Reliability**: Reduces missed clicks caused by elements being outside the viewport
- **Graceful Degradation**: Maintains existing behavior when scroll operations fail
- **Better User Experience**: Enhances automation success rates without introducing breaking changes
- **Minimal Performance Impact**: Adds a lightweight scroll operation that only executes when needed

</details>

_Created with [Palmier](https://www.palmier.io)_