### PR TITLE
Update API specifications with fern api update

### DIFF
--- a/fern/openapi/skyvern_openapi.json
+++ b/fern/openapi/skyvern_openapi.json
@@ -4394,7 +4394,8 @@
           "html_action",
           "trace",
           "har",
-          "script_file"
+          "script_file",
+          "pdf"
         ],
         "title": "ArtifactType"
       },
@@ -5221,7 +5222,8 @@
           "goto_url",
           "pdf_parser",
           "http_request",
-          "human_interaction"
+          "human_interaction",
+          "print_page"
         ],
         "title": "BlockType"
       },
@@ -8794,6 +8796,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/HttpRequestBlock"
+                },
+                {
+                  "$ref": "#/components/schemas/PrintPageBlock"
                 }
               ],
               "discriminator": {
@@ -8814,6 +8819,7 @@
                   "login": "#/components/schemas/LoginBlock",
                   "navigation": "#/components/schemas/NavigationBlock",
                   "pdf_parser": "#/components/schemas/PDFParserBlock",
+                  "print_page": "#/components/schemas/PrintPageBlock",
                   "send_email": "#/components/schemas/SendEmailBlock",
                   "task": "#/components/schemas/TaskBlock",
                   "task_v2": "#/components/schemas/TaskV2Block",
@@ -9028,6 +9034,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/ConditionalBlockYAML"
+                },
+                {
+                  "$ref": "#/components/schemas/PrintPageBlockYAML"
                 }
               ]
             },
@@ -9258,6 +9267,22 @@
             "title": "Follow Redirects",
             "default": true
           },
+          "download_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Download Filename"
+          },
+          "save_response_as_file": {
+            "type": "boolean",
+            "title": "Save Response As File",
+            "default": false
+          },
           "parameters": {
             "items": {
               "oneOf": [
@@ -9436,6 +9461,22 @@
             "type": "boolean",
             "title": "Follow Redirects",
             "default": true
+          },
+          "download_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Download Filename"
+          },
+          "save_response_as_file": {
+            "type": "boolean",
+            "title": "Save Response As File",
+            "default": false
           },
           "parameter_keys": {
             "anyOf": [
@@ -11710,6 +11751,16 @@
         ],
         "title": "OutputParameterYAML"
       },
+      "PDFFormat": {
+        "type": "string",
+        "enum": [
+          "A4",
+          "Letter",
+          "Legal",
+          "Tabloid"
+        ],
+        "title": "PDFFormat"
+      },
       "PDFParserBlock": {
         "properties": {
           "label": {
@@ -11934,6 +11985,184 @@
           "url"
         ],
         "title": "PortalSessionResponse"
+      },
+      "PrintPageBlock": {
+        "properties": {
+          "label": {
+            "type": "string",
+            "title": "Label",
+            "description": "Author-facing identifier for a block; unique within a workflow."
+          },
+          "next_block_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Block Label",
+            "description": "Optional pointer to the next block label when constructing a DAG. Defaults to sequential order when omitted."
+          },
+          "block_type": {
+            "type": "string",
+            "const": "print_page",
+            "title": "Block Type",
+            "default": "print_page"
+          },
+          "output_parameter": {
+            "$ref": "#/components/schemas/OutputParameter"
+          },
+          "continue_on_failure": {
+            "type": "boolean",
+            "title": "Continue On Failure",
+            "default": false
+          },
+          "model": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "disable_cache": {
+            "type": "boolean",
+            "title": "Disable Cache",
+            "default": false
+          },
+          "next_loop_on_failure": {
+            "type": "boolean",
+            "title": "Next Loop On Failure",
+            "default": false
+          },
+          "include_timestamp": {
+            "type": "boolean",
+            "title": "Include Timestamp",
+            "default": true
+          },
+          "custom_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Custom Filename"
+          },
+          "format": {
+            "type": "string",
+            "title": "Format",
+            "default": "A4"
+          },
+          "landscape": {
+            "type": "boolean",
+            "title": "Landscape",
+            "default": false
+          },
+          "print_background": {
+            "type": "boolean",
+            "title": "Print Background",
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "label",
+          "output_parameter"
+        ],
+        "title": "PrintPageBlock"
+      },
+      "PrintPageBlockYAML": {
+        "properties": {
+          "block_type": {
+            "type": "string",
+            "const": "print_page",
+            "title": "Block Type",
+            "default": "print_page"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label",
+            "description": "Author-facing identifier; must be unique per workflow."
+          },
+          "next_block_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Block Label",
+            "description": "Optional pointer to the label of the next block. When omitted, it will default to sequential order. See [[s-4bnl]]."
+          },
+          "continue_on_failure": {
+            "type": "boolean",
+            "title": "Continue On Failure",
+            "default": false
+          },
+          "model": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "next_loop_on_failure": {
+            "type": "boolean",
+            "title": "Next Loop On Failure",
+            "default": false
+          },
+          "include_timestamp": {
+            "type": "boolean",
+            "title": "Include Timestamp",
+            "default": true
+          },
+          "custom_filename": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Custom Filename"
+          },
+          "format": {
+            "$ref": "#/components/schemas/PDFFormat",
+            "default": "A4"
+          },
+          "landscape": {
+            "type": "boolean",
+            "title": "Landscape",
+            "default": false
+          },
+          "print_background": {
+            "type": "boolean",
+            "title": "Print Background",
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "label"
+        ],
+        "title": "PrintPageBlockYAML"
       },
       "PromptAction": {
         "properties": {
@@ -16595,6 +16824,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/HttpRequestBlock"
+                },
+                {
+                  "$ref": "#/components/schemas/PrintPageBlock"
                 }
               ],
               "discriminator": {
@@ -16615,6 +16847,7 @@
                   "login": "#/components/schemas/LoginBlock",
                   "navigation": "#/components/schemas/NavigationBlock",
                   "pdf_parser": "#/components/schemas/PDFParserBlock",
+                  "print_page": "#/components/schemas/PrintPageBlock",
                   "send_email": "#/components/schemas/SendEmailBlock",
                   "task": "#/components/schemas/TaskBlock",
                   "task_v2": "#/components/schemas/TaskV2Block",
@@ -16627,6 +16860,17 @@
             },
             "type": "array",
             "title": "Blocks"
