### PR TITLE
improve credential ui/ux

### DIFF
--- a/skyvern-frontend/src/routes/credentials/CredentialsModal.tsx
+++ b/skyvern-frontend/src/routes/credentials/CredentialsModal.tsx
@@ -67,12 +67,27 @@ function generateDefaultCredentialName(existingNames: string[]): string {
 
 type Props = {
   onCredentialCreated?: (id: string) => void;
+  /** Optional controlled mode: pass isOpen and onOpenChange to control modal state locally */
+  isOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
 };
 
-function CredentialsModal({ onCredentialCreated }: Props) {
+function CredentialsModal({
+  onCredentialCreated,
+  isOpen: controlledIsOpen,
+  onOpenChange: controlledOnOpenChange,
+}: Props) {
   const credentialGetter = useCredentialGetter();
   const queryClient = useQueryClient();
-  const { isOpen, type, setIsOpen } = useCredentialModalState();
+  const {
+    isOpen: urlIsOpen,
+    type,
+    setIsOpen: setUrlIsOpen,
+  } = useCredentialModalState();
+
+  // Use controlled props if provided, otherwise fall back to URL-based state
+  const isOpen = controlledIsOpen ?? urlIsOpen;
+  const setIsOpen = controlledOnOpenChange ?? setUrlIsOpen;
   const { data: credentials } = useCredentialsQuery({
     page_size: 100,
   });
@@ -120,6 +135,7 @@ function CredentialsModal({ onCredentialCreated }: Props) {
       return response.data;
     },
     onSuccess: (data) => {
+      reset();
       setIsOpen(false);
       queryClient.invalidateQueries({
         queryKey: ["credentials"],

--- a/skyvern-frontend/src/routes/workflows/components/CredentialParameterSourceSelector.tsx
+++ b/skyvern-frontend/src/routes/workflows/components/CredentialParameterSourceSelector.tsx
@@ -10,11 +10,8 @@ import { useCredentialsQuery } from "../hooks/useCredentialsQuery";
 import { useWorkflowParametersStore } from "@/store/WorkflowParametersStore";
 import { WorkflowParameterValueType } from "../types/workflowTypes";
 import { PlusIcon } from "@radix-ui/react-icons";
-import {
-  CredentialModalTypes,
-  useCredentialModalState,
-} from "@/routes/credentials/useCredentialModalState";
 import { CredentialsModal } from "@/routes/credentials/CredentialsModal";
+import { useState } from "react";
 
 type Props = {
   value: string;
@@ -25,7 +22,8 @@ function CredentialParameterSourceSelector({ value, onChange }: Props) {
   const { data: credentials, isFetching } = useCredentialsQuery({
     page_size: 100, // Reasonable limit for dropdown selector
   });
-  const { setIsOpen, setType } = useCredentialModalState();
+  // Use local state for modal to avoid conflicts with other CredentialsModal instances
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const { parameters: workflowParameters } = useWorkflowParametersStore();
   const workflowParametersOfTypeCredentialId = workflowParameters.filter(
     (parameter) =>
@@ -65,8 +63,7 @@ function CredentialParameterSourceSelector({ value, onChange }: Props) {
         value={value}
         onValueChange={(value) => {
           if (value === "new") {
-            setIsOpen(true);
-            setType(CredentialModalTypes.PASSWORD);
+            setIsModalOpen(true);
             return;
           }
           onChange(value);
@@ -90,9 +87,11 @@ function CredentialParameterSourceSelector({ value, onChange }: Props) {
         </SelectContent>
       </Select>
       <CredentialsModal
+        isOpen={isModalOpen}
+        onOpenChange={setIsModalOpen}
         onCredentialCreated={(id) => {
           onChange(id);
-          setIsOpen(false);
+          setIsModalOpen(false);
         }}
       />
     </>

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/ParametersMultiSelect.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/TaskNode/ParametersMultiSelect.tsx
@@ -2,6 +2,10 @@ import { MultiSelect } from "@/components/ui/multi-select";
 import { useWorkflowParametersStore } from "@/store/WorkflowParametersStore";
 import { HelpTooltip } from "@/components/HelpTooltip";
 import { helpTooltips } from "../../helpContent";
+import { useCredentialsQuery } from "@/routes/workflows/hooks/useCredentialsQuery";
+import { useContext, useMemo } from "react";
+import CloudContext from "@/store/CloudContext";
+import { parameterIsSkyvernCredential } from "../../types";
 
 type Props = {
   availableOutputParameters: Array<string>;
@@ -14,17 +18,44 @@ function ParametersMultiSelect({
   parameters,
   onParametersChange,
 }: Props) {
+  const isCloud = useContext(CloudContext);
   const { parameters: workflowParameters } = useWorkflowParametersStore();
+
+  // Fetch credentials to check for orphaned Skyvern credential parameters
+  const { data: credentials = [], isSuccess } = useCredentialsQuery({
+    enabled: isCloud,
+    page_size: 100,
+  });
+
+  // Get the set of credential IDs that exist in the vault
+  const credentialIdsInVault = useMemo(
+    () => new Set(credentials.map((c) => c.credential_id)),
+    [credentials],
+  );
+
   const keys = workflowParameters
     .map((parameter) => parameter.key)
     .concat(availableOutputParameters);
 
-  const options = keys.map((key) => {
-    return {
-      label: key,
-      value: key,
-    };
-  });
+  // Build options with warning labels for orphaned Skyvern credential parameters
+  const options = useMemo(() => {
+    return keys.map((key) => {
+      const param = workflowParameters.find((p) => p.key === key);
+
+      // Check if this is an orphaned Skyvern credential parameter
+      const isOrphanedCredential =
+        isSuccess &&
+        param &&
+        param.parameterType === "credential" &&
+        parameterIsSkyvernCredential(param) &&
+        !credentialIdsInVault.has(param.credentialId);
+
+      return {
+        label: isOrphanedCredential ? `⚠️ ${key} (missing credential)` : key,
+        value: key,
+      };
+    });
+  }, [keys, workflowParameters, isSuccess, credentialIdsInVault]);
 
   return (
     <div className="space-y-2">


### PR DESCRIPTION
### Summary

This PR fixes multiple bugs in the credentials system that caused stale data, confusing UX, and potential workflow failures.

---

### Bug 1: Form fields persist after adding credential

**Problem:** When saving a credential and opening the "Add Credential" modal again, the form fields still contained values from the previous entry.

**Root Cause:** The `reset()` function was only called in `onOpenChange` callback, which isn't triggered when the modal is closed programmatically via `setIsOpen(false)` in the success handler.

**Fix:** Added explicit `reset()` call in the `onSuccess` callback before closing the modal.

**Before:**
<!-- Screenshot showing form with old values after reopening -->
<img width="1567" height="825" alt="image" src="https://github.com/user-attachments/assets/eaef82e2-39e3-460e-bfe6-d8ea28206fc0" />
<img width="1536" height="785" alt="image" src="https://github.com/user-attachments/assets/49cb9731-d4ad-460a-b90f-6483f76b12ae" />


**After:**
<!-- Screenshot showing empty form after reopening -->
<img width="1558" height="783" alt="image" src="https://github.com/user-attachments/assets/e5254507-02ab-4a64-bfee-130fd6599867" />
<img width="1612" height="811" alt="image" src="https://github.com/user-attachments/assets/06e329b7-b9af-4a57-be2c-d00f258bba98" />


---

### Bug 2: Deleted credentials show empty state with no warning

**Problem:** When a credential used in a Login Block is deleted, the credential selector showed an empty state with no indication that something was wrong. Users had no way to know the credential was missing until the workflow failed at runtime.

**Root Cause:** The selector didn't validate whether the referenced credential still existed in the vault.

**Fix:** Added `isCredentialMissing` check that detects when the selected credential doesn't exist, and displays a red warning state with "⚠️ Credential not found" message.

**Before:**
<!-- Screenshot showing empty selector with no warning -->
<img width="505" height="272" alt="image" src="https://github.com/user-attachments/assets/da60189f-cf7a-41dc-999a-665845faa8d8" />
<img width="2387" height="873" alt="image" src="https://github.com/user-attachments/assets/ce3ae203-09cd-4d2b-a6c1-32e856371c26" />
<img width="1523" height="531" alt="image" src="https://github.com/user-attachments/assets/df02cda6-fa50-40a5-b196-ca4dbaa87fd3" />
<img width="2404" height="881" alt="image" src="https://github.com/user-attachments/assets/8d5db05d-07a0-428a-9adc-84e405879d94" />


**After:**
<!-- Screenshot showing red warning "Credential not found" -->
<img width="541" height="389" alt="image" src="https://github.com/user-attachments/assets/74ba9dd8-e490-4ad2-a5c5-5e4b301375ab" />
<img width="2411" height="862" alt="image" src="https://github.com/user-attachments/assets/3ea8bc3e-0d89-4aad-acff-390d9856bafb" />
<img width="1097" height="361" alt="image" src="https://github.com/user-attachments/assets/027776e0-1713-48e5-ae94-d54c8e66e7ce" />
<img width="2423" height="858" alt="image" src="https://github.com/user-attachments/assets/6e7d8b32-1917-48e3-b8b6-cd2b4b6e41ff" />

---

### Bug 3: Credential parameters incorrectly shown in credential dropdown

**Problem:** When a credential was deleted, the orphaned credential parameter (e.g., "credentials") would appear in the credential selector dropdown as if it were a selectable credential. This was confusing because:
- It showed the parameter KEY (like "credentials") instead of the credential name
- It mixed internal implementation details with user-facing options

**Root Cause:** The dropdown options included Skyvern credential parameters that referenced deleted credentials, and also included workflow input parameters of type `credential_id`.

**Fix:** 
- Removed Skyvern credential parameters from dropdown entirely (the actual credentials are already shown)
- Removed workflow input parameters from dropdown (users can add these via the Parameters section)
- Enhanced credential resolution to properly show credential names for workflow parameters with defaults

---

### Bug 4: Adding credential from edit panel creates duplicate parameter

**Problem:** When editing an orphaned credential parameter (one with a missing credential) and clicking "Add new credential" from the edit panel's dropdown, a NEW credential parameter was created instead of assigning the new credential to the existing parameter. The Login Block would then auto-select this new parameter, leaving the original orphaned parameter behind.

**Root Cause:** Both `CredentialsModal` instances (in the edit panel and in the Login Block) shared URL-based state via `useCredentialModalState`. When the modal was opened from the edit panel, both modals would open simultaneously, and the Login Block's `onCredentialCreated` callback would execute, creating a new parameter.

**Fix:**
- Added optional `isOpen` and `onOpenChange` props to `CredentialsModal` for controlled mode
- Updated `CredentialParameterSourceSelector` to use local state instead of shared URL state
- This isolates the edit panel's modal from the Login Block's modal, ensuring only the correct callback runs

### Testing

1. **Bug 1:** Go to `/credentials` → Add Password → Fill and Save → Add Password again → Form should be empty
2. **Bug 2:** Create credential → Use in Login Block → Delete credential → Return to workflow → Should see red warning
3. **Bug 3:** Open Login Block credential dropdown → Should only show actual credentials (no parameter keys)
4. **Bug 4:** Create credential → Use in Login Block → Delete credential → Open Parameters panel → Edit orphaned parameter → Add new credential from dropdown → Should update existing parameter (no new parameter created)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced credential validation to detect missing credentials in vault with visual warning indicators.
  * Improved error handling for unavailable credentials in workflow components, displaying clear warnings to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes credential UI bugs by resetting form states, handling missing credentials, and preventing duplicate parameters, enhancing user experience.
> 
>   - **Behavior**:
>     - Fixes form fields persisting after adding a credential by calling `reset()` in `onSuccess` in `CredentialsModal`.
>     - Adds warning for missing credentials in `LoginBlockCredentialSelector` and `ParametersMultiSelect`.
>     - Prevents duplicate parameters when adding credentials from the edit panel in `CredentialParameterSourceSelector`.
>   - **UI Components**:
>     - `CredentialsModal` now supports controlled open/close state.
>     - `LoginBlockCredentialSelector` and `CredentialParameterSourceSelector` updated to handle missing credentials and prevent duplicate parameters.
>     - `ParametersMultiSelect` shows warning for orphaned Skyvern credentials.
>   - **Misc**:
>     - Refactored credential selection logic to ensure only valid options are shown.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5681e81b7295fe11bdc2e99e132a3b109abc5964. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes multiple critical bugs in the credentials system that were causing stale form data, confusing UX with missing credentials, and duplicate parameter creation issues. The changes improve credential management by adding proper form resets, visual warnings for deleted credentials, and better modal state isolation.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Form State Management**: Added explicit `reset()` call in credential creation success handler to prevent form fields from persisting old values
- **Missing Credential Detection**: Implemented `isCredentialMissing` validation to detect and visually warn users when selected credentials no longer exist
- **Modal State Isolation**: Added controlled mode props (`isOpen`, `onOpenChange`) to `CredentialsModal` to prevent conflicts between multiple modal instances
- **Dropdown Cleanup**: Removed orphaned Skyvern credential parameters from dropdown options and added warning labels for missing credentials in multi-selects

### Technical Implementation
```mermaid
flowchart TD
    A[User Creates Credential] --> B[Form Submission]
    B --> C[Success Handler]
    C --> D[reset() Called]
    C --> E[Modal Closed]
    
    F[Credential Deleted] --> G[Login Block Selector]
    G --> H{Credential Exists?}
    H -->|No| I[Show Red Warning]
    H -->|Yes| J[Show Normal State]
    
    K[Edit Panel Modal] --> L[Local State]
    M[Login Block Modal] --> N[URL State]
    L -.-> O[No Conflicts]
    N -.-> O
```

### Impact
- **User Experience**: Users no longer see confusing empty states or stale form data when managing credentials
- **Error Prevention**: Clear visual warnings prevent workflow failures by alerting users to missing credentials before runtime
- **State Management**: Proper modal isolation prevents duplicate parameter creation and ensures correct callback execution
- **Data Integrity**: Enhanced credential resolution properly handles workflow parameters with default values and external vault credentials

</details>

_Created with [Palmier](https://www.palmier.io)_