### PR TITLE
link actions to their screenshots - frontend

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -328,6 +328,7 @@ export type ActionApiResponse = {
   option: Option | null;
   file_url: string | null;
   created_by: string | null;
+  screenshot_artifact_id?: string | null;
 };
 
 export type Action = {
@@ -339,6 +340,7 @@ export type Action = {
   stepId: string;
   index: number;
   created_by: string | null;
+  screenshotArtifactId?: string | null;
 };
 
 export type EvalKind = "workflow" | "task";
@@ -464,6 +466,7 @@ export type ActionsApiResponse = {
   response: string | null;
   created_by: string | null;
   text: string | null;
+  screenshot_artifact_id?: string | null;
 };
 
 export type TaskV2 = {

--- a/skyvern-frontend/src/routes/tasks/detail/ActionScreenshot.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/ActionScreenshot.tsx
@@ -9,18 +9,37 @@ import { statusIsNotFinalized } from "../types";
 import { apiPathPrefix } from "@/util/env";
 
 type Props = {
+  artifactId?: string;
   stepId: string;
   index: number;
   taskStatus?: Status; // to give a hint that screenshot may not be available if task is not finalized
 };
 
-function ActionScreenshot({ stepId, index, taskStatus }: Props) {
+function ActionScreenshot({ artifactId, stepId, index, taskStatus }: Props) {
   const credentialGetter = useCredentialGetter();
 
   const {
+    data: artifactById,
+    isLoading: isLoadingArtifactById,
+    isFetching: isFetchingArtifactById,
+  } = useQuery<ArtifactApiResponse>({
+    queryKey: ["artifact", artifactId],
+    queryFn: async () => {
+      const client = await getClient(credentialGetter);
+      return client
+        .get(`${apiPathPrefix}/artifacts/${artifactId}`)
+        .then((response) => response.data);
+    },
+    enabled: Boolean(artifactId),
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+    retry: 1,
+  });
+
+  const {
     data: artifacts,
-    isLoading,
-    isFetching,
+    isLoading: isLoadingStepArtifacts,
+    isFetching: isFetchingStepArtifacts,
   } = useQuery<Array<ArtifactApiResponse>>({
     queryKey: ["step", stepId, "artifacts"],
     queryFn: async () => {
@@ -39,14 +58,19 @@ function ActionScreenshot({ stepId, index, taskStatus }: Props) {
       }
       return false;
     },
+    enabled: !artifactId, // fallback path only when explicit artifact id is absent
   });
 
   const actionScreenshots = artifacts?.filter(
     (artifact) => artifact.artifact_type === ArtifactType.ActionScreenshot,
   );
 
-  // action screenshots are reverse ordered w.r.t action order
-  const screenshot = actionScreenshots?.[actionScreenshots.length - index - 1];
+  const screenshotFromStep =
+    actionScreenshots?.[actionScreenshots.length - index - 1];
+  const screenshot = artifactById ?? screenshotFromStep;
+
+  const isLoading = isLoadingArtifactById || isLoadingStepArtifacts;
+  const isFetching = isFetchingArtifactById || isFetchingStepArtifacts;
 
   if (isLoading) {
     return (

--- a/skyvern-frontend/src/routes/tasks/detail/TaskActions.tsx
+++ b/skyvern-frontend/src/routes/tasks/detail/TaskActions.tsx
@@ -237,6 +237,7 @@ function TaskActions() {
           {activeSelection === "stream" ? getStream() : null}
           {typeof activeSelection === "number" && activeAction ? (
             <ActionScreenshot
+              artifactId={activeAction.screenshotArtifactId ?? undefined}
               stepId={activeAction.stepId}
               index={activeAction.index}
               taskStatus={task?.status}

--- a/skyvern-frontend/src/routes/tasks/detail/hooks/useActions.ts
+++ b/skyvern-frontend/src/routes/tasks/detail/hooks/useActions.ts
@@ -127,6 +127,7 @@ function useActions({ id }: Props): {
             stepId: action.step_id ?? "",
             index: index,
             created_by: action.created_by,
+            screenshotArtifactId: action.screenshot_artifact_id ?? undefined,
           };
         });
 

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunOverview.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunOverview.tsx
@@ -122,6 +122,7 @@ function WorkflowRunOverview() {
         !showStreamingBrowser &&
         isAction(selection) && (
           <ActionScreenshot
+            artifactId={selection.screenshot_artifact_id ?? undefined}
             index={selection.action_order ?? 0}
             stepId={selection.step_id ?? ""}
           />


### PR DESCRIPTION
	### Summary - [ticket](https://linear.app/skyvern/issue/SKY-7425/govassist-screenshots-not-matching-actions-in-action-list)
- Add `screenshot_artifact_id` to action types and plumb it through task and workflow run views.  
- Update `ActionScreenshot` to fetch by explicit artifact ID when present; fall back to step-artifact indexing and keep the existing “no screenshot found” messaging for legacy/missing data.  
- Wire action selections in task detail and workflow run timelines to pass the artifact ID through to screenshot rendering.  
- No behavioral regression for old runs; new runs use the direct action↔screenshot link.

[Related backend PR:](https://github.com/Skyvern-AI/skyvern-cloud/pull/8040)
- Backend now stores and returns `screenshot_artifact_id` on actions (new column plus API wiring). Ensure that migration is applied (alembic upgrade head) and the backend deployment with this field is live so the frontend can consume it; older runs without the field continue to work via the fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving and displaying specific screenshot artifacts. Screenshot display now includes a fallback mechanism to ensure screenshots load from alternative sources when a specific artifact ID is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Link actions to their screenshots using `screenshot_artifact_id`, ensuring backward compatibility for old runs.
> 
>   - **Behavior**:
>     - Add `screenshot_artifact_id` to `ActionApiResponse`, `Action`, and `ActionsApiResponse` in `types.ts`.
>     - Update `ActionScreenshot` in `ActionScreenshot.tsx` to fetch screenshots by `artifactId` if present, otherwise use step-artifact indexing.
>     - Ensure no regression for old runs; new runs use direct action-screenshot link.
>   - **Components**:
>     - Modify `TaskActions.tsx` and `WorkflowRunOverview.tsx` to pass `artifactId` to `ActionScreenshot`.
>     - Update `useActions` in `useActions.ts` to include `screenshotArtifactId` in action data.
>   - **Misc**:
>     - Add query logic in `ActionScreenshot.tsx` to handle fetching by `artifactId` and step-artifact indexing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 264d6aa2e40f1bead6c6e32203c54827c59228bc. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->