### PR TITLE
Silence annoying OpenAI client shutdown error

### DIFF
--- a/skyvern/forge/forge_app.py
+++ b/skyvern/forge/forge_app.py
@@ -9,6 +9,7 @@ from openai import AsyncAzureOpenAI, AsyncOpenAI
 from skyvern.config import Settings
 from skyvern.forge.agent import ForgeAgent
 from skyvern.forge.agent_functions import AgentFunction
+from skyvern.forge.forge_openai_client import ForgeAsyncHttpxClientWrapper
 from skyvern.forge.sdk.api.azure import AzureClientFactory
 from skyvern.forge.sdk.api.llm.api_handler_factory import LLMAPIHandlerFactory
 from skyvern.forge.sdk.api.llm.models import LLMAPIHandler
@@ -95,7 +96,10 @@ def create_forge_app() -> ForgeApp:
     app.EXPERIMENTATION_PROVIDER = NoOpExperimentationProvider()
 
     app.LLM_API_HANDLER = LLMAPIHandlerFactory.get_llm_api_handler(settings.LLM_KEY)
-    app.OPENAI_CLIENT = AsyncOpenAI(api_key=settings.OPENAI_API_KEY or "")
+    app.OPENAI_CLIENT = AsyncOpenAI(
+        api_key=settings.OPENAI_API_KEY or "",
+        http_client=ForgeAsyncHttpxClientWrapper(),
+    )
     if settings.ENABLE_AZURE_CUA:
         app.OPENAI_CLIENT = AsyncAzureOpenAI(
             api_key=settings.AZURE_CUA_API_KEY,
@@ -113,6 +117,7 @@ def create_forge_app() -> ForgeApp:
         app.UI_TARS_CLIENT = AsyncOpenAI(
             api_key=settings.VOLCENGINE_API_KEY,
             base_url=settings.VOLCENGINE_API_BASE,
+            http_client=ForgeAsyncHttpxClientWrapper(),
         )
 
     app.SECONDARY_LLM_API_HANDLER = LLMAPIHandlerFactory.get_llm_api_handler(

--- a/skyvern/forge/forge_openai_client.py
+++ b/skyvern/forge/forge_openai_client.py
@@ -1,0 +1,24 @@
+import asyncio
+
+from openai import DefaultAsyncHttpxClient
+
+
+class ForgeAsyncHttpxClientWrapper(DefaultAsyncHttpxClient):
+    """
+    Wrapper around OpenAI's AsyncHttpxClientWrapper to mask teardown races.
+
+    The upstream `__del__` checks `self.is_closed`, but during interpreter
+    shutdown httpx internals may already be None, which raises:
+
+    AttributeError: 'NoneType' object has no attribute 'CLOSED'
+
+    We defensively swallow that destructor error so shutdown logs stay clean.
+    """
+
+    def __del__(self) -> None:
+        try:
+            if self.is_closed:
+                return
+            asyncio.get_running_loop().create_task(self.aclose())
+        except Exception:
+            pass


### PR DESCRIPTION
Fixes this annoying error
<img width="1024" height="179" alt="image" src="https://github.com/user-attachments/assets/0926f0f1-c03d-4388-87b6-3d26aac8fff3" />


Basically a workaround for a bug in OpenAI [client](https://github.com/openai/openai-python/blob/41ee03ffe985a7362f0275c7f500080cb1d58cdd/src/openai/_base_client.py#L1353)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved HTTP client shutdown stability to prevent errors during application teardown and reduce noise in logs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces `ForgeAsyncHttpxClientWrapper` to handle OpenAI client shutdown errors by updating client initialization in `forge_app.py` and `api_handler_factory.py`.
> 
>   - **Behavior**:
>     - Introduces `ForgeAsyncHttpxClientWrapper` in `forge_openai_client.py` to handle teardown races by swallowing `AttributeError` during shutdown.
>     - Updates `create_forge_app()` in `forge_app.py` to use `ForgeAsyncHttpxClientWrapper` for `AsyncOpenAI` and `AsyncAzureOpenAI` clients.
>     - Modifies `LLMCaller` in `api_handler_factory.py` to use `ForgeAsyncHttpxClientWrapper` for `AsyncOpenAI` client initialization.
>   - **Misc**:
>     - Minor comment formatting change in `api_handler_factory.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f39ce991d55beab3b347e568a1694ec0a9db125a. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR introduces a custom HTTP client wrapper to silence annoying shutdown errors from the OpenAI client that occur during Python interpreter teardown, preventing noisy error logs without affecting functionality.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **New Wrapper Class**: Created `ForgeAsyncHttpxClientWrapper` that extends `DefaultAsyncHttpxClient` to handle shutdown race conditions gracefully
- **Client Integration**: Updated all OpenAI client instantiations across the codebase to use the new wrapper
- **Error Suppression**: The wrapper's `__del__` method catches and silently handles `AttributeError` exceptions that occur when httpx internals become `None` during interpreter shutdown

### Technical Implementation
```mermaid
flowchart TD
    A[Python Interpreter Shutdown] --> B[OpenAI Client Destructor Called]
    B --> C{httpx internals available?}
    C -->|No| D[AttributeError: 'NoneType' object has no attribute 'CLOSED']
    C -->|Yes| E[Normal cleanup]
    D --> F[ForgeAsyncHttpxClientWrapper catches exception]
    F --> G[Silent handling - no error logged]
    E --> H[Normal shutdown]
    G --> H
```

### Impact
- **Cleaner Logs**: Eliminates annoying shutdown error messages that don't indicate actual problems
- **Improved Developer Experience**: Reduces noise in application logs during shutdown
- **Backward Compatibility**: No breaking changes - purely a defensive improvement that maintains all existing functionality
- **Consistent Error Handling**: Applied uniformly across all OpenAI client instances (main client, Azure client, and OpenRouter client)

</details>

_Created with [Palmier](https://www.palmier.io)_