### PR TITLE
[Frontend] Add SECRET credential type for storing generic sensitive values

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -500,29 +500,51 @@ export type CreditCardCredentialApiResponse = {
   brand: string;
 };
 
+export type SecretCredentialResponse = {
+  secret_label?: string | null;
+};
+
 export type CredentialApiResponse = {
   credential_id: string;
-  credential: PasswordCredentialApiResponse | CreditCardCredentialApiResponse;
-  credential_type: "password" | "credit_card";
+  credential:
+    | PasswordCredentialApiResponse
+    | CreditCardCredentialApiResponse
+    | SecretCredentialResponse;
+  credential_type: "password" | "credit_card" | "secret";
   name: string;
 };
 
 export function isPasswordCredential(
-  credential: PasswordCredentialApiResponse | CreditCardCredentialApiResponse,
+  credential:
+    | PasswordCredentialApiResponse
+    | CreditCardCredentialApiResponse
+    | SecretCredentialResponse,
 ): credential is PasswordCredentialApiResponse {
   return "username" in credential;
 }
 
 export function isCreditCardCredential(
-  credential: PasswordCredentialApiResponse | CreditCardCredentialApiResponse,
+  credential:
+    | PasswordCredentialApiResponse
+    | CreditCardCredentialApiResponse
+    | SecretCredentialResponse,
 ): credential is CreditCardCredentialApiResponse {
   return "last_four" in credential;
 }
 
