### PR TITLE
[Cache] Fix: LocalCache.set() to respect expiration parameter

### DIFF
--- a/tests/unit_tests/test_local_cache.py
+++ b/tests/unit_tests/test_local_cache.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 import pytest
 
+from skyvern.forge.sdk.cache.base import MAX_CACHE_ITEM
 from skyvern.forge.sdk.cache.local import LocalCache
 
 
@@ -45,3 +46,82 @@ async def test_cache_default_expiration():
 
     # Should be available immediately
     assert await cache.get("default_ttl") == "value"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_reads():
+    """Test that concurrent reads can proceed without blocking."""
+    cache = LocalCache()
+
+    # Set multiple values
+    await cache.set("key1", "value1")
+    await cache.set("key2", "value2")
+    await cache.set("key3", "value3")
+
+    # Perform concurrent reads
+    results = await asyncio.gather(
+        cache.get("key1"),
+        cache.get("key2"),
+        cache.get("key3"),
+        cache.get("key1"),
+        cache.get("key2"),
+        cache.get("key3"),
+    )
+
+    # All reads should succeed
+    assert results == ["value1", "value2", "value3", "value1", "value2", "value3"]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_trigger_with_insertion_count():
+    """Test that cleanup triggers based on insertion count, not cache size."""
+
+    cache = LocalCache()
+
+    # Set entries that will expire quickly
+    for i in range(150):
+        await cache.set(f"key_{i}", f"value_{i}", ex=timedelta(seconds=0.1))
+
+    # Wait for entries to expire
+    await asyncio.sleep(0.2)
+
+    # Verify cleanup was triggered (insertion_count % 100 == 0 at 100 and 200)
+    # After 150 insertions, cleanup should have run at insertion 100
+    # The cache should have expired entries cleaned up
+    # Note: We can't directly verify cleanup happened, but we can verify
+    # that the insertion counter works correctly by checking behavior
+
+    # Add more entries to trigger another cleanup
+    for i in range(50):
+        await cache.set(f"key2_{i}", f"value2_{i}", ex=timedelta(seconds=0.1))
+
+    # Wait for expiration
+    await asyncio.sleep(0.2)
+
+    # Verify that non-expired entries still work
+    await cache.set("non_expired", "still_here", ex=timedelta(seconds=10))
+    assert await cache.get("non_expired") == "still_here"
+
+
+@pytest.mark.asyncio
+async def test_max_cache_item_enforcement():
+    """Test that MAX_CACHE_ITEM limit is enforced correctly."""
+    cache = LocalCache()
+
+    # Fill cache to max capacity
+    for i in range(MAX_CACHE_ITEM):
+        await cache.set(f"key_{i}", f"value_{i}")
+
+    # Verify all entries are present
+    assert await cache.get("key_0") == "value_0"
+    assert await cache.get(f"key_{MAX_CACHE_ITEM - 1}") == f"value_{MAX_CACHE_ITEM - 1}"
+
+    # Add one more entry - should remove oldest
+    await cache.set("new_key", "new_value")
+
+    # Oldest entry should be removed
+    assert await cache.get("key_0") is None
+    # New entry should be present
+    assert await cache.get("new_key") == "new_value"
+    # Other entries should still be present
+    assert await cache.get("key_1") == "value_1"


### PR DESCRIPTION
- Replace TTLCache with custom implementation that tracks per-key expiration
- Cache entries now expire at their specified times (1 hour, 1 week, etc.)
- Invalid shapes will expire correctly instead of staying cached for 4 weeks
- Add unit tests to verify expiration behavior
- Use `asyncio.Lock` for task-safe access within event loop
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `TTLCache` with custom implementation in `LocalCache` to handle per-key expiration and add unit tests for verification.
> 
>   - **Behavior**:
>     - Replace `TTLCache` with custom implementation in `LocalCache` to track per-key expiration.
>     - Cache entries now expire at specified times (e.g., 1 hour, 1 week).
>     - Invalid shapes expire correctly instead of staying cached for 4 weeks.
>     - Use `asyncio.Lock` for thread-safe access in `LocalCache`.
>   - **Testing**:
>     - Add unit tests in `test_local_cache.py` to verify expiration behavior for custom and default expiration times.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 05a98e4fb6663185d881d885dc876e7637302522. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Switched to explicit per-item expirations with async-safe access, opportunistic cleanup and periodic cleanup triggered by insertions
  * Enforced max-size eviction of oldest entries to prevent unbounded growth and improved concurrent read behavior

* **Tests**
  * Added comprehensive unit tests covering custom/default expirations, concurrent reads, insertion-triggered cleanup, and max-size enforcement

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->