### PR TITLE
show metadata for non-navigation blocks on workflow parameters page

### DIFF
--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowPostRunParameters.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowPostRunParameters.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useWorkflowRunWithWorkflowQuery } from "../hooks/useWorkflowRunWithWorkflowQuery";
 import { CodeEditor } from "../components/CodeEditor";
 import { AutoResizingTextarea } from "@/components/AutoResizingTextarea/AutoResizingTextarea";
@@ -6,12 +7,21 @@ import { useWorkflowRunTimelineQuery } from "../hooks/useWorkflowRunTimelineQuer
 import { isAction, isWorkflowRunBlock } from "../types/workflowRunTypes";
 import { findBlockSurroundingAction } from "./workflowTimelineUtils";
 import { TaskBlockParameters } from "./TaskBlockParameters";
-import { isTaskVariantBlock, WorkflowBlockTypes } from "../types/workflowTypes";
+import {
+  isTaskVariantBlock,
+  WorkflowBlockTypes,
+  type WorkflowBlock,
+  type WorkflowBlockType,
+} from "../types/workflowTypes";
 import { Input } from "@/components/ui/input";
 import { ProxySelector } from "@/components/ProxySelector";
 import { SendEmailBlockParameters } from "./blockInfo/SendEmailBlockInfo";
 import { ProxyLocation } from "@/api/types";
 import { KeyValueInput } from "@/components/KeyValueInput";
