### PR TITLE
fix: Ensure video recordings upload before stopping artifact sync

### DIFF
--- a/skyvern/forge/sdk/api/aws.py
+++ b/skyvern/forge/sdk/api/aws.py
@@ -175,6 +175,7 @@ class AsyncAWSClient:
         metadata: dict | None = None,
         raise_exception: bool = False,
         tags: dict[str, str] | None = None,
+        content_type: str | None = None,
     ) -> None:
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/upload_file.html
         try:
@@ -185,6 +186,8 @@ class AsyncAWSClient:
                     extra_args["Metadata"] = metadata
                 if tags:
                     extra_args["Tagging"] = self._create_tag_string(tags)
+                if content_type:
+                    extra_args["ContentType"] = content_type
                 await client.upload_file(
                     Filename=file_path,
                     Bucket=parsed_uri.bucket,


### PR DESCRIPTION
Fixes 30s recording load delay for browser sessions by reordering termination sequence, and ensure we actually record the video.

## Problem
(1) `stop_artifact_sync()` was called before `shutdown()`. Playwright finalizes video on browser close, but watchers were already stopped → video never uploaded to S3 → API waited 30s timeout on every page load before falling back to artifact DB.

(2) even after re-ordering, I was seeing blank white screens of recording in staging. Adding a content type seemed to fix this ContentType: video/webm. The other changes were added to make sure we always pick an actual video recording file and the latest one

I tested in staging and i could see the recording right away after closing the persistent browser session now 
<img width="791" height="678" alt="Screenshot 2025-12-12 at 3 54 25 PM" src="https://github.com/user-attachments/assets/0259db07-a62e-4616-b25f-d25071d2889e" />

from the test2 org in staging
https://skyvern-cloud-oe9p0bflm-skyvern.vercel.app/runs/wr_472017624893871812/recording

Though these branch staging stages will get blown away once someone else merges to main 

Note we still store a couple minutes of nothing happening, however I think this is a known issue that we need to trim the recording
https://linear.app/skyvern/issue/SKY-7220/trim-the-video-for-the-current-run-in-browser-session-recording

Note also there was an issue lawy fixed recently where recordings were totally missing, just for context 
https://github.com/Skyvern-AI/skyvern-cloud/pull/7527
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reorder shutdown sequence and enhance video upload handling to ensure timely and correct video recording uploads in `aws.py` and `s3.py`.
> 
>   - **Behavior**:
>     - Reorder shutdown sequence to call `shutdown()` before `stop_artifact_sync()` to ensure video finalization and upload.
>     - Add `content_type` parameter to `upload_file_from_path()` in `aws.py` to specify video content type.
>     - Filter out non-video files and zero-byte objects in `get_shared_recordings_in_browser_session()` in `s3.py`.
>     - Sort recordings by modification date to prioritize the newest in `s3.py`.
>   - **Misc**:
>     - Add logging for unsupported file extensions and zero-byte objects in `s3.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 50677d4e6f5ab954c4505ddeb3aac8c05d6eb21c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying content type during file uploads.

* **Bug Fixes**
  * Improved recording file handling to skip invalid formats and empty files.
  * Recordings now sorted by modification date with newest entries first.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🎥 This PR fixes a critical video recording upload issue that was causing 30-second delays when loading browser session recordings by reordering the shutdown sequence and improving video file handling in S3 storage.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **AWS S3 Upload**: Added `content_type` parameter to `upload_file_from_path()` method to ensure proper video file storage with correct MIME types
- **Recording Retrieval**: Enhanced `get_shared_recordings_in_browser_session()` to filter out non-video files, skip zero-byte uploads, and sort recordings by newest first
- **File Validation**: Added defensive filtering to only process `.webm` and `.mp4` files, preventing issues with unexpected file types

### Technical Implementation
```mermaid
sequenceDiagram
    participant Browser as Browser Session
    participant Playwright as Playwright
    participant Sync as Artifact Sync
    participant S3 as S3 Storage
    participant API as API Client
    
    Browser->>Playwright: Close browser
    Playwright->>Playwright: Finalize video recording
    Note over Browser,Sync: OLD: sync stopped before finalization
    Browser->>Sync: shutdown() before stop_artifact_sync()
    Sync->>S3: Upload video with ContentType: video/webm
    API->>S3: Request recordings
    S3->>API: Return filtered, sorted video files
    Note over API: No 30s timeout, immediate playback
```

### Impact
- **Performance**: Eliminates 30-second timeout delays when loading video recordings, providing immediate playback after browser session closure
- **Reliability**: Prevents upload of incomplete or corrupted video files by filtering zero-byte objects and non-video files
- **User Experience**: Ensures users see actual video content instead of blank white screens by setting proper content types for video files
- **Data Quality**: Prioritizes newest recordings and validates file extensions to ensure only valid video files are processed

</details>

_Created with [Palmier](https://www.palmier.io)_