### PR TITLE
get back gpt 5

### DIFF
--- a/skyvern-frontend/src/components/ModelSelector.tsx
+++ b/skyvern-frontend/src/components/ModelSelector.tsx
@@ -28,7 +28,6 @@ const constants = {
 const deprecatedModelNames = new Set<string>([
   "gemini-2.5-flash-lite",
   "azure/gpt-4.1",
-  "azure/gpt-5",
   "azure/o3",
   "claude-haiku-4-5-20251001",
 ]);


### PR DESCRIPTION
[SKY-7346: Set up GPT 5.2 in Azure for Middesk block](https://linear.app/skyvern/issue/SKY-7346/set-up-gpt-52-in-azure-for-middesk-block)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Removes `azure/gpt-5` from `deprecatedModelNames` in `ModelSelector.tsx`, affecting model visibility and labeling.
> 
>   - **Behavior**:
>     - Removes `azure/gpt-5` from `deprecatedModelNames` in `ModelSelector.tsx`, affecting model visibility and labeling.
>   - **Misc**:
>     - No other changes or additions in the code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d9d042712701c0ba78583528a9c85946e6d36ec5. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔄 This PR removes `azure/gpt-5` from the deprecated models list in the ModelSelector component, effectively restoring GPT-5 as an available model option. The change is part of setting up GPT 5.2 in Azure for the Middesk block functionality.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Model Availability**: Removes `azure/gpt-5` from the `deprecatedModelNames` Set in `ModelSelector.tsx`
- **UI Impact**: GPT-5 model will no longer display with deprecated labeling in the model selector interface
- **Filtering Logic**: Affects model filtering and visibility logic within the ModelSelector component

### Technical Implementation
```mermaid
flowchart TD
    A[ModelSelector Component] --> B[deprecatedModelNames Set]
    B --> C{Model Filtering}
    C --> D[Remove Deprecated Label]
    C --> E[Include in Available Models]
    D --> F[Display GPT-5 as Active]
    E --> F
    F --> G[User Can Select GPT-5]
```

### Impact
- **Model Accessibility**: GPT-5 becomes available for selection without deprecated warnings
- **User Experience**: Users can now access GPT-5 model through the standard model selection interface
- **Feature Enablement**: Supports the broader initiative to set up GPT 5.2 in Azure for Middesk block functionality

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the azure/gpt-5 model as a non-deprecated option, making it available for selection in the model selector without deprecation indicators.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->