### PR TITLE
Add debug/play button to HTTP Request workflow block

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/HttpRequestNode/HttpRequestNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/HttpRequestNode/HttpRequestNode.tsx
@@ -6,19 +6,16 @@ import {
 } from "@/components/ui/accordion";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
-import { useDeleteNodeCallback } from "@/routes/workflows/hooks/useDeleteNodeCallback";
 import { useNodeLabelChangeHandler } from "@/routes/workflows/hooks/useLabelChangeHandler";
 import { Handle, NodeProps, Position, useEdges, useNodes } from "@xyflow/react";
 import { useCallback } from "react";
-import { EditableNodeTitle } from "../components/EditableNodeTitle";
-import { NodeActionMenu } from "../NodeActionMenu";
+import { NodeHeader } from "../components/NodeHeader";
+import type { WorkflowBlockType } from "@/routes/workflows/types/workflowTypes";
 import type { HttpRequestNode as HttpRequestNodeType } from "./types";
 import { HelpTooltip } from "@/components/HelpTooltip";
 import { Switch } from "@/components/ui/switch";
 import { placeholders, helpTooltips } from "../../helpContent";
 import { WorkflowBlockInputTextarea } from "@/components/WorkflowBlockInputTextarea";
-import { WorkflowBlockIcon } from "../WorkflowBlockIcon";
-import { WorkflowBlockTypes } from "@/routes/workflows/types/workflowTypes";
 import { AppNode } from "..";
 import { getAvailableOutputParameterKeys } from "../../workflowEditorUtils";
 import { ParametersMultiSelect } from "../TaskNode/ParametersMultiSelect";
@@ -64,13 +61,12 @@ const timeoutTooltip = "Request timeout in seconds.";
 const followRedirectsTooltip =
   "Whether to automatically follow HTTP redirects.";
 
