### PR TITLE
fix: handle wait_for_load_state timeout for JS redirect downloads

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -937,7 +937,17 @@ async def handle_click_to_download_file_action(
     try:
         if not await skyvern_element.navigate_to_a_href(page=page):
             await locator.click(timeout=settings.BROWSER_ACTION_TIMEOUT_MS)
-        await page.wait_for_load_state(timeout=settings.BROWSER_LOADING_TIMEOUT_MS)
+        try:
+            await page.wait_for_load_state(timeout=settings.BROWSER_LOADING_TIMEOUT_MS)
+        except TimeoutError:
+            # TimeoutError from wait_for_load_state is expected for JS redirect downloads.
+            # The page may never reach load state when redirecting to a file download.
+            # Caller monitors download directory to determine if download was triggered.
+            LOG.debug(
+                "wait_for_load_state timed out during download click, continuing",
+                action=action,
+                workflow_run_id=task.workflow_run_id,
+            )
     except Exception as e:
         LOG.exception(
             "ClickAction with download failed",


### PR DESCRIPTION
Fixes #4255

### What changed
- Catch `TimeoutError` from `wait_for_load_state` in `handle_click_to_download_file_action`
- Log debug message when timeout occurs instead of failing

### Why
JavaScript redirect downloads (like the one in #4255) set a cookie and redirect to the file URL. The page never reaches load state because it's redirecting to a file download. The current code fails on timeout even though the download succeeds.

The caller (`ActionHandler.handle_action`, lines 403-514) already monitors the download directory to determine if a download was triggered. This fix lets the caller's download detection work correctly.

### Testing
- Verified syntax validity
- Logic verified against existing download detection pattern in `handle_action`

### Risk
Low. The outer `except Exception` block still catches actual failures. Only `TimeoutError` from `wait_for_load_state` is now handled gracefully.

---

This PR fixes `wait_for_load_state` timeout handling in `handle_click_to_download_file_action`.

To make download handling production-safe, the remaining work is:
- Add integration test for JS redirect download pattern
- Add retry logic for flaky download detection
- Add download progress monitoring for large files

This is ~2-3 days.
I can own this as a short paid engagement; otherwise this PR stands on its own.

---

🔧 This PR fixes a timeout issue in file download handling where JavaScript redirect downloads would fail even when the download succeeded, by gracefully handling `wait_for_load_state` timeouts that are expected for redirect-based downloads.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Error Handling**: Added try-catch block around `page.wait_for_load_state()` to catch `TimeoutError` specifically
- **Logging**: Added debug logging when timeout occurs instead of letting it bubble up as a failure
- **Download Flow**: Allows the existing download detection mechanism in the caller to work correctly by not failing on expected timeouts

### Technical Implementation
```mermaid
sequenceDiagram
    participant Handler as ActionHandler
    participant Element as SkyvernElement
    participant Page as Browser Page
    participant Download as Download Monitor
    
    Handler->>Element: handle_click_to_download_file_action()
    Element->>Page: click() or navigate_to_a_href()
    Page->>Page: JavaScript sets cookie & redirects
    Page->>Handler: wait_for_load_state()
    Note over Page,Handler: TimeoutError (expected for JS redirects)
    Handler->>Handler: Log debug message & continue
    Handler->>Download: Monitor download directory
    Download->>Handler: File detected/downloaded
```

### Impact
- **Reliability**: Prevents false failures for JavaScript redirect downloads that never reach a complete load state
- **User Experience**: Downloads that previously failed due to timeout now complete successfully
- **Backward Compatibility**: Maintains existing error handling for actual failures while only catching the specific timeout case
- **Risk Mitigation**: Low risk change as the outer exception handler still catches genuine failures, and the caller already has download detection logic

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Catch `TimeoutError` in `handle_click_to_download_file_action` to handle JS redirect downloads without failing.
> 
>   - **Behavior**:
>     - Catch `TimeoutError` in `handle_click_to_download_file_action` in `handler.py` to handle JS redirect downloads.
>     - Logs a debug message instead of failing when `wait_for_load_state` times out.
>   - **Testing**:
>     - Verified syntax validity.
>     - Logic verified against existing download detection pattern in `handle_action`.
>   - **Risk**:
>     - Low risk as `except Exception` block still catches actual failures.
>     - Only `TimeoutError` from `wait_for_load_state` is handled gracefully.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f867948cae8d75c2b3a4817674de87ed37ad7869. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced file download reliability by gracefully handling timeout scenarios that may occur during JavaScript-based download redirects. The application will now continue operation instead of interrupting the process when timeouts occur.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->