### PR TITLE
always capture llm artifacts

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -74,6 +74,24 @@ class LLMCallStats(BaseModel):
     llm_cost: float | None = None
 
 
+def _get_artifact_targets_and_persist_flag(
+    step: Step | None,
+    is_speculative_step: bool,
+    task_v2: TaskV2 | None,
+    thought: Thought | None,
+    ai_suggestion: AISuggestion | None,
+) -> tuple[bool, dict[str, Any]]:
+    artifact_targets = {
+        "step": step if not is_speculative_step else None,
+        "task_v2": task_v2,
+        "thought": thought,
+        "ai_suggestion": ai_suggestion,
+    }
+    has_artifact_target = any(value is not None for value in artifact_targets.values())
+    should_persist_llm_artifacts = not is_speculative_step and has_artifact_target
+    return should_persist_llm_artifacts, artifact_targets
+
+
 async def _log_hashed_href_map_artifacts_if_needed(
     context: SkyvernContext | None,
     step: Step | None,
@@ -83,14 +101,14 @@ async def _log_hashed_href_map_artifacts_if_needed(
     *,
     is_speculative_step: bool,
 ) -> None:
-    if context and context.hashed_href_map and step and not is_speculative_step:
+    should_persist_llm_artifacts, artifact_targets = _get_artifact_targets_and_persist_flag(
+        step, is_speculative_step, task_v2, thought, ai_suggestion
+    )
+    if context and context.hashed_href_map and should_persist_llm_artifacts:
         await app.ARTIFACT_MANAGER.create_llm_artifact(
             data=json.dumps(context.hashed_href_map, indent=2).encode("utf-8"),
             artifact_type=ArtifactType.HASHED_HREF_MAP,
-            step=step,
-            task_v2=task_v2,
-            thought=thought,
-            ai_suggestion=ai_suggestion,
+            **artifact_targets,
         )
 
 
@@ -391,6 +409,9 @@ class LLMAPIHandlerFactory:
 
             context = skyvern_context.current()
             is_speculative_step = step.is_speculative if step else False
+            should_persist_llm_artifacts, artifact_targets = _get_artifact_targets_and_persist_flag(
+                step, is_speculative_step, task_v2, thought, ai_suggestion
+            )
             await _log_hashed_href_map_artifacts_if_needed(
                 context,
                 step,
@@ -401,15 +422,12 @@ class LLMAPIHandlerFactory:
             )
 
             llm_prompt_value = prompt
-
-            if step and not is_speculative_step:
+            if should_persist_llm_artifacts:
                 await app.ARTIFACT_MANAGER.create_llm_artifact(
                     data=llm_prompt_value.encode("utf-8"),
                     artifact_type=ArtifactType.LLM_PROMPT,
                     screenshots=screenshots,
-                    step=step,
-                    task_v2=task_v2,
-                    thought=thought,
+                    **artifact_targets,
                 )
             # Build messages and apply caching in one step
             messages = await llm_messages_builder(prompt, screenshots, llm_config.add_assistant_prefix)
@@ -422,14 +440,11 @@ class LLMAPIHandlerFactory:
                     "vertex_cache_attached": vertex_cache_attached_flag,
                 }
                 llm_request_json = json.dumps(llm_request_payload)
-                if step and not is_speculative_step:
+                if should_persist_llm_artifacts:
                     await app.ARTIFACT_MANAGER.create_llm_artifact(
                         data=llm_request_json.encode("utf-8"),
                         artifact_type=ArtifactType.LLM_REQUEST,
-                        step=step,
-                        task_v2=task_v2,
-                        thought=thought,
-                        ai_suggestion=ai_suggestion,
+                        **artifact_targets,
                     )
                 return llm_request_json
 
@@ -595,14 +610,11 @@ class LLMAPIHandlerFactory:
                 raise LLMProviderError(llm_key) from e
 
             llm_response_json = response.model_dump_json(indent=2)
