### PR TITLE
sync parameter key renames and deletions to all block types

### DIFF
--- a/skyvern-frontend/src/components/WorkflowBlockInputSet.tsx
+++ b/skyvern-frontend/src/components/WorkflowBlockInputSet.tsx
@@ -11,6 +11,14 @@ type Props = {
   values: Set<string>;
 };
 
+function areSetsEqual<T>(a: Set<T>, b: Set<T>): boolean {
+  if (a.size !== b.size) return false;
+  for (const item of a) {
+    if (!b.has(item)) return false;
+  }
+  return true;
+}
+
 function WorkflowBlockInputSet(props: Props) {
   const { nodeId, onChange, values } = props;
   const [parameterKeys, setParameterKeys] = useState<Set<string>>(values);
@@ -19,6 +27,13 @@ function WorkflowBlockInputSet(props: Props) {
   const availableParameterKeys = new Set(
     workflowParameters.map((parameter) => parameter.key),
   );
+
+  // Sync local state when values prop changes (e.g., parameter renamed externally)
+  useEffect(() => {
+    if (!areSetsEqual(parameterKeys, values)) {
+      setParameterKeys(values);
+    }
+  }, [values, parameterKeys]);
 
   useEffect(() => {
     onChange(new Set(parameterKeys));

--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParametersPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParametersPanel.tsx
@@ -196,20 +196,29 @@ function WorkflowParametersPanel({ onMouseDownCapture }: Props) {
                                 setHasChanges(true);
                                 setNodes((nodes) => {
                                   return nodes.map((node) => {
+                                    // All node types that have parameterKeys
                                     if (
                                       node.type === "task" ||
-                                      node.type === "textPrompt"
+                                      node.type === "textPrompt" ||
+                                      node.type === "login" ||
+                                      node.type === "navigation" ||
+                                      node.type === "extraction" ||
+                                      node.type === "fileDownload" ||
+                                      node.type === "action" ||
+                                      node.type === "http_request" ||
+                                      node.type === "validation" ||
+                                      node.type === "codeBlock"
                                     ) {
+                                      const parameterKeys = node.data
+                                        .parameterKeys as Array<string> | null;
                                       return {
                                         ...node,
                                         data: {
                                           ...node.data,
-                                          parameterKeys: (
-                                            node.data
-                                              .parameterKeys as Array<string>
-                                          ).filter(
-                                            (key) => key !== parameter.key,
-                                          ),
+                                          parameterKeys:
+                                            parameterKeys?.filter(
+                                              (key) => key !== parameter.key,
+                                            ) ?? null,
                                         },
                                       };
                                     }
@@ -293,24 +302,34 @@ function WorkflowParametersPanel({ onMouseDownCapture }: Props) {
                     );
                     setNodes((nodes) => {
                       return nodes.map((node) => {
+                        // All node types that have parameterKeys
                         if (
                           node.type === "task" ||
-                          node.type === "textPrompt"
+                          node.type === "textPrompt" ||
+                          node.type === "login" ||
+                          node.type === "navigation" ||
+                          node.type === "extraction" ||
+                          node.type === "fileDownload" ||
+                          node.type === "action" ||
+                          node.type === "http_request" ||
+                          node.type === "validation" ||
+                          node.type === "codeBlock"
                         ) {
+                          const parameterKeys = node.data
+                            .parameterKeys as Array<string> | null;
                           return {
                             ...node,
                             data: {
                               ...node.data,
-                              parameterKeys: (
-                                node.data.parameterKeys as Array<string>
-                              ).map((key) => {
-                                if (
-                                  key === operationPanelState.parameter?.key
-                                ) {
-                                  return editedParameter.key;
-                                }
-                                return key;
-                              }),
+                              parameterKeys:
+                                parameterKeys?.map((key) => {
+                                  if (
+                                    key === operationPanelState.parameter?.key
+                                  ) {
+                                    return editedParameter.key;
+                                  }
+                                  return key;
+                                }) ?? null,
                             },
                           };
                         }


### PR DESCRIPTION
### Summary - [ticket](https://linear.app/skyvern/issue/SKY-7543/parameter-rename-does-not-update-block-parameter-selector)

#### What Changed

1. **`WorkflowParametersPanel.tsx`**: Extended the `setNodes` logic in both the delete and rename handlers to update `parameterKeys` for all node types that use them: `login`, `navigation`, `extraction`, `fileDownload`, `action`, `http_request`, `validation`, and `codeBlock` (in addition to the existing `task` and `textPrompt`).

2. **`WorkflowBlockInputSet.tsx`**: Added a sync effect so that the component's local state updates when the `values` prop changes externally (e.g., when a parameter is renamed via the parameters panel).

#### Previous Behavior

When a user renamed or deleted a workflow parameter, only `task` and `textPrompt` blocks had their `parameterKeys` arrays updated. All other block types (Login, Navigation, Extraction, etc.) retained stale references, causing the parameter selectors to display empty values or show "missing parameter" indicators.

#### Why We Changed It

All block types with `parameterKeys` should stay in sync when parameters are renamed or deleted. The original implementation was incomplete— the logic wasn't extended to blocks other than `textPrompt` and `task`.

### Screenshots

#### Before
<img width="520" height="658" alt="image" src="https://github.com/user-attachments/assets/bc322e60-a6ab-417b-961a-66cd73e4b8c5" />
<img width="756" height="486" alt="image" src="https://github.com/user-attachments/assets/8443a90a-e126-4879-adae-1886b2f352d0" />
<img width="794" height="502" alt="image" src="https://github.com/user-attachments/assets/e1d97a5e-12cd-424c-9286-3e6a7f007400" />
<img width="515" height="570" alt="image" src="https://github.com/user-attachments/assets/b5059ebc-7e2a-4c60-a532-b1db1331aec5" />

#### After
<img width="523" height="570" alt="image" src="https://github.com/user-attachments/assets/bda7f096-9cda-4ac2-b49e-2c42e44e6b50" />
<img width="764" height="504" alt="image" src="https://github.com/user-attachments/assets/2c3c8691-671c-40a3-905c-7519b77e60bb" />
<img width="778" height="501" alt="image" src="https://github.com/user-attachments/assets/c637fe81-438a-4f4a-893a-bb2bb604c9d3" />
<img width="519" height="621" alt="image" src="https://github.com/user-attachments/assets/e23fb9db-67bb-4bfa-bbd0-335fb0c39ac6" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Synchronize parameter key updates across all relevant node types in the workflow editor to prevent stale references.
> 
>   - **Behavior**:
>     - `WorkflowParametersPanel.tsx`: Extends `setNodes` logic to update `parameterKeys` for `login`, `navigation`, `extraction`, `fileDownload`, `action`, `http_request`, `validation`, `codeBlock`, `task`, and `textPrompt` nodes.
>     - `WorkflowBlockInputSet.tsx`: Adds effect to sync local state with external `values` prop changes.
>   - **Previous Behavior**:
>     - Only `task` and `textPrompt` nodes updated `parameterKeys` on parameter rename/delete.
>   - **Reason for Change**:
>     - Ensure all node types with `parameterKeys` stay in sync on parameter updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 89330e5dd838cd576b61195d17eca2a61717e739. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale parameter state in workflow parameter management by improving state synchronization logic.
  * Enhanced parameter handling with better null safety and support for extended workflow node types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔄 This PR fixes a critical synchronization issue where parameter renames and deletions were only being applied to `task` and `textPrompt` workflow blocks, leaving other block types with stale parameter references. The fix extends the parameter update logic to all block types that use parameters and adds proper state synchronization to prevent UI inconsistencies.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **WorkflowParametersPanel.tsx**: Extended parameter deletion and rename handlers to update `parameterKeys` for all node types (`login`, `navigation`, `extraction`, `fileDownload`, `action`, `http_request`, `validation`, `codeBlock`) instead of just `task` and `textPrompt`
- **WorkflowBlockInputSet.tsx**: Added a `useEffect` hook with set equality checking to synchronize local component state when the `values` prop changes externally
- **Null Safety**: Improved handling of potentially null `parameterKeys` arrays with optional chaining and null coalescing operators

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant ParametersPanel
    participant WorkflowNodes
    participant BlockInputSet
    
    User->>ParametersPanel: Rename/Delete Parameter
    ParametersPanel->>WorkflowNodes: Update all node types with parameterKeys
    Note over WorkflowNodes: Previously only task & textPrompt<br/>Now includes all 9 block types
    WorkflowNodes->>BlockInputSet: Props change (values)
    BlockInputSet->>BlockInputSet: useEffect detects change
    BlockInputSet->>BlockInputSet: Sync local state with new values
    BlockInputSet->>User: UI reflects updated parameters
```

### Impact
- **Bug Resolution**: Eliminates the "missing parameter" indicators and empty parameter selectors that appeared in non-task/textPrompt blocks after parameter operations
- **Consistency**: Ensures all workflow block types maintain synchronized parameter references when parameters are modified
- **User Experience**: Parameter renames and deletions now properly propagate across the entire workflow editor, preventing confusion and workflow corruption

</details>

_Created with [Palmier](https://www.palmier.io)_