### PR TITLE
fix http block bug

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -3916,7 +3916,7 @@ class HttpRequestBlock(Block):
 
         # If files are provided, don't set default Content-Type (aiohttp will set multipart/form-data)
         if not self.files:
-            if not self.headers.get("Content-Type") or not self.headers.get("content-type"):
+            if not self.headers.get("Content-Type") and not self.headers.get("content-type"):
                 LOG.info("Adding default content-type as application/json", headers=self.headers)
                 self.headers["Content-Type"] = "application/json"
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes logic in `HttpRequestBlock` in `block.py` to preserve existing `Content-Type` headers when files are not provided.
> 
>   - **Bug Fix**:
>     - Fixes logic in `HttpRequestBlock` in `block.py` to preserve existing `Content-Type` headers when files are not provided, instead of overriding them with defaults.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a078d866035ad6a2dca829c2b212d07b3d431bed. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP request header handling to properly respect existing Content-Type headers and prevent unintended overrides. The default application/json Content-Type is now only applied when no Content-Type header variant is present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔧 This PR fixes a critical logic bug in the HTTP request block that was incorrectly setting default Content-Type headers. The change corrects the boolean logic from OR to AND, ensuring the default "application/json" header is only set when neither "Content-Type" nor "content-type" headers are present.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Logic Fix**: Changed `or` to `and` in the header check condition within `HttpRequestBlock.execute()`
- **Header Handling**: Now properly respects existing Content-Type headers regardless of case variation
- **Default Behavior**: Only sets "application/json" as default when no Content-Type header exists in any case

### Technical Implementation
```mermaid
flowchart TD
    A[HTTP Request Block Execute] --> B{Files provided?}
    B -->|Yes| C[Skip Content-Type setting]
    B -->|No| D{Content-Type OR content-type exists?}
    D -->|Yes - BEFORE| E[Set default application/json - WRONG!]
    D -->|No - BEFORE| F[Skip setting header]
    D2{Content-Type AND content-type both missing?}
    D2 -->|Yes - AFTER| G[Set default application/json - CORRECT!]
    D2 -->|No - AFTER| H[Preserve existing header]
    
    style E fill:#ffcccc
    style G fill:#ccffcc
```

### Impact
- **Bug Resolution**: Prevents overriding of existing Content-Type headers with default values
- **Header Preservation**: Maintains user-specified Content-Type headers in any case variation
- **Backward Compatibility**: No breaking changes - only fixes incorrect behavior where defaults were inappropriately applied

</details>

_Created with [Palmier](https://www.palmier.io)_