### PR TITLE
Autofill totp_identifier for user/email based on creds

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -528,6 +528,7 @@ export type PasswordCredential = {
   password: string;
   totp: string | null;
   totp_type: "authenticator" | "email" | "text" | "none";
+  totp_identifier?: string | null;
 };
 
 export type CreditCardCredential = {

--- a/skyvern-frontend/src/routes/credentials/CredentialsModal.tsx
+++ b/skyvern-frontend/src/routes/credentials/CredentialsModal.tsx
@@ -28,6 +28,7 @@ const PASSWORD_CREDENTIAL_INITIAL_VALUES = {
   password: "",
   totp: "",
   totp_type: "none" as "none" | "authenticator" | "email" | "text",
+  totp_identifier: "",
 };
 
 const CREDIT_CARD_CREDENTIAL_INITIAL_VALUES = {
@@ -141,6 +142,7 @@ function CredentialsModal({ onCredentialCreated }: Props) {
       const username = passwordCredentialValues.username.trim();
       const password = passwordCredentialValues.password.trim();
       const totp = passwordCredentialValues.totp.trim();
+      const totpIdentifier = passwordCredentialValues.totp_identifier.trim();
 
       if (username === "" || password === "") {
         toast({
@@ -158,6 +160,7 @@ function CredentialsModal({ onCredentialCreated }: Props) {
           password,
           totp: totp === "" ? null : totp,
           totp_type: passwordCredentialValues.totp_type,
+          totp_identifier: totpIdentifier === "" ? null : totpIdentifier,
         },
       });
     } else if (type === CredentialModalTypes.CREDIT_CARD) {


### PR DESCRIPTION
Follow up to here
https://github.com/Skyvern-AI/skyvern-cloud/pull/7543

If someone enters a user/email, we will autofill this as a totp_identifier, cause we are storing the totp_identifier with the credentials now. this way, the totp_identifier doesn't have to be specified in the workflow run separately. 

I chose not to fill that value into the phone field cause it wouldn't make sense ... the totp_identifier for text message isn't gonna be the username or email for the cred (not likely).

<img width="876" height="869" alt="Screenshot 2025-12-02 at 3 33 41 PM" src="https://github.com/user-attachments/assets/2bb73026-47b2-4832-87b5-4258b3a0c56d" />
<img width="753" height="773" alt="Screenshot 2025-12-02 at 3 33 38 PM" src="https://github.com/user-attachments/assets/4c2666d1-f433-4fe7-ad18-ed77e6ed2d88" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added optional TOTP identifier field to password credentials, enabling users to specify identifiers for email and text-based authentication methods.
  - Enhanced credential configuration UI with contextual guidance for the new identifier field.

* **Refactor**
  - Streamlined credential form state management to improve workflow handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Autofill `totp_identifier` based on `username` for email TOTP method and clear it for text method in `PasswordCredentialContent`.
> 
>   - **Behavior**:
>     - Autofill `totp_identifier` with `username` when TOTP method is "email" in `PasswordCredentialContent`.
>     - Clear `totp_identifier` when switching TOTP method to "text".
>   - **Types**:
>     - Add `totp_identifier` to `PasswordCredential` in `types.ts`.
>   - **UI**:
>     - Update `PasswordCredentialContent` to handle autofill logic and display dynamic labels and helper text for `totp_identifier`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 06769f5c330918ec271c65156d9cd58a0b3fd2b0. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔐 This PR enhances the TOTP (Two-Factor Authentication) credential management system by automatically populating the `totp_identifier` field with the username/email when using email-based 2FA, streamlining the credential setup process and reducing manual input requirements.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Type System**: Added optional `totp_identifier` field to `PasswordCredential` type in the API types
- **UI Enhancement**: Introduced dynamic TOTP identifier input field with context-aware labels and helper text
- **Auto-fill Logic**: Implemented intelligent auto-population of TOTP identifier based on username/email for email-based 2FA
- **State Management**: Enhanced form handling with proper initialization and validation of the new field

### Technical Implementation
```mermaid
flowchart TD
    A[User enters username/email] --> B{TOTP method selected?}
    B -->|Email| C[Auto-fill totp_identifier with username]
    B -->|Text| D[Clear totp_identifier if auto-filled]
    B -->|Authenticator| E[No auto-fill needed]
    C --> F[Update form state]
    D --> F
    E --> F
    F --> G[Save credential with totp_identifier]
```

### Impact
- **User Experience**: Reduces manual data entry by intelligently pre-filling TOTP identifiers for email-based authentication
- **Workflow Efficiency**: Eliminates the need to specify TOTP identifiers separately in workflow runs since they're now stored with credentials
- **Smart Defaults**: Provides contextual behavior - auto-fills for email 2FA but leaves blank for text/SMS 2FA where username wouldn't be applicable

</details>

_Created with [Palmier](https://www.palmier.io)_