### PR TITLE
shu/revert transaction pooler

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -54,7 +54,6 @@ class Settings(BaseSettings):
     LONG_RUNNING_TASK_WARNING_RATIO: float = 0.95
     MAX_RETRIES_PER_STEP: int = 5
     DEBUG_MODE: bool = False
-    # Database settings
     DATABASE_STRING: str = (
         "postgresql+asyncpg://skyvern@localhost/skyvern"
         if platform.system() == "Windows"
@@ -63,8 +62,6 @@ class Settings(BaseSettings):
     DATABASE_REPLICA_STRING: str | None = None
     DATABASE_STATEMENT_TIMEOUT_MS: int = 60000
     DISABLE_CONNECTION_POOL: bool = False
-    DB_DISABLE_PREPARED_STATEMENTS: bool = False
-
     PROMPT_ACTION_HISTORY_WINDOW: int = 1
     TASK_RESPONSE_ACTION_SCREENSHOT_COUNT: int = 3
 


### PR DESCRIPTION
- Revert "test transaction pooler db connection in k8s workers (#7767)"
- Revert "test transaction pooler db connection in k8s workers (#7800)"

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reverts transaction pooler changes, removes `DB_DISABLE_PREPARED_STATEMENTS`, and simplifies database connection handling in `config.py` and `agent_db.py`.
> 
>   - **Reverts**:
>     - Reverts changes from PRs #7767 and #7800 related to transaction pooler database connections in Kubernetes workers.
>   - **Configuration**:
>     - Removes `DB_DISABLE_PREPARED_STATEMENTS` from `Settings` in `config.py`.
>   - **Database Connection**:
>     - Simplifies connection initialization in `agent_db.py` by centralizing connection arguments.
>     - Removes `_connect_args_for_driver()` and `_install_statement_timeout()` functions.
>     - Uses `DB_CONNECT_ARGS` for connection parameters based on `DATABASE_STRING`.
>   - **Misc**:
>     - Adjusts logging and error handling in `agent_db.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f2bf882d95d6c40ab0446e5941c9f6fa20c132d1. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed `DB_DISABLE_PREPARED_STATEMENTS` configuration option.
  * Simplified internal database connection handling for improved maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔄 This PR reverts transaction pooler and prepared statement configurations, simplifying database connection handling by removing the `DB_DISABLE_PREPARED_STATEMENTS` setting and related infrastructure. The changes streamline the database engine creation process and revert to a more straightforward connection timeout implementation.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Configuration Cleanup**: Removed `DB_DISABLE_PREPARED_STATEMENTS` setting from `config.py` and cleaned up database-related comments
- **Database Engine Simplification**: Replaced complex `make_async_engine()` function with inline engine creation in `AgentDB.__init__()`
- **Connection Arguments Refactor**: Simplified connection argument handling by using static `DB_CONNECT_ARGS` based on database driver type
- **Statement Timeout Handling**: Reverted from event-based timeout setting to driver-specific connection arguments

### Technical Implementation
```mermaid
flowchart TD
    A[AgentDB.__init__] --> B{Database Driver Check}
    B -->|postgresql+psycopg| C[Set options with statement_timeout]
    B -->|postgresql+asyncpg| D[Set server_settings with statement_timeout]
    C --> E[create_async_engine with DB_CONNECT_ARGS]
    D --> E
    E --> F[Initialize BaseAlchemyDB]
```

### Impact
- **Code Simplification**: Removes complex prepared statement configuration logic and event-based timeout handling
- **Reduced Complexity**: Eliminates the need for driver-specific prepared statement management and connection pooler compatibility code
- **Maintainability**: Streamlines database connection setup by consolidating timeout configuration into connection arguments rather than runtime events

</details>

_Created with [Palmier](https://www.palmier.io)_