### PR TITLE
add drop_params to router fallback call to handle unsupported parameters

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -491,6 +491,7 @@ class LLMAPIHandlerFactory:
                     model=main_model_group,
                     messages=messages,
                     timeout=settings.LLM_CONFIG_TIMEOUT,
+                    drop_params=True,
                     **parameters,
                 )
                 return response, request_payload_json


### PR DESCRIPTION
	## Fix router fallback failure when dropping unsupported parameters

### Problem
When the router falls back from Gemini to GPT-5 (or other models), the fallback fails with `UnsupportedParamsError` because parameters like `thinking` (used for Gemini reasoning) are still included, and GPT-5 doesn't support them.

### Solution
Added `drop_params=True` to the `router.acompletion()` call in `_call_router_without_cache()`. This matches the behavior of the direct cached call and allows LiteLLM to drop unsupported parameters when falling back to different models.

### Impact
- Router fallbacks to GPT-5 (or other models) now succeed even when the original request includes model-specific parameters
- Prevents `UnsupportedParamsError` during fallbacks
- Aligns router fallback behavior with direct calls

### Testing
This fixes the error seen in production logs where 429 errors on Gemini caused router fallbacks to GPT-5 to fail due to unsupported `thinking` parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parameter handling in LLM requests by automatically removing unsupported or extraneous parameters, ensuring more reliable and consistent behavior across different router configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `drop_params=True` to handle unsupported parameters during router fallback in `api_handler_factory.py`, preventing `UnsupportedParamsError`.
> 
>   - **Behavior**:
>     - Adds `drop_params=True` to `router.acompletion()` in `_call_router_without_cache()` in `api_handler_factory.py` to handle unsupported parameters during router fallback.
>     - Prevents `UnsupportedParamsError` when falling back from Gemini to models like GPT-5.
>   - **Impact**:
>     - Router fallbacks now succeed even with model-specific parameters in the original request.
>     - Aligns fallback behavior with direct calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d9787f7a2a32cf3af3f70a3726ba569b26940d08. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->