### PR TITLE
[Frontend] Saving Workflows as Templates

### DIFF
--- a/skyvern-frontend/src/routes/workflows/WorkflowActions.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowActions.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuPortal,
+  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -24,6 +25,8 @@ import {
 import { toast } from "@/components/ui/use-toast";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
 import {
+  BookmarkFilledIcon,
+  BookmarkIcon,
   CopyIcon,
   DotsHorizontalIcon,
   DownloadIcon,
@@ -98,6 +101,46 @@ function WorkflowActions({ workflow, onSuccessfullyDeleted }: Props) {
     },
   });
 
+  const templateMutation = useMutation({
+    mutationFn: async ({
+      workflowPermanentId,
+      isTemplate,
+    }: {
+      workflowPermanentId: string;
+      isTemplate: boolean;
+    }) => {
+      // Template endpoint only exists on /v1 (no /api prefix)
+      const client = await getClient(credentialGetter, "sans-api-v1");
+      return client.put(
+        `/workflows/${workflowPermanentId}/template?is_template=${isTemplate}`,
+      );
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["workflows"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["orgTemplates"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["workflow", variables.workflowPermanentId],
+      });
+      toast({
+        title: variables.isTemplate
+          ? "Saved as template"
+          : "Removed from templates",
+        variant: "success",
+      });
+    },
+    onError: (error: AxiosError) => {
+      toast({
+        variant: "destructive",
+        title: "Failed to update template status",
+        description: error.message,
+      });
+    },
+  });
+
   return (
     <Dialog>
       <DropdownMenu>
@@ -123,6 +166,26 @@ function WorkflowActions({ workflow, onSuccessfullyDeleted }: Props) {
             <CopyIcon className="mr-2 h-4 w-4" />
             Clone Workflow
           </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={() => {
+              templateMutation.mutate({
+                workflowPermanentId: workflow.workflow_permanent_id,
+                isTemplate: !workflow.is_template,
+              });
+            }}
+            className="p-2"
+            disabled={templateMutation.isPending}
+          >
+            {workflow.is_template ? (
+              <BookmarkFilledIcon className="mr-2 h-4 w-4" />
+            ) : (
+              <BookmarkIcon className="mr-2 h-4 w-4" />
+            )}
+            {workflow.is_template
+              ? "Remove from Templates"
+              : "Save as Template"}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
               <DownloadIcon className="mr-2 h-4 w-4" />

--- a/skyvern-frontend/src/routes/workflows/Workflows.tsx
+++ b/skyvern-frontend/src/routes/workflows/Workflows.tsx
@@ -26,6 +26,8 @@ import { useCredentialGetter } from "@/hooks/useCredentialGetter";
 import { basicLocalTimeFormat, basicTimeFormat } from "@/util/timeFormat";
 import { cn } from "@/util/utils";
 import {
+  BookmarkFilledIcon,
+  ChevronDownIcon,
   DotsHorizontalIcon,
   FileIcon,
   LightningBoltIcon,
@@ -39,9 +41,16 @@ import { useQuery } from "@tanstack/react-query";
 import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useDebounce } from "use-debounce";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { NarrativeCard } from "./components/header/NarrativeCard";
 import { FolderCard } from "./components/FolderCard";
 import { CreateFolderDialog } from "./components/CreateFolderDialog";
+import { CreateFromTemplateDialog } from "./components/CreateFromTemplateDialog";
 import { ViewAllFoldersDialog } from "./components/ViewAllFoldersDialog";
 import { WorkflowFolderSelector } from "./components/WorkflowFolderSelector";
 import { HighlightText } from "./components/HighlightText";
@@ -49,6 +58,7 @@ import { useCreateWorkflowMutation } from "./hooks/useCreateWorkflowMutation";
 import { useFoldersQuery } from "./hooks/useFoldersQuery";
 import { useActiveImportsPolling } from "./hooks/useActiveImportsPolling";
 import { ImportWorkflowButton } from "./ImportWorkflowButton";
+import { convert } from "./editor/workflowEditorUtils";
 import { WorkflowApiResponse } from "./types/workflowTypes";
 import { WorkflowCreateYAMLRequest } from "./types/workflowYamlTypes";
 import { WorkflowActions } from "./WorkflowActions";
@@ -87,6 +97,9 @@ function Workflows() {
   const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null);
   const [isCreateFolderOpen, setIsCreateFolderOpen] = useState(false);
   const [isViewAllFoldersOpen, setIsViewAllFoldersOpen] = useState(false);
+
+  // Template dialog state
+  const [isTemplateDialogOpen, setIsTemplateDialogOpen] = useState(false);
 
   // Poll for active imports
   const { activeImports, startPolling } = useActiveImportsPolling();
@@ -390,22 +403,38 @@ function Workflows() {
               onImportStart={startPolling}
               selectedFolderId={selectedFolderId}
             />
-            <Button
-              disabled={createWorkflowMutation.isPending}
-              onClick={() => {
-                createWorkflowMutation.mutate({
-                  ...emptyWorkflowRequest,
-                  folder_id: selectedFolderId,
-                });
-              }}
-            >
-              {createWorkflowMutation.isPending ? (
-                <ReloadIcon className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <PlusIcon className="mr-2 h-4 w-4" />
-              )}
-              Create
-            </Button>
+            <DropdownMenu modal={false}>
+              <DropdownMenuTrigger asChild>
+                <Button disabled={createWorkflowMutation.isPending}>
+                  {createWorkflowMutation.isPending ? (
+                    <ReloadIcon className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <PlusIcon className="mr-2 h-4 w-4" />
+                  )}
+                  Create
+                  <ChevronDownIcon className="ml-2 h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  onSelect={() => {
+                    createWorkflowMutation.mutate({
+                      ...emptyWorkflowRequest,
+                      folder_id: selectedFolderId,
+                    });
+                  }}
+                >
+                  <PlusIcon className="mr-2 h-4 w-4" />
+                  Blank Workflow
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onSelect={() => setIsTemplateDialogOpen(true)}
+                >
+                  <BookmarkFilledIcon className="mr-2 h-4 w-4" />
+                  From Template
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
         <div className="rounded-lg border">
@@ -532,10 +561,22 @@ function Workflows() {
                               );
                             }}
                           >
