### PR TITLE
add step count to webhooks and get run payload

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -3406,11 +3406,13 @@ class ForgeAgent:
         last_step: Step | None = None,
         failure_reason: str | None = None,
         need_browser_log: bool = False,
+        step_count: int | None = None,
     ) -> TaskResponse:
         # no last step means the task didn't start, so we don't have any other artifacts
         if last_step is None:
             return task.to_task_response(
                 failure_reason=failure_reason,
+                step_count=step_count,
             )
 
         screenshot_url = None
@@ -3512,6 +3514,7 @@ class ForgeAgent:
             browser_console_log_url=browser_console_log_url,
             downloaded_files=downloaded_files,
             failure_reason=failure_reason,
+            step_count=step_count,
         )
 
     async def cleanup_browser_and_create_artifacts(

--- a/skyvern/forge/sdk/db/agent_db.py
+++ b/skyvern/forge/sdk/db/agent_db.py
@@ -513,6 +513,22 @@ class AgentDB(BaseAlchemyDB):
             LOG.error("UnexpectedError", exc_info=True)
             raise
 
+    async def get_task_step_count(self, task_id: str, organization_id: str | None = None) -> int:
+        try:
+            async with self.Session() as session:
+                result = await session.scalar(
+                    select(func.count(StepModel.step_id))
+                    .filter_by(task_id=task_id)
+                    .filter_by(organization_id=organization_id)
+                )
+                return result or 0
+        except SQLAlchemyError:
+            LOG.error("SQLAlchemyError", exc_info=True)
+            raise
+        except Exception:
+            LOG.error("UnexpectedError", exc_info=True)
+            raise
+
     async def get_task_actions(self, task_id: str, organization_id: str | None = None) -> list[Action]:
         try:
             async with self.Session() as session:

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -339,6 +339,7 @@ class Task(TaskBase):
         browser_console_log_url: str | None = None,
         downloaded_files: list[FileInfo] | None = None,
         failure_reason: str | None = None,
+        step_count: int | None = None,
     ) -> TaskResponse:
         return TaskResponse(
             request=self,
@@ -362,6 +363,7 @@ class Task(TaskBase):
             max_steps_per_run=self.max_steps_per_run,
             workflow_run_id=self.workflow_run_id,
             max_screenshot_scrolls=self.max_screenshot_scrolls,
+            step_count=step_count,
         )
 
 
@@ -387,6 +389,7 @@ class TaskResponse(BaseModel):
     started_at: datetime | None = None
     finished_at: datetime | None = None
     max_screenshot_scrolls: int | None = None
+    step_count: int | None = None
 
 
 class TaskOutput(BaseModel):

--- a/skyvern/schemas/runs.py
+++ b/skyvern/schemas/runs.py
@@ -607,6 +607,10 @@ class BaseRunResponse(BaseModel):
         default=None,
         description="The errors for the run",
     )
+    step_count: int | None = Field(
+        default=None,
+        description="Total number of steps executed in this run",
+    )
 
 
 class TaskRunResponse(BaseRunResponse):

--- a/skyvern/services/run_service.py
+++ b/skyvern/services/run_service.py
@@ -70,6 +70,7 @@ async def get_run_response(run_id: str, organization_id: str | None = None) -> R
                 max_screenshot_scrolls=task_v1_response.request.max_screenshot_scrolls,
             ),
             errors=task_v1_response.errors,
+            step_count=task_v1_response.step_count,
         )
     elif run.task_run_type == RunType.task_v2:
         task_v2 = await app.DATABASE.get_task_v2(run.run_id, organization_id=organization_id)

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -1799,6 +1799,7 @@ async def build_task_v2_run_response(task_v2: TaskV2) -> TaskRunResponse:
             error_code_mapping=task_v2.error_code_mapping,
         ),
         errors=workflow_run_resp.errors if workflow_run_resp else None,
+        step_count=workflow_run_resp.step_count if workflow_run_resp else None,
     )
 
 