+          },
+          "finally_block_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finally Block Label"
           }
         },
         "type": "object",
@@ -16764,6 +17008,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/ConditionalBlockYAML"
+                },
+                {
+                  "$ref": "#/components/schemas/PrintPageBlockYAML"
                 }
               ],
               "discriminator": {
@@ -16784,6 +17031,7 @@
                   "login": "#/components/schemas/LoginBlockYAML",
                   "navigation": "#/components/schemas/NavigationBlockYAML",
                   "pdf_parser": "#/components/schemas/PDFParserBlockYAML",
+                  "print_page": "#/components/schemas/PrintPageBlockYAML",
                   "send_email": "#/components/schemas/SendEmailBlockYAML",
                   "task": "#/components/schemas/TaskBlockYAML",
                   "task_v2": "#/components/schemas/TaskV2BlockYAML",
@@ -16796,6 +17044,17 @@
             },
             "type": "array",
             "title": "Blocks"
+          },
+          "finally_block_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finally Block Label"
           }
         },
         "type": "object",


### PR DESCRIPTION
Update API specifications by running fern api update.

---

📋 This PR updates the OpenAPI specification to add new PDF generation capabilities and HTTP request enhancements, introducing a new `print_page` block type and expanding artifact types to support PDF outputs.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **New Block Type**: Added `PrintPageBlock` and `PrintPageBlockYAML` schemas with support for PDF generation from web pages
- **Artifact Types**: Extended `ArtifactType` enum to include "pdf" as a supported output format
- **HTTP Request Enhancement**: Added `download_filename` and `save_response_as_file` parameters to HTTP request blocks
- **PDF Configuration**: Introduced `PDFFormat` enum with standard page sizes (A4, Letter, Legal, Tabloid)
- **Workflow Structure**: Added `finally_block_label` field to workflow definitions for cleanup operations

### Technical Implementation
```mermaid
flowchart TD
    A[Workflow Execution] --> B{Block Type}
    B -->|print_page| C[PrintPageBlock]
    B -->|http_request| D[HttpRequestBlock]
    B -->|other| E[Other Blocks]
    
    C --> F[Configure PDF Settings]
    F --> G[Generate PDF Artifact]
    
    D --> H{Save as File?}
    H -->|Yes| I[Save with Custom Filename]
    H -->|No| J[Return Response]
    
    G --> K[Store as PDF Artifact]
    I --> L[Store as File Artifact]
    J --> M[Continue Workflow]
    K --> M
    L --> M
```

### Impact
- **Enhanced Automation**: Users can now generate PDF documents directly from web pages within workflows
- **File Management**: HTTP requests can save responses as files with custom filenames, improving data handling
- **Workflow Control**: The `finally_block_label` provides better error handling and cleanup capabilities
- **API Completeness**: The specification now covers more comprehensive automation scenarios including document generation

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update API specifications with new block types and properties for print page operations and file downloads.
> 
>   - **New Block Types**:
>     - Added `PrintPageBlock` and `PrintPageBlockYAML` to handle print page operations.
>   - **New Properties**:
>     - Added `download_filename` and `save_response_as_file` properties to support file download operations.
>     - Introduced `finally_block_label` property for block sequencing.
>   - **Enums and Defaults**:
>     - Added `PDFFormat` enum with values `A4`, `Letter`, `Legal`, `Tabloid`.
>     - Set default values for `PrintPageBlock` properties like `format`, `landscape`, and `print_background`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 8dc288fad8f6796d0e95c6fbd3d3561e14b3b7c8. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new print-to-PDF workflow block with configurable page formats (A4, Letter, Legal, Tabloid) and printing options including landscape orientation and background printing
  * Added PDF as a supported artifact type for workflow outputs
  * Enhanced HTTP request handling with the ability to save responses as files and specify custom download filenames
  * Added optional workflow finalization blocks that execute at the end of a workflow definition

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->