### PR TITLE
fix workflow update validation to return non-500 errors

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -3339,7 +3339,9 @@ class WorkflowService:
                     loop_over_parameter = parameters[trimmed_key]
 
             if loop_over_parameter is None and not block_yaml.loop_variable_reference:
-                raise Exception("Loop value parameter is required for for loop block")
+                raise InvalidWorkflowDefinition(
+                    f"For loop block '{block_yaml.label}' requires either loop_over_parameter_key or loop_variable_reference"
+                )
 
             return ForLoopBlock(
                 **base_kwargs,
@@ -3458,7 +3460,9 @@ class WorkflowService:
             )
 
             if not block_yaml.complete_criterion and not block_yaml.terminate_criterion:
-                raise Exception("Both complete criterion and terminate criterion are empty")
+                raise InvalidWorkflowDefinition(
+                    f"Validation block '{block_yaml.label}' requires at least one of complete_criterion or terminate_criterion"
+                )
 
             return ValidationBlock(
                 **base_kwargs,
@@ -3479,7 +3483,7 @@ class WorkflowService:
             )
 
             if not block_yaml.navigation_goal:
-                raise Exception("empty action instruction")
+                raise InvalidWorkflowDefinition(f"Action block '{block_yaml.label}' requires navigation_goal")
 
             return ActionBlock(
                 **base_kwargs,


### PR DESCRIPTION
	### Summary - [ticket](https://linear.app/skyvern/issue/SKY-7227/fix-workflow-update-validation-to-return-non-500-errors)
- Stopped wrapping validation errors into 500s. `SkyvernHTTPException` and `ValidationError` now bubble to FastAPI’s handlers, which return the `detail` message to the client. The frontend will see these messages directly.
- The validation we added returns actionable, user-facing messages that name the problematic block and what is missing:
- For-loop without a loop target → `"For loop block '<label>' requires either loop_over_parameter_key or loop_variable_reference"`.
- Validation block with no criteria → `"Validation block '<label>' requires at least one of complete_criterion or terminate_criterion"`.
- Action block without a navigation goal → `"Action block '<label>' requires navigation_goal"`.

Existing validation (e.g., `WorkflowParameterMissingRequiredValue`, reserved keys, duplicate labels/params, invalid YAML) already returns clear details via 400/422, and now those aren’t masked. The only time a 500 remains is for unexpected server-side errors (still wrapped in `FailedToUpdateWorkflow`), which is appropriate.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves workflow update error handling by allowing validation errors to bubble up, providing specific user-facing error messages for validation failures.
> 
>   - **Error Handling**:
>     - In `agent_protocol.py`, `SkyvernHTTPException` and `ValidationError` are now raised directly in `update_workflow_legacy()` and `update_workflow()`, preventing them from being converted to 500 errors.
>     - In `service.py`, specific error messages are added for validation failures in `block_yaml_to_block()` for `ForLoopBlock`, `ValidationBlock`, and `ActionBlock`.
>   - **Validation Messages**:
>     - `ForLoopBlock` requires `loop_over_parameter_key` or `loop_variable_reference`.
>     - `ValidationBlock` requires `complete_criterion` or `terminate_criterion`.
>     - `ActionBlock` requires `navigation_goal`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for e9937d9268d3a889ad89b5803e3d35d61cd0ca50. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Client-side errors are now propagated correctly so they return proper error responses instead of generic server errors.
  * Workflow validation messages improved to include block-specific context for clearer, actionable troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->