-function HttpRequestNode({ id, data }: NodeProps<HttpRequestNodeType>) {
+function HttpRequestNode({ id, data, type }: NodeProps<HttpRequestNodeType>) {
   const { editable } = data;
-  const [label, setLabel] = useNodeLabelChangeHandler({
+  const [label] = useNodeLabelChangeHandler({
     id,
     initialValue: data.label,
   });
-  const deleteNodeCallback = useDeleteNodeCallback();
   const rerender = useRerender({ prefix: "accordian" });
   const nodes = useNodes<AppNode>();
   const edges = useEdges();
@@ -139,27 +135,14 @@ function HttpRequestNode({ id, data }: NodeProps<HttpRequestNodeType>) {
         className="opacity-0"
       />
       <div className="w-[36rem] space-y-4 rounded-lg bg-slate-elevation3 px-6 py-4">
-        <header className="flex h-[2.75rem] justify-between">
-          <div className="flex gap-2">
-            <div className="flex h-[2.75rem] w-[2.75rem] items-center justify-center rounded border border-slate-600">
-              <WorkflowBlockIcon
-                workflowBlockType={WorkflowBlockTypes.HttpRequest}
-                className="size-6"
-              />
-            </div>
-            <div className="flex flex-col gap-1">
-              <EditableNodeTitle
-                value={label}
-                editable={editable}
-                onChange={setLabel}
-                titleClassName="text-base"
-                inputClassName="text-base"
-              />
-              <span className="text-xs text-slate-400">HTTP Request Block</span>
-            </div>
-          </div>
-          <div className="flex gap-2">
-            {/* Quick Action Buttons */}
+        <NodeHeader
+          blockLabel={label}
+          editable={editable}
+          nodeId={id}
+          totpIdentifier={null}
+          totpUrl={null}
+          type={type as WorkflowBlockType}
+          extraActions={
             <CurlImportDialog onImport={handleCurlImport}>
               <Button
                 variant="outline"
@@ -171,14 +154,8 @@ function HttpRequestNode({ id, data }: NodeProps<HttpRequestNodeType>) {
                 Import cURL
               </Button>
             </CurlImportDialog>
-
-            <NodeActionMenu
-              onDelete={() => {
-                deleteNodeCallback(id);
-              }}
-            />
-          </div>
-        </header>
+          }
+        />
 
         <div className="space-y-4">
           {/* Method and URL Section */}

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/components/NodeHeader.tsx
@@ -64,6 +64,7 @@ interface Props {
   blockLabel: string; // today, this + wpid act as the identity of a block
   disabled?: boolean;
   editable: boolean;
+  extraActions?: React.ReactNode;
   nodeId: string;
   totpIdentifier: string | null;
   totpUrl: string | null;
@@ -156,6 +157,7 @@ function NodeHeader({
   blockLabel,
   disabled = false,
   editable,
+  extraActions,
   nodeId,
   totpIdentifier,
   totpUrl,
@@ -563,6 +565,7 @@ function NodeHeader({
           </div>
         </div>
         <div className="pointer-events-auto ml-auto flex items-center gap-2">
+          {extraActions}
           {thisBlockIsPlaying && (
             <div className="ml-auto">
               <button className="rounded p-1 hover:bg-red-500 hover:text-black disabled:opacity-50">


### PR DESCRIPTION
The HTTP Request block couldn't be run individually in debug mode because it used a custom header instead of the shared NodeHeader component.

This PR:
- adds optional prop to NodeHeader for custom action buttons
- replaced HttpRequestNode's custom header with NodeHeader, passing the "Import cURL" button as extraActions prop

<img width="2396" height="918" alt="Screenshot 2025-12-10 at 3 11 23 PM" src="https://github.com/user-attachments/assets/c9f0f628-274b-4b11-b301-c77146d8288a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated HTTP request node header rendering to use a standardized NodeHeader component for improved consistency and maintainability.
  * Enhanced NodeHeader component to support additional custom actions via an extraActions slot.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `HttpRequestNode` to use shared `NodeHeader` with custom actions, enabling debug functionality and consistent UI.
> 
>   - **Refactor**:
>     - Replace custom header in `HttpRequestNode` with `NodeHeader`, passing "Import cURL" as `extraActions`.
>     - Add `extraActions` prop to `NodeHeader` in `NodeHeader.tsx` to support custom action buttons.
>   - **Behavior**:
>     - Enable debug/play functionality for HTTP Request block using shared `NodeHeader`.
>     - Remove inline delete action from `HttpRequestNode` header.
>   - **UI**:
>     - Consistent header UI across nodes by using `NodeHeader`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d794e1b7723bdadfee50967991e0713d6ae77601. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR enables debug/play functionality for HTTP Request workflow blocks by refactoring the custom header to use the shared NodeHeader component, which includes built-in debug controls. The change adds an `extraActions` prop to NodeHeader to support custom buttons like the existing "Import cURL" functionality.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Component Refactoring**: Replaced custom header implementation in `HttpRequestNode` with the shared `NodeHeader` component
- **NodeHeader Enhancement**: Added optional `extraActions` prop to support custom action buttons alongside standard debug controls
- **Code Cleanup**: Removed unused imports and simplified label handling by removing the setter from `useNodeLabelChangeHandler`

### Technical Implementation
```mermaid
flowchart TD
    A[HttpRequestNode] --> B[Custom Header Implementation]
    A --> C[NodeHeader Component]
    B --> D[Missing Debug Controls]
    C --> E[Built-in Debug/Play Button]
    C --> F[extraActions Prop]
    F --> G[Import cURL Button]
    E --> H[Individual Block Execution]
```

### Impact
- **Debug Capability**: HTTP Request blocks can now be executed individually in debug mode, improving developer workflow
- **UI Consistency**: All workflow blocks now use the same header component, providing a unified user experience
- **Maintainability**: Reduced code duplication by leveraging the shared NodeHeader component instead of custom implementations

</details>

_Created with [Palmier](https://www.palmier.io)_