### PR TITLE
test transaction pooler db connection in k8s workers

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -54,6 +54,7 @@ class Settings(BaseSettings):
     LONG_RUNNING_TASK_WARNING_RATIO: float = 0.95
     MAX_RETRIES_PER_STEP: int = 5
     DEBUG_MODE: bool = False
+    # Database settings
     DATABASE_STRING: str = (
         "postgresql+asyncpg://skyvern@localhost/skyvern"
         if platform.system() == "Windows"
@@ -62,6 +63,8 @@ class Settings(BaseSettings):
     DATABASE_REPLICA_STRING: str | None = None
     DATABASE_STATEMENT_TIMEOUT_MS: int = 60000
     DISABLE_CONNECTION_POOL: bool = False
+    DB_DISABLE_PREPARED_STATEMENTS: bool = False
+
     PROMPT_ACTION_HISTORY_WINDOW: int = 1
     TASK_RESPONSE_ACTION_SCREENSHOT_COUNT: int = 3
 

--- a/skyvern/forge/sdk/db/agent_db.py
+++ b/skyvern/forge/sdk/db/agent_db.py
@@ -3,7 +3,23 @@ from datetime import datetime, timedelta
 from typing import Any, List, Literal, Sequence, overload
 
 import structlog
-from sqlalchemy import and_, asc, case, delete, distinct, exists, func, or_, pool, select, tuple_, update
+from sqlalchemy import (
+    Connection,
+    and_,
+    asc,
+    case,
+    delete,
+    distinct,
+    event,
+    exists,
+    func,
+    or_,
+    pool,
+    select,
+    tuple_,
+    update,
+)
+from sqlalchemy.engine.url import make_url
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
 
@@ -153,28 +169,53 @@ def _serialize_proxy_location(proxy_location: ProxyLocationInput) -> str | None:
     return result
 
 
-DB_CONNECT_ARGS: dict[str, Any] = {}
+def _connect_args_for_driver(database_string: str) -> dict[str, Any]:
+    driver = make_url(database_string).drivername  # "postgresql+psycopg" or "postgresql+asyncpg"
+    args: dict[str, Any] = {}
 
-if "postgresql+psycopg" in settings.DATABASE_STRING:
-    DB_CONNECT_ARGS = {"options": f"-c statement_timeout={settings.DATABASE_STATEMENT_TIMEOUT_MS}"}
-elif "postgresql+asyncpg" in settings.DATABASE_STRING:
-    DB_CONNECT_ARGS = {"server_settings": {"statement_timeout": str(settings.DATABASE_STATEMENT_TIMEOUT_MS)}}
+    if settings.DB_DISABLE_PREPARED_STATEMENTS:
+        if driver == "postgresql+psycopg":
+            # psycopg3: disable server-side prepares
+            args["prepare_threshold"] = 0
+        elif driver == "postgresql+asyncpg":
+            # asyncpg: disable statement cache (prepared statements)
+            args["statement_cache_size"] = 0
+        else:
+            LOG.warning(
+                "The database driver might not be well optimized or supported by skyvern: {driver}", driver=driver
+            )
+
+    return args
+
+
+def _install_statement_timeout(engine: AsyncEngine, timeout_ms: int) -> None:
+    if not timeout_ms or timeout_ms <= 0:
+        return
+
+    # Works for direct AND poolers because it's not a startup parameter.
+    # Applies per-transaction, which is the most reliable behavior with transaction pooling.
+    @event.listens_for(engine.sync_engine, "begin")
+    def _set_timeout(conn: Connection) -> None:
+        conn.exec_driver_sql(f"SET LOCAL statement_timeout = {int(timeout_ms)}")
+
+
+def make_async_engine(database_string: str) -> AsyncEngine:
+    engine = create_async_engine(
+        database_string,
+        json_serializer=_custom_json_serializer,
+        connect_args=_connect_args_for_driver(database_string),
+        poolclass=pool.NullPool if settings.DISABLE_CONNECTION_POOL else None,
+    )
+
+    _install_statement_timeout(engine, settings.DATABASE_STATEMENT_TIMEOUT_MS)
+    return engine
 
 
 class AgentDB:
     def __init__(self, database_string: str, debug_enabled: bool = False, db_engine: AsyncEngine | None = None) -> None:
         super().__init__()
         self.debug_enabled = debug_enabled
-        self.engine = (
-            create_async_engine(
-                database_string,
-                json_serializer=_custom_json_serializer,
-                connect_args=DB_CONNECT_ARGS,
-                poolclass=pool.NullPool if settings.DISABLE_CONNECTION_POOL else None,
-            )
-            if db_engine is None
-            else db_engine
-        )
+        self.engine = db_engine or make_async_engine(database_string)
         self.Session = async_sessionmaker(bind=self.engine)
 
     async def create_task(


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `DB_DISABLE_PREPARED_STATEMENTS` setting to control prepared statements in database connections for Kubernetes environments.
> 
>   - **Behavior**:
>     - Added `DB_DISABLE_PREPARED_STATEMENTS` setting in `skyvern/config.py` to control prepared statement behavior.
>     - Updated `_connect_args_for_driver()` in `agent_db.py` to disable prepared statements for `postgresql+psycopg` and `postgresql+asyncpg` drivers based on the new setting.
>     - Ensured consistent database connection settings across staging and production environments.
>   - **Functions**:
>     - Refactored `make_async_engine()` in `agent_db.py` to use `_connect_args_for_driver()` for connection arguments.
>     - Added `_install_statement_timeout()` in `agent_db.py` to set per-transaction statement timeouts.
>   - **Misc**:
>     - Minor import reordering in `agent_db.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a4e818ab68bbb11f0ac6f3949d3757afebca3cf6. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Added a new database setting to control prepared statement behavior. The default behavior remains unchanged.

* **Improvements**
  * Enhanced database connection initialization with improved driver-specific configuration and per-transaction timeout management for better reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔧 This PR optimizes database connection handling for Kubernetes workers by adding configurable prepared statement control and improving transaction pooler compatibility with per-transaction statement timeouts.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Configuration**: Added `DB_DISABLE_PREPARED_STATEMENTS` boolean setting to control prepared statement behavior across different database drivers
- **Database Connection Logic**: Refactored connection handling with driver-specific optimizations for both psycopg and asyncpg drivers
- **Statement Timeout**: Replaced connection-level timeout configuration with per-transaction timeout using SQLAlchemy events for better transaction pooler compatibility

### Technical Implementation
```mermaid
flowchart TD
    A[Database Connection Request] --> B[_connect_args_for_driver]
    B --> C{Driver Type?}
    C -->|postgresql+psycopg| D[Set prepare_threshold=0]
    C -->|postgresql+asyncpg| E[Set statement_cache_size=0]
    C -->|Other| F[Log Warning]
    D --> G[create_async_engine]
    E --> G
    F --> G
    G --> H[_install_statement_timeout]
    H --> I[Register 'begin' event listener]
    I --> J[Per-transaction timeout via SET LOCAL]
```

### Impact
- **Transaction Pooler Compatibility**: Per-transaction timeouts work reliably with connection poolers like PgBouncer, unlike connection-level settings
- **Performance Tuning**: Prepared statements can be disabled when they cause issues with certain pooling configurations or workload patterns
- **Driver Flexibility**: Supports both psycopg and asyncpg drivers with appropriate configuration for each
- **Kubernetes Optimization**: Better suited for containerized environments where database connections may be managed by external poolers

</details>

_Created with [Palmier](https://www.palmier.io)_