### PR TITLE
Axis Unblock - slimmer workflow run overview payload

### DIFF
--- a/skyvern/forge/sdk/workflow/context_manager.py
+++ b/skyvern/forge/sdk/workflow/context_manager.py
@@ -284,6 +284,62 @@ class WorkflowRunContext:
             return [self.mask_secrets_in_data(item, mask) for item in data]
         return data
 
+    def build_workflow_run_summary(self) -> dict[str, Any]:
+        """
+        Build a workflow-level summary from per-block outputs.
+
+        Aggregates data across all blocks into a single workflow-level structure
+        suitable for webhook payloads.
+
+        Returns a dict with:
+            - workflow_run_id: The workflow run ID
+            - status: Status from the last block
+            - output.extracted_information: Merged extracted_information from all blocks
+            - downloaded_files: Aggregated list from all blocks
+            - errors: Aggregated list from all blocks
+            - failure_reason: First non-null failure reason found
+        """
+        last_status: str | None = None
+        merged_extracted_information: dict[str, Any] = {}
+        aggregated_downloaded_files: list[Any] = []
+        aggregated_errors: list[Any] = []
+        aggregated_failure_reason: str | None = None
+
+        for _, block_output in self.workflow_run_outputs.items():
+            if not isinstance(block_output, dict):
+                continue
+
+            block_status = block_output.get("status")
+            if block_status:
+                last_status = str(block_status)
+
+            extracted_info = block_output.get("extracted_information")
+            if extracted_info is not None and isinstance(extracted_info, dict):
+                # Merge extracted_information from all blocks together
+                merged_extracted_information.update(extracted_info)
+
+            downloaded_files = block_output.get("downloaded_files")
+            if downloaded_files:
+                aggregated_downloaded_files.extend(downloaded_files)
+
+            errors = block_output.get("errors")
+            if errors:
+                aggregated_errors.extend(errors)
+
+            if aggregated_failure_reason is None:
+                failure_reason = block_output.get("failure_reason")
+                if failure_reason:
+                    aggregated_failure_reason = failure_reason
+
+        return {
+            "workflow_run_id": self.workflow_run_id,
+            "status": last_status,
+            "output": {"extracted_information": merged_extracted_information},
+            "downloaded_files": aggregated_downloaded_files,
+            "errors": aggregated_errors,
+            "failure_reason": aggregated_failure_reason,
+        }
+
     async def get_secrets_from_password_manager(self) -> dict[str, Any]:
         """
         Get the secrets from the password manager. The secrets dict will contain the actual secret values.

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -125,10 +125,9 @@ def _json_type_filter(value: Any) -> str:
     When _render_templates_in_json() detects these markers, it unwraps and
     parses the JSON to get the native typed value (bool, int, list, etc.).
 
-    Args:
-        value: Any JSON-serializable value (bool, int, float, str, list, dict, None).
+    Uses default=str to handle non-JSON-serializable types (datetime, Enum, etc.)
     """
-    return f"{_JSON_TYPE_MARKER}{json.dumps(value)}{_JSON_TYPE_MARKER}"
+    return f"{_JSON_TYPE_MARKER}{json.dumps(value, default=str)}{_JSON_TYPE_MARKER}"
 
 
 jinja_sandbox_env.filters["json"] = _json_type_filter
@@ -397,6 +396,7 @@ class Block(BaseModel, abc.ABC):
             template_data["workflow_run_id"] = workflow_run_context.workflow_run_id
 
         template_data["workflow_run_outputs"] = workflow_run_context.workflow_run_outputs
+        template_data["workflow_run_summary"] = workflow_run_context.build_workflow_run_summary()
 
         if settings.WORKFLOW_TEMPLATING_STRICTNESS == "strict":
             if missing_variables := get_missing_variables(potential_template, template_data):


### PR DESCRIPTION
This is for a ticket marked urgent to unblock Axis. currently, they cannot use the output of the existing ``{{workflow_run_output }}`` directly because it's too long and breaks their make integration. 

