### PR TITLE
add cached steps flag to db (is_script_cached in Step)

### DIFF
--- a/skyvern/forge/sdk/db/client.py
+++ b/skyvern/forge/sdk/db/client.py
@@ -257,6 +257,7 @@ class AgentDB:
         retry_index: int,
         organization_id: str | None = None,
         status: StepStatus = StepStatus.created,
+        created_by: str | None = None,
     ) -> Step:
         try:
             async with self.Session() as session:
@@ -266,6 +267,7 @@ class AgentDB:
                     retry_index=retry_index,
                     status=status,
                     organization_id=organization_id,
+                    created_by=created_by,
                 )
                 session.add(new_step)
                 await session.commit()
@@ -595,6 +597,7 @@ class AgentDB:
         incremental_output_tokens: int | None = None,
         incremental_reasoning_tokens: int | None = None,
         incremental_cached_tokens: int | None = None,
+        created_by: str | None = None,
     ) -> Step:
         try:
             async with self.Session() as session:
@@ -627,6 +630,8 @@ class AgentDB:
                         step.reasoning_token_count = incremental_reasoning_tokens + (step.reasoning_token_count or 0)
                     if incremental_cached_tokens is not None:
                         step.cached_token_count = incremental_cached_tokens + (step.cached_token_count or 0)
+                    if created_by is not None:
+                        step.created_by = created_by
 
                     await session.commit()
                     updated_step = await self.get_step(step_id, organization_id)

--- a/skyvern/forge/sdk/db/models.py
+++ b/skyvern/forge/sdk/db/models.py
@@ -142,6 +142,7 @@ class StepModel(Base):
     cached_token_count = Column(Integer, default=0)
     step_cost = Column(Numeric, default=0)
     finished_at = Column(DateTime, nullable=True)
+    created_by = Column(String, nullable=True)
 
 
 class OrganizationModel(Base):

--- a/skyvern/forge/sdk/db/utils.py
+++ b/skyvern/forge/sdk/db/utils.py
@@ -234,6 +234,7 @@ def convert_to_step(step_model: StepModel, debug_enabled: bool = False) -> Step:
         reasoning_token_count=step_model.reasoning_token_count,
         cached_token_count=step_model.cached_token_count,
         step_cost=step_model.step_cost,
+        created_by=step_model.created_by,
     )
 
 

--- a/skyvern/forge/sdk/models.py
+++ b/skyvern/forge/sdk/models.py
@@ -71,6 +71,7 @@ class Step(BaseModel):
     reasoning_token_count: int | None = None
     cached_token_count: int | None = None
     step_cost: float = 0
+    created_by: str | None = None
     is_speculative: bool = False
     speculative_original_status: StepStatus | None = None
     speculative_llm_metadata: SpeculativeLLMMetadata | None = None

--- a/skyvern/services/script_service.py
+++ b/skyvern/services/script_service.py
@@ -398,6 +398,7 @@ async def _create_workflow_block_run_and_task(
     url: str | None = None,
     label: str | None = None,
     model: dict[str, Any] | None = None,
+    created_by: str | None = None,
 ) -> tuple[str | None, str | None, str | None]:
     """
     Create a workflow block run and optionally a task if workflow_run_id is available in context.
@@ -460,6 +461,7 @@ async def _create_workflow_block_run_and_task(
                 retry_index=0,
                 organization_id=organization_id,
                 status=StepStatus.running,
+                created_by=created_by,
             )
             step_id = step.step_id
             # reset the action order to 0
@@ -1334,6 +1336,7 @@ async def run_task(
             url=url,
             label=cache_key,
             model=model,
+            created_by="script",
         )
         prompt = _render_template_with_label(prompt, cache_key)
         # set the prompt in the RunContext
@@ -1419,6 +1422,7 @@ async def download(
             url=url,
             label=cache_key,
             model=model,
+            created_by="script",
         )
         prompt = _render_template_with_label(prompt, cache_key)
         # set the prompt in the RunContext
@@ -1499,6 +1503,7 @@ async def action(
             url=url,
             label=cache_key,
             model=model,
+            created_by="script",
         )
         prompt = _render_template_with_label(prompt, cache_key)
         # set the prompt in the RunContext
@@ -1578,6 +1583,7 @@ async def login(
             url=url,
             label=cache_key,
             model=model,
+            created_by="script",
         )
         prompt = _render_template_with_label(prompt, cache_key)
         if totp_url:
@@ -1660,6 +1666,7 @@ async def extract(
             url=url,
             label=cache_key,
             model=model,
+            created_by="script",
         )
         prompt = _render_template_with_label(prompt, cache_key)
         # set the prompt in the RunContext


### PR DESCRIPTION
To test it:

built workflow. run with code. first run is not cached (can see that flag correctly in db).
second run is cached and we mark it as true. example:


<img width="1429" height="286" alt="Screenshot 2025-12-04 at 11 25 45 AM" src="https://github.com/user-attachments/assets/99434c87-016f-4bbe-aab9-038c8bb58cde" />
<img width="584" height="220" alt="Screenshot 2025-12-04 at 11 25 49 AM" src="https://github.com/user-attachments/assets/556260e2-cba9-43bc-8618-e85bbf3701f8" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `created_by` field to `Step` model and update related functions to track step creation source.
> 
>   - **Models**:
>     - Add `created_by` field to `StepModel` in `models.py`.
>     - Update `Step` class in `models.py` to include `created_by`.
>   - **Database Operations**:
>     - Update `create_step()` and `update_step()` in `client.py` to handle `created_by`.
>   - **Service Functions**:
>     - Update `_create_workflow_block_run_and_task()` in `script_service.py` to set `created_by` to "script".
>     - Update `run_task()`, `download()`, `action()`, `login()`, and `extract()` in `script_service.py` to pass `created_by` as "script".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 505ccc71c5114da521beb9b35e6a86114df5b180. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Steps now include creator attribution to track who or what initiated their creation
  * Script-triggered operations automatically record their creation source for improved tracking and auditability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🏷️ This PR adds a `created_by` field to the Step model to track the source of step creation, enabling better visibility into whether steps were created by scripts or other sources. The implementation includes database schema updates, model changes, and automatic tagging of script-generated steps with "script" as the creator.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Database Schema**: Added `created_by` column to the `StepModel` in the database with nullable string type
- **Model Updates**: Extended both `StepModel` and `Step` classes to include the new `created_by` field
- **Database Operations**: Updated `create_step()` and `update_step()` functions to handle the new field parameter
- **Script Service Integration**: Modified all script service functions (`run_task`, `download`, `action`, `login`, `extract`) to automatically set `created_by="script"` for script-generated steps
- **Data Conversion**: Updated `convert_to_step()` utility function to properly map the database field to the model

### Technical Implementation
```mermaid
flowchart TD
    A[Script Service Functions] --> B[_create_workflow_block_run_and_task]
    B --> C[create_step with created_by='script']
    C --> D[StepModel in Database]
    D --> E[convert_to_step]
    E --> F[Step Model with created_by field]
    
    G[Other Sources] --> H[create_step with created_by=None]
    H --> D
```

### Impact
- **Traceability**: Enables tracking of step creation sources, distinguishing between script-generated and manually created steps
- **Debugging & Analytics**: Provides valuable metadata for understanding workflow execution patterns and debugging cached vs non-cached step behavior
- **Backward Compatibility**: The field is nullable, ensuring existing data and functionality remain unaffected
- **Cache Management**: Supports the broader goal of implementing cached steps functionality by providing context about step origins

</details>

_Created with [Palmier](https://www.palmier.io)_