### PR TITLE
add proper response to upload files endpoint

### DIFF
--- a/skyvern/schemas/runs.py
+++ b/skyvern/schemas/runs.py
@@ -542,6 +542,11 @@ class ScriptRunResponse(BaseModel):
     ai_fallback_triggered: bool = False
 
 
+class UploadFileResponse(BaseModel):
+    s3_uri: str = Field(description="S3 URI where the file was uploaded")
+    presigned_url: str = Field(description="Presigned URL to access the uploaded file")
+
+
 class BaseRunResponse(BaseModel):
     run_id: str = Field(
         description="Unique identifier for this run. Run ID starts with `tsk_` for task runs and `wr_` for workflow runs.",


### PR DESCRIPTION
This is related to getting the Upload Files endpoint added to API Reference page. It doesn't have a proper response setup yet, so the response is blank in API docs. This changes that. Test showing response:

<img width="869" height="105" alt="Screenshot 2025-12-17 at 1 04 54 PM" src="https://github.com/user-attachments/assets/721bed55-ba02-4bf7-9332-6fd6daefca2f" />

Current doesn't have response:

<img width="1000" height="1033" alt="Screenshot 2025-12-17 at 1 07 33 PM" src="https://github.com/user-attachments/assets/f5164f06-28ca-44e0-bda5-9dac77910c8b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File upload endpoint now returns a comprehensive response including both the S3 storage location and a presigned URL, allowing direct access to uploaded files without additional requests.

* **Improvements**
  * File upload response now uses proper type definitions for improved consistency and reliability in the API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `UploadFileResponse` model to `upload_file` endpoint, providing structured response with `s3_uri` and `presigned_url`.
> 
>   - **Behavior**:
>     - Adds `UploadFileResponse` model to `upload_file` endpoint in `agent_protocol.py`, providing structured response with `s3_uri` and `presigned_url`.
>   - **Models**:
>     - Introduces `UploadFileResponse` in `runs.py` with fields `s3_uri` and `presigned_url`.
>   - **Misc**:
>     - Updates `upload_file` function signature in `agent_protocol.py` to return `UploadFileResponse` instead of `ORJSONResponse`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a4a27a72110ae2022d99238747e624e429dde92d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

📝 This PR adds proper response model documentation to the upload files endpoint by creating a structured `UploadFileResponse` class and updating the endpoint to return this model instead of a generic JSON response. This improvement ensures the API documentation properly displays the response schema with clear field descriptions for `s3_uri` and `presigned_url`.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Response Model Creation**: Added `UploadFileResponse` class in `skyvern/schemas/runs.py` with explicit fields for S3 URI and presigned URL
- **Endpoint Enhancement**: Updated `upload_file` function in `agent_protocol.py` to return the structured response model instead of `ORJSONResponse`
- **API Documentation**: Added `response_model=UploadFileResponse` parameter to the FastAPI decorator to ensure proper OpenAPI schema generation

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant API as Upload Endpoint
    participant Storage as S3 Storage
    participant Response as UploadFileResponse

    Client->>API: POST /upload_file (file)
    API->>Storage: save_legacy_file()
    Storage-->>API: (presigned_url, s3_uri)
    API->>Response: Create UploadFileResponse
    Response-->>Client: {s3_uri, presigned_url}
```

### Impact
- **API Documentation**: The endpoint now properly displays response schema in API reference documentation, making it easier for developers to understand the expected response format
- **Type Safety**: Structured response model provides better type checking and validation compared to generic JSON responses
- **Developer Experience**: Clear field descriptions help API consumers understand what each response field contains and how to use them

</details>

_Created with [Palmier](https://www.palmier.io)_