### PR TITLE
launch show & tell for OSS

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowAddMenu.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowAddMenu.tsx
@@ -2,7 +2,6 @@ import { SquareIcon, PlusIcon } from "@radix-ui/react-icons";
 import { ReactNode } from "react";
 
 import { RadialMenu } from "@/components/RadialMenu";
-import { useIsSkyvernUser } from "@/hooks/useIsSkyvernUser";
 import { useDebugStore } from "@/store/useDebugStore";
 import { useRecordingStore } from "@/store/useRecordingStore";
 import { useSettingsStore } from "@/store/SettingsStore";
@@ -33,13 +32,8 @@ function WorkflowAddMenu({
   const debugStore = useDebugStore();
   const recordingStore = useRecordingStore();
   const settingsStore = useSettingsStore();
-  const isSkyvernUser = useIsSkyvernUser();
 
-  if (
-    !isSkyvernUser ||
-    !debugStore.isDebugMode ||
-    !settingsStore.isUsingABrowser
-  ) {
+  if (!debugStore.isDebugMode || !settingsStore.isUsingABrowser) {
     return <>{children}</>;
   }
 


### PR DESCRIPTION
	### Summary
- Removed `!isSkyvernUser` guard on Record browser button enabled check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unnecessary restriction on the workflow editor's "Record Browser" so it is now accessible under the existing debug and browser conditions (no longer gated by an additional user flag). This simplifies access and reduces confusion without changing any public interfaces.



<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Simplifies access control for 'Record Browser' in `WorkflowAddMenu.tsx` by removing `useIsSkyvernUser` hook.
> 
>   - **Access Control Simplification**:
>     - Removes `useIsSkyvernUser` hook from `WorkflowAddMenu.tsx`.
>     - Simplifies condition in `WorkflowAddMenu` to only check `debugStore.isDebugMode` and `settingsStore.isUsingABrowser`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 35f21085bc65edfa19fe162b9c64539dc9b43530. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->