### PR TITLE
fix: prevent Vertex cache contamination across different prompt templates

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -406,10 +406,13 @@ class LLMAPIHandlerFactory:
                 return llm_request_json
 
             # Inject context caching system message when available
+            # IMPORTANT: Only inject for extract-actions prompt to avoid contaminating other prompts
+            # (e.g., check-user-goal) with the extract-action schema
             try:
-                context_cached_static_prompt = getattr(context, "cached_static_prompt", None)
                 if (
-                    context_cached_static_prompt
+                    context
+                    and context.cached_static_prompt
+                    and prompt_name == EXTRACT_ACTION_PROMPT_NAME  # Only inject for extract-actions
                     and isinstance(llm_config, LLMConfig)
                     and isinstance(llm_config.model_name, str)
                 ):
@@ -426,7 +429,7 @@ class LLMAPIHandlerFactory:
                             "content": [
                                 {
                                     "type": "text",
-                                    "text": context_cached_static_prompt,
+                                    "text": context.cached_static_prompt,
                                 }
                             ],
                         }
@@ -789,10 +792,13 @@ class LLMAPIHandlerFactory:
             messages = await llm_messages_builder(prompt, screenshots, llm_config.add_assistant_prefix)
 
             # Inject context caching system message when available
+            # IMPORTANT: Only inject for extract-actions prompt to avoid contaminating other prompts
+            # (e.g., check-user-goal) with the extract-action schema
             try:
-                context_cached_static_prompt = getattr(context, "cached_static_prompt", None)
                 if (
-                    context_cached_static_prompt
+                    context
+                    and context.cached_static_prompt
+                    and prompt_name == EXTRACT_ACTION_PROMPT_NAME  # Only inject for extract-actions
                     and isinstance(llm_config, LLMConfig)
                     and isinstance(llm_config.model_name, str)
                 ):
@@ -809,7 +815,7 @@ class LLMAPIHandlerFactory:
                             "content": [
                                 {
                                     "type": "text",
-                                    "text": context_cached_static_prompt,
+                                    "text": context.cached_static_prompt,
                                 }
                             ],
                         }


### PR DESCRIPTION
	## Fix: Prevent Vertex Cache Contamination Across Different Prompt Templates

### Summary

Fixes a bug where Vertex AI cache created for `extract-action-static.j2` prompts was being incorrectly attached to validation prompts (`decisive-criterion-validate.j2`), causing the LLM to return `CLICK` actions when only `COMPLETE` or `TERMINATE` were valid.

### Problem

A workflow was failing with "validation block failed" after 2 steps. The LLM returned a `CLICK` action with the exact schema from `extract-action-static.j2` even though the validation prompt explicitly asked for only `COMPLETE` or `TERMINATE` actions.

**Root causes identified:**
**Hardcoded `prompt_name`:** `_build_extract_action_prompt` was always passing `prompt_name="extract-actions"` regardless of the actual template being used (e.g., `decisive-criterion-validate`)

**Unrelated but safer alterations:**
1. **Persistent `vertex_cache_name`:** The `vertex_cache_name` was not being reset between different prompt types, so the cache created for `extract-action-static.j2` was being attached to subsequent calls of extract-actions-type templates
2. **OpenAI caching injection:** The OpenAI context caching system message might have been injected for all prompt types, not just `extract-actions`, in some edge cases

### Changes

| File | Change |
|------|--------|
| `skyvern/forge/agent.py` | Reset `vertex_cache_name = None` at start of `_build_extract_action_prompt`; return actual template name instead of hardcoded "extract-actions"; update return type annotations |
| `skyvern/forge/sdk/api/llm/api_handler_factory.py` | Guard OpenAI caching injection with `prompt_name == EXTRACT_ACTION_PROMPT_NAME` |
| `scripts/replay_task_actions.py` | Update unpacking for new return signature |
| `tests/unit/test_parallel_verification.py` | Update mock return value |
| `tests/unit/test_api_handler_factory.py` | Add tests for OpenAI caching injection behavior |

### Testing

- [x] `uv run pytest tests/unit/test_api_handler_factory.py tests/unit/test_parallel_verification.py`
- [x] `pre-commit run --all-files`
- [x] `mypy` passes

### Related

Reported in Slack by Aditya – validation block failed with maximum steps (2), LLM returned `CLICK` instead of `COMPLETE`/`TERMINATE`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime prompt naming introduced for extraction flows to improve observability and enable per-prompt cache gating.
* **Bug Fixes**
  * Scoped cached prompt usage so cached guidance is applied only to extraction prompts, preventing contamination of other prompt types.
* **Tests**
  * Added/updated tests validating prompt-name propagation and that cached content is injected only for extraction workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes Vertex AI cache contamination by resetting cache references and ensuring prompt-specific caching in `agent.py` and `api_handler_factory.py`.
> 
>   - **Behavior**:
>     - Fixes cache contamination by resetting `vertex_cache_name` in `_build_extract_action_prompt()` in `agent.py`.
>     - Ensures `prompt_name` is correctly set and used in `agent.py` and `api_handler_factory.py`.
>     - Guards OpenAI caching injection with `prompt_name == EXTRACT_ACTION_PROMPT_NAME` in `api_handler_factory.py`.
>   - **Testing**:
>     - Updates to `test_parallel_verification.py` and `test_api_handler_factory.py` to verify caching behavior.
>   - **Misc**:
>     - Updates return type annotations in `agent.py` functions.
>     - Adjusts unpacking for new return signature in `scripts/replay_task_actions.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5192183e05d3104ec95e8763b603a1afea1e081a. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->