### PR TITLE
Block duplication in nested loop save fix

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -2352,6 +2352,19 @@ function getOrderedChildrenBlocks(
     return false;
   };
 
+  // This prevents nested loop children from being added to the parent loop.
+  const isInsideIncludedLoop = (nodeId: string): boolean => {
+    let current = nodesById.get(nodeId);
+    while (current?.parentId) {
+      const parent = nodesById.get(current.parentId);
+      if (parent?.type === "loop" && includedIds.has(parent.id)) {
+        return true;
+      }
+      current = parent;
+    }
+    return false;
+  };
+
   const parentNode = nodes.find((node) => node.id === parentId);
   if (!parentNode) {
     return [];
@@ -2408,6 +2421,9 @@ function getOrderedChildrenBlocks(
       return;
     }
     if (!hasAncestor(node.id, parentId)) {
+      return;
+    }
+    if (isInsideIncludedLoop(node.id)) {
       return;
     }
 


### PR DESCRIPTION
Kaitlyn IDed this bug

```
they had multiple blocks named the same thing
i go in and rename -> download -> download1 ->download2 -> download3 etc
I go to save -> it appends all of the first set of blocks in the first loop to the bottom of the second loop
```

To test:

I re-created the workflow and see the same behavior. With these changes, we can rename and save in the nested loops without duplication
https://www.loom.com/share/0e9e596ed79944409c3e7cfb7d8b32b0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nested loop handling in the workflow editor to prevent child nodes from being incorrectly added to parent loops.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes block duplication in nested loops during save by adding a check to prevent nested loop children from being added to parent loop in `workflowEditorUtils.ts`.
> 
>   - **Bug Fix**:
>     - Fixes block duplication in nested loops during save in `workflowEditorUtils.ts`.
>     - Adds `isInsideIncludedLoop()` to prevent nested loop children from being added to parent loop in `getOrderedChildrenBlocks()`.
>   - **Testing**:
>     - Verified by recreating the workflow and observing correct behavior without duplication.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 182d0d80187403f1cc2a9fc9c7a227e426b2eaf5. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔄 This PR fixes a critical bug in the workflow editor where blocks from nested loops were being duplicated and incorrectly appended to parent loops during save operations. The fix introduces a new validation function to prevent nested loop children from being processed by their parent loops.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **New Validation Function**: Added `isInsideIncludedLoop()` function that traverses up the node hierarchy to check if a node is already inside an included loop
- **Enhanced Block Processing**: Modified `getOrderedChildrenBlocks()` to skip nodes that are inside included loops, preventing duplication
- **Bug Fix Implementation**: The fix specifically addresses the issue where renaming blocks in nested loops caused them to be duplicated in parent loops during save operations

### Technical Implementation
```mermaid
flowchart TD
    A[getOrderedChildrenBlocks called] --> B[Check if node has ancestor]
    B --> C{Is node inside included loop?}
    C -->|Yes| D[Skip node - return early]
    C -->|No| E[Process node normally]
    E --> F{Is node a loop?}
    F -->|Yes| G[Recursively get loop children]
    F -->|No| H[Add to children array]
    G --> H
    H --> I[Continue processing]
    
    subgraph "isInsideIncludedLoop Function"
        J[Start with current node] --> K[Get parent node]
        K --> L{Is parent a loop in includedIds?}
        L -->|Yes| M[Return true]
        L -->|No| N{Has parent?}
        N -->|Yes| O[Move to parent]
        N -->|No| P[Return false]
        O --> K
    end
```

### Impact
- **Bug Resolution**: Eliminates the duplication of blocks when saving workflows with nested loops and renamed elements
- **Data Integrity**: Ensures that nested loop structures maintain proper hierarchy and don't leak blocks to parent scopes
- **User Experience**: Fixes the workflow editor behavior where users experienced unexpected block duplication after renaming and saving

</details>

_Created with [Palmier](https://www.palmier.io)_