-            if step and not is_speculative_step:
+            if should_persist_llm_artifacts:
                 await app.ARTIFACT_MANAGER.create_llm_artifact(
                     data=llm_response_json.encode("utf-8"),
                     artifact_type=ArtifactType.LLM_RESPONSE,
-                    step=step,
-                    task_v2=task_v2,
-                    thought=thought,
-                    ai_suggestion=ai_suggestion,
+                    **artifact_targets,
                 )
             prompt_tokens = 0
             completion_tokens = 0
@@ -661,14 +673,11 @@ class LLMAPIHandlerFactory:
                 )
             parsed_response = parse_api_response(response, llm_config.add_assistant_prefix, force_dict)
             parsed_response_json = json.dumps(parsed_response, indent=2)
-            if step and not is_speculative_step:
+            if should_persist_llm_artifacts:
                 await app.ARTIFACT_MANAGER.create_llm_artifact(
                     data=parsed_response_json.encode("utf-8"),
                     artifact_type=ArtifactType.LLM_RESPONSE_PARSED,
-                    step=step,
-                    task_v2=task_v2,
-                    thought=thought,
-                    ai_suggestion=ai_suggestion,
+                    **artifact_targets,
                 )
 
             rendered_response_json = None
@@ -677,14 +686,11 @@ class LLMAPIHandlerFactory:
                 rendered_content = Template(llm_content).render(context.hashed_href_map)
                 parsed_response = json.loads(rendered_content)
                 rendered_response_json = json.dumps(parsed_response, indent=2)
-                if step and not is_speculative_step:
+                if should_persist_llm_artifacts:
                     await app.ARTIFACT_MANAGER.create_llm_artifact(
                         data=rendered_response_json.encode("utf-8"),
                         artifact_type=ArtifactType.LLM_RESPONSE_RENDERED,
-                        step=step,
-                        task_v2=task_v2,
-                        thought=thought,
-                        ai_suggestion=ai_suggestion,
+                        **artifact_targets,
                     )
 
             # Track LLM API handler duration, token counts, and cost
@@ -796,6 +802,9 @@ class LLMAPIHandlerFactory:
 
             context = skyvern_context.current()
             is_speculative_step = step.is_speculative if step else False
+            should_persist_llm_artifacts, artifact_targets = _get_artifact_targets_and_persist_flag(
+                step, is_speculative_step, task_v2, thought, ai_suggestion
+            )
             await _log_hashed_href_map_artifacts_if_needed(
                 context,
                 step,
@@ -806,15 +815,12 @@ class LLMAPIHandlerFactory:
             )
 
             llm_prompt_value = prompt
-            if step and not is_speculative_step:
+            if should_persist_llm_artifacts:
                 await app.ARTIFACT_MANAGER.create_llm_artifact(
                     data=llm_prompt_value.encode("utf-8"),
                     artifact_type=ArtifactType.LLM_PROMPT,
                     screenshots=screenshots,
-                    step=step,
-                    task_v2=task_v2,
-                    thought=thought,
-                    ai_suggestion=ai_suggestion,
+                    **artifact_targets,
                 )
 
             if not llm_config.supports_vision:
@@ -900,14 +906,11 @@ class LLMAPIHandlerFactory:
                 "vertex_cache_attached": vertex_cache_attached,
             }
             llm_request_json = json.dumps(llm_request_payload)
-            if step and not is_speculative_step:
+            if should_persist_llm_artifacts:
                 await app.ARTIFACT_MANAGER.create_llm_artifact(
                     data=llm_request_json.encode("utf-8"),
                     artifact_type=ArtifactType.LLM_REQUEST,
-                    step=step,
-                    task_v2=task_v2,
-                    thought=thought,
-                    ai_suggestion=ai_suggestion,
+                    **artifact_targets,
                 )
 
             t_llm_request = time.perf_counter()
@@ -966,14 +969,11 @@ class LLMAPIHandlerFactory:
                 raise LLMProviderError(llm_key) from e
 
             llm_response_json = response.model_dump_json(indent=2)
