### PR TITLE
Preserve data schema when cloning file parser blocks

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -3254,6 +3254,7 @@ function convertBlocksToBlockYAML(
           block_type: "file_url_parser",
           file_url: block.file_url,
           file_type: block.file_type,
+          json_schema: block.json_schema,
         };
         return blockYaml;
       }
@@ -3298,6 +3299,7 @@ function convertBlocksToBlockYAML(
           url: block.url,
           headers: block.headers,
           body: block.body,
+          files: block.files,
           timeout: block.timeout,
           follow_redirects: block.follow_redirects,
           parameter_keys: block.parameters.map((p) => p.key),


### PR DESCRIPTION
currently, when cloning a file parser block with a data extraction schema, the clone doesn't preserve the schema, it's stripped like this 

<img width="720" height="673" alt="Screenshot 2025-12-18 at 6 59 45 PM" src="https://github.com/user-attachments/assets/2542ca44-8549-499e-b4f0-204538ec4459" />

This change makes sure we keep it, as tested here

<img width="736" height="886" alt="Screenshot 2025-12-18 at 6 58 42 PM" src="https://github.com/user-attachments/assets/5704a1ca-47eb-4454-a225-0ad508de7419" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * File URL Parser block now properly handles JSON schema configurations
  * HTTP Request block now properly handles file attachments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Preserve `json_schema` in `file_url_parser` blocks and add `files` support in `http_request` blocks in `workflowEditorUtils.ts`.
> 
>   - **Behavior**:
>     - Preserve `json_schema` when cloning `file_url_parser` blocks in `convertBlocksToBlockYAML()` in `workflowEditorUtils.ts`.
>     - Add support for `files` attribute in `http_request` blocks in `convertBlocksToBlockYAML()`.
>   - **Misc**:
>     - No changes to existing functionality, only enhancements to block cloning and HTTP request handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5e5dc51e8012544efe8955989576d4d8c185387d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes a data loss issue in the workflow editor where cloning file parser blocks would strip their JSON schema configuration, ensuring that data extraction schemas are properly preserved during block duplication operations.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **File Parser Block Cloning**: Added `json_schema` field preservation in the `convertBlocksToBlockYAML` function for `file_url_parser` blocks
- **HTTP Request Block Enhancement**: Added `files` field support for HTTP request blocks to handle file uploads
- **Data Integrity**: Ensures that configured data extraction schemas are maintained when users clone workflow blocks

### Technical Implementation
```mermaid
flowchart TD
    A[User Clones File Parser Block] --> B[convertBlocksToBlockYAML Function]
    B --> C{Block Type Check}
    C -->|file_url_parser| D[Create Block YAML]
    D --> E[Include file_url]
    E --> F[Include file_type]
    F --> G[Include json_schema ✅ NEW]
    G --> H[Return Complete Block]
    C -->|http_request| I[Include files field ✅ NEW]
    I --> J[Return HTTP Block]
```

### Impact
- **User Experience**: Eliminates frustrating data loss when duplicating file parser blocks with configured schemas
- **Workflow Consistency**: Maintains data extraction configurations across cloned blocks, reducing setup time
- **Feature Completeness**: Ensures the cloning functionality works as expected for all block properties, improving overall editor reliability

</details>

_Created with [Palmier](https://www.palmier.io)_