### PR TITLE
fix recording for browser session run

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -3287,16 +3287,31 @@ class ForgeAgent:
         if screenshot_artifact:
             screenshot_url = await app.ARTIFACT_MANAGER.get_share_link(screenshot_artifact)
 
-        first_step = await app.DATABASE.get_first_step(task_id=task.task_id, organization_id=task.organization_id)
-        if first_step:
-            recording_artifact = await app.DATABASE.get_artifact(
-                task_id=task.task_id,
-                step_id=first_step.step_id,
-                artifact_type=ArtifactType.RECORDING,
-                organization_id=task.organization_id,
-            )
-            if recording_artifact:
-                recording_url = await app.ARTIFACT_MANAGER.get_share_link(recording_artifact)
+        # Get recording url from browser session first,
+        # if not found, get the recording url from the first step
+        if task.browser_session_id:
+            try:
+                async with asyncio.timeout(GET_DOWNLOADED_FILES_TIMEOUT):
+                    recordings = await app.STORAGE.get_shared_recordings_in_browser_session(
+                        organization_id=task.organization_id,
+                        browser_session_id=task.browser_session_id,
+                    )
+                    # FIXME: we only support one recording for now
+                    recording_url = recordings[0].url if recordings else None
+            except asyncio.TimeoutError:
+                LOG.warning("Timeout getting recordings", browser_session_id=task.browser_session_id)
+
+        if recording_url is None:
+            first_step = await app.DATABASE.get_first_step(task_id=task.task_id, organization_id=task.organization_id)
+            if first_step:
+                recording_artifact = await app.DATABASE.get_artifact(
+                    task_id=task.task_id,
+                    step_id=first_step.step_id,
+                    artifact_type=ArtifactType.RECORDING,
+                    organization_id=task.organization_id,
+                )
+                if recording_artifact:
+                    recording_url = await app.ARTIFACT_MANAGER.get_share_link(recording_artifact)
 
         # get the artifact of the last TASK_RESPONSE_ACTION_SCREENSHOT_COUNT screenshots and get the screenshot_url
         latest_action_screenshot_artifacts = await app.DATABASE.get_latest_n_artifacts(

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -2220,13 +2220,28 @@ class WorkflowService:
             screenshot_urls = await app.ARTIFACT_MANAGER.get_share_links(screenshot_artifacts)
 
         recording_url = None
-        recording_artifact = await app.DATABASE.get_artifact_for_run(
-            run_id=task_v2.observer_cruise_id if task_v2 else workflow_run_id,
-            artifact_type=ArtifactType.RECORDING,
-            organization_id=organization_id,
-        )
-        if recording_artifact:
-            recording_url = await app.ARTIFACT_MANAGER.get_share_link(recording_artifact)
+        # Get recording url from browser session first,
+        # if not found, get the recording url from the artifacts
+        if workflow_run.browser_session_id:
+            try:
+                async with asyncio.timeout(GET_DOWNLOADED_FILES_TIMEOUT):
+                    recordings = await app.STORAGE.get_shared_recordings_in_browser_session(
+                        organization_id=workflow_run.organization_id,
+                        browser_session_id=workflow_run.browser_session_id,
+                    )
+                    # FIXME: we only support one recording for now
+                    recording_url = recordings[0].url if recordings else None
+            except asyncio.TimeoutError:
+                LOG.warning("Timeout getting recordings", browser_session_id=workflow_run.browser_session_id)
+
+        if recording_url is None:
+            recording_artifact = await app.DATABASE.get_artifact_for_run(
+                run_id=task_v2.observer_cruise_id if task_v2 else workflow_run_id,
+                artifact_type=ArtifactType.RECORDING,
+                organization_id=organization_id,
+            )
+            if recording_artifact:
+                recording_url = await app.ARTIFACT_MANAGER.get_share_link(recording_artifact)
 
         downloaded_files: list[FileInfo] = []
         downloaded_file_urls: list[str] | None = None


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved recording retrieval process with enhanced timeout handling and fallback mechanisms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Prioritize live browser-session recordings over artifact-based recordings with timeout and warning in `agent.py` and `service.py`.
> 
>   - **Behavior**:
>     - Prioritize live browser-session recordings over artifact-based recordings in `build_task_response()` in `agent.py` and `build_workflow_run_status_response()` in `service.py`.
>     - Implement timeout and warning for live recording retrieval.
>   - **Functions**:
>     - Modify `build_task_response()` in `agent.py` to first attempt to get recording from `app.STORAGE.get_shared_recordings_in_browser_session()`.
>     - Modify `build_workflow_run_status_response()` in `service.py` to use the same logic for recording retrieval.
>   - **Misc**:
>     - Add logging for timeout events when retrieving recordings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for bb411ff4a0747c0abeab7ff1a697385b3a62a50f. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🎥 This PR improves recording retrieval for browser sessions by prioritizing live browser-session recordings over artifact-based recordings, with proper timeout handling and fallback mechanisms. The changes ensure more reliable access to session recordings in both task responses and workflow run status responses.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Recording Retrieval Logic**: Modified `build_task_response()` in `agent.py` and `build_workflow_run_status_response()` in `service.py` to prioritize browser session recordings over artifact-based recordings
- **Timeout Handling**: Added `asyncio.timeout()` wrapper with `GET_DOWNLOADED_FILES_TIMEOUT` to prevent hanging when fetching recordings from browser sessions
- **Fallback Mechanism**: Maintains backward compatibility by falling back to the original artifact-based recording retrieval when browser session recordings are unavailable
- **Error Handling**: Added warning logs for timeout scenarios to aid in debugging and monitoring

### Technical Implementation
```mermaid
flowchart TD
    A[Start Recording Retrieval] --> B{Browser Session ID exists?}
    B -->|Yes| C[Try to get recordings from browser session]
    B -->|No| F[Get recording from first step/artifacts]
    C --> D{Timeout or Error?}
    D -->|Yes| E[Log Warning] --> F
    D -->|No| G{Recordings found?}
    G -->|Yes| H[Use browser session recording URL]
    G -->|No| F
    F --> I{Recording artifact found?}
    I -->|Yes| J[Use artifact recording URL]
    I -->|No| K[No recording URL]
    H --> L[Return recording URL]
    J --> L
    K --> L
```

### Impact
- **Reliability**: Prioritizes live browser session recordings which are more current and reliable than stored artifacts
- **Performance**: Adds timeout protection to prevent indefinite blocking when accessing browser session recordings
- **Backward Compatibility**: Maintains existing functionality by falling back to artifact-based recordings when browser session recordings are unavailable
- **Monitoring**: Improved observability through timeout warning logs for better debugging and system monitoring

</details>

_Created with [Palmier](https://www.palmier.io)_