### PR TITLE
Fix HTTP Request block rename not updating the label

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/HttpRequestNode/HttpRequestNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/HttpRequestNode/HttpRequestNode.tsx
@@ -6,7 +6,6 @@ import {
 } from "@/components/ui/accordion";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
-import { useNodeLabelChangeHandler } from "@/routes/workflows/hooks/useLabelChangeHandler";
 import { Handle, NodeProps, Position, useEdges, useNodes } from "@xyflow/react";
 import { useCallback } from "react";
 import { NodeHeader } from "../components/NodeHeader";
@@ -71,11 +70,7 @@ const downloadFilenameTooltip =
   "The complete filename (without extension) for downloaded files. Extension is automatically determined from the response Content-Type.";
 
 function HttpRequestNode({ id, data, type }: NodeProps<HttpRequestNodeType>) {
-  const { editable } = data;
-  const [label] = useNodeLabelChangeHandler({
-    id,
-    initialValue: data.label,
-  });
+  const { editable, label } = data;
   const rerender = useRerender({ prefix: "accordian" });
   const nodes = useNodes<AppNode>();
   const edges = useEdges();


### PR DESCRIPTION
### Summary - [ticket](https://linear.app/skyvern/issue/SKY-7365/cannot-rename-blocks-as-shown-in-loom)
Removed the incorrectly used `useNodeLabelChangeHandler` hook from `HttpRequestNode` component and aligned it with the established pattern used by all other workflow block nodes. The change touches only `HttpRequestNode.tsx` - removing one import and changing how the `label` variable is obtained.

### Problem
Kaitlyn reported users cannot rename blocks in the workflow editor. When attempting to rename, the label would revert to its original value.

Video sent by Kaitlyn showing the issue:
https://www.loom.com/share/cef9687577f54b7fb3cb9c72c5e7c0f7

**Root cause**: During a previous refactor (PR #7739 - "Add debug/play button to HTTP Request workflow block"), the component was updated to use `NodeHeader` instead of an inline `EditableNodeTitle`. However, the `useNodeLabelChangeHandler` hook was left behind from the old implementation.

This created a state synchronization issue:
1. `HttpRequestNode` created a local state via `useNodeLabelChangeHandler` initialized with `data.label`
2. `NodeHeader` (which handles the editable title) has its own internal `useNodeLabelChangeHandler` 
3. When the user renamed the block, `NodeHeader` updated the ReactFlow node data correctly
4. But `HttpRequestNode`'s local state was only initialized once and never synced with the updated `data.label`
5. The stale label was passed back to `NodeHeader`, causing the UI to show the old value

All other 20+ workflow block nodes get `label` directly from `data` props - `HttpRequestNode` was the only one incorrectly using the hook.

### Solution
Changed `HttpRequestNode` to follow the same pattern as all other workflow block nodes:

**Before:**
```tsx
const { editable } = data;
const [label] = useNodeLabelChangeHandler({ id, initialValue: data.label });
```

**After:**
```tsx
const { editable, label } = data;
```

This ensures the label is always sourced from the ReactFlow node data, which `NodeHeader` correctly updates when the user renames the block.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes label update issue in `HttpRequestNode` by removing `useNodeLabelChangeHandler` and using `label` from `data` props.
> 
>   - **Behavior**:
>     - Fixes label update issue in `HttpRequestNode` by removing `useNodeLabelChangeHandler` hook.
>     - Aligns `HttpRequestNode` with other nodes by directly using `label` from `data` props.
>   - **Code Changes**:
>     - Removes `useNodeLabelChangeHandler` import and usage in `HttpRequestNode.tsx`.
>     - Updates `HttpRequestNode` to destructure `label` directly from `data`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b5199f164b9fb2032becbc9f33f209552f24bb1c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal data management in the HTTP Request node editor component to improve code organization and maintainability without affecting functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔧 This PR fixes a critical bug where HTTP Request workflow blocks couldn't be renamed due to a state synchronization issue between two competing label management systems. The fix removes the redundant `useNodeLabelChangeHandler` hook and aligns the component with the established pattern used by all other workflow nodes.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Hook Removal**: Eliminated the `useNodeLabelChangeHandler` import and usage from `HttpRequestNode.tsx`
- **State Management**: Changed from local state management to direct prop consumption (`const { editable, label } = data`)
- **Code Alignment**: Brought `HttpRequestNode` in line with 20+ other workflow block components that correctly use `data.label`

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant NodeHeader
    participant HttpRequestNode
    participant ReactFlow
    
    Note over HttpRequestNode: Before Fix
    User->>NodeHeader: Rename block
    NodeHeader->>ReactFlow: Update node data
    ReactFlow->>HttpRequestNode: Pass updated data
    Note over HttpRequestNode: Uses stale local state
    HttpRequestNode->>NodeHeader: Pass old label
    NodeHeader->>User: Shows reverted name
    
    Note over HttpRequestNode: After Fix
    User->>NodeHeader: Rename block
    NodeHeader->>ReactFlow: Update node data
    ReactFlow->>HttpRequestNode: Pass updated data
    HttpRequestNode->>NodeHeader: Pass data.label directly
    NodeHeader->>User: Shows updated name
```

### Impact
- **Bug Resolution**: Users can now successfully rename HTTP Request blocks without the label reverting
- **Code Consistency**: Eliminates the architectural inconsistency where only `HttpRequestNode` used a different label management pattern
- **State Synchronization**: Removes the dual state management that caused the synchronization issue between `NodeHeader` and `HttpRequestNode`

</details>

_Created with [Palmier](https://www.palmier.io)_