### PR TITLE
add support for nesting conditional blocks inside loop blocks - frontend

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
@@ -319,15 +319,6 @@ function WorkflowNodeLibraryPanel({
       };
     }
 
-    // Disable conditional inside loop
-    if (nodeType === "conditional" && parentType === "loop") {
-      return {
-        disabled: true,
-        reason:
-          "We're working on supporting conditionals inside loops. Soon you'll be able to use this feature!",
-      };
-    }
-
     // Disable loop inside conditional
     if (nodeType === "loop" && parentType === "conditional") {
       return {


### PR DESCRIPTION
	<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for nesting conditional blocks inside loop blocks in the frontend, updating node and edge handling logic.
> 
>   - **Behavior**:
>     - Allow conditional blocks inside loop blocks by removing restriction in `WorkflowNodeLibraryPanel.tsx`.
>     - Update `reconstructConditionalStructure()` in `workflowEditorUtils.ts` to handle nested conditionals within loops.
>   - **Logic**:
>     - Modify `getElements()` in `workflowEditorUtils.ts` to correctly serialize nested conditionals inside loops.
>     - Ensure edges and nodes are correctly created and connected for nested structures.
>   - **Misc**:
>     - Improve handling of add-button and child connections within loops in `workflowEditorUtils.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 463b3f66eacd6eeff2930086d72cdd2b96e33fae. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conditional blocks can now be placed inside Loop blocks for more flexible workflow design.

* **Bug Fixes**
  * Improved wiring for loops and conditionals so nested conditionals are preserved and correctly connected in the editor and exports.
  * More reliable add-button and first/last-child connections within loops.
  * Better handling of branch labels, child ordering, and visibility so exported workflow structure matches the editor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->