### PR TITLE
Increase DB retry backoff

### DIFF
--- a/skyvern/forge/sdk/db/base_alchemy_db.py
+++ b/skyvern/forge/sdk/db/base_alchemy_db.py
@@ -34,7 +34,7 @@ def read_retry(retries: int = 3) -> Callable:
                         LOG.error("SQLAlchemyError after all retries", exc_info=True, attempt=attempt)
                         raise
 
-                    backoff_time = 0.1 * (2**attempt)
+                    backoff_time = 0.2 * (2**attempt)
                     LOG.warning(
                         "SQLAlchemyError retrying",
                         attempt=attempt,


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Increase backoff time multiplier from 0.1 to 0.2 in `wrapper()` for database retry logic in `base_alchemy_db.py`.
> 
>   - **Behavior**:
>     - Increase backoff time multiplier from `0.1` to `0.2` in `wrapper()` function in `base_alchemy_db.py` for retrying database operations.
>     - Affects retry timing for transient `SQLAlchemyError` exceptions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b9018b552e234433aa575185aa13a71dc5f70f99. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection retry behavior by adjusting backoff timing between retry attempts, enhancing system stability during temporary database connectivity issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->