### PR TITLE
manual line breaking support on tooltip component

### DIFF
--- a/skyvern-frontend/src/components/ui/tooltip.tsx
+++ b/skyvern-frontend/src/components/ui/tooltip.tsx
@@ -18,7 +18,7 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 overflow-hidden whitespace-pre-line rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/ConditionalNode/ConditionalNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/ConditionalNode/ConditionalNode.tsx
@@ -666,8 +666,7 @@ function ConditionalNodeComponent({ id, data }: NodeProps<ConditionalNode>) {
                     </Label>
                     {!activeBranch.is_default && (
                       <HelpTooltip
-                        content={`Jinja: {{ y > 100 }}
-Natural language: y is greater than 100`}
+                        content={`Jinja: {{ y > 100 }}\nNatural language: y is greater than 100`}
                       />
                     )}
                   </div>


### PR DESCRIPTION
	### Summary - [ticket](https://linear.app/skyvern/issue/SKY-7282/improve-the-uiux-of-the-tool-tip-for-conditional-blocks)
Added whitespace-pre-line to tooltip content so newline characters in help text render as line breaks. 

Before
<img width="316" height="116" alt="image" src="https://github.com/user-attachments/assets/d6f156f1-5967-4877-8ebc-67e1f258dcbb" />

After
<img width="260" height="98" alt="image" src="https://github.com/user-attachments/assets/4cb7ad47-634a-4557-a168-f5fc1dc7f866" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved tooltip text rendering to preserve intentional line breaks and whitespace, ensuring clearer multiline display.
  * Normalized tooltip help text formatting so newline characters render consistently without changing visible content or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for manual line breaks in tooltip content by updating CSS and tooltip text in `tooltip.tsx` and `ConditionalNode.tsx`.
> 
>   - **Behavior**:
>     - Adds `whitespace-pre-line` to `TooltipContent` in `tooltip.tsx` to render newline characters as line breaks.
>     - Updates `HelpTooltip` content in `ConditionalNode.tsx` to include newline characters for better readability.
>   - **UI**:
>     - Tooltip content now supports manual line breaks, improving text formatting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 31f57d77590dc06eeaa19bdab36a01429d45517b. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->