### PR TITLE
remove _cached in initialize_llm_api_handler

### DIFF
--- a/skyvern/forge/sdk/experimentation/llm_prompt_config.py
+++ b/skyvern/forge/sdk/experimentation/llm_prompt_config.py
@@ -13,13 +13,13 @@ LOG = structlog.get_logger()
 
 async def get_llm_config_by_prompt_type(distinct_id: str, organization_id: str | None = None) -> dict[str, str] | None:
     """Return PostHog-configured LLM mapping for each prompt type."""
-    llm_config_experiment = await app.EXPERIMENTATION_PROVIDER.get_value_cached(
+    llm_config_experiment = await app.EXPERIMENTATION_PROVIDER.get_value(
         "LLM_CONFIG_BY_PROMPT_TYPE", distinct_id, properties={"organization_id": organization_id}
     )
     if llm_config_experiment in (False, "False") or not llm_config_experiment:
         return None
 
-    payload = await app.EXPERIMENTATION_PROVIDER.get_payload_cached(
+    payload = await app.EXPERIMENTATION_PROVIDER.get_payload(
         "LLM_CONFIG_BY_PROMPT_TYPE", distinct_id, properties={"organization_id": organization_id}
     )
     if not payload:


### PR DESCRIPTION
PostHog is evaluated locally now, no need for `_cached`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated LLM prompt configuration lookups to fetch fresh configurations on each access instead of using cached versions, ensuring current settings are always applied.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replaces cached retrieval methods with non-cached ones in `get_llm_config_by_prompt_type()` to ensure fresh LLM configuration and payload data.
> 
>   - **Behavior**:
>     - Replaces `get_value_cached` with `get_value` in `get_llm_config_by_prompt_type()` to ensure fresh LLM configuration values.
>     - Replaces `get_payload_cached` with `get_payload` in `get_llm_config_by_prompt_type()` to ensure fresh payload data.
>   - **Logging**:
>     - No changes to logging behavior, warnings and errors remain the same.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f98e6af2ac13f99c2840312a4217fdc27991441f. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔄 This PR removes cached method calls from LLM configuration retrieval, switching from `get_value_cached` and `get_payload_cached` to their non-cached counterparts. The change ensures that PostHog experiment configurations are always fetched fresh since PostHog is now evaluated locally.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **LLM Configuration Retrieval**: Replaced `get_value_cached()` with `get_value()` for fetching LLM experiment values
- **Payload Fetching**: Replaced `get_payload_cached()` with `get_payload()` for retrieving experiment payloads
- **Function Scope**: Changes affect `get_llm_config_by_prompt_type()` in `llm_prompt_config.py`

### Technical Implementation
```mermaid
sequenceDiagram
    participant App as Application
    participant EP as EXPERIMENTATION_PROVIDER
    participant PH as PostHog (Local)
    
    App->>EP: get_value() [was get_value_cached()]
    EP->>PH: Fetch fresh experiment value
    PH-->>EP: Return current value
    EP-->>App: Return experiment result
    
    App->>EP: get_payload() [was get_payload_cached()]
    EP->>PH: Fetch fresh payload
    PH-->>EP: Return current payload
    EP-->>App: Return payload data
```

### Impact
- **Configuration Freshness**: Ensures LLM configurations always reflect the latest PostHog experiment settings without relying on potentially stale cached data
- **Local Evaluation**: Aligns with the architectural change where PostHog is now evaluated locally, eliminating the need for caching optimization
- **Behavioral Consistency**: Guarantees that configuration changes in PostHog experiments are immediately reflected across all sessions

</details>

_Created with [Palmier](https://www.palmier.io)_