+export function isSecretCredential(
+  credential:
+    | PasswordCredentialApiResponse
+    | CreditCardCredentialApiResponse
+    | SecretCredentialResponse,
+): credential is SecretCredentialResponse {
+  return !("username" in credential) && !("last_four" in credential);
+}
+
 export type CreateCredentialRequest = {
   name: string;
-  credential_type: "password" | "credit_card";
-  credential: PasswordCredential | CreditCardCredential;
+  credential_type: "password" | "credit_card" | "secret";
+  credential: PasswordCredential | CreditCardCredential | SecretCredential;
 };
 
 export type PasswordCredential = {
@@ -540,6 +562,11 @@ export type CreditCardCredential = {
   card_exp_year: string;
   card_brand: string;
   card_holder_name: string;
+};
+
+export type SecretCredential = {
+  secret_value: string;
+  secret_label?: string | null;
 };
 
 export const OtpType = {

--- a/skyvern-frontend/src/routes/credentials/CredentialItem.tsx
+++ b/skyvern-frontend/src/routes/credentials/CredentialItem.tsx
@@ -1,12 +1,17 @@
-import { isPasswordCredential } from "@/api/types";
+import {
+  CredentialApiResponse,
+  isCreditCardCredential,
+  isPasswordCredential,
+  isSecretCredential,
+} from "@/api/types";
 import { DeleteCredentialButton } from "./DeleteCredentialButton";
-import { CredentialApiResponse } from "@/api/types";
 
 type Props = {
   credential: CredentialApiResponse;
 };
 
 function CredentialItem({ credential }: Props) {
+  const credentialData = credential.credential;
   const getTotpTypeDisplay = (totpType: string) => {
     switch (totpType) {
       case "authenticator":
@@ -21,6 +26,69 @@ function CredentialItem({ credential }: Props) {
     }
   };
 
+  let credentialDetails = null;
+
+  if (isPasswordCredential(credentialData)) {
+    credentialDetails = (
+      <div className="border-l pl-5">
+        <div className="flex gap-5">
+          <div className="shrink-0 space-y-2">
+            <p className="text-sm text-slate-400">Username/Email</p>
+            <p className="text-sm text-slate-400">Password</p>
+            {credentialData.totp_type !== "none" && (
+              <p className="text-sm text-slate-400">2FA Type</p>
+            )}
+          </div>
+          <div className="space-y-2">
+            <p className="text-sm">{credentialData.username}</p>
+            <p className="text-sm">{"********"}</p>
+            {credentialData.totp_type !== "none" && (
+              <p className="text-sm text-blue-400">
+                {getTotpTypeDisplay(credentialData.totp_type)}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  } else if (isCreditCardCredential(credentialData)) {
+    credentialDetails = (
+      <div className="flex gap-5 border-l pl-5">
+        <div className="flex gap-5">
+          <div className="shrink-0 space-y-2">
+            <p className="text-sm text-slate-400">Card Number</p>
+            <p className="text-sm text-slate-400">Brand</p>
+          </div>
+        </div>
+        <div className="flex gap-5">
+          <div className="shrink-0 space-y-2">
+            <p className="text-sm">
+              {"************" + credentialData.last_four}
+            </p>
+            <p className="text-sm">{credentialData.brand}</p>
+          </div>
+        </div>
+      </div>
+    );
+  } else if (isSecretCredential(credentialData)) {
+    credentialDetails = (
+      <div className="flex gap-5 border-l pl-5">
+        <div className="shrink-0 space-y-2">
+          <p className="text-sm text-slate-400">Secret Value</p>
+          {credentialData.secret_label ? (
+            <p className="text-sm text-slate-400">Type</p>
+          ) : null}
+        </div>
+        <div className="space-y-2">
+          <p className="text-sm">{"************"}</p>
+          {credentialData.secret_label ? (
+            <p className="text-sm">{credentialData.secret_label}</p>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex gap-5 rounded-lg bg-slate-elevation2 p-4">
       <div className="w-48 space-y-2">
@@ -29,45 +97,7 @@ function CredentialItem({ credential }: Props) {
         </p>
         <p className="text-sm text-slate-400">{credential.credential_id}</p>
       </div>
-      {isPasswordCredential(credential.credential) ? (
-        <div className="border-l pl-5">
-          <div className="flex gap-5">
-            <div className="shrink-0 space-y-2">
-              <p className="text-sm text-slate-400">Username/Email</p>
-              <p className="text-sm text-slate-400">Password</p>
-              {credential.credential.totp_type !== "none" && (
-                <p className="text-sm text-slate-400">2FA Type</p>
-              )}
-            </div>
-            <div className="space-y-2">
-              <p className="text-sm">{credential.credential.username}</p>
-              <p className="text-sm">{"********"}</p>
-              {credential.credential.totp_type !== "none" && (
-                <p className="text-sm text-blue-400">
-                  {getTotpTypeDisplay(credential.credential.totp_type)}
-                </p>
-              )}
-            </div>
-          </div>
-        </div>
-      ) : (
-        <div className="flex gap-5 border-l pl-5">
-          <div className="flex gap-5">
-            <div className="shrink-0 space-y-2">
-              <p className="text-sm text-slate-400">Card Number</p>
-              <p className="text-sm text-slate-400">Brand</p>
-            </div>
-          </div>
-          <div className="flex gap-5">
-            <div className="shrink-0 space-y-2">
-              <p className="text-sm">
-                {"************" + credential.credential.last_four}
-              </p>
-              <p className="text-sm">{credential.credential.brand}</p>
-            </div>
-          </div>
-        </div>
-      )}
+      {credentialDetails}
       <div className="ml-auto">
         <DeleteCredentialButton credential={credential} />
       </div>

--- a/skyvern-frontend/src/routes/credentials/CredentialsList.tsx
+++ b/skyvern-frontend/src/routes/credentials/CredentialsList.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { CredentialItem } from "./CredentialItem";
 import { useCredentialsQuery } from "@/routes/workflows/hooks/useCredentialsQuery";
 
-type CredentialFilter = "password" | "credit_card";
+type CredentialFilter = "password" | "credit_card" | "secret";
 
 type Props = {
   filter?: CredentialFilter;
@@ -11,6 +11,7 @@ type Props = {
 const EMPTY_MESSAGE: Record<CredentialFilter, string> = {
   password: "No password credentials stored yet.",
   credit_card: "No credit cards stored yet.",
+  secret: "No secrets stored yet.",
 };
 
 function CredentialsList({ filter }: Props = {}) {

--- a/skyvern-frontend/src/routes/credentials/CredentialsPage.tsx
+++ b/skyvern-frontend/src/routes/credentials/CredentialsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { CardStackIcon, PlusIcon } from "@radix-ui/react-icons";
+import { CardStackIcon, LockClosedIcon, PlusIcon } from "@radix-ui/react-icons";
 import {
   CredentialModalTypes,
   useCredentialModalState,
@@ -19,9 +19,14 @@ import { CredentialsTotpTab } from "./CredentialsTotpTab";
 import { useSearchParams } from "react-router-dom";
 
 const subHeaderText =
-  "Securely store your passwords, credit cards, and manage incoming 2FA codes for your workflows.";
+  "Securely store your passwords, credit cards, secrets, and manage incoming 2FA codes for your workflows.";
 
-const TAB_VALUES = ["passwords", "creditCards", "twoFactor"] as const;
+const TAB_VALUES = [
+  "passwords",
+  "creditCards",
+  "secrets",
+  "twoFactor",
+] as const;
 type TabValue = (typeof TAB_VALUES)[number];
 const DEFAULT_TAB: TabValue = "passwords";
 
@@ -79,6 +84,16 @@ function CredentialsPage() {
               <CardStackIcon className="mr-2 size-4" />
               Credit Card
             </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => {
+                setIsOpen(true);
+                setType(CredentialModalTypes.SECRET);
+              }}
+              className="cursor-pointer"
+            >
+              <LockClosedIcon className="mr-2 size-4" />
+              Secret
+            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
@@ -90,6 +105,7 @@ function CredentialsPage() {
         <TabsList className="bg-slate-elevation1">
           <TabsTrigger value="passwords">Passwords</TabsTrigger>
           <TabsTrigger value="creditCards">Credit Cards</TabsTrigger>
+          <TabsTrigger value="secrets">Secrets</TabsTrigger>
           <TabsTrigger value="twoFactor">2FA</TabsTrigger>
         </TabsList>
 
@@ -99,6 +115,10 @@ function CredentialsPage() {
 
         <TabsContent value="creditCards" className="space-y-4">
           <CredentialsList filter="credit_card" />
+        </TabsContent>
+
+        <TabsContent value="secrets" className="space-y-4">
+          <CredentialsList filter="secret" />
         </TabsContent>
 
         <TabsContent value="twoFactor" className="space-y-4">

--- a/skyvern-frontend/src/routes/credentials/SecretCredentialContent.tsx
+++ b/skyvern-frontend/src/routes/credentials/SecretCredentialContent.tsx
@@ -1,0 +1,82 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { EyeNoneIcon, EyeOpenIcon } from "@radix-ui/react-icons";
+import { useState } from "react";
+
+type Props = {
+  values: {
+    name: string;
+    secretLabel: string;
+    secretValue: string;
+  };
+  onChange: (values: {
+    name: string;
+    secretLabel: string;
+    secretValue: string;
+  }) => void;
+};
+
+function SecretCredentialContent({ values, onChange }: Props) {
+  const { name, secretLabel, secretValue } = values;
+  const [showSecret, setShowSecret] = useState(false);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex">
+        <div className="w-72 shrink-0 space-y-1">
+          <Label>Name</Label>
+          <div className="text-sm text-slate-400">
+            The name of the credential
+          </div>
+        </div>
+        <Input
+          value={name}
+          onChange={(e) => onChange({ ...values, name: e.target.value })}
+        />
+      </div>
+      <Separator />
+      <div className="space-y-2">
+        <Label>Secret Label (optional)</Label>
+        <Input
+          placeholder="e.g., API Key, Bearer Token"
+          value={secretLabel}
+          onChange={(e) => onChange({ ...values, secretLabel: e.target.value })}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label>Secret Value</Label>
+        <div className="relative w-full">
+          <Input
+            className="pr-9"
+            type={showSecret ? "text" : "password"}
+            value={secretValue}
+            onChange={(e) =>
+              onChange({ ...values, secretValue: e.target.value })
+            }
+          />
+          <div
+            className="absolute right-0 top-0 flex size-9 cursor-pointer items-center justify-center"
+            onClick={() => {
+              setShowSecret((value) => !value);
+            }}
+            aria-label="Toggle secret value visibility"
+          >
+            {showSecret ? (
+              <EyeOpenIcon className="size-4" />
+            ) : (
+              <EyeNoneIcon className="size-4" />
+            )}
+          </div>
+        </div>
+        <p className="text-sm text-slate-400">
+          {
+            "Use in HTTP Request blocks with: {{ credential_name.secret_value }}"
+          }
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export { SecretCredentialContent };

--- a/skyvern-frontend/src/routes/credentials/useCredentialModalState.ts
+++ b/skyvern-frontend/src/routes/credentials/useCredentialModalState.ts
@@ -6,6 +6,7 @@ const typeParam = "type";
 export const CredentialModalTypes = {
   PASSWORD: "password",
   CREDIT_CARD: "credit-card",
+  SECRET: "secret",
 } as const;
 
 export type CredentialModalType =

--- a/skyvern-frontend/src/routes/workflows/components/CredentialSelector.tsx
+++ b/skyvern-frontend/src/routes/workflows/components/CredentialSelector.tsx
@@ -62,7 +62,9 @@ function CredentialSelector({ value, onChange }: Props) {
                 <p className="text-xs text-slate-400">
                   {credential.credential_type === "password"
                     ? "Password"
-                    : "Credit Card"}
+                    : credential.credential_type === "credit_card"
+                      ? "Credit Card"
+                      : "Secret"}
                 </p>
               </div>
             </CustomSelectItem>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/HttpRequestNode/HttpRequestNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/HttpRequestNode/HttpRequestNode.tsx
@@ -399,9 +399,10 @@ function HttpRequestNode({ id, data }: NodeProps<HttpRequestNodeType>) {
                 authentication and content headers
               </li>
               <li>
-                Pass a credential/secret parameter and reference it in headers
-                or body with {"{{ my_credential.password }}"}
+                Password credential: {"{{ my_credential.username }}"} /{" "}
+                {"{{ my_credential.password }}"}
               </li>
+              <li>Secret credential: {"{{ my_secret.secret_value }}"}</li>
               <li>
                 The request will return response data including status, headers,
                 and body


### PR DESCRIPTION
Add a new SECRET credential type to Skyvern for storing generic sensitive values (API keys, bearer tokens, SSNs, etc.) that can be accessed in HTTP Request block templates via {{ my_secret.secret_value }}.

This is part of the scope of
https://linear.app/skyvern/issue/SKY-7251/reference-credential-in-http-request-block

Here are the relevant screenshots, and it works in my local bitwarden


<img width="1911" height="964" alt="Screenshot 2025-12-05 at 5 22 00 PM" src="https://github.com/user-attachments/assets/9e03f0bf-fda1-4e82-b19a-44811b59eec8" />

<img width="1540" height="593" alt="Screenshot 2025-12-05 at 5 22 13 PM" src="https://github.com/user-attachments/assets/7d7e310a-011d-4770-98ae-4ceba90bd8e3" />
<img width="828" height="516" alt="Screenshot 2025-12-05 at 5 29 02 PM" src="https://github.com/user-attachments/assets/fa9f91ae-aa45-4ae7-a303-af43d856e3c7" />
<img width="469" height="435" alt="Screenshot 2025-12-05 at 5 31 09 PM" src="https://github.com/user-attachments/assets/04dddcdf-d808-4ecd-bf55-df306db5491c" />


One thing that is gonna be confusing in the UI (not saying we need to address immediately, just calling it out) is that we have this Bitwarden Identity-based secret dropdown (the one in the dropdown with Identity Key, Identity Fields, Collection ID). So secrets is sort of overloaded term when you click Add Parameter from workflow run:

<img width="498" height="553" alt="Screenshot 2025-12-05 at 5 23 18 PM" src="https://github.com/user-attachments/assets/6cd10799-1d6a-4d95-9155-13c8672b0a26" />

Cause our new SECRET is one of the Credentials
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `SECRET` credential type to Skyvern frontend for storing sensitive values, with UI and HTTP request integration.
> 
>   - **New Features**:
>     - Add `SECRET` credential type to store sensitive values like API keys and tokens.
>     - Update `CredentialApiResponse` and `CreateCredentialRequest` in `types.ts` to include `secret` type.
>     - Add `SecretCredentialContent` component for secret input in `SecretCredentialContent.tsx`.
>   - **UI Changes**:
>     - Add "Secrets" tab and dropdown option in `CredentialsPage.tsx`.
>     - Update `CredentialsModal.tsx` to handle secret creation.
>     - Modify `CredentialItem.tsx` to display secret credentials.
>     - Update `CredentialsList.tsx` to filter and display secrets.
>   - **HTTP Request Integration**:
>     - Update `HttpRequestNode.tsx` to support secret credentials in request blocks.
>     - Add usage example for secret credentials in HTTP request tips.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a9231ae0ea686fe4d10dc2d56930e562e0768363. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Secret" credential type for storing and managing sensitive values like API keys
  * Secret credentials support optional labels and masked display for security
  * Integrated secrets into credential management with dedicated tabs and organization alongside passwords and credit cards
  * Secrets are now available for use in workflows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔐 This PR adds a new SECRET credential type to Skyvern's frontend for storing generic sensitive values like API keys, bearer tokens, and other secrets. The implementation provides a complete UI experience for creating, managing, and referencing secret credentials in HTTP Request blocks via template syntax like `{{ my_secret.secret_value }}`.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Type System**: Extended credential types to include "secret" alongside existing "password" and "credit_card" types, with new `SecretCredentialResponse` and `SecretCredential` interfaces
- **UI Components**: Added `SecretCredentialContent` component with password-style input field, optional label field, and show/hide toggle for secret values
- **Navigation & Management**: Integrated secrets into the credentials page with a new "Secrets" tab, dropdown menu option, and filtering capabilities
- **Template Integration**: Updated HTTP Request node documentation to show how to reference secret credentials using `{{ my_secret.secret_value }}` syntax

### Technical Implementation
```mermaid
flowchart TD
    A[User clicks Add Credential] --> B[Select SECRET type]
    B --> C[SecretCredentialContent Form]
    C --> D[Enter secret_value & optional secret_label]
    D --> E[Save to API]
    E --> F[Display in Secrets tab]
    F --> G[Available in CredentialSelector]
    G --> H[Reference in HTTP Request: {{ my_secret.secret_value }}]
    
    I[CredentialItem Display] --> J{Check credential type}
    J -->|isSecretCredential| K[Show masked secret with label]
    J -->|isPasswordCredential| L[Show username/password fields]
    J -->|isCreditCardCredential| M[Show card details]
```

### Impact
- **Enhanced Security**: Provides a dedicated, secure way to store sensitive values beyond just passwords and credit cards
- **Workflow Integration**: Enables users to reference secrets in HTTP Request blocks using template syntax, improving automation capabilities  
- **User Experience**: Maintains consistency with existing credential management patterns while adding new functionality through familiar UI components
- **Extensibility**: The type-safe implementation with proper type guards makes it easy to extend credential types in the future

</details>

_Created with [Palmier](https://www.palmier.io)_