### PR TITLE
Fix openai flex usage

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -653,6 +653,9 @@ class LLMAPIHandlerFactory:
             if llm_config.litellm_params:  # type: ignore
                 active_parameters.update(llm_config.litellm_params)  # type: ignore
 
+            if "timeout" not in active_parameters:
+                active_parameters["timeout"] = settings.LLM_CONFIG_TIMEOUT
+
             # Apply thinking budget optimization if settings are available
             if (
                 LLMAPIHandlerFactory._thinking_budget_settings
@@ -773,13 +776,11 @@ class LLMAPIHandlerFactory:
 
             t_llm_request = time.perf_counter()
             try:
-                # TODO (kerem): add a timeout to this call
                 # TODO (kerem): add a retry mechanism to this call (acompletion_with_retries)
                 # TODO (kerem): use litellm fallbacks? https://litellm.vercel.app/docs/tutorials/fallbacks#how-does-completion_with_fallbacks-work
                 response = await litellm.acompletion(
                     model=model_name,
                     messages=messages,
-                    timeout=settings.LLM_CONFIG_TIMEOUT,
                     drop_params=True,  # Drop unsupported parameters gracefully
                     **active_parameters,
                 )

--- a/skyvern/forge/sdk/api/llm/models.py
+++ b/skyvern/forge/sdk/api/llm/models.py
@@ -19,6 +19,7 @@ class LiteLLMParams(TypedDict, total=False):
     vertex_location: str | None
     thinking: dict[str, Any] | None
     service_tier: str | None
+    timeout: float | None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default timeout is now applied to LLM API requests when not explicitly provided.

* **Refactor**
  * Updated timeout parameter handling mechanism for API calls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces configurable timeout for LLM requests, defaulting to `settings.LLM_CONFIG_TIMEOUT`, and updates `LiteLLMParams` to include `timeout`.
> 
>   - **Timeout Handling**:
>     - Injects default `timeout` in `llm_api_handler` if absent, using `settings.LLM_CONFIG_TIMEOUT` (`api_handler_factory.py`).
>     - Removes hardcoded `timeout` from `litellm.acompletion`.
>   - **Configuration Updates**:
>     - Adds `timeout` to `LiteLLMParams` in `models.py`.
>     - Sets `timeout=900.0` for `MAGNIFEX_OPENAI_GPT_5_MINI` in `cloud/__init__.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 0bc7a472d239ed66191d63863bd41f375091f37d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces a default LLM request timeout and passes it via LiteLLM params instead of hardcoding it in calls.
> 
> - **Backend**
>   - **Timeout handling**:
>     - Inject default `timeout` from `settings.LLM_CONFIG_TIMEOUT` into `active_parameters` when absent in `api_handler_factory.llm_api_handler`.
>     - Remove hardcoded `timeout` from `litellm.acompletion` and rely on `active_parameters`.
>   - **Models**:
>     - Add `timeout` to `LiteLLMParams` in `models.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bc7a472d239ed66191d63863bd41f375091f37d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

⏱️ This PR standardizes timeout handling for LLM API requests by implementing a flexible timeout configuration system that ensures consistent timeout behavior across all LLM configurations. The changes move from hardcoded timeout values to a parameter-based approach that allows for model-specific timeout customization while providing sensible defaults.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Timeout Parameter Injection**: Added logic to automatically inject default timeout from `settings.LLM_CONFIG_TIMEOUT` when not explicitly provided in LLM configuration parameters
- **API Call Refactoring**: Removed hardcoded `timeout` parameter from `litellm.acompletion()` call, now relying on the timeout value passed through `active_parameters`
- **Type System Enhancement**: Extended `LiteLLMParams` TypedDict to include optional `timeout` field, improving type safety and documentation

### Technical Implementation
```mermaid
flowchart TD
    A[LLM API Handler Called] --> B{Timeout in active_parameters?}
    B -->|No| C[Inject settings.LLM_CONFIG_TIMEOUT]
    B -->|Yes| D[Use Existing Timeout]
    C --> E[Update active_parameters]
    D --> E
    E --> F[Call litellm.acompletion with parameters]
    F --> G[Return Response]
```

### Impact
- **Configuration Flexibility**: Enables model-specific timeout configurations while maintaining consistent fallback behavior
- **Code Maintainability**: Eliminates hardcoded timeout values and centralizes timeout logic, making the codebase more maintainable
- **Type Safety**: Adding timeout to LiteLLMParams improves IDE support and catches potential configuration errors at development time
- **Backward Compatibility**: Changes are fully backward compatible as existing configurations without timeout will automatically receive the default value

</details>

_Created with [Palmier](https://www.palmier.io)_