### PR TITLE
Add support for custom URLs in the retry webhook API

### DIFF
--- a/skyvern/client/client.py
+++ b/skyvern/client/client.py
@@ -790,7 +790,11 @@ class Skyvern:
         return _response.data
 
     def retry_run_webhook(
-        self, run_id: str, *, request_options: typing.Optional[RequestOptions] = None
+        self,
+        run_id: str,
+        *,
+        webhook_url: typing.Optional[str] = None,
+        request_options: typing.Optional[RequestOptions] = None,
     ) -> typing.Optional[typing.Any]:
         """
         Retry sending the webhook for a run
@@ -819,7 +823,7 @@ class Skyvern:
             run_id="tsk_123",
         )
         """
-        _response = self._raw_client.retry_run_webhook(run_id, request_options=request_options)
+        _response = self._raw_client.retry_run_webhook(run_id, webhook_url=webhook_url, request_options=request_options)
         return _response.data
 
     def get_run_timeline(
@@ -2701,7 +2705,11 @@ class AsyncSkyvern:
         return _response.data
 
     async def retry_run_webhook(
-        self, run_id: str, *, request_options: typing.Optional[RequestOptions] = None
+        self,
+        run_id: str,
+        *,
+        webhook_url: typing.Optional[str] = None,
+        request_options: typing.Optional[RequestOptions] = None,
     ) -> typing.Optional[typing.Any]:
         """
         Retry sending the webhook for a run
@@ -2738,7 +2746,9 @@ class AsyncSkyvern:
 
         asyncio.run(main())
         """
-        _response = await self._raw_client.retry_run_webhook(run_id, request_options=request_options)
+        _response = await self._raw_client.retry_run_webhook(
+            run_id, webhook_url=webhook_url, request_options=request_options
+        )
         return _response.data
 
     async def get_run_timeline(

--- a/skyvern/client/raw_client.py
+++ b/skyvern/client/raw_client.py
@@ -957,7 +957,11 @@ class RawSkyvern:
         raise ApiError(status_code=_response.status_code, headers=dict(_response.headers), body=_response_json)
 
     def retry_run_webhook(
-        self, run_id: str, *, request_options: typing.Optional[RequestOptions] = None
+        self,
+        run_id: str,
+        *,
+        webhook_url: typing.Optional[str] = None,
+        request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[typing.Optional[typing.Any]]:
         """
         Retry sending the webhook for a run
@@ -975,10 +979,18 @@ class RawSkyvern:
         HttpResponse[typing.Optional[typing.Any]]
             Successful Response
         """
+        request_kwargs: dict[str, typing.Any] = {}
+        if webhook_url is not None:
+            request_kwargs = {
+                "json": {"webhook_url": webhook_url},
+                "headers": {"content-type": "application/json"},
+                "omit": OMIT,
+            }
         _response = self._client_wrapper.httpx_client.request(
             f"v1/runs/{jsonable_encoder(run_id)}/retry_webhook",
             method="POST",
             request_options=request_options,
+            **request_kwargs,
         )
         try:
             if _response is None or not _response.text.strip():
@@ -3477,7 +3489,11 @@ class AsyncRawSkyvern:
         raise ApiError(status_code=_response.status_code, headers=dict(_response.headers), body=_response_json)
 
     async def retry_run_webhook(
-        self, run_id: str, *, request_options: typing.Optional[RequestOptions] = None
+        self,
+        run_id: str,
+        *,
+        webhook_url: typing.Optional[str] = None,
+        request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[typing.Optional[typing.Any]]:
         """
         Retry sending the webhook for a run
@@ -3495,10 +3511,18 @@ class AsyncRawSkyvern:
         AsyncHttpResponse[typing.Optional[typing.Any]]
             Successful Response
         """
+        request_kwargs: dict[str, typing.Any] = {}
+        if webhook_url is not None:
+            request_kwargs = {
+                "json": {"webhook_url": webhook_url},
+                "headers": {"content-type": "application/json"},
+                "omit": OMIT,
+            }
         _response = await self._client_wrapper.httpx_client.request(
             f"v1/runs/{jsonable_encoder(run_id)}/retry_webhook",
             method="POST",
             request_options=request_options,
+            **request_kwargs,
         )
         try:
             if _response is None or not _response.text.strip():

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -116,6 +116,7 @@ from skyvern.schemas.runs import (
     WorkflowRunRequest,
     WorkflowRunResponse,
 )
+from skyvern.schemas.webhooks import RetryRunWebhookRequest
 from skyvern.schemas.workflows import BlockType, WorkflowCreateYAMLRequest, WorkflowRequest, WorkflowStatus
 from skyvern.services import block_service, run_service, task_v1_service, task_v2_service, workflow_service
 from skyvern.services.pdf_import_service import pdf_import_service
@@ -1372,11 +1373,17 @@ async def get_run_artifacts(
 @base_router.post("/runs/{run_id}/retry_webhook/", include_in_schema=False)
 async def retry_run_webhook(
     run_id: str = Path(..., description="The id of the task run or the workflow run.", examples=["tsk_123", "wr_123"]),
+    request: RetryRunWebhookRequest | None = None,
     current_org: Organization = Depends(org_auth_service.get_current_org),
     x_api_key: Annotated[str | None, Header()] = None,
 ) -> None:
     analytics.capture("skyvern-oss-agent-run-retry-webhook")
-    await run_service.retry_run_webhook(run_id, organization_id=current_org.organization_id, api_key=x_api_key)
+    await run_service.retry_run_webhook(
+        run_id,
+        organization_id=current_org.organization_id,
+        api_key=x_api_key,
+        webhook_url=request.webhook_url if request else None,
+    )
 
 
 @base_router.get(

--- a/skyvern/schemas/webhooks.py
+++ b/skyvern/schemas/webhooks.py
@@ -32,6 +32,13 @@ class RunWebhookReplayRequest(BaseModel):
     )
 
 
+class RetryRunWebhookRequest(BaseModel):
+    webhook_url: str | None = Field(
+        None,
+        description="Optional webhook URL to send the payload to instead of the stored configuration",
+    )
+
+
 class RunWebhookReplayResponse(BaseModel):
     run_id: str = Field(..., description="Identifier of the run that was replayed")
     run_type: str = Field(..., description="Run type associated with the payload")


### PR DESCRIPTION
Add support for custom URLs in the retry webhook API, mirroring the behavior available in the Test Webhook UI.

The intended behavior here is if you call `v1/runs/$RUN_ID/retry_webhook/` with a webhook_url, it will override the one originally configured for the run. This was requested by Middesk, but also makes sense to do generally.

To test this, I called it with the code changes and passed this custom webhook URL which was different than the originally configured one.


configured in UI with:

<img width="371" height="198" alt="Screenshot 2025-12-17 at 5 48 08 PM" src="https://github.com/user-attachments/assets/4696c26c-9ade-40ad-a266-79c5a282fb88" />

then

<img width="745" height="100" alt="Screenshot 2025-12-17 at 5 48 41 PM" src="https://github.com/user-attachments/assets/c27d6e32-02a4-4180-b55c-5bf30d3b7a04" />

And we send the response to webhook.site and not to the original (it essentially overrides)

<img width="932" height="800" alt="Screenshot 2025-12-17 at 5 49 17 PM" src="https://github.com/user-attachments/assets/ca3fe66b-1249-472d-9abc-2c144e39cb7a" />


---
Linear Issue: [SKY-7347](https://linear.app/skyvern/issue/SKY-7347/support-custom-urls-in-retry-webhook-api)

<a href="https://cursor.com/background-agent?bcId=bc-e5fd192c-ba13-4245-bb86-d32d22b9589b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e5fd192c-ba13-4245-bb86-d32d22b9589b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for custom URLs in the retry webhook API, allowing users to override the default webhook URL.
> 
>   - **Behavior**:
>     - Added support for custom `webhook_url` in `retry_run_webhook` API, allowing override of default URL.
>     - If `webhook_url` is provided, it overrides the stored configuration for the run.
>   - **Code Changes**:
>     - Updated `retry_run_webhook` in `run_service.py` and `agent_protocol.py` to accept `webhook_url`.
>     - Modified `replay_run_webhook` in `webhook_service.py` to handle custom URL logic.
>   - **Models**:
>     - Added `webhook_url` field to `RetryRunWebhookRequest` in `webhooks.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 6a0fd89db1b9baad478faf7e22a8fe31c2d4bea8. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optionally specify a webhook URL when retrying run webhooks (sync and async) to replay payloads to an alternative endpoint.
  * Public API endpoint now accepts an optional request payload carrying webhook_url.

* **Refactor**
  * Service and webhook workflows updated to accept webhook_url and optional api_key for replay/signing, enabling caller-specified targets and signing keys.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔗 This PR adds support for custom webhook URLs in the retry webhook API, allowing users to override the default configured webhook URL when retrying failed webhooks. The enhancement mirrors functionality already available in the Test Webhook UI and was specifically requested by Middesk to provide more flexibility in webhook management.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Client Layer**: Added optional `webhook_url` parameter to both sync and async `retry_run_webhook()` methods in `client.py` and `raw_client.py`
- **API Layer**: Updated the `/runs/{run_id}/retry_webhook/` endpoint to accept a `RetryRunWebhookRequest` body containing the optional webhook URL
- **Service Layer**: Enhanced `run_service.retry_run_webhook()` to handle custom webhook URLs and delegate to the webhook service when provided
- **Schema Definition**: Created new `RetryRunWebhookRequest` model in `webhooks.py` to structure the request payload
- **Webhook Service**: Modified `replay_run_webhook()` to accept an optional API key parameter for proper signature generation

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant API
    participant RunService
    participant WebhookService
    participant ExternalWebhook

    Client->>API: POST /runs/{id}/retry_webhook with webhook_url
    API->>RunService: retry_run_webhook(webhook_url)
    alt webhook_url provided
        RunService->>WebhookService: replay_run_webhook(custom_url, api_key)
        WebhookService->>ExternalWebhook: Send to custom URL
    else no webhook_url
        RunService->>RunService: Use original webhook logic
        RunService->>ExternalWebhook: Send to configured URL
    end
```

### Impact
- **Enhanced Flexibility**: Users can now test webhooks against different endpoints without modifying the original configuration
- **Improved Debugging**: Developers can redirect webhook payloads to testing services like webhook.site for debugging purposes
- **Backward Compatibility**: The change is fully backward compatible as the webhook_url parameter is optional
- **API Consistency**: The implementation maintains consistency with existing webhook replay functionality while extending capabilities

</details>

_Created with [Palmier](https://www.palmier.io)_