### PR TITLE
enable VNC streaming for task v1 page

### DIFF
--- a/skyvern-frontend/src/api/types.ts
+++ b/skyvern-frontend/src/api/types.ts
@@ -150,6 +150,7 @@ export type TaskApiResponse = {
   max_steps_per_run: number | null;
   task_v2: TaskV2 | null;
   workflow_run_id: string | null;
+  browser_session_id: string | null;
 };
 
 export type CreateTaskRequest = {


### PR DESCRIPTION
<img width="1338" height="846" alt="Screenshot 2026-01-19 at 9 35 27 PM" src="https://github.com/user-attachments/assets/cf7d1d64-ee31-471b-ae1c-dbd76bd07f0f" />


##
Summary
- Add browser VNC streaming support to the task v1 detail page (`/tasks/{taskId}`)
- When `browser_session_id` is available in the task response, display live VNC streaming via `BrowserStream` component
- Fall back to existing screenshot-based WebSocket streaming when no `browser_session_id` is present

## Test plan
- [x] Verify VNC streaming displays on task v1 page when `browser_session_id` is returned from API
- [ ] Verify screenshot-based streaming still works when `browser_session_id` is null
- [ ] Verify stream closes properly and queries are invalidated when VNC connection ends

Closes SKY-7595

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced VNC streaming support for real-time visual monitoring of task execution when available.
  * Implemented intelligent fallback mechanism that switches to screenshot-based streaming when VNC is unavailable, ensuring continuous monitoring capability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable VNC streaming on task v1 page using `BrowserStream` when `browser_session_id` is available, with fallback to screenshot streaming.
> 
>   - **Behavior**:
>     - Add VNC streaming to task v1 page using `BrowserStream` when `browser_session_id` is present in `TaskApiResponse`.
>     - Fall back to screenshot-based WebSocket streaming if `browser_session_id` is absent.
>   - **API Changes**:
>     - Add `browser_session_id` to `TaskApiResponse` in `types.ts`.
>   - **Components**:
>     - Modify `TaskActions.tsx` to use `BrowserStream` for VNC streaming and manage WebSocket connections for screenshot streaming.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 203727c55c6f26af285ed9e80099a11d339242cf. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🖥️ This PR enables VNC streaming for task v1 pages by adding browser session support to the TaskApiResponse type and implementing conditional streaming logic in TaskActions component. When a browser_session_id is available, the component now displays live VNC streaming via BrowserStream, otherwise it falls back to the existing screenshot-based WebSocket streaming.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **API Types**: Added `browser_session_id: string | null` field to `TaskApiResponse` type to support VNC streaming identification
- **Streaming Logic**: Enhanced `TaskActions.tsx` to conditionally use VNC streaming when `browser_session_id` is present, with graceful fallback to screenshot streaming
- **Component Integration**: Integrated `BrowserStream` component with proper aspect ratio (16:9) and query invalidation on stream closure
- **WebSocket Management**: Modified useEffect dependency array and added early return logic to skip screenshot WebSocket when VNC is available

### Technical Implementation
```mermaid
flowchart TD
    A[Task Detail Page Load] --> B{browser_session_id exists?}
    B -->|Yes| C[Use VNC Streaming]
    B -->|No| D[Use Screenshot WebSocket]
    C --> E[Render BrowserStream Component]
    D --> F[Initialize WebSocket Connection]
    E --> G[Display Live VNC Feed]
    F --> H[Display Screenshot Updates]
    G --> I[On Close: Invalidate Queries]
    H --> I
```

### Impact
- **Enhanced User Experience**: Users can now view real-time VNC streaming for tasks with browser sessions, providing better visibility into task execution
- **Backward Compatibility**: Maintains existing screenshot-based streaming for tasks without browser sessions, ensuring no regression
- **Performance Optimization**: Prevents unnecessary WebSocket connections when VNC streaming is available, reducing resource usage
- **Query Management**: Proper query invalidation ensures UI state consistency when streams are closed

</details>

_Created with [Palmier](https://www.palmier.io)_