-            if step and not is_speculative_step:
+            if should_persist_llm_artifacts:
                 await app.ARTIFACT_MANAGER.create_llm_artifact(
                     data=llm_response_json.encode("utf-8"),
                     artifact_type=ArtifactType.LLM_RESPONSE,
-                    step=step,
-                    task_v2=task_v2,
-                    thought=thought,
-                    ai_suggestion=ai_suggestion,
+                    **artifact_targets,
                 )
 
             prompt_tokens = 0
@@ -1036,14 +1036,11 @@ class LLMAPIHandlerFactory:
                 )
             parsed_response = parse_api_response(response, llm_config.add_assistant_prefix, force_dict)
             parsed_response_json = json.dumps(parsed_response, indent=2)
-            if step and not is_speculative_step:
+            if should_persist_llm_artifacts:
                 await app.ARTIFACT_MANAGER.create_llm_artifact(
                     data=parsed_response_json.encode("utf-8"),
                     artifact_type=ArtifactType.LLM_RESPONSE_PARSED,
-                    step=step,
-                    task_v2=task_v2,
-                    thought=thought,
-                    ai_suggestion=ai_suggestion,
+                    **artifact_targets,
                 )
 
             rendered_response_json = None
@@ -1052,14 +1049,11 @@ class LLMAPIHandlerFactory:
                 rendered_content = Template(llm_content).render(context.hashed_href_map)
                 parsed_response = json.loads(rendered_content)
                 rendered_response_json = json.dumps(parsed_response, indent=2)
-                if step and not is_speculative_step:
+                if should_persist_llm_artifacts:
                     await app.ARTIFACT_MANAGER.create_llm_artifact(
                         data=rendered_response_json.encode("utf-8"),
                         artifact_type=ArtifactType.LLM_RESPONSE_RENDERED,
-                        step=step,
-                        task_v2=task_v2,
-                        thought=thought,
-                        ai_suggestion=ai_suggestion,
+                        **artifact_targets,
                     )
 
             # Track LLM API handler duration, token counts, and cost
@@ -1217,6 +1211,9 @@ class LLMCaller:
 
         context = skyvern_context.current()
         is_speculative_step = step.is_speculative if step else False
+        should_persist_llm_artifacts, artifact_targets = _get_artifact_targets_and_persist_flag(
+            step, is_speculative_step, task_v2, thought, ai_suggestion
+        )
         await _log_hashed_href_map_artifacts_if_needed(
             context,
             step,
@@ -1244,15 +1241,12 @@ class LLMCaller:
             screenshots = resize_screenshots(screenshots, target_dimension)
 
         llm_prompt_value = prompt or ""
-        if prompt and step and not is_speculative_step:
+        if prompt and should_persist_llm_artifacts:
             await app.ARTIFACT_MANAGER.create_llm_artifact(
                 data=prompt.encode("utf-8"),
                 artifact_type=ArtifactType.LLM_PROMPT,
                 screenshots=screenshots,
-                step=step,
-                task_v2=task_v2,
-                thought=thought,
-                ai_suggestion=ai_suggestion,
+                **artifact_targets,
             )
 
         if not self.llm_config.supports_vision:
@@ -1283,14 +1277,11 @@ class LLMCaller:
             **parameters,
         }
         llm_request_json = json.dumps(llm_request_payload)
-        if step and not is_speculative_step:
+        if should_persist_llm_artifacts:
             await app.ARTIFACT_MANAGER.create_llm_artifact(
                 data=llm_request_json.encode("utf-8"),
                 artifact_type=ArtifactType.LLM_REQUEST,
-                step=step,
-                task_v2=task_v2,
-                thought=thought,
-                ai_suggestion=ai_suggestion,
+                **artifact_targets,
             )
         t_llm_request = time.perf_counter()
         try:
@@ -1337,14 +1328,11 @@ class LLMCaller:
             raise LLMProviderError(self.llm_key) from e
 
         llm_response_json = response.model_dump_json(indent=2)
