### PR TITLE
set extract-actions thinking budget to 512, others to 1024

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -291,7 +291,7 @@ class Settings(BaseSettings):
     # GEMINI
     GEMINI_API_KEY: str | None = None
     GEMINI_INCLUDE_THOUGHT: bool = False
-    GEMINI_THINKING_BUDGET: int | None = 512
+    GEMINI_THINKING_BUDGET: int | None = None
 
     # VERTEX_AI
     VERTEX_CREDENTIALS: str | None = None

--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -49,6 +49,9 @@ LOG = structlog.get_logger()
 EXTRACT_ACTION_PROMPT_NAME = "extract-actions"
 CHECK_USER_GOAL_PROMPT_NAMES = {"check-user-goal", "check-user-goal-with-termination"}
 
+# Default thinking budget for extract-actions prompt (can be overridden by THINKING_BUDGET_OPTIMIZATION experiment)
+EXTRACT_ACTION_DEFAULT_THINKING_BUDGET = 512
+
 
 @runtime_checkable
 class RouterWithModelList(Protocol):
@@ -379,6 +382,11 @@ class LLMAPIHandlerFactory:
                 new_budget = LLMAPIHandlerFactory._thinking_budget_settings[prompt_name]
                 LLMAPIHandlerFactory._apply_thinking_budget_optimization(
                     parameters, new_budget, llm_config, prompt_name
+                )
+            elif prompt_name == EXTRACT_ACTION_PROMPT_NAME:
+                # Apply default thinking budget for extract-actions (512) unless overridden by experiment
+                LLMAPIHandlerFactory._apply_thinking_budget_optimization(
+                    parameters, EXTRACT_ACTION_DEFAULT_THINKING_BUDGET, llm_config, prompt_name
                 )
 
             context = skyvern_context.current()
@@ -779,6 +787,11 @@ class LLMAPIHandlerFactory:
                 new_budget = LLMAPIHandlerFactory._thinking_budget_settings[prompt_name]
                 LLMAPIHandlerFactory._apply_thinking_budget_optimization(
                     active_parameters, new_budget, llm_config, prompt_name
+                )
+            elif prompt_name == EXTRACT_ACTION_PROMPT_NAME:
+                # Apply default thinking budget for extract-actions (512) unless overridden by experiment
+                LLMAPIHandlerFactory._apply_thinking_budget_optimization(
+                    active_parameters, EXTRACT_ACTION_DEFAULT_THINKING_BUDGET, llm_config, prompt_name
                 )
 
             context = skyvern_context.current()


### PR DESCRIPTION
Summary of changes:
extract-actions: 512 (default, overridable via feature flag)
All other prompts: 1024 default (some overridable via feature flag)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Set default thinking budget to 512 tokens for `extract-actions` and 1024 for other prompts, with some overridable via feature flag.
> 
>   - **Behavior**:
>     - Set default thinking budget for `extract-actions` prompt to 512 tokens in `api_handler_factory.py`.
>     - Set default thinking budget for other prompts to 1024 tokens, with some overridable via feature flag.
>   - **Configuration**:
>     - Set `GEMINI_THINKING_BUDGET` to `None` in `config.py`.
>   - **Implementation**:
>     - Add logic in `llm_api_handler_with_router_and_fallback()` and `llm_api_handler()` in `api_handler_factory.py` to apply default thinking budgets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6913f1092b5bf43539ea544140084b37baf7c638. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Adjusted default AI thinking budget configuration to allow more flexible resource allocation across different task types.
  * Optimized thinking budget allocation for action extraction tasks with improved fallback handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

⚙️ This PR optimizes thinking budget allocation for different AI prompt types, setting extract-actions to use 512 tokens while other prompts default to 1024 tokens. The changes provide more granular control over AI model resource usage with configurable overrides via feature flags.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Configuration Management**: Removed hardcoded `GEMINI_THINKING_BUDGET` default value (512) from `config.py`, making it configurable
- **Prompt-Specific Budgets**: Added `EXTRACT_ACTION_DEFAULT_THINKING_BUDGET` constant set to 512 tokens for extract-actions prompts
- **Handler Logic**: Updated both `llm_api_handler_with_router_and_fallback` and `llm_api_handler` methods to apply the 512 token budget specifically for extract-actions prompts
- **Feature Flag Integration**: Maintained ability to override budgets via `THINKING_BUDGET_OPTIMIZATION` experiment while providing sensible defaults

### Technical Implementation
```mermaid
flowchart TD
    A[LLM API Handler Called] --> B{Prompt Type Check}
    B -->|extract-actions| C[Apply 512 Token Budget]
    B -->|Other prompts| D[Apply 1024 Token Budget]
    C --> E{Feature Flag Override?}
    D --> E
    E -->|Yes| F[Use Experiment Budget]
    E -->|No| G[Use Default Budget]
    F --> H[Execute LLM Call]
    G --> H
```

### Impact
- **Resource Optimization**: Extract-actions prompts now use 50% fewer tokens (512 vs 1024), potentially reducing costs and latency
- **Flexibility**: Maintains override capability through feature flags while providing optimized defaults
- **Backward Compatibility**: Changes are non-breaking as they only affect default behavior when no explicit configuration is provided
- **Performance**: Lower token budget for extract-actions may improve response times for this frequently-used prompt type

</details>

_Created with [Palmier](https://www.palmier.io)_