### PR TITLE
Warn missing auth in workflow_run_streaming

### DIFF
--- a/skyvern/forge/sdk/routes/streaming/screenshot.py
+++ b/skyvern/forge/sdk/routes/streaming/screenshot.py
@@ -14,7 +14,7 @@ import base64
 from datetime import datetime
 
 import structlog
-from fastapi import WebSocket, WebSocketDisconnect
+from fastapi import HTTPException, WebSocket, WebSocketDisconnect
 from pydantic import ValidationError
 from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 
@@ -156,8 +156,8 @@ async def workflow_run_streaming(
     try:
         organization = await get_current_org(x_api_key=apikey, authorization=token)
         organization_id = organization.organization_id
-    except Exception:
-        LOG.exception(
+    except HTTPException:
+        LOG.warning(
             "WofklowRun Streaming: Error while getting organization",
             workflow_run_id=workflow_run_id,
             token=token,


### PR DESCRIPTION
This always happens while running locally, wanna warn it to avoid distraction

<img width="1060" height="298" alt="image" src="https://github.com/user-attachments/assets/9a5dd98c-240a-4809-adba-d5181f191e9d" />

---

⚠️ This PR improves error handling in the workflow run streaming endpoint by changing authentication failures from exceptions to warnings, reducing log noise during local development.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Error Handling**: Changed exception catching from generic `Exception` to specific `HTTPException` for authentication failures
- **Logging Level**: Downgraded log level from `LOG.exception()` to `LOG.warning()` for authentication errors
- **Import Addition**: Added `HTTPException` import from FastAPI to support the more specific exception handling

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant StreamingEndpoint
    participant AuthService
    participant Logger
    
    Client->>StreamingEndpoint: Connect to workflow_run_streaming
    StreamingEndpoint->>AuthService: get_current_org(apikey, token)
    AuthService-->>StreamingEndpoint: HTTPException (auth failure)
    StreamingEndpoint->>Logger: LOG.warning() instead of LOG.exception()
    Note over Logger: Reduced log noise for expected auth failures
```

### Impact
- **Developer Experience**: Reduces distracting exception logs during local development when authentication is expected to fail
- **Log Quality**: More appropriate warning level for authentication failures that are common in development environments
- **Error Specificity**: Better exception handling by catching specific `HTTPException` rather than all exceptions
- **Backward Compatibility**: No breaking changes - only improves logging behavior without affecting functionality

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `workflow_run_streaming` to log a warning instead of an exception for missing auth, reducing log noise when running locally.
> 
>   - **Behavior**:
>     - Change `workflow_run_streaming` in `screenshot.py` to log a warning instead of an exception for `HTTPException` when fetching organization fails.
>     - Sends "Invalid credential provided" message to WebSocket client on `HTTPException`.
>   - **Logging**:
>     - Adjusts log level from exception to warning for missing auth in `workflow_run_streaming`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for fa16758f4a7b8289904b53d89c769d1899d01bd7. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling during streaming operations to more reliably manage credential validation failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->