--- a/skyvern/services/workflow_service.py
+++ b/skyvern/services/workflow_service.py
@@ -113,6 +113,7 @@ async def get_workflow_run_response(
     workflow_run_resp = await app.WORKFLOW_SERVICE.build_workflow_run_status_response_by_workflow_id(
         workflow_run_id=workflow_run.workflow_run_id,
         organization_id=organization_id,
+        include_step_count=True,
     )
     app_url = f"{settings.SKYVERN_APP_URL.rstrip('/')}/runs/{workflow_run.workflow_run_id}"
     return WorkflowRunResponse(
@@ -145,4 +146,5 @@ async def get_workflow_run_response(
             # TODO: add browser session id
         ),
         errors=workflow_run_resp.errors,
+        step_count=workflow_run_resp.total_steps,
     )


### PR DESCRIPTION
From a customer request:
https://linear.app/skyvern/issue/SKY-7318/add-step-count-to-webhooks-and-get-run-payload-by-jan-14th

To test:

kicked off this workflow

```
curl -X POST "$BASE_URL/v1/run/tasks" \                                                  
-H "x-api-key: $API_KEY" \
-H "Content-Type: application/json" \
-d '{
  "engine": "skyvern-2.0",
  "url": "https://news.ycombinator.com/",
  "prompt": "Extract the top 2 posts",
  "webhook_url": "https://webhook.site/516cb4f6-c858-4442-aba2-8d7a5f8aec8c"
}'
```

2 steps are recorded, displayed in webhook
<img width="233" height="83" alt="Screenshot 2026-01-05 at 1 38 14 PM" src="https://github.com/user-attachments/assets/b0cf27ad-de69-4b87-890e-5bc8e5b6237c" />
https://webhook.site/#!/view/516cb4f6-c858-4442-aba2-8d7a5f8aec8c/8f00c78a-cc60-4350-ad58-724e927cbe3a/1

and can get the same value via call here
<img width="577" height="173" alt="Screenshot 2026-01-05 at 1 42 25 PM" src="https://github.com/user-attachments/assets/4152c1b8-e1a2-4f1f-9387-81242a8c2c01" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task and workflow run responses now include a `step_count` field displaying the total number of steps executed in each run.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add step count to task and workflow responses, including webhooks, in various parts of the system.
> 
>   - **Behavior**:
>     - Add `step_count` to `TaskResponse` in `agent.py` and `tasks.py`.
>     - Add `get_task_step_count()` in `agent_db.py` to retrieve step count from the database.
>     - Include `step_count` in `WorkflowRunResponseBase` in `workflow/service.py`.
>   - **Webhooks**:
>     - Add `step_count` to webhook payloads in `workflow_service.py` and `run_service.py`.
>     - Modify `execute_workflow_webhook()` in `workflow_service.py` to include `step_count`.
>   - **Misc**:
>     - Update `get_run_response()` in `run_service.py` to include `step_count` in task responses.
>     - Add `step_count` to `BaseRunResponse` in `runs.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9921ba0fd3827ef31fb5be3d137c6f6b4bd0631a. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

📊 This PR adds step count tracking to task and workflow run responses, including webhook payloads, fulfilling a customer request to provide visibility into the total number of steps executed during automation runs.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Database Layer**: Added `get_task_step_count()` method in `agent_db.py` to efficiently retrieve step counts using SQL COUNT queries
- **Response Models**: Extended `TaskResponse` and `BaseRunResponse` schemas to include optional `step_count` field
- **Service Layer**: Updated `build_task_response()`, `build_workflow_run_status_response()`, and related service methods to populate and propagate step count data
- **Webhook Integration**: Modified webhook execution to include step count in payload data sent to external endpoints

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant API
    participant TaskService
    participant Database
    participant Webhook
    
    Client->>API: GET /run/{id} or Task execution
    API->>TaskService: get_task_v1_response()
    TaskService->>Database: get_task_step_count()
    Database-->>TaskService: step count
    TaskService->>TaskService: build_task_response(step_count)
    TaskService-->>API: TaskResponse with step_count
    API-->>Client: Response with step count
    
    Note over Webhook: For webhook scenarios
    TaskService->>Webhook: execute_workflow_webhook()
    Webhook->>Webhook: Include step_count in payload
    Webhook->>External: Send webhook with step count
```

### Impact
- **Enhanced Monitoring**: Customers can now track the total number of steps executed in their automation runs through both API responses and webhook notifications
- **Improved Observability**: Step count provides valuable metrics for understanding automation complexity and performance
- **Backward Compatibility**: All changes are additive with optional fields, ensuring existing integrations continue to work without modification
- **Performance Optimization**: Uses efficient SQL COUNT queries rather than fetching and counting all step records in memory

</details>

_Created with [Palmier](https://www.palmier.io)_