-        if step and not is_speculative_step:
+        if should_persist_llm_artifacts:
             await app.ARTIFACT_MANAGER.create_llm_artifact(
                 data=llm_response_json.encode("utf-8"),
                 artifact_type=ArtifactType.LLM_RESPONSE,
-                step=step,
-                task_v2=task_v2,
-                thought=thought,
-                ai_suggestion=ai_suggestion,
+                **artifact_targets,
             )
 
         call_stats = await self.get_call_stats(response)
@@ -1397,14 +1385,11 @@ class LLMCaller:
 
         parsed_response = parse_api_response(response, self.llm_config.add_assistant_prefix, force_dict)
         parsed_response_json = json.dumps(parsed_response, indent=2)
-        if step and not is_speculative_step:
+        if should_persist_llm_artifacts:
             await app.ARTIFACT_MANAGER.create_llm_artifact(
                 data=parsed_response_json.encode("utf-8"),
                 artifact_type=ArtifactType.LLM_RESPONSE_PARSED,
-                step=step,
-                task_v2=task_v2,
-                thought=thought,
-                ai_suggestion=ai_suggestion,
+                **artifact_targets,
             )
 
         rendered_response_json = None
@@ -1413,14 +1398,11 @@ class LLMCaller:
             rendered_content = Template(llm_content).render(context.hashed_href_map)
             parsed_response = json.loads(rendered_content)
             rendered_response_json = json.dumps(parsed_response, indent=2)
-            if step and not is_speculative_step:
+            if should_persist_llm_artifacts:
                 await app.ARTIFACT_MANAGER.create_llm_artifact(
                     data=rendered_response_json.encode("utf-8"),
                     artifact_type=ArtifactType.LLM_RESPONSE_RENDERED,
-                    step=step,
-                    task_v2=task_v2,
-                    thought=thought,
-                    ai_suggestion=ai_suggestion,
+                    **artifact_targets,
                 )
 
         if step and is_speculative_step:

--- a/skyvern/forge/sdk/artifact/manager.py
+++ b/skyvern/forge/sdk/artifact/manager.py
@@ -52,6 +52,8 @@ class ArtifactManager:
             task_id = context.task_id
         if not run_id and context:
             run_id = context.run_id
