### PR TITLE
store totp_identifier to credentials with fallback for login runs

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -4515,6 +4515,7 @@ class AgentDB:
         totp_type: str,
         card_last4: str | None,
         card_brand: str | None,
+        totp_identifier: str | None = None,
     ) -> Credential:
         async with self.Session() as session:
             credential = CredentialModel(
@@ -4525,6 +4526,7 @@ class AgentDB:
                 credential_type=credential_type,
                 username=username,
                 totp_type=totp_type,
+                totp_identifier=totp_identifier,
                 card_last4=card_last4,
                 card_brand=card_brand,
             )

--- a/skyvern/forge/sdk/routes/run_blocks.py
+++ b/skyvern/forge/sdk/routes/run_blocks.py
@@ -94,12 +94,15 @@ async def login(
     label = "login"
     yaml_parameters = []
     parameter_key = "credential"
+    resolved_totp_identifier = login_request.totp_identifier
     if login_request.credential_type == CredentialType.skyvern:
         if not login_request.credential_id:
             raise HTTPException(status_code=400, detail="credential_id is required to login with Skyvern credential")
         credential = await app.DATABASE.get_credential(login_request.credential_id, organization.organization_id)
         if not credential:
             raise HTTPException(status_code=404, detail=f"Credential {login_request.credential_id} not found")
+        if not resolved_totp_identifier:
+            resolved_totp_identifier = credential.totp_identifier
 
         yaml_parameters = [
             WorkflowParameterYAML(
@@ -169,7 +172,7 @@ async def login(
         max_steps_per_run=10,
         parameter_keys=[parameter_key],
         totp_verification_url=totp_verification_url,
-        totp_identifier=login_request.totp_identifier,
+        totp_identifier=resolved_totp_identifier,
     )
     yaml_blocks = [login_block_yaml]
     workflow_definition_yaml = WorkflowDefinitionYAML(
@@ -198,7 +201,7 @@ async def login(
     legacy_workflow_request = WorkflowRequestBody(
         proxy_location=login_request.proxy_location,
         webhook_callback_url=webhook_url,
-        totp_identifier=login_request.totp_identifier,
+        totp_identifier=resolved_totp_identifier,
         totp_verification_url=totp_verification_url,
         browser_session_id=login_request.browser_session_id,
         browser_profile_id=login_request.browser_profile_id,
@@ -235,7 +238,7 @@ async def login(
             proxy_location=login_request.proxy_location,
             webhook_url=webhook_url,
             totp_url=totp_verification_url,
-            totp_identifier=login_request.totp_identifier,
+            totp_identifier=resolved_totp_identifier,
             browser_session_id=login_request.browser_session_id,
             browser_profile_id=login_request.browser_profile_id,
             max_screenshot_scrolls=login_request.max_screenshot_scrolling_times,

--- a/skyvern/forge/sdk/schemas/credentials.py
+++ b/skyvern/forge/sdk/schemas/credentials.py
@@ -34,6 +34,11 @@ class PasswordCredentialResponse(BaseModel):
         description="Type of 2FA method used for this credential",
         examples=[TotpType.AUTHENTICATOR],
     )
+    totp_identifier: str | None = Field(
+        default=None,
+        description="Identifier (email or phone number) used to fetch TOTP codes",
+        examples=["user@example.com", "+14155550123"],
+    )
 
 
 class CreditCardCredentialResponse(BaseModel):
@@ -57,6 +62,11 @@ class PasswordCredential(BaseModel):
         TotpType.NONE,
         description="Type of 2FA method used for this credential",
         examples=[TotpType.AUTHENTICATOR],
+    )
+    totp_identifier: str | None = Field(
+        default=None,
+        description="Identifier (email or phone number) used to fetch TOTP codes",
+        examples=["user@example.com", "+14155550123"],
     )
 
 
@@ -154,6 +164,11 @@ class Credential(BaseModel):
         TotpType.NONE,
         description="Type of 2FA method used for this credential",
         examples=[TotpType.AUTHENTICATOR],
+    )
+    totp_identifier: str | None = Field(
+        default=None,
+        description="Identifier (email or phone number) used to fetch TOTP codes",
+        examples=["user@example.com", "+14155550123"],
     )
     card_last4: str | None = Field(..., description="For credit_card credentials: the last four digits of the card")
     card_brand: str | None = Field(..., description="For credit_card credentials: the card brand")

--- a/skyvern/forge/sdk/services/credential/credential_vault_service.py
+++ b/skyvern/forge/sdk/services/credential/credential_vault_service.py
@@ -51,6 +51,7 @@ class CredentialVaultService(ABC):
                 credential_type=data.credential_type,
                 username=data.credential.username,
                 totp_type=data.credential.totp_type,
+                totp_identifier=data.credential.totp_identifier,
                 card_last4=None,
                 card_brand=None,
             )
@@ -65,6 +66,7 @@ class CredentialVaultService(ABC):
                 totp_type="none",
                 card_last4=data.credential.card_number[-4:],
                 card_brand=data.credential.card_brand,
+                totp_identifier=None,
             )
         else:
             raise Exception(f"Unsupported credential type: {data.credential_type}")


### PR DESCRIPTION
	**Problem**
For Email/Text 2FA, users had to specify `totp_identifier` on every run—even though they'd already told us which email/phone receives codes when creating the credential.

**Solution**
Store `totp_identifier` on the credential itself. At runtime, if not explicitly provided, fall back to the credential's stored value.

will follow up w a frontend addressing [this](https://skyvern.slack.com/archives/C09ME48U6G1/p1764607159707469?thread_ts=1764606969.173029&cid=C09ME48U6G1)

Test run (store cred in local db. submit login run w null totp_identifier and note how it uses the fallback):


<img width="738" height="279" alt="Screenshot 2025-12-01 at 2 14 59 PM" src="https://github.com/user-attachments/assets/170a7a6d-0da5-49f8-b094-f63eb5d5a057" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Store `totp_identifier` in credentials for fallback during login, updating models, services, and context management accordingly.
> 
>   - **Behavior**:
>     - Store `totp_identifier` in credentials for fallback during login if not provided.
>     - Update `login()` in `run_blocks.py` to use stored `totp_identifier` if not explicitly provided.
>   - **Models**:
>     - Add `totp_identifier` field to `PasswordCredential`, `Credential`, and `PasswordCredentialResponse` in `credentials.py`.
>   - **Services**:
>     - Update `_create_db_credential()` in `credential_vault_service.py` to handle `totp_identifier`.
>   - **Context Management**:
>     - Add `credential_totp_identifiers` to `WorkflowRunContext` in `context_manager.py` for managing TOTP identifiers.
>   - **Blocks**:
>     - Update `execute()` in `block.py` to handle `totp_identifier` resolution.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b441ed91f9129ea6dc9f738ba890ff8f8eefe2a0. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password credentials can now store an optional TOTP identifier (email or phone) for automatic 2FA code retrieval.
  * Workflows and login runs will automatically use a stored TOTP identifier when one isn’t explicitly provided.
  * Run responses and login flows surface the resolved TOTP identifier so downstream steps receive the effective value.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->