### PR TITLE
New Billing - per action credit consumption

### DIFF
--- a/skyvern/forge/sdk/db/agent_db.py
+++ b/skyvern/forge/sdk/db/agent_db.py
@@ -560,6 +560,26 @@ class AgentDB(BaseAlchemyDB):
             LOG.error("UnexpectedError", exc_info=True)
             raise
 
+    async def get_action_count_for_step(self, step_id: str, task_id: str, organization_id: str) -> int:
+        """Get count of actions for a step. Uses composite index for efficiency."""
+        try:
+            async with self.Session() as session:
+                query = (
+                    select(func.count())
+                    .select_from(ActionModel)
+                    .where(ActionModel.organization_id == organization_id)
+                    .where(ActionModel.task_id == task_id)
+                    .where(ActionModel.step_id == step_id)
+                )
+                result = await session.scalar(query)
+                return result or 0
+        except SQLAlchemyError:
+            LOG.error("SQLAlchemyError", exc_info=True)
+            raise
+        except Exception:
+            LOG.error("UnexpectedError", exc_info=True)
+            raise
+
     async def get_first_step(self, task_id: str, organization_id: str | None = None) -> Step | None:
         try:
             async with self.Session() as session:

--- a/skyvern/forge/sdk/db/id.py
+++ b/skyvern/forge/sdk/db/id.py
@@ -68,6 +68,7 @@ WORKFLOW_RUN_BLOCK_PREFIX = "wrb"
 WORKFLOW_RUN_PREFIX = "wr"
 WORKFLOW_SCRIPT_PREFIX = "ws"
 WORKFLOW_TEMPLATE_PREFIX = "wt"
+ORGANIZATION_BILLING_PREFIX = "ob"
 
 
 def generate_workflow_id() -> str:
@@ -258,6 +259,11 @@ def generate_script_file_id() -> str:
 def generate_script_block_id() -> str:
     int_id = generate_id()
     return f"{SCRIPT_BLOCK_PREFIX}_{int_id}"
+
+
+def generate_billing_id() -> str:
+    int_id = generate_id()
+    return f"{ORGANIZATION_BILLING_PREFIX}_{int_id}"
 
 
 ############# Helper functions below ##############


### PR DESCRIPTION
Note - setting to false for now, so this won't launch on merge ENABLE_PER_ACTION_METERING=false

---
Prior PRs
https://github.com/Skyvern-AI/skyvern-cloud/pull/7840
https://github.com/Skyvern-AI/skyvern-cloud/pull/7839
https://github.com/Skyvern-AI/skyvern-cloud/pull/7798


After running 2 non-cached workflows with 1 action each, we decrement by .03 * 2 = .06 or 60 credits.

<img width="339" height="285" alt="Screenshot 2025-12-22 at 12 34 34 PM" src="https://github.com/user-attachments/assets/e9cd17d3-052e-4aeb-a015-c821c5b998e6" />

And after a cached action it's 15 credits or .015 cents:
<img width="626" height="120" alt="Screenshot 2025-12-22 at 12 34 36 PM" src="https://github.com/user-attachments/assets/91735a1b-999f-4d76-a507-5a0a0c0e50e0" />

Also tested that this 'enable_overage' flag works. Set the test account to maximum credits allowed for the plan and it properly rejects:
<img width="394" height="61" alt="Screenshot 2025-12-22 at 2 05 40 PM" src="https://github.com/user-attachments/assets/82584541-e6bc-4826-ac2f-b819735b7f09" />

We can choose when launching whether to make this overage flag an opt-in or not, but should be handy

importantly, the 3rd commit here made a change to the meter in stripe for more readable invoices. When we hit the usage meters, we have them set as stripe as .03 (normal actions) and .015 (cached actions). However on the backend, note we still track usage of the plan in terms of credits (29000) at units of 1 mill (.001). So we can have the granularity we need for gating, but the invoices will show a clear `num_actions x action_price`

<img width="845" height="1029" alt="Screenshot 2025-12-22 at 3 43 49 PM" src="https://github.com/user-attachments/assets/b61adeb4-569c-4b24-8447-eeb7337c4c49" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces per-action credit consumption with new functions in `agent_db.py` and `id.py`, not enabled by default.
> 
>   - **Behavior**:
>     - Introduces per-action credit consumption feature, not enabled by default (`ENABLE_PER_ACTION_METERING=false`).
>     - Adds `get_action_count_for_step()` in `agent_db.py` to count actions for a specific step.
>   - **ID Generation**:
>     - Adds `generate_billing_id()` in `id.py` for generating billing-related IDs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for e0d66185c23c64821217073fa4040bf87ef37b3c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added action counting functionality to monitor and track actions per workflow step for enhanced visibility and analytics
  * Introduced organization billing ID generation system to support billing operations and identifier creation for organization-level billing entities

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

💳 This PR introduces a comprehensive per-action billing system with Stripe integration, implementing credit-based consumption tracking for workflow actions. The system supports different pricing tiers (Free, Hobby, Pro) with monthly credit quotas and includes both cached and non-cached action pricing models.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Database Layer**: Added `get_action_count_for_step()` method in `agent_db.py` to efficiently count actions per step using composite indexes
- **ID Generation**: Introduced `ORGANIZATION_BILLING_PREFIX` and `generate_billing_id()` function for billing record identification
- **Billing Infrastructure**: Complete billing system with Stripe integration, subscription management, and credit tracking
- **Action Metering**: Per-action credit consumption with different rates for cached (.015) vs non-cached (.03) actions

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant App
    participant DB
    participant Stripe
    
    User->>App: Execute Workflow Action
    App->>DB: get_action_count_for_step()
    DB-->>App: Action count
    App->>App: Calculate credit cost
    App->>DB: Deduct credits
    App->>Stripe: Report usage metrics
    Stripe-->>App: Billing confirmation
    App-->>User: Action completed
```

### Impact
- **Monetization**: Enables granular billing based on actual usage rather than flat subscription fees
- **Performance**: Optimized action counting using composite database indexes for efficient queries
- **Flexibility**: Feature flag (`ENABLE_PER_ACTION_METERING=false`) allows controlled rollout
- **User Experience**: Clear credit tracking with overage protection and readable Stripe invoices
- **Scalability**: Atomic credit operations prevent race conditions and double-billing scenarios

</details>

_Created with [Palmier](https://www.palmier.io)_