+        if not workflow_run_block_id and context:
+            workflow_run_block_id = context.parent_workflow_run_block_id
 
         artifact = await app.DATABASE.create_artifact(
             artifact_id,
@@ -157,6 +159,8 @@ class ArtifactManager:
             uri=uri,
             thought_id=thought.observer_thought_id,
             task_v2_id=thought.observer_cruise_id,
+            workflow_run_id=thought.workflow_run_id,
+            workflow_run_block_id=thought.workflow_run_block_id,
             organization_id=thought.organization_id,
             data=data,
             path=path,
@@ -182,6 +186,7 @@ class ArtifactManager:
             artifact_type=artifact_type,
             uri=uri,
             task_v2_id=task_v2.observer_cruise_id,
+            workflow_run_id=task_v2.workflow_run_id,
             organization_id=task_v2.organization_id,
             data=data,
             path=path,

--- a/skyvern/forge/sdk/artifact/models.py
+++ b/skyvern/forge/sdk/artifact/models.py
@@ -76,6 +76,7 @@ class Artifact(BaseModel):
     step_id: str | None = None
     workflow_run_id: str | None = None
     workflow_run_block_id: str | None = None
+    run_id: str | None = None
     observer_cruise_id: str | None = None
     observer_thought_id: str | None = None
     ai_suggestion_id: str | None = None

--- a/skyvern/forge/sdk/db/utils.py
+++ b/skyvern/forge/sdk/db/utils.py
@@ -300,6 +300,7 @@ def convert_to_artifact(artifact_model: ArtifactModel, debug_enabled: bool = Fal
         step_id=artifact_model.step_id,
         workflow_run_id=artifact_model.workflow_run_id,
         workflow_run_block_id=artifact_model.workflow_run_block_id,
+        run_id=artifact_model.run_id,
         observer_cruise_id=artifact_model.observer_cruise_id,
         observer_thought_id=artifact_model.observer_thought_id,
         created_at=artifact_model.created_at,


### PR DESCRIPTION
	## Always Log LLM Artifacts and Enrich Metadata

### Problem

Previously, LLM artifacts (prompts, requests, responses) were only logged when a `Step` object was present. This meant:
- LLM calls from Task V2 contexts (without steps) had no artifacts
- Observer thoughts had no artifacts
- AI suggestions had no artifacts
- Artifacts lacked `run_id` and `workflow_run_block_id` metadata, making it hard to trace them back to workflow runs/blocks in the UI

This made debugging and analysis difficult when LLM calls occurred outside traditional step-based flows.

### Solution

This PR makes three changes:

1. **Always log LLM artifacts when any target entity exists**: The code now checks for `step`, `task_v2`, `thought`, or `ai_suggestion` and logs artifacts if any are present (not just steps). This ensures we capture prompts/requests/responses even when there's no step.

2. **Enrich artifact metadata**: Artifacts now automatically capture:
 - `run_id` from context (for run-level tracking)
 - `workflow_run_block_id` from context's `parent_workflow_run_block_id` (for workflow block association)
 - `workflow_run_id` from thought/task_v2 objects when available

3. **Update helper functions**: The `_log_hashed_href_map_artifacts_if_needed` helper and `_log_llm_request_artifact` function now use the new artifact target logic to support all entity types.

### Changes

- **`api_handler_factory.py`**: Updated all three LLM handler paths (router, direct, LLMCaller) to use `artifact_targets` dict and `should_persist_llm_artifacts` flag instead of `if step and not is_speculative_step`
- **`artifact/manager.py`**: 
- Added automatic `workflow_run_block_id` extraction from context
- Updated `create_thought_artifact` and `create_task_v2_artifact` to pass through `workflow_run_id` and `workflow_run_block_id`
- **`artifact/models.py`**: Added `run_id` field to `Artifact` model
- **`db/utils.py`**: Updated `convert_to_artifact` to include `run_id` in conversion

### Testing

- Existing unit tests pass (verified with `test_llm_router_fallback.py`)
- No linter errors
- Rebased on latest main

### Notes

- Speculative steps still defer artifact creation until adoption/discard (existing behavior preserved)
- Artifacts are only created when at least one target entity exists (`step`, `task_v2`, `thought`, or `ai_suggestion`)
- The raw response is logged before parsing, as requested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Centralized artifact persistence gating so prompts, requests, parsed and rendered responses are saved consistently and only when applicable.
  * Artifact target fields and workflow identifiers are propagated more reliably into artifact creation, improving artifact-to-run association and ensuring speculative steps don't persist artifacts.

* **New Features**
  * Artifacts now include an optional run_id field for additional artifact-to-run linkage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> This PR ensures consistent logging of LLM artifacts across various contexts and enriches them with additional metadata for improved traceability.
> 
>   - **Behavior**:
>     - LLM artifacts (prompts, requests, responses) are now logged for `task_v2`, `thought`, and `ai_suggestion` contexts, not just `step`.
>     - Artifacts include `run_id` and `workflow_run_block_id` for better traceability.
>   - **Functions**:
>     - `_get_artifact_targets_and_persist_flag()` in `api_handler_factory.py` determines artifact logging conditions.
>     - `_log_hashed_href_map_artifacts_if_needed()` and `_log_llm_request_artifact()` updated to use new artifact target logic.
>   - **Models**:
>     - `run_id` field added to `Artifact` model in `models.py`.
>   - **Misc**:
>     - `convert_to_artifact()` in `db/utils.py` updated to include `run_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 6a94570ee0306ec3e6c010c97832aff63db3af58. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->