### PR TITLE
SDK: filter out empty sessions in use_cloud_browser

### DIFF
--- a/skyvern-ts/client/src/library/Skyvern.ts
+++ b/skyvern-ts/client/src/library/Skyvern.ts
@@ -254,12 +254,13 @@ export class Skyvern extends SkyvernClient {
 
         const browserSessions = await this.getBrowserSessions();
         const browserSession = browserSessions
-            .filter((s) => s.runnable_id == null)
+            .filter((s) => s.runnable_id == null && s.started_at != null && s.browser_address != null)
             .sort((a, b) => {
-                const aTime = a.started_at ? new Date(a.started_at).getTime() : 0;
-                const bTime = b.started_at ? new Date(b.started_at).getTime() : 0;
+                const aTime = new Date(a.started_at!).getTime();
+                const bTime = new Date(b.started_at!).getTime();
                 return bTime - aTime;
-            })[0];
+            })
+            .at(0);
 
         if (!browserSession) {
             LOG.info("No existing cloud browser session found, launching a new session");

--- a/skyvern/library/skyvern.py
+++ b/skyvern/library/skyvern.py
@@ -529,9 +529,12 @@ class Skyvern(AsyncSkyvern):
         """
         self._ensure_cloud_environment()
         browser_sessions = await self.get_browser_sessions()
-        browser_session = max(
-            (s for s in browser_sessions if s.runnable_id is None), key=lambda s: s.started_at, default=None
-        )
+        available_sessions = [
+            s
+            for s in browser_sessions
+            if s.runnable_id is None and s.started_at is not None and s.browser_address is not None
+        ]
+        browser_session = max(available_sessions, key=lambda s: s.started_at, default=None)
         if browser_session is None:
             LOG.info("No existing cloud browser session found, launching a new session")
             browser_session = await self.create_browser_session(


### PR DESCRIPTION
---

🔧 This PR improves the cloud browser session filtering logic in both TypeScript and Python SDKs by adding validation checks to ensure only properly initialized sessions are considered for reuse, preventing potential runtime errors from incomplete session data.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Session Filtering Enhancement**: Added null checks for `started_at` and `browser_address` fields in addition to the existing `runnable_id` filter
- **TypeScript Implementation**: Updated filtering logic in `Skyvern.ts` with non-null assertions and replaced array indexing with `.at(0)` method
- **Python Implementation**: Refactored session filtering into a separate list comprehension with explicit null checks before applying the `max()` function
- **Code Safety**: Eliminated potential runtime errors from attempting to sort or process sessions with missing critical data

### Technical Implementation
```mermaid
flowchart TD
    A[Get Browser Sessions] --> B[Filter Sessions]
    B --> C{Check runnable_id == null}
    C -->|Yes| D{Check started_at != null}
    C -->|No| E[Exclude Session]
    D -->|Yes| F{Check browser_address != null}
    D -->|No| E
    F -->|Yes| G[Include in Available Sessions]
    F -->|No| E
    G --> H[Sort by started_at DESC]
    H --> I[Select Most Recent Session]
    I --> J{Session Found?}
    J -->|Yes| K[Reuse Existing Session]
    J -->|No| L[Create New Session]
```

### Impact
- **Reliability Improvement**: Prevents runtime errors when processing browser sessions with incomplete data
- **Session Management**: Ensures only fully initialized and usable browser sessions are considered for reuse
- **Code Consistency**: Aligns filtering logic between TypeScript and Python implementations with consistent validation rules
- **Error Prevention**: Eliminates potential crashes from null pointer exceptions when accessing session properties during sorting operations

</details>

_Created with [Palmier](https://www.palmier.io)_

---

🔧 This PR improves the cloud browser session filtering logic in both TypeScript and Python SDKs by adding validation checks to ensure only properly initialized sessions are considered for reuse, preventing potential runtime errors from incomplete session data.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Session Filtering Enhancement**: Added null checks for `started_at` and `browser_address` fields in addition to the existing `runnable_id` filter
- **TypeScript Implementation**: Updated filtering logic in `Skyvern.ts` with non-null assertions and replaced array indexing with `.at(0)` method
- **Python Implementation**: Refactored session filtering to use a separate `available_sessions` list with explicit null checks before applying the `max()` function
- **Code Safety**: Eliminated potential runtime errors from attempting to sort or process sessions with missing critical data

### Technical Implementation
```mermaid
flowchart TD
    A[Get Browser Sessions] --> B{Filter Sessions}
    B --> C[Check runnable_id == null]
    C --> D[Check started_at != null]
    D --> E[Check browser_address != null]
    E --> F[Sort by started_at DESC]
    F --> G[Select Most Recent]
    G --> H{Session Found?}
    H -->|Yes| I[Reuse Existing Session]
    H -->|No| J[Create New Session]
```

### Impact
- **Reliability Improvement**: Prevents runtime errors when processing browser sessions with incomplete data
- **Session Management**: Ensures only fully initialized and usable browser sessions are considered for reuse
- **Cross-Platform Consistency**: Maintains identical filtering logic between TypeScript and Python SDK implementations
- **Error Prevention**: Eliminates potential crashes from null/undefined values in session sorting operations

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Filter out empty sessions in `useCloudBrowser` in `Skyvern.ts` and `use_cloud_browser` in `skyvern.py`.
> 
>   - **Behavior**:
>     - In `Skyvern.ts`, `useCloudBrowser` now filters sessions with non-null `started_at` and `browser_address`.
>     - In `skyvern.py`, `use_cloud_browser` filters sessions with non-null `started_at` and `browser_address`.
>   - **Functions**:
>     - `useCloudBrowser` in `Skyvern.ts` and `use_cloud_browser` in `skyvern.py` updated to filter out empty sessions.
>   - **Misc**:
>     - Minor refactoring in `Skyvern.ts` to use `.at(0)` instead of `[0]` for selecting the first session.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a0b9b08218c11feea89ecff30ddddc3d8d6bb3c2. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cloud browser session selection now enforces stricter validation requirements, ensuring only sessions with complete and necessary metadata are reused for improved stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->