### PR TITLE
Revert "Move get_workflow_script_by_cache_key_value to replica"

### DIFF
--- a/skyvern/forge/sdk/routes/scripts.py
+++ b/skyvern/forge/sdk/routes/scripts.py
@@ -418,7 +418,7 @@ async def get_workflow_script_blocks(
         raise HTTPException(status_code=404, detail="Workflow not found")
     workflow_run_id = block_script_request.workflow_run_id
     if workflow_run_id:
-        workflow_run = await app.REPLICA_DATABASE.get_workflow_run(
+        workflow_run = await app.DATABASE.get_workflow_run(
             workflow_run_id=workflow_run_id,
             organization_id=current_org.organization_id,
         )
@@ -441,7 +441,7 @@ async def get_workflow_script_blocks(
     cache_key = block_script_request.cache_key or workflow.cache_key or ""
     status = block_script_request.status
 
-    script = await app.REPLICA_DATABASE.get_workflow_script_by_cache_key_value(
+    script = await app.DATABASE.get_workflow_script_by_cache_key_value(
         organization_id=current_org.organization_id,
         workflow_permanent_id=workflow_permanent_id,
         workflow_run_id=block_script_request.workflow_run_id,

--- a/skyvern/services/workflow_script_service.py
+++ b/skyvern/services/workflow_script_service.py
@@ -66,7 +66,7 @@ async def get_workflow_script(
     rendered_cache_key_value = ""
 
     try:
-        parameter_tuples = await app.REPLICA_DATABASE.get_workflow_run_parameters(
+        parameter_tuples = await app.DATABASE.get_workflow_run_parameters(
             workflow_run_id=workflow_run.workflow_run_id,
         )
         parameters = {wf_param.key: run_param.value for wf_param, run_param in parameter_tuples}
@@ -78,7 +78,7 @@ async def get_workflow_script(
             return None, rendered_cache_key_value
 
         # Check if there are existing cached scripts for this workflow + cache_key_value
-        existing_script = await app.REPLICA_DATABASE.get_workflow_script_by_cache_key_value(
+        existing_script = await app.DATABASE.get_workflow_script_by_cache_key_value(
             organization_id=workflow.organization_id,
             workflow_permanent_id=workflow.workflow_permanent_id,
             cache_key_value=rendered_cache_key_value,


### PR DESCRIPTION
Reverts Skyvern-AI/skyvern-cloud#7835
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Revert database calls from `REPLICA_DATABASE` to `DATABASE` in `scripts.py` and `workflow_script_service.py` for improved internal performance and reliability.
> 
>   - **Database Routing**:
>     - Revert database calls from `REPLICA_DATABASE` to `DATABASE` in `scripts.py` and `workflow_script_service.py`.
>     - Affects `get_workflow_run`, `get_workflow_script_by_cache_key_value`, and `get_workflow_run_parameters` functions.
>   - **Files Affected**:
>     - `scripts.py`: Reverts database calls in `get_workflow_script_blocks()`.
>     - `workflow_script_service.py`: Reverts database calls in `get_workflow_script()` and `generate_or_update_pending_workflow_script()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for c1c162159f2e378b93805cc5fa0627b329529310. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated workflow script and parameter retrieval operations to use the primary database, ensuring improved data consistency across workflow operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔄 This PR reverts a previous change that moved workflow script database operations from the main database to a replica database, restoring the original behavior of using the primary database for all workflow script-related queries.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Database routing reversion**: Changed `app.REPLICA_DATABASE` back to `app.DATABASE` in 4 specific database calls
- **Scripts API endpoint**: Reverted `get_workflow_script_blocks()` function in `scripts.py` to use primary database for workflow run and script retrieval
- **Workflow script service**: Reverted `get_workflow_script()` function in `workflow_script_service.py` to use primary database for parameter and script fetching

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant API as Scripts API
    participant Service as Workflow Script Service
    participant DB as Primary Database
    participant RDB as Replica Database (removed)
    
    Client->>API: Request workflow script blocks
    API->>DB: get_workflow_run() [REVERTED from RDB]
    API->>DB: get_workflow_script_by_cache_key_value() [REVERTED from RDB]
    
    Service->>DB: get_workflow_run_parameters() [REVERTED from RDB]
    Service->>DB: get_workflow_script_by_cache_key_value() [REVERTED from RDB]
    
    Note over RDB: No longer used for these operations
```

### Impact
- **Data consistency**: Ensures all workflow script operations read from the primary database, eliminating potential replica lag issues
- **Simplified architecture**: Reduces complexity by removing the need to manage replica database connections for these specific operations
- **Potential performance trade-off**: May increase load on the primary database but ensures data freshness and consistency for workflow script operations

</details>

_Created with [Palmier](https://www.palmier.io)_