### PR TITLE
File Download renaming reliability - customer bug fix

### DIFF
--- a/skyvern/forge/sdk/api/files.py
+++ b/skyvern/forge/sdk/api/files.py
@@ -233,6 +233,33 @@ def get_download_dir(run_id: str | None) -> str:
     return download_dir
 
 
+def get_effective_download_run_id(
+    context_run_id: str | None = None,
+    workflow_run_id: str | None = None,
+    task_id: str | None = None,
+) -> str:
+    """
+    Get the effective run_id for download operations.
+
+    This ensures consistent run_id logic across all download-related operations
+    (save_downloaded_files, get_downloaded_files, get_download_dir).
+
+    Priority:
+    1. context_run_id (if set explicitly)
+    2. workflow_run_id (for workflow tasks)
+    3. task_id (for standalone tasks)
+
+    Raises ValueError if no valid run_id can be determined.
+    """
+    if context_run_id:
+        return context_run_id
+    if workflow_run_id:
+        return workflow_run_id
+    if task_id:
+        return task_id
+    raise ValueError("Cannot determine run_id: no context_run_id, workflow_run_id, or task_id provided")
+
+
 def list_files_in_directory(directory: Path, recursive: bool = False) -> list[str]:
     listed_files: list[str] = []
     for root, dirs, files in os.walk(directory):

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -36,6 +36,7 @@ from skyvern.exceptions import (
 )
 from skyvern.forge import app
 from skyvern.forge.prompts import prompt_engine
+from skyvern.forge.sdk.api.files import get_effective_download_run_id
 from skyvern.forge.sdk.artifact.models import Artifact, ArtifactType
 from skyvern.forge.sdk.core import skyvern_context
 from skyvern.forge.sdk.core.security import generate_skyvern_webhook_signature
@@ -2608,9 +2609,13 @@ class WorkflowService:
         try:
             async with asyncio.timeout(GET_DOWNLOADED_FILES_TIMEOUT):
                 context = skyvern_context.current()
+                download_run_id = get_effective_download_run_id(
+                    context_run_id=context.run_id if context else None,
+                    workflow_run_id=workflow_run.workflow_run_id,
+                )
                 downloaded_files = await app.STORAGE.get_downloaded_files(
                     organization_id=workflow_run.organization_id,
-                    run_id=context.run_id if context and context.run_id else workflow_run.workflow_run_id,
+                    run_id=download_run_id,
                 )
                 if task_v2:
                     task_v2_downloaded_files = await app.STORAGE.get_downloaded_files(
@@ -2743,9 +2748,13 @@ class WorkflowService:
         try:
             async with asyncio.timeout(SAVE_DOWNLOADED_FILES_TIMEOUT):
                 context = skyvern_context.current()
+                download_run_id = get_effective_download_run_id(
+                    context_run_id=context.run_id if context else None,
+                    workflow_run_id=workflow_run.workflow_run_id,
+                )
                 await app.STORAGE.save_downloaded_files(
                     organization_id=workflow_run.organization_id,
-                    run_id=context.run_id if context and context.run_id else workflow_run.workflow_run_id,
+                    run_id=download_run_id,
                 )
         except asyncio.TimeoutError:
             LOG.warning(


### PR DESCRIPTION
This customer [reported](https://linear.app/skyvern/issue/SKY-7268/paf-downloaded-files-not-showing-up-in-json-output-and-file-names-are)

```
I'm trying to understand how the download block works,
I'm using the File Name setting to rename downloaded files but it seems unreliable. 
The files I want downloaded end up in the downloaded_files list 
but still named incorrectly and also not attached to each individual download block. 
So files are getting downloaded but don't end up where they should.
```

It looks like it was caused by block outputs being built before files were uploaded to S3, and also different code used different fallback logic to determine the S3 path.

Tested this locally with:

```
SKYVERN_STORAGE_TYPE=s3
AWS_S3_BUCKET_UPLOADS=skyvern-uploads
```

And seems to work now:

<img width="1065" height="501" alt="Screenshot 2025-12-11 at 4 43 04 PM" src="https://github.com/user-attachments/assets/f62bbdb5-86a2-422d-a359-eb8316e7ef1a" />
<img width="689" height="186" alt="Screenshot 2025-12-11 at 4 42 51 PM" src="https://github.com/user-attachments/assets/41578528-8dc6-4ad9-9148-d9af255a5e6d" />


<img width="514" height="1175" alt="Screenshot 2025-12-11 at 5 00 59 PM" src="https://github.com/user-attachments/assets/fc4947b4-a7b7-40cb-8daa-efb408fd619c" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes file download renaming issue by ensuring consistent run ID logic and improving synchronization and error handling in download operations.
> 
>   - **Bug Fixes**:
>     - Introduced `get_effective_download_run_id()` in `files.py` to ensure consistent run ID logic for download operations.
>     - Updated `execute_step()`, `clean_up_task()`, and `build_task_response()` in `agent.py` to use `get_effective_download_run_id()` for determining download run ID.
>     - Fixed issue where block outputs were built before files were uploaded to S3.
>   - **Improvements**:
>     - Added synchronization step to persist downloaded files before building block/workflow outputs in `block.py`.
>     - Enhanced error handling and added timeout protection when saving downloaded files in `service.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e5d31ed823243adaef4d0b7b5f9a016b75470059. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of downloaded file operations with standardized run ID resolution across the system
  * Enhanced error handling and recovery for file save operations with timeout protection

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔧 This PR fixes a critical file download reliability issue where downloaded files were not properly renamed or attached to workflow blocks due to inconsistent run_id logic and timing issues between file operations and S3 storage.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Centralized Run ID Logic**: Introduced `get_effective_download_run_id()` function to ensure consistent run_id determination across all download operations with clear priority: context_run_id → workflow_run_id → task_id
- **Timing Synchronization**: Added explicit file saving to S3 before building block outputs to prevent race conditions where files exist locally but not in cloud storage
- **Consistent File Operations**: Updated all download-related functions in `agent.py`, `block.py`, and `service.py` to use the centralized run_id logic
- **Error Handling**: Added timeout protection and proper exception handling for file persistence operations

### Technical Implementation
```mermaid
sequenceDiagram
    participant WF as Workflow
    participant Agent as Agent
    participant Files as Files API
    participant S3 as S3 Storage
    
    WF->>Agent: Execute download task
    Agent->>Files: get_effective_download_run_id()
    Files-->>Agent: Consistent run_id
    Agent->>S3: List files before download
    Agent->>Agent: Execute download actions
    Agent->>S3: Save downloaded files (with timeout)
    Agent->>S3: Get downloaded files for response
    Agent-->>WF: Return task with proper file attachments
```

### Impact
- **Reliability**: Files are now consistently saved and retrieved using the same run_id, eliminating mismatched file locations
- **User Experience**: Downloaded files properly appear in block outputs with correct names and attachments
- **Robustness**: Added timeout protection prevents hanging operations and improves error recovery
- **Maintainability**: Centralized run_id logic reduces code duplication and makes the system easier to debug and maintain

</details>

_Created with [Palmier](https://www.palmier.io)_