### PR TITLE
initializes string parameters without defaults as empty strings instead of null

### DIFF
--- a/skyvern-frontend/src/routes/workflows/utils.ts
+++ b/skyvern-frontend/src/routes/workflows/utils.ts
@@ -33,7 +33,8 @@ export const getInitialValues = (
             acc[curr.key] = curr.default_value;
             return acc;
           }
-          acc[curr.key] = null;
+          // For string parameters, keep empty string instead of null to match run form behavior
+          acc[curr.key] = curr.workflow_parameter_type === "string" ? "" : null;
           return acc;
         },
         {} as Record<string, unknown>,


### PR DESCRIPTION
	### Summary - [ticket](https://linear.app/skyvern/issue/SKY-7454/debugger-fails-when-parameters-lack-default-values)
- **What changed:** When the debugger builds initial parameter values, required string parameters that lack defaults are now initialized to an empty string (`""`) instead of `null`.
- **Why:** The run form already treats string params this way—empty strings are allowed while nulls can trigger backend “missing parameter” errors. Aligning the debugger payload prevents sending `null` for strings, matching run behavior and avoiding backend rejects for missing values.
- **Impact:** Only affects debugger block-run payloads. Other parameter types are unchanged, and the run form behavior remains the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow parameter initialization to correctly default string-type parameters to empty values instead of null, ensuring consistent behavior across forms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Initialize string parameters without defaults as empty strings in `getInitialValues` to prevent backend errors.
> 
>   - **Behavior**:
>     - In `getInitialValues` function, string parameters without defaults are initialized to `""` instead of `null`.
>     - This change aligns debugger behavior with run form, preventing backend errors for missing values.
>   - **Impact**:
>     - Affects only debugger block-run payloads; other parameter types and run form behavior remain unchanged.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 373c5f31d46ada3e33bc404d97f1dd34117c80b6. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->