### PR TITLE
conditional inside conditional

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
@@ -11,14 +11,6 @@ import { WorkflowBlockNode } from "../nodes";
 import { WorkflowBlockIcon } from "../nodes/WorkflowBlockIcon";
 import { AddNodeProps } from "../Workspace";
 import { Input } from "@/components/ui/input";
-import { useNodes } from "@xyflow/react";
-import { AppNode } from "../nodes";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 
 const enableCodeBlock =
   import.meta.env.VITE_ENABLE_CODE_BLOCK?.toLowerCase() === "true";
@@ -287,7 +279,6 @@ function WorkflowNodeLibraryPanel({
   onNodeClick,
   first,
 }: Props) {
-  const nodes = useNodes() as Array<AppNode>;
   const workflowPanelData = useWorkflowPanelStore(
     (state) => state.workflowPanelState.data,
   );
@@ -299,27 +290,6 @@ function WorkflowNodeLibraryPanel({
   );
   const [search, setSearch] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
-
-  // Determine parent context to check if certain blocks should be disabled
-  const parentNode = workflowPanelData?.parent
-    ? nodes.find((n) => n.id === workflowPanelData.parent)
-    : null;
-  const parentType = parentNode?.type;
-
-  // Check if a node type should be disabled based on parent context
-  const isBlockDisabled = (
-    nodeType: NonNullable<WorkflowBlockNode["type"]>,
-  ): { disabled: boolean; reason: string } => {
-    // Disable conditional inside conditional
-    if (nodeType === "conditional" && parentType === "conditional") {
-      return {
-        disabled: true,
-        reason:
-          "We're working on supporting nested conditionals. Soon you'll be able to use this feature!",
-      };
-    }
-    return { disabled: false, reason: "" };
-  };
 
   useEffect(() => {
     // Focus the input when the panel becomes active
@@ -416,17 +386,11 @@ function WorkflowNodeLibraryPanel({
             <div className="space-y-2">
               {filteredItems.length > 0 ? (
                 filteredItems.map((item) => {
-                  const { disabled, reason } = isBlockDisabled(item.nodeType);
                   const itemContent = (
                     <div
                       key={item.nodeType}
-                      className={`flex items-center justify-between rounded-sm bg-slate-elevation4 p-4 ${
-                        disabled
-                          ? "cursor-not-allowed opacity-50"
-                          : "cursor-pointer hover:bg-slate-elevation5"
-                      }`}
+                      className={`flex items-center justify-between rounded-sm bg-slate-elevation4 p-4 ${"cursor-pointer hover:bg-slate-elevation5"}`}
                       onClick={() => {
-                        if (disabled) return;
                         onNodeClick({
                           nodeType: item.nodeType,
                           next: workflowPanelData?.next ?? null,
@@ -456,20 +420,6 @@ function WorkflowNodeLibraryPanel({
                       <PlusIcon className="size-6 shrink-0" />
                     </div>
                   );
-
-                  // Wrap with tooltip if disabled
-                  if (disabled) {
-                    return (
-                      <TooltipProvider key={item.nodeType}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>{itemContent}</TooltipTrigger>
-                          <TooltipContent side="right">
-                            <p className="max-w-xs">{reason}</p>
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    );
-                  }
 
                   return itemContent;
                 })

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -1925,6 +1925,11 @@ function findNextBlockLabel(
       return null;
     }
 
+    // If this node itself is a conditional, prefer its own merge label
+    if (currentNode.type === "conditional") {
+      return currentNode.data.mergeLabel ?? null;
+    }
+
     const conditionalNodeId = currentNode.data.conditionalNodeId;
     if (!conditionalNodeId) {
       return null;


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor workflow editor to remove nested conditional restrictions and improve conditional block flow handling.
> 
>   - **Refactor**:
>     - Removed nested conditional restrictions in `WorkflowNodeLibraryPanel.tsx`.
>     - Updated `findNextBlockLabel()` in `workflowEditorUtils.ts` to prefer a conditional node's own merge label.
>   - **Behavior**:
>     - All workflow library items are now uniformly clickable.
>     - Improved handling of conditional block flows in the workflow editor.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9242b6fa46a74689bb841f7220cf938f19a3418e. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved restrictions that prevented selecting certain workflow node types in the node library panel.

* **Improvements**
  * Enhanced conditional block flow logic for improved workflow navigation accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔄 This PR enables nested conditional blocks in the workflow editor by removing previous restrictions and improving conditional node flow handling.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Restriction Removal**: Eliminated logic that prevented conditional blocks from being nested inside other conditional blocks
- **UI Simplification**: Removed disabled state styling, tooltips, and warning messages for nested conditionals
- **Flow Logic Enhancement**: Updated `findNextBlockLabel()` to prioritize a conditional node's own merge label when the current node is conditional
- **Code Cleanup**: Removed unused imports including `useNodes`, `AppNode`, and tooltip-related components

### Technical Implementation
```mermaid
flowchart TD
    A[User clicks conditional block] --> B{Is parent conditional?}
    B -->|Before: Yes| C[Block disabled with tooltip]
    B -->|After: Yes| D[Allow creation]
    B -->|No| D
    D --> E[Create conditional node]
    E --> F[findNextBlockLabel checks if current node is conditional]
    F --> G[Use node's own merge label if available]
```

### Impact
- **Enhanced Flexibility**: Users can now create complex nested conditional workflows without artificial restrictions
- **Improved User Experience**: Eliminates confusing disabled states and warning messages that blocked legitimate use cases
- **Better Flow Control**: Conditional nodes now properly handle their own merge labels, improving workflow execution logic
- **Code Maintainability**: Simplified codebase with fewer conditional checks and removed unused dependencies

</details>

_Created with [Palmier](https://www.palmier.io)_