### PR TITLE
fix conditional serialization to drop stale targets for deleted downstream/branch blocks

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -775,10 +775,7 @@ function serializeConditionalBlock(
   nodes: Array<AppNode>,
   edges: Array<Edge>,
 ): ConditionalBlockYAML {
-  const mergeLabel =
-    findConditionalMergeLabel(node, nodes, edges) ??
-    node.data.mergeLabel ??
-    null;
+  const mergeLabel = findConditionalMergeLabel(node, nodes, edges) ?? null;
 
   const branchConditions = node.data.branches.map((branch) => {
     const orderedNodes = getConditionalBranchNodeSequence(
@@ -787,11 +784,7 @@ function serializeConditionalBlock(
       nodes,
       edges,
     );
-    const nextBlockLabel =
-      orderedNodes[0]?.data.label ??
-      mergeLabel ??
-      branch.next_block_label ??
-      null;
+    const nextBlockLabel = orderedNodes[0]?.data.label ?? mergeLabel ?? null;
 
     return {
       ...branch,


### PR DESCRIPTION
## Bugs
- Conditional downstream drift: When the conditional was effectively the last block in the main chain (either originally last or became last after deleting the block after it), saving still wrote `next_block_label` to the deleted downstream block (fallback to cached mergeLabel). On reload, the final node-adder drifted off the main chain.
- Empty branch drift: When a branch had its only block removed (branch became empty) and the conditional had no downstream block (last in the chain), saving still wrote that branch’s `next_block_label` to the deleted block (fallback to cached branch label). On reload, that branch’s NodeAdder appeared outside the conditional.

## Fixes
- Conditional serialization now derives the merge/`next_block_label` only from the live graph; if no merge target exists, we save `null`. No cached mergeLabel fallback.
- Branch serialization now derives `next_block_label` from the branch’s first block or the conditional’s merge target; if neither exists (empty branch, no downstream), we save `null`. No cached branch label fallback.

## Result
- When the conditional is last (or becomes last after deleting the block after it) or when a branch becomes empty, we no longer persist dangling labels, so adders stay correctly anchored after reload.

## Screenshots
### Case : delete block_6 -> save the workflow -> reload the page
<img width="454" height="1080" alt="image" src="https://github.com/user-attachments/assets/ce778343-68f5-421c-a2a6-88c90ab6ebb0" /> 

Before the fix
<img width="444" height="1185" alt="image" src="https://github.com/user-attachments/assets/c9e3c5fa-e382-4380-a54f-741f2bb1674d" />

After the fix
<img width="275" height="948" alt="image" src="https://github.com/user-attachments/assets/c8f60838-8da8-430d-88c7-64f3495ede54" />

### Case : delete block_4 -> save the workflow -> reload the page

Before the fix
<img width="483" height="1142" alt="image" src="https://github.com/user-attachments/assets/04f0de91-d511-42fe-a763-0c965b7c8d22" />
<img width="480" height="1153" alt="image" src="https://github.com/user-attachments/assets/ee97f0f9-d2cc-44e9-bb9c-9e7c8ed05044" />
after block_4 deleted & wf saved & page reloaded
<img width="587" height="932" alt="image" src="https://github.com/user-attachments/assets/a0bf65a8-acc7-4e6d-90e2-ee6ab71fb010" />

After the fix
<img width="472" height="1029" alt="image" src="https://github.com/user-attachments/assets/db29d7b7-67ba-4511-8935-f2ed7b7e779b" />





<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes conditional and branch serialization to prevent persisting stale labels for deleted blocks in `workflowEditorUtils.ts`.
> 
>   - **Behavior**:
>     - Fixes conditional downstream drift by removing fallback to cached `mergeLabel` in `serializeConditionalBlock()`.
>     - Fixes empty branch drift by removing fallback to cached `branch.next_block_label` in `serializeConditionalBlock()`.
>   - **Serialization**:
>     - `mergeLabel` and `next_block_label` are now derived only from the live graph in `serializeConditionalBlock()`.
>     - Saves `null` if no merge target or branch's first block exists.
>   - **Result**:
>     - Prevents persisting dangling labels when conditionals are last or branches are empty, keeping adders correctly anchored after reload.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a7b20bbacc0a39b9f1e9830b3e54bf6d1edd3ca5. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes a critical bug in the workflow editor where node-adder buttons would drift to incorrect positions after deleting downstream blocks from conditional statements and reloading the page. The fix removes fallback logic that was persisting stale references to deleted blocks, ensuring proper UI positioning.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Conditional Block Serialization**: Removed fallback to cached `node.data.mergeLabel` when determining merge targets, now only uses live graph data via `findConditionalMergeLabel()`
- **Branch Serialization**: Eliminated fallback to cached `branch.next_block_label` when setting next block labels, ensuring only valid references are persisted
- **Stale Reference Prevention**: Both merge labels and branch next block labels now default to `null` when no valid target exists in the current graph state

### Technical Implementation
```mermaid
flowchart TD
    A[Delete Block from Conditional] --> B[Save Workflow]
    B --> C{Old Logic: Check Live Graph}
    C -->|No Target Found| D[Fallback to Cached Labels]
    D --> E[Persist Stale References]
    E --> F[Reload Page]
    F --> G[Node Adders Drift Off Position]
    
    B --> H{New Logic: Check Live Graph}
    H -->|No Target Found| I[Set to null]
    I --> J[No Stale References Persisted]
    J --> K[Reload Page]
    K --> L[Node Adders Stay Correctly Positioned]
```

### Impact
- **UI Stability**: Node-adder buttons now maintain correct positioning after workflow modifications and page reloads
- **Data Integrity**: Eliminates persistence of dangling references to deleted workflow blocks
- **User Experience**: Prevents confusing UI drift that could lead to workflow construction errors, especially when conditionals are the last blocks in a chain or when branches become empty

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced conditional workflow block processing with improved label consistency, ensuring more predictable and deterministic behavior during workflow operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->