### PR TITLE
decrease max svg parsing

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -374,6 +374,7 @@ class Settings(BaseSettings):
     BITWARDEN_SERVER_PORT: int = 8002
 
     SVG_MAX_LENGTH: int = 100000
+    SVG_MAX_PARSING_ELEMENT_CNT: int = 3000
 
     ENABLE_LOG_ARTIFACTS: bool = False
     ENABLE_CODE_BLOCK: bool = True

--- a/skyvern/forge/agent_functions.py
+++ b/skyvern/forge/agent_functions.py
@@ -504,7 +504,7 @@ class AgentFunction:
         task: Task | None = None,
         step: Step | None = None,
     ) -> CleanupElementTreeFunc:
-        MAX_ELEMENT_CNT = 3000
+        MAX_ELEMENT_CNT = settings.SVG_MAX_PARSING_ELEMENT_CNT
 
         @TraceManager.traced_async(ignore_input=True)
         async def cleanup_element_tree_func(frame: Page | Frame, url: str, element_tree: list[dict]) -> list[dict]:


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Made the SVG element processing limit configurable through settings, allowing customization of the maximum element count parsed during operations (default: 3,000 elements).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add configurable SVG parsing limit via `SVG_MAX_PARSING_ELEMENT_CNT` in `Settings` and update `cleanup_element_tree_factory` to use it.
> 
>   - **Configuration**:
>     - Add `SVG_MAX_PARSING_ELEMENT_CNT` to `Settings` in `config.py` for configurable SVG parsing limits.
>   - **Functionality**:
>     - Update `cleanup_element_tree_factory` in `agent_functions.py` to use `settings.SVG_MAX_PARSING_ELEMENT_CNT` for element count limit.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9acc6f1e86c9da06e6fb2ed52934cde283eee7fb. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

⚙️ This PR makes SVG parsing element limits configurable by introducing a new environment variable `SVG_MAX_PARSING_ELEMENT_CNT`, replacing the hardcoded limit of 3000 elements with a configurable setting. This change enables better control over SVG processing performance and resource usage across different deployment environments.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Configuration Management**: Added `SVG_MAX_PARSING_ELEMENT_CNT` setting to the `Settings` class in `config.py` with a default value of 3000
- **Agent Functions**: Updated `cleanup_element_tree_factory` function to use the configurable setting instead of a hardcoded `MAX_ELEMENT_CNT` value
- **Environment Flexibility**: Enables different SVG parsing limits for production (30 elements) and staging environments through environment variables

### Technical Implementation
```mermaid
flowchart TD
    A[Environment Variables] --> B[Settings Class]
    B --> C[SVG_MAX_PARSING_ELEMENT_CNT = 3000]
    C --> D[cleanup_element_tree_factory]
    D --> E[MAX_ELEMENT_CNT = settings.SVG_MAX_PARSING_ELEMENT_CNT]
    E --> F[SVG Element Processing]
    
    G[Production: 30 elements] --> A
    H[Staging: 30 elements] --> A
    I[Default: 3000 elements] --> A
```

### Impact
- **Performance Control**: Allows fine-tuning of SVG parsing performance by adjusting element count limits based on environment needs
- **Resource Management**: Prevents potential memory issues or processing delays when dealing with complex SVG files by enforcing configurable limits
- **Deployment Flexibility**: Enables different configurations for production and staging environments, with production using a much lower limit (30) for better performance

</details>

_Created with [Palmier](https://www.palmier.io)_