### PR TITLE
Add invalid response to log to help us better debug it

### DIFF
--- a/skyvern/forge/sdk/api/llm/utils.py
+++ b/skyvern/forge/sdk/api/llm/utils.py
@@ -143,6 +143,12 @@ def _coerce_response_to_dict(response: Any) -> dict[str, Any]:
     if isinstance(response, dict):
         return response
 
+    LOG.warning(
+        "Parsed LLM response is not a dict",
+        response_type=type(response).__name__,
+        response=response,
+    )
+
     if isinstance(response, list):
         first_dict = next((item for item in response if isinstance(item, dict)), None)
         LOG.warning(
@@ -156,11 +162,6 @@ def _coerce_response_to_dict(response: Any) -> dict[str, Any]:
 
         LOG.warning("List response contained no dict entries; returning empty dict")
         raise InvalidLLMResponseType("list")
-
-    LOG.warning(
-        "Parsed LLM response is not a dict; returning empty dict",
-        response_type=type(response).__name__,
-    )
 
     raise InvalidLLMResponseType(type(response).__name__)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Logs response type and payload when parsed LLM response isn’t a dict and removes older generic warning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8041ea6095e142d029421cc64816edbb8167b1fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated error logging in response handling for improved consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances logging in `_coerce_response_to_dict` to include response type and payload for non-dict responses and removes an outdated warning.
> 
>   - **Logging Enhancements**:
>     - In `skyvern/forge/sdk/api/llm/utils.py`, `_coerce_response_to_dict` now logs a warning with `response_type` and `response` when the response is not a `dict`.
>     - Removed outdated warning about returning an empty dict; the function still raises `InvalidLLMResponseType` for unsupported types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 8041ea6095e142d029421cc64816edbb8167b1fa. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

---

🔍 This PR enhances debugging capabilities by improving logging in the LLM response handling utility function. It adds detailed logging information when parsed LLM responses are not dictionaries and removes misleading log messages to provide clearer diagnostic information.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Logging Enhancement**: Added a warning log that captures both the response type and actual response content when the parsed LLM response is not a dictionary
- **Code Reorganization**: Moved the logging statement to occur immediately after the dict type check, providing earlier visibility into problematic responses
- **Message Cleanup**: Removed the misleading "returning empty dict" warning message that was inaccurate since the function actually raises an exception

### Technical Implementation
```mermaid
flowchart TD
    A[LLM Response] --> B{Is Dict?}
    B -->|Yes| C[Return Response]
    B -->|No| D[Log Warning with Type & Content]
    D --> E{Is List?}
    E -->|Yes| F[Process List Logic]
    E -->|No| G[Raise InvalidLLMResponseType]
    F --> H{Contains Dict?}
    H -->|Yes| I[Return First Dict]
    H -->|No| J[Raise Exception]
```

### Impact
- **Debugging Improvement**: Developers can now see the actual content and type of invalid responses, making it easier to diagnose LLM parsing issues
- **Error Clarity**: Removes confusion by eliminating the "returning empty dict" message that didn't match the actual behavior (exception throwing)
- **Operational Visibility**: Better logging helps identify patterns in LLM response formatting issues for system monitoring and improvement

</details>

_Created with [Palmier](https://www.palmier.io)_