### PR TITLE
add action history to action block prompt

### DIFF
--- a/skyvern/forge/prompts/skyvern/single-click-action.j2
+++ b/skyvern/forge/prompts/skyvern/single-click-action.j2
@@ -40,7 +40,12 @@ HTML elements from `{{ current_url }}`:
 ```
 {{ elements }}
 ```
-
+{% if action_history %}
+Consider the action history from the previous steps and the screenshot together, if actions from the previous steps don't yield positive impact, try to take an action on a different element.
+Action history from previous steps:
+```
+{{ action_history }}
+```{% endif %}
 Current datetime, ISO format:
 ```
 {{ local_datetime }}

--- a/skyvern/forge/prompts/skyvern/single-input-action.j2
+++ b/skyvern/forge/prompts/skyvern/single-input-action.j2
@@ -46,7 +46,12 @@ HTML elements from `{{ current_url }}`:
 ```
 {{ elements }}
 ```
-
+{% if action_history %}
+Consider the action history from the previous steps and the screenshot together, if actions from the previous steps don't yield positive impact, try to take an action on a different element.
+Action history from previous steps:
+```
+{{ action_history }}
+```{% endif %}
 Current datetime, ISO format:
 ```
 {{ local_datetime }}

--- a/skyvern/forge/prompts/skyvern/single-select-action.j2
+++ b/skyvern/forge/prompts/skyvern/single-select-action.j2
@@ -47,7 +47,12 @@ HTML elements from `{{ current_url }}`:
 ```
 {{ elements }}
 ```
-
+{% if action_history %}
+Consider the action history from the previous steps and the screenshot together, if actions from the previous steps don't yield positive impact, try to take an action on a different element.
+Action history from previous steps:
+```
+{{ action_history }}
+```{% endif %}
 Current datetime, ISO format:
 ```
 {{ local_datetime }}

--- a/skyvern/forge/prompts/skyvern/single-upload-action.j2
+++ b/skyvern/forge/prompts/skyvern/single-upload-action.j2
@@ -34,7 +34,12 @@ HTML elements from `{{ current_url }}`:
 ```
 {{ elements }}
 ```
-
+{% if action_history %}
+Consider the action history from the previous steps and the screenshot together, if actions from the previous steps don't yield positive impact, try to take an action on a different element.
+Action history from previous steps:
+```
+{{ action_history }}
+```{% endif %}
 Current datetime, ISO format:
 ```
 {{ local_datetime }}


### PR DESCRIPTION
	<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds action history consideration to action prompts for click, input, select, and upload actions.
> 
>   - **New Features**:
>     - Adds action history consideration to `single-click-action.j2`, `single-input-action.j2`, `single-select-action.j2`, and `single-upload-action.j2`.
>     - Displays action history from previous steps in the prompt if available.
>     - Suggests trying a different element if previous actions don't yield positive impact.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 84c5360d57b0e5fc0d82c2dc090bbead03331ae1. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Action history from previous workflow steps is now displayed when available across all action types: click, input, select, and upload. The system now maintains visible historical action records within its operational context, providing a reference of previously completed actions during ongoing workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->