### PR TITLE
fix totp identifier fallback from stored credentials

### DIFF
--- a/skyvern/forge/sdk/workflow/context_manager.py
+++ b/skyvern/forge/sdk/workflow/context_manager.py
@@ -296,7 +296,7 @@ class WorkflowRunContext:
         credential_item = await credential_service.get_credential_item(db_credential)
         credential = credential_item.credential
 
-        credential_totp_identifier = getattr(credential, "totp_identifier", None)
+        credential_totp_identifier = db_credential.totp_identifier or getattr(credential, "totp_identifier", None)
         if credential_totp_identifier:
             self.credential_totp_identifiers[parameter.key] = credential_totp_identifier
 

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -3493,6 +3493,13 @@ class TaskV2Block(Block):
     max_iterations: int = settings.MAX_ITERATIONS_PER_TASK_V2
     max_steps: int = settings.MAX_STEPS_PER_TASK_V2
 
+    def _resolve_totp_identifier(self, workflow_run_context: WorkflowRunContext) -> str | None:
+        if self.totp_identifier:
+            return self.totp_identifier
+        if workflow_run_context.credential_totp_identifiers:
+            return next(iter(workflow_run_context.credential_totp_identifiers.values()), None)
+        return None
+
     def get_all_parameters(
         self,
         workflow_run_id: str,
@@ -3535,7 +3542,7 @@ class TaskV2Block(Block):
             # Use the resolved values directly
             resolved_prompt = self.prompt
             resolved_url = self.url
-            resolved_totp_identifier = self.totp_identifier
+            resolved_totp_identifier = self._resolve_totp_identifier(workflow_run_context)
             resolved_totp_verification_url = self.totp_verification_url
 
         except Exception as e:


### PR DESCRIPTION
Implemented the correct runtime fallback plumbing. Other attempt here was [missing important wiring](https://github.com/Skyvern-AI/skyvern-cloud/pull/7543/files#diff-87a2d0c616fcb1a6175d68b655a6d7845552aa6cf2ef40716bf107590b1f7094). Found out in staging when testing the [frontend](https://github.com/Skyvern-AI/skyvern-cloud/pull/7569/files) for this.

This PR
- skyvern/forge/sdk/workflow/context_manager.py: when registering credential parameters, we now pull totp_identifier from the DB credential (falling back to the vault item) so the context tracks stored identifiers even if vault payloads omit them.
- skyvern/forge/sdk/workflow/models/block.py: TaskV2 now resolves totp_identifier from the credential-backed context when none is provided, matching the TaskV1 behavior.
- Added tests/unit/test_totp_identifier_fallback.py to cover the context registration path and the TaskV2 fallback resolver.

<img width="541" height="83" alt="Screenshot 2025-12-03 at 4 26 48 PM" src="https://github.com/user-attachments/assets/c918047a-e833-435f-bf44-c1983c635153" />

[Slack context on this ask
](https://skyvern.slack.com/archives/C09ME48U6G1/p1764606969173029)

---

🔧 This PR fixes TOTP identifier fallback logic to properly retrieve stored credentials from the database when vault payloads omit them, ensuring TaskV2 blocks can access TOTP identifiers consistently like TaskV1 blocks.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Context Manager**: Modified `_register_credential_parameter_value` to prioritize `db_credential.totp_identifier` over vault-stored values, ensuring stored identifiers are preserved even when vault payloads are incomplete
- **TaskV2 Block**: Added `_resolve_totp_identifier` method that falls back to credential context when no explicit TOTP identifier is provided, matching TaskV1 behavior
- **Runtime Resolution**: Enhanced the execution flow to use the new resolver instead of direct property access

### Technical Implementation
```mermaid
sequenceDiagram
    participant WRC as WorkflowRunContext
    participant CM as ContextManager
    participant DB as Database
    participant Vault as Credential Vault
    participant T2 as TaskV2Block
    
    WRC->>CM: Register credential parameter
    CM->>DB: Get db_credential.totp_identifier
    CM->>Vault: Get credential.totp_identifier (fallback)
    CM->>WRC: Store resolved identifier in context
    T2->>T2: _resolve_totp_identifier()
    T2->>WRC: Check credential_totp_identifiers
    T2->>T2: Return first available identifier
```

### Impact
- **Reliability**: Ensures TOTP identifiers are consistently available during task execution, preventing authentication failures
- **Consistency**: Aligns TaskV2 behavior with TaskV1, providing uniform credential handling across task types
- **Robustness**: Adds proper fallback mechanism that handles cases where vault payloads may be incomplete or missing TOTP data

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix TOTP identifier fallback in `context_manager.py` and `block.py` to ensure correct resolution from stored credentials.
> 
>   - **Behavior**:
>     - In `context_manager.py`, modify `_register_credential_parameter_value()` to use `db_credential.totp_identifier` as a fallback for TOTP identifiers.
>     - In `block.py`, add `_resolve_totp_identifier()` to `TaskV2Block` to resolve TOTP identifiers from the credential-backed context if not provided.
>   - **Testing**:
>     - Add `test_totp_identifier_fallback.py` to test context registration and TaskV2 fallback resolver.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for fbe2d4b3f873bb493bc3f10ce6b907d7d2b0dad4. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved two-factor authentication credential resolution in workflows by prioritizing database records when available and intelligently handling contextual fallbacks for more reliable credential authentication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->