### PR TITLE
honor x-www-form-urlencoded in http block

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -291,7 +291,7 @@ class Settings(BaseSettings):
     # GEMINI
     GEMINI_API_KEY: str | None = None
     GEMINI_INCLUDE_THOUGHT: bool = False
-    GEMINI_THINKING_BUDGET: int | None = 500
+    GEMINI_THINKING_BUDGET: int | None = None
 
     # VERTEX_AI
     VERTEX_CREDENTIALS: str | None = None

--- a/skyvern/forge/sdk/core/aiohttp_helper.py
+++ b/skyvern/forge/sdk/core/aiohttp_helper.py
@@ -14,6 +14,8 @@ async def aiohttp_request(
     method: str,
     url: str,
     headers: dict[str, str] | None = None,
+    *,
+    body: dict[str, Any] | str | None = None,
     data: dict[str, Any] | None = None,
     json_data: dict[str, Any] | None = None,
     cookies: dict[str, str] | None = None,
@@ -39,10 +41,17 @@ async def aiohttp_request(
 
         # Handle body based on content type and method
         if method.upper() != "GET":
+            # Explicit overrides first
             if json_data is not None:
                 request_kwargs["json"] = json_data
             elif data is not None:
                 request_kwargs["data"] = data
+            elif body is not None:
+                content_type = (headers or {}).get("Content-Type") or (headers or {}).get("content-type") or ""
+                if "application/x-www-form-urlencoded" in content_type.lower():
+                    request_kwargs["data"] = body
+                else:
+                    request_kwargs["json"] = body
 
         async with session.request(method.upper(), **request_kwargs) as response:
             response_headers = dict(response.headers)

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -3891,7 +3891,7 @@ class HttpRequestBlock(Block):
                 method=self.method,
                 url=self.url,
                 headers=self.headers,
-                json_data=self.body,
+                body=self.body,
                 timeout=self.timeout,
                 follow_redirects=self.follow_redirects,
             )


### PR DESCRIPTION
		Issue from centria. We were getting an error like this in the HttpBlock

<img width="1486" height="184" alt="Screenshot 2025-12-08 at 1 14 52 PM" src="https://github.com/user-attachments/assets/2367781b-2262-4f21-825c-3b29ee179ab2" />

from some digging, seems like we need to use `application/x-www-form-urlencoded` for OAuth 2.0
https://datatracker.ietf.org/doc/html/rfc6749. They had been using application/json


<img width="865" height="920" alt="Screenshot 2025-12-08 at 1 21 05 PM" src="https://github.com/user-attachments/assets/c38795d5-12a5-47bc-b3fd-16a7968808e3" />


However, when I tried application/x-www-form-urlencoded in http block, it was still trying to send it as JSON and then the body was blank (hence `missing grant_type`)

With this change locally, we do send the right request body type when `application/x-www-form-urlencoded` is selected. tested locally. 

Also used their creds since it was printed out in prod in their workflow run output (I should maybe remove that from printing out there). It does pass the body, but they might have an issue still with the value they are sending for the client_secret even after this change, below is from my local test:


<img width="1453" height="126" alt="Screenshot 2025-12-08 at 1 26 38 PM" src="https://github.com/user-attachments/assets/e34973b4-5068-49b1-a218-52024655176e" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an explicit request-body option to control payload serialization for non-GET requests.
* **Bug Fixes**
  * Improved HTTP request handling so explicit bodies are honored and form-urlencoded payloads are sent with the correct format based on Content-Type headers, avoiding misformatted requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improved HTTP request handling in `aiohttp_request` to support `application/x-www-form-urlencoded` and updated `HttpRequestBlock` to use `body` parameter.
> 
>   - **Behavior**:
>     - `aiohttp_request` in `aiohttp_helper.py` now supports `application/x-www-form-urlencoded` by checking `Content-Type` and setting `data` or `json` accordingly.
>     - `HttpRequestBlock` in `block.py` updated to use `body` instead of `json_data` for request execution.
>   - **Config**:
>     - `GEMINI_THINKING_BUDGET` in `config.py` changed from `500` to `None`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c63cdab5f03b94c42be48721a3d38697a09f1f05. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->