### PR TITLE
improve workflow parameter failure messaging

### DIFF
--- a/skyvern/exceptions.py
+++ b/skyvern/exceptions.py
@@ -197,6 +197,14 @@ class MissingValueForParameter(SkyvernHTTPException):
         )
 
 
+class WorkflowRunParameterPersistenceError(SkyvernException):
+    def __init__(self, parameter_key: str, workflow_id: str, workflow_run_id: str, reason: str) -> None:
+        super().__init__(
+            f"Failed to persist workflow parameter '{parameter_key}' for workflow run {workflow_run_id} "
+            f"of workflow {workflow_id}. Reason: {reason}"
+        )
+
+
 class InvalidCredentialId(SkyvernHTTPException):
     def __init__(self, credential_id: str) -> None:
         super().__init__(

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -12,6 +12,8 @@ from typing import Any, Literal, cast
 
 import httpx
 import structlog
+from asyncpg.exceptions import NotNullViolationError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 
 import skyvern
 from skyvern import analytics
@@ -32,6 +34,7 @@ from skyvern.exceptions import (
     WorkflowNotFound,
     WorkflowNotFoundForWorkflowRun,
     WorkflowRunNotFound,
+    WorkflowRunParameterPersistenceError,
 )
 from skyvern.forge import app
 from skyvern.forge.prompts import prompt_engine
@@ -484,19 +487,35 @@ class WorkflowService:
                     request_body_value = workflow_request.data[workflow_parameter.key]
                     if workflow_parameter.workflow_parameter_type == WorkflowParameterType.CREDENTIAL_ID:
                         await self._validate_credential_id(str(request_body_value), organization)
-                    await self.create_workflow_run_parameter(
-                        workflow_run_id=workflow_run.workflow_run_id,
-                        workflow_parameter=workflow_parameter,
-                        value=request_body_value,
-                    )
+                    try:
+                        await self.create_workflow_run_parameter(
+                            workflow_run_id=workflow_run.workflow_run_id,
+                            workflow_parameter=workflow_parameter,
+                            value=request_body_value,
+                        )
+                    except SQLAlchemyError as parameter_error:
+                        raise WorkflowRunParameterPersistenceError(
+                            parameter_key=workflow_parameter.key,
+                            workflow_id=workflow.workflow_permanent_id,
+                            workflow_run_id=workflow_run.workflow_run_id,
+                            reason=self._format_parameter_persistence_error(parameter_error),
+                        ) from parameter_error
                 elif workflow_parameter.default_value is not None:
                     if workflow_parameter.workflow_parameter_type == WorkflowParameterType.CREDENTIAL_ID:
                         await self._validate_credential_id(str(workflow_parameter.default_value), organization)
-                    await self.create_workflow_run_parameter(
-                        workflow_run_id=workflow_run.workflow_run_id,
-                        workflow_parameter=workflow_parameter,
-                        value=workflow_parameter.default_value,
-                    )
+                    try:
+                        await self.create_workflow_run_parameter(
+                            workflow_run_id=workflow_run.workflow_run_id,
+                            workflow_parameter=workflow_parameter,
+                            value=workflow_parameter.default_value,
+                        )
+                    except SQLAlchemyError as parameter_error:
+                        raise WorkflowRunParameterPersistenceError(
+                            parameter_key=workflow_parameter.key,
+                            workflow_id=workflow.workflow_permanent_id,
+                            workflow_run_id=workflow_run.workflow_run_id,
+                            reason=self._format_parameter_persistence_error(parameter_error),
+                        ) from parameter_error
                 else:
                     raise MissingValueForParameter(
                         parameter_key=workflow_parameter.key,
@@ -527,6 +546,14 @@ class WorkflowService:
             )
 
         return workflow_run
+
+    @staticmethod
+    def _format_parameter_persistence_error(error: SQLAlchemyError) -> str:
+        if isinstance(error, IntegrityError):
+            orig_error = getattr(error, "orig", None)
+            if isinstance(orig_error, NotNullViolationError):
+                return "value cannot be null"
+        return "database error while saving parameter value"
 
     async def auto_create_browser_session_if_needed(
         self,


### PR DESCRIPTION
### Summary - [ticket](https://linear.app/skyvern/issue/SKY-7152/backend-run-workflow-parameter-validaiton-improvement-if-a-bad-value)

Workflow runs already fail when a required parameter is missing, but the failure reason returned to API users only showed a raw database `NotNullViolation`. **This update keeps validation behavior unchanged** while surfacing the offending parameter key in the error message. We added a dedicated exception for workflow parameter persistence failures and wrapped each per-parameter insert inside `setup_workflow_run` with a `try/except`, so any DB or validation error now re-raises with context about which key blew up. That context propagates into the workflow run’s `failure_reason`, making debugging malformed API requests simpler without altering validation rules.

- Added WorkflowRunParameterPersistenceError for contextual parameter failures.
- Wrapped each create_workflow_run_parameter call to re-raise with the parameter key on error.
- Ensured failure_reason now reports the specific parameter when inserts fail (e.g., null values).

Before:

Failure Reason
Setup workflow failed due to an unexpected exception: (psycopg.errors.NotNullViolation) null value in column "value" of relation "workflow_run_parameters" violates not-null constraint DETAIL: Failing row contains (wr_464051200322233756, wp_464051194071931966, null, 2025-11-21 12:35:39.768209). [SQL: INSERT INTO workflow_run_parameters (workflow_run_id, workflow_parameter_id, value, created_at) VALUES (%(workflow_run_id)s::VARCHAR, %(workflow_parameter_id)s::VARCHAR, %(value)s::VARCHAR, %(created_at)s::TIMESTAMP WITHOUT TIME ZONE)] [parameters: {'workflow_run_id': 'wr_464051200322233756', 'workflow_parameter_id': 'wp_464051194071931966', 'value': None, 'created_at': datetime.datetime(2025, 11, 21, 12, 35, 39, 768209)}] (Background on this error at: https://sqlalche.me/e/20/gkpj)

Now:

Failed to persist workflow parameter 'parameter_testing' … Reason: value cannot be null"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced error handling for workflow parameter persistence operations with more descriptive error messages to help diagnose storage failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves workflow parameter failure messaging by introducing `WorkflowRunParameterPersistenceError` and enhancing error handling in `setup_workflow_run` in `service.py`.
> 
>   - **Behavior**:
>     - Introduces `WorkflowRunParameterPersistenceError` in `exceptions.py` for detailed error messages on parameter persistence failures.
>     - Wraps `create_workflow_run_parameter` calls in `setup_workflow_run` in `service.py` with `try/except` to raise `WorkflowRunParameterPersistenceError` with parameter key context.
>     - Updates `failure_reason` to include specific parameter details when persistence errors occur.
>   - **Error Handling**:
>     - Adds `_format_parameter_persistence_error()` in `service.py` to format error messages for `NotNullViolationError` and other `SQLAlchemyError` types.
>   - **Misc**:
>     - Imports `NotNullViolationError`, `IntegrityError`, and `SQLAlchemyError` in `service.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1d9a0556989160b40efcd4f51c045d6d6333dc0a. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR improves error messaging for workflow parameter persistence failures by replacing cryptic database errors with clear, contextual messages that include the specific parameter key, workflow ID, and failure reason.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Exception Handling**: Added `WorkflowRunParameterPersistenceError` exception class to provide structured error messages with parameter context
- **Service Layer**: Wrapped `create_workflow_run_parameter` calls in try-catch blocks to intercept SQLAlchemy errors and re-raise with meaningful context
- **Error Formatting**: Implemented `_format_parameter_persistence_error` method to translate database-specific errors (like `NotNullViolationError`) into user-friendly messages

### Technical Implementation
```mermaid
sequenceDiagram
    participant API as API Request
    participant Service as WorkflowService
    participant DB as Database
    participant Exception as Error Handler

    API->>Service: setup_workflow_run()
    Service->>Service: create_workflow_run_parameter()
    Service->>DB: INSERT parameter
    DB-->>Service: SQLAlchemyError (e.g., NotNullViolation)
    Service->>Exception: WorkflowRunParameterPersistenceError
    Exception->>Service: Formatted error with parameter context
    Service-->>API: Clear error message with parameter key
```

### Impact
- **Developer Experience**: Transforms raw database errors like "null value in column 'value' violates not-null constraint" into clear messages like "Failed to persist workflow parameter 'parameter_testing'... Reason: value cannot be null"
- **Debugging Efficiency**: API users can immediately identify which specific parameter caused the failure without parsing SQL error messages
- **Backward Compatibility**: Maintains existing validation behavior while only improving error reporting - no breaking changes to API contracts or validation logic

</details>

_Created with [Palmier](https://www.palmier.io)_