-                            <HighlightText
-                              text={workflow.title}
-                              query={debouncedSearch}
-                            />
+                            <div className="flex items-center gap-2">
+                              <HighlightText
+                                text={workflow.title}
+                                query={debouncedSearch}
+                              />
+                              {workflow.is_template && (
+                                <TooltipProvider>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <BookmarkFilledIcon className="h-3.5 w-3.5 shrink-0 text-blue-500" />
+                                    </TooltipTrigger>
+                                    <TooltipContent>Template</TooltipContent>
+                                  </Tooltip>
+                                </TooltipProvider>
+                              )}
+                            </div>
                           </TableCell>
                           <TableCell
                             onClick={(event) => {
@@ -747,6 +788,22 @@ function Workflows() {
           onOpenChange={setIsViewAllFoldersOpen}
           selectedFolderId={selectedFolderId}
           onFolderSelect={setSelectedFolderId}
+        />
+
+        {/* Template Dialog */}
+        <CreateFromTemplateDialog
+          open={isTemplateDialogOpen}
+          onOpenChange={setIsTemplateDialogOpen}
+          onSelectTemplate={(template) => {
+            const clonedWorkflow = convert({
+              ...template,
+              title: `${template.title} (copy)`,
+            });
+            createWorkflowMutation.mutate({
+              ...clonedWorkflow,
+              folder_id: selectedFolderId,
+            });
+          }}
         />
 
         <WorkflowTemplates />

--- a/skyvern-frontend/src/routes/workflows/components/CreateFromTemplateDialog.tsx
+++ b/skyvern-frontend/src/routes/workflows/components/CreateFromTemplateDialog.tsx
@@ -1,0 +1,138 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { BookmarkFilledIcon, MagnifyingGlassIcon } from "@radix-ui/react-icons";
+import { useOrgTemplatesQuery } from "../hooks/useOrgTemplatesQuery";
+import { WorkflowApiResponse } from "../types/workflowTypes";
+import { cn } from "@/util/utils";
+
+interface CreateFromTemplateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelectTemplate: (template: WorkflowApiResponse) => void;
+}
+
+function CreateFromTemplateDialog({
+  open,
+  onOpenChange,
+  onSelectTemplate,
+}: CreateFromTemplateDialogProps) {
+  const [search, setSearch] = useState("");
+  const { data: templates = [], isLoading } = useOrgTemplatesQuery();
+
+  const filteredTemplates = templates.filter((template) =>
+    template.title.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  const handleSelect = (template: WorkflowApiResponse) => {
+    onSelectTemplate(template);
+    onOpenChange(false);
+    setSearch("");
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    onOpenChange(open);
+    if (!open) {
+      setSearch("");
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Create from Template</DialogTitle>
+          <DialogDescription>
+            Select a template to create a new workflow with pre-filled blocks.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="relative">
+            <MagnifyingGlassIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search templates..."
+              className="pl-9"
+              autoFocus
+            />
+          </div>
+          <div className="max-h-[400px] overflow-y-auto">
+            {isLoading ? (
+              <div className="grid grid-cols-2 gap-3">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <Skeleton key={i} className="h-24 rounded-lg" />
+                ))}
+              </div>
+            ) : filteredTemplates.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-12 text-center">
+                <BookmarkFilledIcon className="mb-3 h-10 w-10 text-slate-400" />
+                {templates.length === 0 ? (
+                  <>
+                    <p className="text-slate-600 dark:text-slate-300">
+                      No templates yet
+                    </p>
+                    <p className="text-sm text-slate-400">
+                      Save a workflow as a template to see it here.
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <p className="text-slate-600 dark:text-slate-300">
+                      No templates match your search
+                    </p>
+                    <p className="text-sm text-slate-400">
+                      Try a different search term.
+                    </p>
+                  </>
+                )}
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-3">
+                {filteredTemplates.map((template) => (
+                  <Button
+                    key={template.workflow_permanent_id}
+                    variant="outline"
+                    className={cn(
+                      "flex h-auto flex-col items-start gap-1 p-4 text-left",
+                      "hover:border-blue-400 hover:bg-blue-50 dark:hover:bg-blue-950/30",
+                    )}
+                    onClick={() => handleSelect(template)}
+                  >
+                    <div className="flex w-full items-center gap-2">
+                      <BookmarkFilledIcon className="h-4 w-4 shrink-0 text-blue-500" />
+                      <span className="truncate font-medium">
+                        {template.title}
+                      </span>
+                    </div>
+                    {template.description && (
+                      <p className="line-clamp-2 text-xs text-slate-500">
+                        {template.description}
+                      </p>
+                    )}
+                    <p className="text-xs text-slate-400">
+                      {template.workflow_definition.blocks.length} block
+                      {template.workflow_definition.blocks.length !== 1
+                        ? "s"
+                        : ""}
+                    </p>
+                  </Button>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export { CreateFromTemplateDialog };

--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -1123,6 +1123,7 @@ function Workspace({
           cacheKeyValue={cacheKeyValue}
           cacheKeyValues={cacheKeyValues}
           isGeneratingCode={isGeneratingCode}
+          isTemplate={workflow?.is_template}
           saving={workflowChangesStore.saveIsPending}
           cacheKeyValuesPanelOpen={
             workflowPanelState.active &&

--- a/skyvern-frontend/src/routes/workflows/hooks/useOrgTemplatesQuery.ts
+++ b/skyvern-frontend/src/routes/workflows/hooks/useOrgTemplatesQuery.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import { getClient } from "@/api/AxiosClient";
+import { useCredentialGetter } from "@/hooks/useCredentialGetter";
+import { WorkflowApiResponse } from "../types/workflowTypes";
+
+function useOrgTemplatesQuery() {
+  const credentialGetter = useCredentialGetter();
+
+  return useQuery<WorkflowApiResponse[]>({
+    queryKey: ["orgTemplates"],
+    queryFn: async () => {
+      const client = await getClient(credentialGetter);
+      const params = new URLSearchParams();
+      params.append("only_templates", "true");
+      params.append("page_size", "100");
+      return client
+        .get<WorkflowApiResponse[]>("/workflows", { params })
+        .then((response) => response.data);
+    },
+  });
+}
+
+export { useOrgTemplatesQuery };

--- a/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
+++ b/skyvern-frontend/src/routes/workflows/types/workflowTypes.ts
@@ -562,6 +562,7 @@ export type WorkflowApiResponse = {
   workflow_id: string;
   organization_id: string;
   is_saved_task: boolean;
+  is_template: boolean;
   title: string;
   workflow_permanent_id: string;
   version: number;


### PR DESCRIPTION
Frontend for enabling the ability to save a workflow as a template and pre-populate the blocks (of a new copied wpid).

Below are some screenshots of how it works. there are 2 ways to save an existing wpid as a template. from the workflow run screen, a new save/remove template button, which will store it as a template. and from the workflows screen, the `...` menu icon allows you to save/remove the wpid as a template.

To create from template: from the workflows screen, the create button has two options now, one for blank workflow, one to create from template, which opens up a modal. I didn't totally love needing this extra click to create a blank template now, but couldn't think of anything else that made sense UX wise

<img width="1294" height="466" alt="Screenshot 2025-12-09 at 7 52 25 PM" src="https://github.com/user-attachments/assets/f4fe83e4-5f26-4340-99e8-a2b72b60f49b" />


<img width="980" height="229" alt="Screenshot 2025-12-09 at 7 52 32 PM" src="https://github.com/user-attachments/assets/2d2ac9b7-9fc4-4b2a-9680-2ada5df4f17a" />


<img width="342" height="216" alt="Screenshot 2025-12-09 at 7 52 40 PM" src="https://github.com/user-attachments/assets/cbcfe8ed-ae43-4093-be2c-474b07cb32e5" />


<img width="749" height="366" alt="Screenshot 2025-12-09 at 7 52 46 PM" src="https://github.com/user-attachments/assets/2cba6f43-f2e4-44fd-a369-3937451b21dd" />


<img width="1041" height="389" alt="Screenshot 2025-12-09 at 7 53 29 PM" src="https://github.com/user-attachments/assets/b0a919b3-1089-4a48-a7a0-df2c0a184f2c" />


<img width="1316" height="269" alt="Screenshot 2025-12-09 at 7 53 41 PM" src="https://github.com/user-attachments/assets/7ffe1be3-00d1-4391-a54e-e5632e8d666d" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add functionality to save workflows as templates and create new workflows from templates, with UI and API enhancements.
> 
>   - **Features**:
>     - Add ability to save workflows as templates in `WorkflowActions` and `WorkflowHeader`.
>     - Implement `CreateFromTemplateDialog` for selecting templates to create new workflows.
>     - Update `Workflows` to include template creation options in the UI.
>   - **API**:
>     - Add `useOrgTemplatesQuery` to fetch organization templates.
>     - Modify API interactions in `WorkflowActions` and `WorkflowHeader` to handle template status updates.
>   - **UI**:
>     - Add template indicators and selection dialogs in `Workflows` and `CreateFromTemplateDialog`.
>     - Update `Workspace` to handle template-related UI changes.
>   - **Types**:
>     - Update `WorkflowApiResponse` in `workflowTypes.ts` to include `is_template` field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for eab70dc8ad3e48bc229758f59924d4b870e5d2dc. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Save workflows as templates and toggle template status from workflow lists and editor header
  * Create new workflows from templates via the Create dropdown and a template selection dialog with search and previews
  * Visual bookmark indicators mark template workflows in listings
  * Success/error toasts and disabled states while template actions are processing
  * Slight UI separation between template actions and export options

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

📋 This PR introduces a comprehensive workflow template system that allows users to save existing workflows as reusable templates and create new workflows from these templates, enhancing workflow reusability and productivity across the organization.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Template Management**: Added ability to mark workflows as templates via dropdown actions and workflow editor header with bookmark icons
- **Template Creation Dialog**: New `CreateFromTemplateDialog` component with search functionality and grid layout for template selection
- **UI Enhancements**: Updated create workflow button to dropdown with "Blank Workflow" and "From Template" options, plus visual template indicators
- **API Integration**: New `useOrgTemplatesQuery` hook and template mutation endpoints for managing template status
- **Type System**: Extended `WorkflowApiResponse` to include `is_template` boolean field

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant UI
    participant API
    participant Backend
    
    User->>UI: Click "Save as Template"
    UI->>API: PUT /workflows/{id}/template?is_template=true
    API->>Backend: Update workflow template status
    Backend-->>API: Success response
    API-->>UI: Invalidate queries & show toast
    
    User->>UI: Click "Create from Template"
    UI->>API: GET /workflows?only_templates=true
    API-->>UI: Return template list
    User->>UI: Select template
    UI->>API: POST /workflows (with cloned data)
    API-->>UI: Create new workflow from template
```

### Impact
- **Workflow Reusability**: Organizations can now standardize common workflow patterns and share them across teams
- **Productivity Enhancement**: Users can quickly bootstrap new workflows from proven templates instead of starting from scratch
- **Visual Organization**: Template workflows are clearly marked with bookmark icons, making them easily identifiable in workflow lists
- **Seamless UX**: Integrated template management directly into existing workflow actions without disrupting current workflows

</details>

_Created with [Palmier](https://www.palmier.io)_