### PR TITLE
Handle WorkflowNotFound in create_workflow_from_request

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -2798,13 +2798,18 @@ class WorkflowService:
         )
         new_workflow_id: str | None = None
 
+        if workflow_permanent_id:
+            # Would return 404: WorkflowNotFound to the client if wpid does not match the organization
+            existing_latest_workflow = await self.get_workflow_by_permanent_id(
+                workflow_permanent_id=workflow_permanent_id,
+                organization_id=organization_id,
+                exclude_deleted=False,
+            )
+        else:
+            existing_latest_workflow = None
+
         try:
-            if workflow_permanent_id:
-                existing_latest_workflow = await self.get_workflow_by_permanent_id(
-                    workflow_permanent_id=workflow_permanent_id,
-                    organization_id=organization_id,
-                    exclude_deleted=False,
-                )
+            if existing_latest_workflow:
                 existing_version = existing_latest_workflow.version
 
                 # NOTE: it's only potential, as it may be immediately deleted!
@@ -2821,7 +2826,7 @@ class WorkflowService:
                     model=request.model,
                     max_screenshot_scrolling_times=request.max_screenshot_scrolls,
                     extra_http_headers=request.extra_http_headers,
-                    workflow_permanent_id=workflow_permanent_id,
+                    workflow_permanent_id=existing_latest_workflow.workflow_permanent_id,
                     version=existing_version + 1,
                     is_saved_task=request.is_saved_task,
                     status=request.status,


### PR DESCRIPTION
Example [here](https://us5.datadoghq.com/logs?query=%28env%3Aproduction%20OR%20%40env%3Aproduction%29%20%40version%3A%2A%20%40request_id%3Aefe307a1-ec30-4a8f-9d45-0c9c66f05866&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=service%2C%40version&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1764030227590&to_ts=1764635027590&live=true)

The user probably works from different Chrome tabs under different accounts, tried to update a workflow that belongs to a another organization. 

Just making sure we give 404 instead of 500 to avoid noise (no need to ping oncall)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow versioning consistency and folder association handling
  * Optimized workflow retrieval and creation performance
  * Ensured proper organization-scoped context preservation across workflow versions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Handle `WorkflowNotFound` in `create_workflow_from_request()` by returning 404 instead of 500 for mismatched workflow IDs.
> 
>   - **Behavior**:
>     - In `create_workflow_from_request()` in `service.py`, handle `WorkflowNotFound` by returning 404 instead of 500 when `workflow_permanent_id` does not match the organization.
>   - **Error Handling**:
>     - Ensures that mismatched workflow IDs result in a 404 error, reducing unnecessary alerts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 10949c286be49df5738a2a83d29d336b7e6e736a. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🛡️ This PR improves error handling in workflow creation by moving the workflow lookup outside the try-catch block to ensure proper 404 responses when a workflow permanent ID doesn't match the organization, preventing unnecessary 500 errors and oncall alerts.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Error Handling**: Moved `get_workflow_by_permanent_id` call outside the try-catch block to allow WorkflowNotFound exceptions to propagate as 404 responses
- **Code Structure**: Reorganized the workflow lookup logic to check for `workflow_permanent_id` existence before attempting database queries
- **Variable Usage**: Changed from using the input `workflow_permanent_id` directly to using `existing_latest_workflow.workflow_permanent_id` for consistency

### Technical Implementation
```mermaid
flowchart TD
    A[create_workflow_from_request] --> B{workflow_permanent_id exists?}
    B -->|Yes| C[get_workflow_by_permanent_id]
    B -->|No| D[existing_latest_workflow = None]
    C --> E{Workflow found?}
    E -->|Yes| F[Set existing_latest_workflow]
    E -->|No| G[Return 404 WorkflowNotFound]
    F --> H[Continue with workflow creation]
    D --> H
    H --> I[Create new workflow with incremented version]
```

### Impact
- **Better Error Responses**: Users now receive proper 404 errors instead of 500 server errors when trying to access workflows from different organizations
- **Reduced Alert Noise**: Prevents unnecessary oncall alerts by avoiding 500 errors for expected user behavior (cross-organization access attempts)
- **Improved User Experience**: Clearer error messaging helps users understand when they're trying to access workflows they don't have permission for

</details>

_Created with [Palmier](https://www.palmier.io)_