### PR TITLE
Update data center proxies to point to new provider

### DIFF
--- a/skyvern/schemas/docs/doc_strings.py
+++ b/skyvern/schemas/docs/doc_strings.py
@@ -27,11 +27,11 @@ Available geotargeting options:
 - RESIDENTIAL_AR: Argentina
 - RESIDENTIAL_AU: Australia
 - RESIDENTIAL_ISP: ISP proxy
-- US-CA: California
-- US-NY: New York
-- US-TX: Texas
-- US-FL: Florida
-- US-WA: Washington
+- US-CA: California (deprecated, routes through RESIDENTIAL_ISP)
+- US-NY: New York (deprecated, routes through RESIDENTIAL_ISP)
+- US-TX: Texas (deprecated, routes through RESIDENTIAL_ISP)
+- US-FL: Florida (deprecated, routes through RESIDENTIAL_ISP)
+- US-WA: Washington (deprecated, routes through RESIDENTIAL_ISP)
 - NONE: No proxy
 """
 


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Deprecated US proxy locations in `doc_strings.py`, now routing through `RESIDENTIAL_ISP`.
> 
>   - **Documentation**:
>     - Deprecated US proxy locations `US-CA`, `US-NY`, `US-TX`, `US-FL`, `US-WA` in `doc_strings.py`, now routing through `RESIDENTIAL_ISP`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b32a10a4db22f93f094724ecaed586f2aec21266. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated proxy location documentation for five US locations (California, New York, Texas, Florida, Washington). These locations are now marked as deprecated and noted to route through RESIDENTIAL_ISP.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔄 This PR updates the proxy infrastructure by migrating from datacenter proxies to a new ISP provider and deprecating specific US state-based proxy locations. The changes mark US-CA, US-NY, US-TX, US-FL, and US-WA proxy options as deprecated while routing them through the new RESIDENTIAL_ISP configuration.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Documentation Update**: Modified `doc_strings.py` to mark five US state-specific proxy locations (CA, NY, TX, FL, WA) as deprecated
- **Proxy Routing**: All deprecated US locations now route through `RESIDENTIAL_ISP` instead of their original datacenter configurations
- **Provider Migration**: Transition from datacenter proxy provider to a new ISP-based proxy solution (JoinMassive)

### Technical Implementation
```mermaid
flowchart TD
    A[US State Proxy Request] --> B{Proxy Location}
    B -->|US-CA| C[RESIDENTIAL_ISP]
    B -->|US-NY| C
    B -->|US-TX| C
    B -->|US-FL| C
    B -->|US-WA| C
    B -->|Other Locations| D[Original Proxy Config]
    C --> E[JoinMassive ISP Provider]
    D --> F[Existing Provider]
    
    style C fill:#ffeb3b
    style E fill:#4caf50
```

### Impact
- **Improved Reliability**: ISP proxies typically offer better stability and lower detection rates compared to datacenter proxies
- **Backward Compatibility**: Existing code using deprecated US state proxies will continue to work without breaking changes
- **Infrastructure Consolidation**: Simplifies proxy management by routing multiple locations through a single ISP provider
- **User Experience**: Transparent migration ensures users experience improved proxy performance without code changes

</details>

_Created with [Palmier](https://www.palmier.io)_