### PR TITLE
use default value when workflow parameter is explicitly set to null in API requests

### DIFF
--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -437,6 +437,10 @@ class WorkflowService:
             for workflow_parameter in all_workflow_parameters:
                 if workflow_request.data and workflow_parameter.key in workflow_request.data:
                     request_body_value = workflow_request.data[workflow_parameter.key]
+                    # Fall back to default value if the request explicitly sends null
+                    # This supports API clients (e.g., n8n) that include the key with null value
+                    if request_body_value is None and workflow_parameter.default_value is not None:
+                        request_body_value = workflow_parameter.default_value
                     if self._is_missing_required_value(workflow_parameter, request_body_value):
                         missing_parameters.append(workflow_parameter.key)
                         continue


### PR DESCRIPTION
## Summary - [ticket](https://linear.app/skyvern/issue/SKY-7551/investigate-default-parameter-values-not-being-captured-correctly-in)

API clients like n8n include all parameter keys in the request payload, sending `null` when the user doesn't provide a value. Previously, this caused a 422 validation error even when the parameter had a default value defined in the workflow, because the system only used defaults when the key was completely absent from the request.

**Previous behavior:** `{"param": null}` with a default value → 422 error

**New behavior:** `{"param": null}` with a default value → uses the default value

This fix only affects `null` values. Empty strings (`""`) are still treated as intentional values and will not fall back to the default, following conventional API design where `null` means "not specified" and empty string means "explicitly empty."

### STRING Parameter Type

| Scenario | Before | After |
|----------|--------|-------|
| `{"param": null}` + has default | ❌ Error (missing parameter) | ✅ Uses default value |
| `{"param": ""}` + has default | Uses `""` | Uses `""` |
| `{"param": " "}` + has default | Uses `" "` | Uses `" "` |
| `{"param": "value"}` + has default | Uses `"value"` | Uses `"value"` |
| `{}` (absent) + has default | Uses default value | Uses default value |
| `{"param": null}` + NO default | ❌ Error (missing parameter) | ❌ Error (missing parameter) |
| `{"param": ""}` + NO default | Uses `""` | Uses `""` |
| `{"param": " "}` + NO default | Uses `" "` | Uses `" "` |
| `{"param": "value"}` + NO default | Uses `"value"` | Uses `"value"` |
| `{}` (absent) + NO default | ❌ Error (missing parameter) | ❌ Error (missing parameter) |

### JSON/BOOLEAN/INTEGER/FLOAT Parameter Types

| Scenario | Before | After |
|----------|--------|-------|
| `{"param": null}` + has default | ❌ Error (missing parameter) | ✅ Uses default value |
| `{"param": ""}` + has default | ❌ Error (missing parameter) | ❌ Error (missing parameter) |
| `{"param": " "}` + has default | ❌ Error (missing parameter) | ❌ Error (missing parameter) |
| `{"param": "value"}` + has default | Uses `"value"` | Uses `"value"` |
| `{}` (absent) + has default | Uses default value | Uses default value |
| `{"param": null}` + NO default | ❌ Error (missing parameter) | ❌ Error (missing parameter) |
| `{"param": ""}` + NO default | ❌ Error (missing parameter) | ❌ Error (missing parameter) |
| `{"param": " "}` + NO default | ❌ Error (missing parameter) | ❌ Error (missing parameter) |
| `{"param": "value"}` + NO default | Uses `"value"` | Uses `"value"` |
| `{}` (absent) + NO default | ❌ Error (missing parameter) | ❌ Error (missing parameter) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow parameters now correctly fall back to their default values when null values are explicitly provided in requests, improving consistency in parameter handling and validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> In `service.py`, `setup_workflow_run()` now uses default values for `null` parameters in API requests, preventing 422 errors.
> 
>   - **Behavior**:
>     - In `setup_workflow_run()` in `service.py`, `null` values in API requests now use default values if defined, preventing 422 errors.
>     - Only affects `null` values; empty strings and other types remain unchanged.
>   - **Misc**:
>     - Added comments to clarify handling of `null` values in API requests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d336365290d0f452392facafe454ade763f5e817. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes workflow parameter handling to use default values when API clients explicitly send `null` values, resolving 422 validation errors that occurred with clients like n8n. The change ensures that `null` is treated as "not specified" while empty strings remain intentional values, following conventional API design patterns.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Parameter Validation Logic**: Added a null-check condition in `setup_workflow_run()` that falls back to default values when request parameters are explicitly set to `null`
- **API Client Compatibility**: Specifically addresses issues with API clients like n8n that include all parameter keys in requests, sending `null` for unspecified values
- **Semantic Distinction**: Maintains the important distinction between `null` (not specified) and empty string `""` (explicitly empty)

### Technical Implementation
```mermaid
flowchart TD
    A[API Request with Parameters] --> B{Parameter exists in request?}
    B -->|Yes| C{Parameter value is null?}
    B -->|No| D{Has default value?}
    C -->|Yes| E{Has default value?}
    C -->|No| F[Use provided value]
    E -->|Yes| G[Use default value]
    E -->|No| H[Mark as missing parameter]
    D -->|Yes| G
    D -->|No| H
    F --> I[Continue validation]
    G --> I
    H --> J[Add to missing parameters list]
```

### Impact
- **API Client Integration**: Resolves compatibility issues with third-party API clients that send comprehensive parameter objects with null values
- **User Experience**: Eliminates unexpected 422 errors when users don't provide optional parameters that have defaults
- **Backward Compatibility**: Maintains existing behavior for all other scenarios - no breaking changes for current implementations
- **Type Safety**: Preserves different handling semantics across parameter types (STRING vs JSON/BOOLEAN/INTEGER/FLOAT)

</details>

_Created with [Palmier](https://www.palmier.io)_