### PR TITLE
Masking secrets after templating creds in HttpRequest Block

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -3913,6 +3913,9 @@ class HttpRequestBlock(Block):
                 "url": self.url,
             }
 
+            # Mask secrets in output to prevent credential exposure in DB/UI
+            response_data = workflow_run_context.mask_secrets_in_data(response_data)
+
             LOG.info(
                 "HTTP request completed",
                 status_code=status_code,


### PR DESCRIPTION
In prior PR, we templated real secrets in HttpRequest block to be able to send to endpoint (Centria Healthcare login process). That worked, but by doing so, we need to mask them before saving to our DB. This fixes that. You can see they get templated as real values and can send to an endpoint, but are masked in our DB

<img width="702" height="290" alt="Screenshot 2025-12-09 at 10 26 08 AM" src="https://github.com/user-attachments/assets/0dbfd81d-1be8-4a95-916a-cbb71e65c5dc" />


<img width="659" height="661" alt="Screenshot 2025-12-09 at 10 31 26 AM" src="https://github.com/user-attachments/assets/76973f62-a24e-496a-8640-cdbfe94329e0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Secrets are now automatically masked in HTTP response data and logs during workflow execution, preventing accidental exposure of sensitive information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add secret masking in `HttpRequestBlock` responses to prevent sensitive data exposure.
> 
>   - **Behavior**:
>     - `mask_secrets_in_data()` added to `WorkflowRunContext` to mask secrets in nested data structures.
>     - `HttpRequestBlock` now masks secrets in response data before logging and storage.
>   - **Functions**:
>     - `mask_secrets_in_data()` handles strings, dictionaries, and lists, replacing secret values with a mask.
>   - **Misc**:
>     - Minor logging changes in `HttpRequestBlock` to reflect masked data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 22bc6cfeb3570c61dd3d07c66ecbb258b839ee05. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔒 This PR implements secret masking functionality to prevent credential exposure in the database after templating real secrets in HttpRequest blocks for authentication purposes.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Secret Masking Utility**: Added `mask_secrets_in_data()` method to `WorkflowRunContext` that recursively replaces real secret values with masked tokens ("*****") in nested data structures
- **HttpRequest Block Security**: Modified `HttpRequestBlock.execute()` to mask secrets in response data before logging and database storage
- **Data Structure Support**: The masking function handles strings, dictionaries, and lists recursively to ensure comprehensive secret protection

### Technical Implementation
```mermaid
sequenceDiagram
    participant HRB as HttpRequestBlock
    participant WRC as WorkflowRunContext
    participant DB as Database
    participant API as External API
    
    HRB->>WRC: Template real secrets for request
    HRB->>API: Send HTTP request with real credentials
    API->>HRB: Return response data
    HRB->>WRC: mask_secrets_in_data(response_data)
    WRC->>WRC: Replace secret values with "*****"
    WRC->>HRB: Return masked data
    HRB->>DB: Store masked response data
```

### Impact
- **Security Enhancement**: Prevents accidental exposure of credentials in database records and UI displays while maintaining functionality
- **Backward Compatibility**: Non-breaking change that only affects data storage, not the actual HTTP request functionality
- **Comprehensive Protection**: Recursive masking ensures secrets are hidden regardless of data structure complexity (nested objects, arrays, etc.)

</details>

_Created with [Palmier](https://www.palmier.io)_