The proposed solution between Nazmus and Kaitlyn in these two tickets is to send a slimmer webhook

https://linear.app/skyvern/issue/SKY-7610/longstring-text-workflow-run-outputs-is-returning-incomplete-task
https://linear.app/skyvern/issue/SKY-7585/updating-sheet-issue-data-too-long-misformats-it-so-the-integration

I added a new `{{workflow_run_summary}}`. This achieves a few things:

- has access to workflow_run_id, which they need and `{{workflow_run_outputs}}` did not
- aggregates over multiple blocks. for instance, there is a loop block they use to extract docs. they want all of that in this slimmer payload, so there's aggregation logic as part of this PR.
- leave {{workflow_run_outputs}} untouched because other customers  might want the full output of every block to access with dot notation

I emulated their workflow and this is the output 
https://webhook.site/#!/view/7ec3150a-5dc0-41e9-862f-8b9eb3b74ed4/4d853ed1-a1b7-4876-bd32-a6b9f3f70e39/1

Matching the requested format in the ticket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workflows now generate comprehensive run summaries synthesizing outputs across all blocks, including extracted information, files, and errors
  * Workflow run summaries accessible within template rendering
  * Enhanced JSON serialization to properly handle complex data types such as dates and enums

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `workflow_run_summary` to provide a concise overview of workflow runs, aggregating data across blocks, and improve JSON serialization in templates.
> 
>   - **Behavior**:
>     - Add `build_workflow_run_summary()` in `WorkflowRunContext` in `context_manager.py` to aggregate data across blocks into a summary.
>     - Add `workflow_run_summary` to template data in `format_block_parameter_template_from_workflow_run_context()` in `block.py`.
>     - `workflow_run_summary` includes `workflow_run_id`, last block status, merged `extracted_information`, aggregated `downloaded_files`, `errors`, and first `failure_reason`.
>   - **JSON Serialization**:
>     - Update `_json_type_filter()` in `block.py` to handle non-JSON-serializable types using `default=str`.
>   - **Tests**:
>     - Add unit tests for summary aggregation and JSON serialization behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 1f2c3bad51a3764dd8f80ef29657db99cada2764. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🚀 This PR introduces a new `workflow_run_summary` template variable that provides a consolidated, slimmer payload for webhook integrations, specifically addressing Axis customer's integration issues with overly large workflow outputs that were breaking their Make.com integration.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **New Summary Builder**: Added `build_workflow_run_summary()` method in `context_manager.py` that aggregates data across all workflow blocks into a single consolidated structure
- **Template Integration**: Made `workflow_run_summary` available in Jinja templates alongside existing `workflow_run_outputs`
- **JSON Serialization Enhancement**: Improved `_json_type_filter()` to handle non-JSON-serializable types (datetime, Enum) by converting them to strings using `default=str`

### Technical Implementation
```mermaid
flowchart TD
    A[Workflow Run Context] --> B[build_workflow_run_summary()]
    B --> C[Iterate through workflow_run_outputs]
    C --> D[Extract & Merge Data]
    D --> E[Status from last block]
    D --> F[Merge extracted_information]
    D --> G[Aggregate downloaded_files]
    D --> H[Aggregate errors]
    D --> I[First failure_reason]
    E --> J[Consolidated Summary Object]
    F --> J
    G --> J
    H --> J
    I --> J
    J --> K[Available as {{workflow_run_summary}} in templates]
```

### Impact
- **Customer Unblocking**: Resolves urgent issue for Axis customer whose Make.com integration was failing due to oversized payloads
- **Data Aggregation**: Enables access to consolidated data across multiple workflow blocks (especially useful for loop blocks)
- **Backward Compatibility**: Preserves existing `{{workflow_run_outputs}}` functionality for other customers who need detailed per-block access
- **Enhanced Templating**: Improves JSON serialization robustness by handling edge cases with non-standard data types

</details>

_Created with [Palmier](https://www.palmier.io)_