### PR TITLE
fix: multiple entry blocks detected on nested loops

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -2398,11 +2398,14 @@ function getOrderedChildrenBlocks(
         edges,
         currentNode.id,
       );
+      // Compute next_block_label for nested loops (same as regular blocks)
+      const nextBlockLabel = findNextBlockLabel(currentNode.id, nodes, edges);
       children.push({
         block_type: "for_loop",
         label: currentNode.data.label,
         continue_on_failure: currentNode.data.continueOnFailure,
         next_loop_on_failure: currentNode.data.nextLoopOnFailure,
+        next_block_label: nextBlockLabel,
         loop_blocks: loopChildren,
         loop_variable_reference: currentNode.data.loopVariableReference,
         complete_if_empty: currentNode.data.completeIfEmpty,


### PR DESCRIPTION
	## Summary
### The Bug
When a for_loop was nested inside another for_loop, and there was a block after the inner loop, the inner loop's next_block_label was never serialized - it was always null.
### Root Cause
In `getOrderedChildrenBlocks()`, when serializing nested loops, the code manually constructed the block object without calling `findNextBlockLabel()` to compute the next block.
### The Fix
Added two lines to compute and include `next_block_label` for nested loops
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes missing `next_block_label` for nested `for_loop` blocks in `workflowEditorUtils.ts` by computing it using `findNextBlockLabel()`.
> 
>   - **Bug Fix**:
>     - Fixes missing `next_block_label` for nested `for_loop` blocks in `getOrderedChildrenBlocks()` in `workflowEditorUtils.ts`.
>     - Ensures `next_block_label` is computed using `findNextBlockLabel()` for inner loops.
>   - **Root Cause**:
>     - Manual construction of block object without computing `next_block_label` in nested loops.
>   - **Solution**:
>     - Added computation of `next_block_label` for nested loops in `getOrderedChildrenBlocks()` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for d8d7131b25fd755d78902d292bb0d01a1216fe4b. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent behavior of nested for loops in workflow editors to align with standard control flow blocks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->