+import { CodeBlockParameters } from "./blockInfo/CodeBlockParameters";
+import { TextPromptBlockParameters } from "./blockInfo/TextPromptBlockParameters";
+import { GotoUrlBlockParameters } from "./blockInfo/GotoUrlBlockParameters";
+import { FileDownloadBlockParameters } from "./blockInfo/FileDownloadBlockParameters";
 
 function WorkflowPostRunParameters() {
   const { data: workflowRunTimeline, isLoading: workflowRunTimelineIsLoading } =
@@ -20,14 +30,7 @@ function WorkflowPostRunParameters() {
   const { data: workflowRun, isLoading: workflowRunIsLoading } =
     useWorkflowRunWithWorkflowQuery();
   const parameters = workflowRun?.parameters ?? {};
-
-  if (workflowRunIsLoading || workflowRunTimelineIsLoading) {
-    return <div>Loading workflow parameters...</div>;
-  }
-
-  if (!workflowRun || !workflowRunTimeline) {
-    return null;
-  }
+  const workflow = workflowRun?.workflow;
 
   function getActiveBlock() {
     if (!workflowRunTimeline) {
@@ -45,19 +48,37 @@ function WorkflowPostRunParameters() {
   }
 
   const activeBlock = getActiveBlock();
-  const isTaskV2 = workflowRun.task_v2 !== null;
+  const activeBlockLabel = activeBlock?.label ?? null;
+  const definitionBlock = useMemo(() => {
+    if (!workflow || !activeBlockLabel) {
+      return null;
+    }
+    return findWorkflowBlockByLabel(
+      workflow.workflow_definition.blocks,
+      activeBlockLabel,
+    );
+  }, [workflow, activeBlockLabel]);
+  const isTaskV2 = Boolean(workflowRun?.task_v2);
 
   const webhookCallbackUrl = isTaskV2
-    ? workflowRun.task_v2?.webhook_callback_url
-    : workflowRun.webhook_callback_url;
+    ? workflowRun?.task_v2?.webhook_callback_url ?? null
+    : workflowRun?.webhook_callback_url ?? null;
 
   const proxyLocation = isTaskV2
-    ? workflowRun.task_v2?.proxy_location
-    : workflowRun.proxy_location;
+    ? workflowRun?.task_v2?.proxy_location ?? null
+    : workflowRun?.proxy_location ?? null;
 
   const extraHttpHeaders = isTaskV2
-    ? workflowRun.task_v2?.extra_http_headers
-    : workflowRun.extra_http_headers;
+    ? workflowRun?.task_v2?.extra_http_headers ?? null
+    : workflowRun?.extra_http_headers ?? null;
+
+  if (workflowRunIsLoading || workflowRunTimelineIsLoading) {
+    return <div>Loading workflow parameters...</div>;
+  }
+
+  if (!workflowRun || !workflowRunTimeline) {
+    return null;
+  }
 
   return (
     <div className="space-y-5">
@@ -66,6 +87,27 @@ function WorkflowPostRunParameters() {
           <div className="space-y-4">
             <h1 className="text-lg font-bold">Block Parameters</h1>
             <TaskBlockParameters block={activeBlock} />
+          </div>
+        </div>
+      ) : null}
+      {activeBlock &&
+      activeBlock.block_type === WorkflowBlockTypes.FileDownload &&
+      isBlockOfType(definitionBlock, WorkflowBlockTypes.FileDownload) ? (
+        <div className="rounded bg-slate-elevation2 p-6">
+          <div className="space-y-4">
+            <h1 className="text-lg font-bold">File Download Settings</h1>
+            <FileDownloadBlockParameters
+              prompt={
+                activeBlock.navigation_goal ??
+                definitionBlock.navigation_goal ??
+                null
+              }
+              downloadSuffix={definitionBlock.download_suffix ?? null}
+              downloadTimeout={definitionBlock.download_timeout ?? null}
+              errorCodeMapping={definitionBlock.error_code_mapping ?? null}
+              maxRetries={definitionBlock.max_retries ?? null}
+              maxStepsPerRun={definitionBlock.max_steps_per_run ?? null}
+            />
           </div>
         </div>
       ) : null}
@@ -102,6 +144,50 @@ function WorkflowPostRunParameters() {
                 maxHeight="200px"
               />
             </div>
+          </div>
+        </div>
+      ) : null}
+      {activeBlock &&
+      activeBlock.block_type === WorkflowBlockTypes.Code &&
+      isBlockOfType(definitionBlock, WorkflowBlockTypes.Code) ? (
+        <div className="rounded bg-slate-elevation2 p-6">
+          <div className="space-y-4">
+            <h1 className="text-lg font-bold">Code Block</h1>
+            <CodeBlockParameters
+              code={definitionBlock.code}
+              parameters={definitionBlock.parameters}
+            />
+          </div>
+        </div>
+      ) : null}
+      {activeBlock &&
+      activeBlock.block_type === WorkflowBlockTypes.TextPrompt &&
+      isBlockOfType(definitionBlock, WorkflowBlockTypes.TextPrompt) ? (
+        <div className="rounded bg-slate-elevation2 p-6">
+          <div className="space-y-4">
+            <h1 className="text-lg font-bold">Text Prompt Block</h1>
+            <TextPromptBlockParameters
+              prompt={activeBlock.prompt ?? definitionBlock.prompt ?? ""}
+              llmKey={definitionBlock.llm_key}
+              jsonSchema={definitionBlock.json_schema}
+              parameters={definitionBlock.parameters}
+            />
+          </div>
+        </div>
+      ) : null}
+      {activeBlock && activeBlock.block_type === WorkflowBlockTypes.URL ? (
+        <div className="rounded bg-slate-elevation2 p-6">
+          <div className="space-y-4">
+            <h1 className="text-lg font-bold">Go To URL Block</h1>
+            <GotoUrlBlockParameters
+              url={
+                activeBlock.url ??
+                (isBlockOfType(definitionBlock, WorkflowBlockTypes.URL)
+                  ? definitionBlock.url
+                  : "")
+              }
+              continueOnFailure={activeBlock.continue_on_failure}
+            />
           </div>
         </div>
       ) : null}
@@ -192,3 +278,31 @@ function WorkflowPostRunParameters() {
 }
 
 export { WorkflowPostRunParameters };
+
+function findWorkflowBlockByLabel(
+  blocks: Array<WorkflowBlock>,
+  label: string,
+): WorkflowBlock | null {
+  for (const block of blocks) {
+    if (block.label === label) {
+      return block;
+    }
+    if (
+      block.block_type === WorkflowBlockTypes.ForLoop &&
+      block.loop_blocks.length > 0
+    ) {
+      const nested = findWorkflowBlockByLabel(block.loop_blocks, label);
+      if (nested) {
+        return nested;
+      }
+    }
+  }
+  return null;
+}
+
+function isBlockOfType<T extends WorkflowBlockType>(
+  block: WorkflowBlock | null,
+  type: T,
+): block is Extract<WorkflowBlock, { block_type: T }> {
+  return block?.block_type === type;
+}

--- a/skyvern-frontend/src/routes/workflows/workflowRun/blockInfo/CodeBlockParameters.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/blockInfo/CodeBlockParameters.tsx
@@ -1,0 +1,57 @@
+import { CodeEditor } from "@/routes/workflows/components/CodeEditor";
+import type { WorkflowParameter } from "@/routes/workflows/types/workflowTypes";
+
+type Props = {
+  code: string;
+  parameters?: Array<WorkflowParameter>;
+};
+
+function CodeBlockParameters({ code, parameters }: Props) {
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-16">
+        <div className="w-80">
+          <h1 className="text-lg">Code</h1>
+          <h2 className="text-base text-slate-400">
+            The Python snippet executed for this block
+          </h2>
+        </div>
+        <CodeEditor
+          className="w-full"
+          language="python"
+          value={code}
+          readOnly
+          minHeight="160px"
+          maxHeight="400px"
+        />
+      </div>
+      {parameters && parameters.length > 0 ? (
+        <div className="flex gap-16">
+          <div className="w-80">
+            <h1 className="text-lg">Parameters</h1>
+            <h2 className="text-base text-slate-400">
+              Inputs passed to this code block
+            </h2>
+          </div>
+          <div className="flex w-full flex-col gap-3">
+            {parameters.map((parameter) => (
+              <div
+                key={parameter.key}
+                className="rounded border border-slate-700/40 bg-slate-elevation3 p-3"
+              >
+                <p className="font-medium">{parameter.key}</p>
+                {parameter.description ? (
+                  <p className="text-sm text-slate-400">
+                    {parameter.description}
+                  </p>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export { CodeBlockParameters };

--- a/skyvern-frontend/src/routes/workflows/workflowRun/blockInfo/FileDownloadBlockParameters.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/blockInfo/FileDownloadBlockParameters.tsx
@@ -1,0 +1,95 @@
+import { Input } from "@/components/ui/input";
+import { AutoResizingTextarea } from "@/components/AutoResizingTextarea/AutoResizingTextarea";
+
+type Props = {
+  prompt?: string | null;
+  downloadSuffix?: string | null;
+  downloadTimeout?: number | null;
+  errorCodeMapping?: Record<string, string> | null;
+  maxRetries?: number | null;
+  maxStepsPerRun?: number | null;
+};
+
+function FileDownloadBlockParameters({
+  prompt,
+  downloadSuffix,
+  downloadTimeout,
+  errorCodeMapping,
+  maxRetries,
+  maxStepsPerRun,
+}: Props) {
+  const formattedErrorCodeMapping = errorCodeMapping
+    ? JSON.stringify(errorCodeMapping, null, 2)
+    : null;
+
+  return (
+    <div className="space-y-4">
+      {prompt ? (
+        <div className="flex gap-16">
+          <div className="w-80">
+            <h1 className="text-lg">Prompt</h1>
+            <h2 className="text-base text-slate-400">
+              Instructions followed to download the file
+            </h2>
+          </div>
+          <AutoResizingTextarea value={prompt} readOnly />
+        </div>
+      ) : null}
+      {downloadSuffix ? (
+        <div className="flex gap-16">
+          <div className="w-80">
+            <h1 className="text-lg">Download Suffix</h1>
+            <h2 className="text-base text-slate-400">
+              Expected suffix or filename for the downloaded file
+            </h2>
+          </div>
+          <Input value={downloadSuffix} readOnly />
+        </div>
+      ) : null}
+      {typeof downloadTimeout === "number" ? (
+        <div className="flex gap-16">
+          <div className="w-80">
+            <h1 className="text-lg">Download Timeout</h1>
+            <h2 className="text-base text-slate-400">In seconds</h2>
+          </div>
+          <Input value={downloadTimeout.toString()} readOnly />
+        </div>
+      ) : null}
+      {typeof maxRetries === "number" ? (
+        <div className="flex gap-16">
+          <div className="w-80">
+            <h1 className="text-lg">Max Retries</h1>
+          </div>
+          <Input value={maxRetries.toString()} readOnly />
+        </div>
+      ) : null}
+      {typeof maxStepsPerRun === "number" ? (
+        <div className="flex gap-16">
+          <div className="w-80">
+            <h1 className="text-lg">Max Steps Per Run</h1>
+          </div>
+          <Input value={maxStepsPerRun.toString()} readOnly />
+        </div>
+      ) : null}
+      {formattedErrorCodeMapping ? (
+        <div className="flex gap-16">
+          <div className="w-80">
+            <h1 className="text-lg">Error Code Mapping</h1>
+          </div>
+          <AutoResizingTextarea value={formattedErrorCodeMapping} readOnly />
+        </div>
+      ) : null}
+      {!downloadSuffix &&
+      typeof downloadTimeout !== "number" &&
+      typeof maxRetries !== "number" &&
+      typeof maxStepsPerRun !== "number" &&
+      !formattedErrorCodeMapping ? (
+        <div className="text-sm text-slate-400">
+          No additional download-specific metadata configured for this block.
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export { FileDownloadBlockParameters };

--- a/skyvern-frontend/src/routes/workflows/workflowRun/blockInfo/GotoUrlBlockParameters.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/blockInfo/GotoUrlBlockParameters.tsx
@@ -1,0 +1,39 @@
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+
+type Props = {
+  url: string;
+  continueOnFailure: boolean;
+};
+
+function GotoUrlBlockParameters({ url, continueOnFailure }: Props) {
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-16">
+        <div className="w-80">
+          <h1 className="text-lg">URL</h1>
+          <h2 className="text-base text-slate-400">
+            The destination Skyvern navigates to
+          </h2>
+        </div>
+        <Input value={url} readOnly />
+      </div>
+      <div className="flex gap-16">
+        <div className="w-80">
+          <h1 className="text-lg">Continue on Failure</h1>
+          <h2 className="text-base text-slate-400">
+            Whether to continue if navigation fails
+          </h2>
+        </div>
+        <div className="flex w-full items-center gap-3">
+          <Switch checked={continueOnFailure} disabled />
+          <span className="text-sm text-slate-400">
+            {continueOnFailure ? "Enabled" : "Disabled"}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { GotoUrlBlockParameters };

--- a/skyvern-frontend/src/routes/workflows/workflowRun/blockInfo/TextPromptBlockParameters.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/blockInfo/TextPromptBlockParameters.tsx
@@ -1,0 +1,86 @@
+import { AutoResizingTextarea } from "@/components/AutoResizingTextarea/AutoResizingTextarea";
+import { Input } from "@/components/ui/input";
+import { CodeEditor } from "@/routes/workflows/components/CodeEditor";
+import type { WorkflowParameter } from "@/routes/workflows/types/workflowTypes";
+
+type Props = {
+  prompt: string;
+  llmKey?: string | null;
+  jsonSchema?: Record<string, unknown> | string | null;
+  parameters?: Array<WorkflowParameter>;
+};
+
+function TextPromptBlockParameters({
+  prompt,
+  llmKey,
+  jsonSchema,
+  parameters,
+}: Props) {
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-16">
+        <div className="w-80">
+          <h1 className="text-lg">Prompt</h1>
+          <h2 className="text-base text-slate-400">
+            Instructions passed to the selected LLM
+          </h2>
+        </div>
+        <AutoResizingTextarea value={prompt} readOnly />
+      </div>
+      {llmKey ? (
+        <div className="flex gap-16">
+          <div className="w-80">
+            <h1 className="text-lg">LLM Key</h1>
+          </div>
+          <Input value={llmKey} readOnly />
+        </div>
+      ) : null}
+      {jsonSchema ? (
+        <div className="flex gap-16">
+          <div className="w-80">
+            <h1 className="text-lg">JSON Schema</h1>
+            <h2 className="text-base text-slate-400">
+              Expected shape of the model response
+            </h2>
+          </div>
+          <CodeEditor
+            className="w-full"
+            language="json"
+            value={
+              typeof jsonSchema === "string"
+                ? jsonSchema
+                : JSON.stringify(jsonSchema, null, 2)
+            }
+            readOnly
+            minHeight="160px"
+            maxHeight="400px"
+          />
+        </div>
+      ) : null}
+      {parameters && parameters.length > 0 ? (
+        <div className="flex gap-16">
+          <div className="w-80">
+            <h1 className="text-lg">Parameters</h1>
+          </div>
+          <div className="flex w-full flex-col gap-3">
+            {parameters.map((parameter) => (
+              <div
+                key={parameter.key}
+                className="rounded border border-slate-700/40 bg-slate-elevation3 p-3"
+              >
+                <p className="font-medium">{parameter.key}</p>
+                {parameter.description ? (
+                  <p className="text-sm text-slate-400">
+                    {parameter.description}
+                  </p>
+                ) : null}
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export { TextPromptBlockParameters };


### PR DESCRIPTION
	### Summary - [ticket](https://linear.app/skyvern/issue/SKY-5938/make-the-file-download-block-show-the-prompt-and-other-metadata)
This PR updates the workflow run Parameters tab so every block type surfaces the same metadata available in the navigation block. Previously, only task-style blocks showed their prompt or inputs; file download, code, text prompt, and go-to-url blocks displayed nothing, leaving users without context when validating runs. I now locate the active block inside the workflow definition, then render targeted UI cards for each block type so their prompts, code, download options, and URLs are visible alongside existing workflow-level settings. The UI follows the navigation block’s layout and relies on new, reusable block info components, keeping styling consistent while filling the metadata gap.

**Bulletpoints**  
- `WorkflowPostRunParameters.tsx`: Added workflow-definition lookup, new block-specific render branches, and helper utilities to drive the enhanced metadata display.  
- `blockInfo/CodeBlockParameters.tsx`: New component showing code snippets plus referenced parameters for code blocks.  
- `blockInfo/TextPromptBlockParameters.tsx`: New component rendering prompt text, LLM key, schema, and parameters for text prompt blocks.  
- `blockInfo/FileDownloadBlockParameters.tsx`: New component exposing download suffix, timeout, retry, and error mapping settings.  
- `blockInfo/GotoUrlBlockParameters.tsx`: New component surfacing URL targets and failure handling for go-to-url blocks.

## Go To Url Block - Before & After
<img width="1490" height="794" alt="image" src="https://github.com/user-attachments/assets/c9bf0410-c99d-4cdc-b053-ff80f80512d8" />
<img width="1488" height="797" alt="image" src="https://github.com/user-attachments/assets/d64da8b8-7ba7-485d-9373-0c67842fa05d" />

## File Download Block - Before & After
<img width="1505" height="806" alt="image" src="https://github.com/user-attachments/assets/8afddc61-2882-4582-a564-50994cf20d92" />
<img width="1500" height="807" alt="image" src="https://github.com/user-attachments/assets/62345eef-bbdb-4ca2-ae21-7817101c3c09" />

## Code Block - Before & After
<img width="1492" height="788" alt="image" src="https://github.com/user-attachments/assets/d30b0ebf-42f6-4ce0-82fe-14d2435dde7c" />
<img width="1502" height="807" alt="image" src="https://github.com/user-attachments/assets/e9bd57e9-75b2-4b32-aa4e-5f28dde3b539" />

## Text Prompt Block - Before & After
<img width="1496" height="803" alt="image" src="https://github.com/user-attachments/assets/407a0e0b-80ac-4129-ae15-76a47728b282" />
<img width="1500" height="806" alt="image" src="https://github.com/user-attachments/assets/765733a8-f9c5-4569-a07b-e749f36c509f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced post-run block details with read-only displays for Code, File Download, URL navigation, and Text Prompt blocks, including code view, parameters, prompts, schemas, retry/timeout settings, and error mappings.

* **Bug Fixes**
  * Improved loading and selection behavior and safer handling of optional fields to avoid missing-data rendering issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance workflow run parameters page to display metadata for non-navigation blocks using new block-specific components.
> 
>   - **Behavior**:
>     - `WorkflowPostRunParameters.tsx`: Added logic to display metadata for non-navigation blocks (file download, code, text prompt, go-to-url) using new block-specific components.
>     - Displays prompts, code, download options, and URLs for respective block types.
>   - **Components**:
>     - `CodeBlockParameters.tsx`: New component to display code snippets and parameters for code blocks.
>     - `TextPromptBlockParameters.tsx`: New component to show prompt text, LLM key, schema, and parameters for text prompt blocks.
>     - `FileDownloadBlockParameters.tsx`: New component to display download suffix, timeout, retry, and error mapping settings.
>     - `GotoUrlBlockParameters.tsx`: New component to show URL targets and failure handling for go-to-url blocks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for d106092a03773cf927e3b07355e32bf499fb21ce. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->