### PR TITLE
Add BranchCriteriaTypeVar and ConditionalBlockYAML

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -3969,7 +3969,7 @@ class JinjaBranchCriteria(BranchCriteria):
 class BranchCondition(BaseModel):
     """Represents a single conditional branch edge within a ConditionalBlock."""
 
-    criteria: BranchCriteria | None = None
+    criteria: BranchCriteriaTypeVar | None = None
     next_block_label: str | None = None
     description: str | None = None
     is_default: bool = False
@@ -4085,3 +4085,7 @@ BlockSubclasses = Union[
     HttpRequestBlock,
 ]
 BlockTypeVar = Annotated[BlockSubclasses, Field(discriminator="block_type")]
+
+
+BranchCriteriaSubclasses = Union[JinjaBranchCriteria]
+BranchCriteriaTypeVar = Annotated[BranchCriteriaSubclasses, Field(discriminator="criteria_type")]

--- a/skyvern/schemas/workflows.py
+++ b/skyvern/schemas/workflows.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from skyvern.config import settings
 from skyvern.forge.sdk.workflow.models.parameter import OutputParameter, ParameterType, WorkflowParameterType
@@ -256,6 +256,44 @@ class ForLoopBlockYAML(BlockYAML):
     loop_over_parameter_key: str = ""
     loop_variable_reference: str | None = None
     complete_if_empty: bool = False
+
+
+class BranchCriteriaYAML(BaseModel):
+    criteria_type: Literal["jinja2_template"] = "jinja2_template"
+    expression: str
+    description: str | None = None
+
+
+class BranchConditionYAML(BaseModel):
+    criteria: BranchCriteriaYAML | None = None
+    next_block_label: str | None = None
+    description: str | None = None
+    is_default: bool = False
+
+    @model_validator(mode="after")
+    def validate_condition(cls, condition: "BranchConditionYAML") -> "BranchConditionYAML":
+        if condition.criteria is None and not condition.is_default:
+            raise ValueError("Branches without criteria must be marked as default.")
+        if condition.criteria is not None and condition.is_default:
+            raise ValueError("Default branches may not define criteria.")
+        return condition
+
+
+class ConditionalBlockYAML(BlockYAML):
+    block_type: Literal[BlockType.CONDITIONAL] = BlockType.CONDITIONAL  # type: ignore
+
+    branch_conditions: list[BranchConditionYAML] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_branches(cls, block: "ConditionalBlockYAML") -> "ConditionalBlockYAML":
+        if not block.branch_conditions:
+            raise ValueError("Conditional blocks require at least one branch.")
+
+        default_branches = [branch for branch in block.branch_conditions if branch.is_default]
+        if len(default_branches) > 1:
+            raise ValueError("Only one default branch is permitted per conditional block.")
+
+        return block
 
 
 class CodeBlockYAML(BlockYAML):
@@ -538,6 +576,7 @@ BLOCK_YAML_SUBCLASSES = (
     | PDFParserBlockYAML
     | TaskV2BlockYAML
     | HttpRequestBlockYAML
+    | ConditionalBlockYAML
 )
 BLOCK_YAML_TYPES = Annotated[BLOCK_YAML_SUBCLASSES, Field(discriminator="block_type")]
 
@@ -546,6 +585,20 @@ class WorkflowDefinitionYAML(BaseModel):
     version: int = 1
     parameters: list[PARAMETER_YAML_TYPES]
     blocks: list[BLOCK_YAML_TYPES]
+
+    @model_validator(mode="after")
+    def validate_unique_block_labels(cls, workflow: "WorkflowDefinitionYAML") -> "WorkflowDefinitionYAML":
+        labels = [block.label for block in workflow.blocks]
+        duplicates = [label for label in labels if labels.count(label) > 1]
+
+        if duplicates:
+            unique_duplicates = sorted(set(duplicates))
+            raise ValueError(
+                f"Block labels must be unique within a workflow. "
+                f"Found duplicate label(s): {', '.join(unique_duplicates)}"
+            )
+
+        return workflow
 
 
 class WorkflowCreateYAMLRequest(BaseModel):


### PR DESCRIPTION
split https://github.com/Skyvern-AI/skyvern-cloud/pull/7489/files and deliver the first part of the workflow DAG execution.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add branching logic with `BranchCriteriaTypeVar` and `ConditionalBlockYAML`, enhancing workflow validation for unique labels and proper branch configuration.
> 
>   - **New Features**:
>     - Add `BranchCriteriaTypeVar` in `block.py` for Jinja2-based branch conditions.
>     - Add `ConditionalBlockYAML` in `workflows.py` for defining conditional blocks in YAML.
>   - **Validation**:
>     - Ensure unique block labels in `WorkflowDefinitionYAML` in `workflows.py`.
>     - Validate `ConditionalBlockYAML` to have at least one branch and only one default branch.
>   - **Misc**:
>     - Rename `criteria` to `BranchCriteriaTypeVar` in `BranchCondition` in `block.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 436e86e657557df1dfa154cf0d4467bef64feae5. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added conditional branching support in workflows with Jinja2 template expressions for evaluating branch conditions.

* **Improvements**
  * Enhanced workflow validation to enforce unique block labels and enforce proper branch condition requirements (default branches cannot have criteria; non-default branches must have criteria).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔀 This PR introduces conditional branching capabilities to the workflow system by adding `BranchCriteriaTypeVar` and `ConditionalBlockYAML` classes. It enables dynamic workflow routing through Jinja2-based branch conditions and enhances type safety for branch criteria handling.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Type System Enhancement**: Introduced `BranchCriteriaTypeVar` as a discriminated union type for branch criteria, replacing the previous `BranchCriteria` type in `BranchCondition`
- **YAML Schema Addition**: Added comprehensive YAML representation classes (`BranchCriteriaYAML`, `BranchConditionYAML`, `ConditionalBlockYAML`) for workflow definition parsing
- **Validation Logic**: Implemented robust validation rules ensuring proper conditional block structure with required branches and single default branch constraints
- **Workflow Integrity**: Added workflow-level validation to enforce unique block labels across the entire workflow definition

### Technical Implementation
```mermaid
flowchart TD
    A[ConditionalBlockYAML] --> B[BranchConditionYAML]
    B --> C[BranchCriteriaYAML]
    C --> D[Jinja2 Expression]
    B --> E[Default Branch]
    
    F[Validation Rules] --> G[At least one branch required]
    F --> H[Only one default branch allowed]
    F --> I[Non-default branches must have criteria]
    F --> J[Default branches cannot have criteria]
    
    K[WorkflowDefinitionYAML] --> L[Unique block labels validation]
```

### Impact
- **Enhanced Workflow Control**: Enables complex conditional logic in workflows through Jinja2 template expressions for dynamic decision making
- **Type Safety Improvement**: The discriminated union approach provides better type checking and serialization/deserialization handling
- **Robust Validation**: Comprehensive validation prevents common configuration errors like missing default branches or duplicate block labels
- **Foundation for DAG Execution**: This appears to be the first part of a larger workflow DAG execution feature, establishing the groundwork for conditional workflow routing

</details>

_Created with [Palmier](https://www.palmier.io)_