### PR TITLE
add LLM-safe context to conditional NL branch evaluation

### DIFF
--- a/skyvern/forge/prompts/skyvern/conditional-prompt-branch-evaluation.j2
+++ b/skyvern/forge/prompts/skyvern/conditional-prompt-branch-evaluation.j2
@@ -5,6 +5,9 @@ Criteria (order matters; align outputs to these indices):
 - {{ criterion.index }}: {{ criterion.expression }}
 {% endfor %}
 
+Context (use this data to evaluate each criterion; if a value is absent, treat it as missing/Falsey):
+{{ context_snapshot }}
+
 Respond with JSON exactly in this shape:
 {
   "branch_results": [true | false per criterion, in order]


### PR DESCRIPTION
### Summary - [ticket](https://linear.app/skyvern/issue/SKY-7371/conditional-block-natural-language-expressions-not-working)

With this change, we're now able to support `jinja2+natlang`, `jinja2 `and `natlang only` expressions in conditional blocks.

- Include a sanitized params/outputs context snapshot in NL branch evaluation so plain natural-language criteria can be grounded without explicit templating.
- Pass the context snapshot into `conditional-prompt-branch-evaluation` and expose it in the prompt; continue using the secure template renderer for Jinja/NL expressions.
- Build the context snapshot from workflow values and block metadata with secrets masked.

Current behavior:
- Natural-language branch criteria are sent to the LLM with no runtime context unless the expression explicitly inlines values via Jinja. Pure NL sentences (e.g., “comment count … > 100”) fail or guess because the LLM has no data.

What changes:
- The evaluator now attaches an LLM-safe context (params, outputs, block metadata, loop info) with secrets stripped, enabling the LLM to resolve plain NL criteria without templating.
- The prompt template now surfaces that context to the model.

Impact / compatibility:
- Existing Jinja and NL+Jinja expressions keep working (still rendered through the secure formatter).
- Secrets remain protected: context is masked and respects the “LLM-facing” policy.
- No known regressions; NL-only criteria gain functionality.

### Screenshots
<img width="575" height="229" alt="image" src="https://github.com/user-attachments/assets/d33ca138-91a9-42ed-916b-984024a07e85" />
<img width="576" height="225" alt="image" src="https://github.com/user-attachments/assets/c3eb4918-6336-4281-8766-8010d9d7b5ed" />
<img width="572" height="238" alt="image" src="https://github.com/user-attachments/assets/2400a197-e099-4473-86f1-b3bd360383b5" />



<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds LLM-safe context snapshot for evaluating natural language expressions in conditional blocks, ensuring secrets are masked.
> 
>   - **Behavior**:
>     - Adds LLM-safe context snapshot to `BranchEvaluationContext` in `block.py` for evaluating natural language expressions in conditional blocks.
>     - Modifies `conditional-prompt-branch-evaluation.j2` to include `context_snapshot` for LLM evaluation.
>   - **Functions**:
>     - Adds `build_llm_safe_context_snapshot()` to `BranchEvaluationContext` in `block.py` to create a context with secrets masked.
>     - Updates `_evaluate_prompt_branches()` in `ConditionalBlock` in `block.py` to use the context snapshot for LLM evaluations.
>   - **Impact**:
>     - Supports `jinja2+natlang`, `jinja2`, and `natlang only` expressions in conditional blocks.
>     - Ensures secrets are masked and context is LLM-safe.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 26dc2548a7c776228fab8d076920d47410b1eeb9. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conditional branch evaluation now has access to workflow context data (parameters, outputs, environment) for more informed decision-making.

* **Security**
  * Added secure masking of sensitive information to prevent secret exposure during context evaluation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔧 This PR enhances conditional branch evaluation in Skyvern workflows by adding LLM-safe context snapshots, enabling natural language expressions to access runtime data without explicit Jinja templating while maintaining security through secret masking.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Context Snapshot Generation**: Added `build_llm_safe_context_snapshot()` method to create sanitized context data including workflow parameters, outputs, environment variables, and block metadata
- **Prompt Template Enhancement**: Updated `conditional-prompt-branch-evaluation.j2` to include context snapshot in LLM prompts for better grounding of natural language expressions
- **Security Implementation**: Implemented automatic secret masking to prevent sensitive data exposure during LLM evaluation
- **Evaluation Pipeline**: Modified `_evaluate_prompt_branches()` to generate and pass context snapshots to the prompt engine

### Technical Implementation
```mermaid
flowchart TD
    A[Conditional Branch Evaluation] --> B[Build LLM-Safe Context]
    B --> C[Extract Workflow Values]
    C --> D[Add Block Metadata]
    D --> E[Mask Secrets]
    E --> F[Generate JSON Snapshot]
    F --> G[Pass to Prompt Template]
    G --> H[LLM Evaluation with Context]
    H --> I[Return Branch Results]
```

### Impact
- **Enhanced Natural Language Support**: Pure NL expressions like "comment count > 100" now work without requiring Jinja templating syntax
- **Improved Security**: Secrets are automatically masked from context data sent to LLMs, maintaining data protection standards
- **Backward Compatibility**: Existing Jinja and mixed Jinja+NL expressions continue to function unchanged, ensuring no breaking changes
- **Better User Experience**: Users can write more intuitive conditional expressions without needing to understand templating syntax

</details>

_Created with [Palmier](https://www.palmier.io)_