### PR TITLE
fix conditional block branch evaluation for all expression types

### DIFF
--- a/skyvern/forge/prompts/skyvern/conditional-prompt-branch-evaluation.j2
+++ b/skyvern/forge/prompts/skyvern/conditional-prompt-branch-evaluation.j2
@@ -1,14 +1,14 @@
-You are evaluating conditional branches for a workflow. Return the results to tell me whether each natural language criterion is satisfied.
-
-Criteria (order matters; align outputs to these indices):
-{% for criterion in branch_criteria -%}
-- {{ criterion.index }}: {{ criterion.expression }}
+Evaluate if the following condition(s) are TRUE or FALSE.
+{% if conditions|length == 1 %}
+Condition: {{ conditions[0] }}
+{% else %}
+{% for condition in conditions %}
+Condition {{ loop.index }}: {{ condition }}
 {% endfor %}
+{% endif %}
+{% if context_json %}
 
-Context (use this data to evaluate each criterion; if a value is absent, treat it as missing/Falsey):
-{{ context_snapshot }}
+Use this context to understand variable values:
+{{ context_json }}
+{% endif %}
 
-Respond with JSON exactly in this shape:
-{
-  "branch_results": [true | false per criterion, in order]
-}


### PR DESCRIPTION
What this PR did:
- Fix expression classification to correctly distinguish pure Jinja from 
Jinja+NatLang expressions by counting `{{` occurrences
- Replace `ExtractionBlock `with direct LLM call to avoid double Jinja 
rendering of JSON-containing prompts
- Copy loop variables (`current_value`, `current_index`, `current_item`) to 
top level of `context_snapshot `for pure NatLang expressions}
- If all expressions have Jinja (values pre-rendered), send empty context {} (for Jinja+NatLang)

Previously:
- Jinja+NatLang expressions like "{{ A }} is same as {{ B }}" were 
incorrectly classified as pure Jinja and always evaluated to True
- ExtractionBlock failed with "unexpected char '\\'" when prompt 
contained JSON with escape characters
- Pure NatLang expressions couldn't find `current_value `because it was 
nested in `blocks_metadata`
- Full context sent unnecessarily for Jinja+NatLang

Now all expression types work correctly:
- Pure Jinja: `{{ A == B }}`
- Jinja+NatLang: `{{ A }} is same as {{ B }}`
- Pure NatLang: `A is same as current_value["date"]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned conditional branch evaluation to use explicit TRUE/FALSE logic with improved support for multiple conditions
  * Optimized batch processing of branch evaluations for enhanced efficiency
  * Improved context handling in condition evaluation workflows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix expression classification and optimize conditional block evaluation by distinguishing pure Jinja from Jinja+NatLang expressions and batching prompt-based conditions into a single LLM call.
> 
>   - **Behavior**:
>     - Fix expression classification by counting `{{` occurrences to distinguish pure Jinja from Jinja+NatLang expressions.
>     - Replace `ExtractionBlock` with direct LLM call to avoid double Jinja rendering in `conditional-prompt-branch-evaluation.j2`.
>     - Copy loop variables to top level of `context_snapshot` for pure NatLang expressions in `block.py`.
>     - Send empty context for Jinja+NatLang expressions if all expressions have Jinja.
>   - **Functions**:
>     - Add `_is_pure_jinja_expression()` to determine if an expression is pure Jinja in `block.py`.
>     - Modify `_evaluate_prompt_branches()` in `ConditionalBlock` to batch prompt-based conditions into one LLM call.
>   - **Misc**:
>     - Update `conditional-prompt-branch-evaluation.j2` to simplify prompt template and condition evaluation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 823e1cb90f05aace1e15202c28b1cc93ae40ad59. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes critical issues in conditional branch evaluation by improving expression classification, context management, and prompt rendering to correctly handle all types of Jinja and natural language expressions in workflow conditions.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Expression Classification**: Fixed logic to distinguish between pure Jinja expressions (`{{ A == B }}`) and mixed Jinja+NatLang expressions (`{{ A }} is same as {{ B }}`) by counting `{{` occurrences
- **Prompt Template Simplification**: Replaced complex multi-criterion evaluation with a streamlined single condition evaluation format that handles optional context inclusion
- **Context Management**: Improved variable accessibility by copying loop variables (`current_value`, `current_index`, `current_item`) to top-level context for pure NatLang expressions
- **Rendering Pipeline**: Replaced `ExtractionBlock` with direct LLM calls to prevent double Jinja rendering issues with JSON-containing prompts

### Technical Implementation
```mermaid
flowchart TD
    A[Conditional Expression] --> B{Expression Type?}
    B -->|Pure Jinja| C[Pre-render with context]
    B -->|Jinja+NatLang| D[Pre-render + send empty context]
    B -->|Pure NatLang| E[Send full context with loop vars]
    C --> F[Direct LLM Call]
    D --> F
    E --> F
    F --> G[Boolean Result]
    G --> H[Branch Selection]
```

### Impact
- **Bug Resolution**: Fixes incorrect classification where Jinja+NatLang expressions were treated as pure Jinja and always evaluated to True
- **Reliability Improvement**: Eliminates `ExtractionBlock` failures when prompts contain JSON with escape characters
- **Context Accessibility**: Ensures pure NatLang expressions can properly access loop variables like `current_value`
- **Performance Optimization**: Reduces unnecessary context transmission for pre-rendered Jinja+NatLang expressions

</details>

_Created with [Palmier](https://www.palmier.io)_