### PR TITLE
Store screenshot artifacts, generate URLs when needed

### DIFF
--- a/skyvern/forge/sdk/db/agent_db.py
+++ b/skyvern/forge/sdk/db/agent_db.py
@@ -1325,6 +1325,30 @@ class AgentDB(BaseAlchemyDB):
             LOG.exception("UnexpectedError")
             raise
 
+    async def get_artifacts_by_ids(
+        self,
+        artifact_ids: list[str],
+        organization_id: str,
+    ) -> list[Artifact]:
+        if not artifact_ids:
+            return []
+        try:
+            async with self.Session() as session:
+                artifacts = (
+                    await session.scalars(
+                        select(ArtifactModel)
+                        .filter(ArtifactModel.artifact_id.in_(artifact_ids))
+                        .filter_by(organization_id=organization_id)
+                    )
+                ).all()
+                return [convert_to_artifact(artifact, self.debug_enabled) for artifact in artifacts]
+        except SQLAlchemyError:
+            LOG.exception("SQLAlchemyError")
+            raise
+        except Exception:
+            LOG.exception("UnexpectedError")
+            raise
+
     async def get_artifacts_by_entity_id(
         self,
         *,

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -404,13 +404,15 @@ class TaskOutput(BaseModel):
     downloaded_file_urls: list[str] | None = None  # For backward compatibility
     task_screenshots: list[str] | None = None
     workflow_screenshots: list[str] | None = None
+    task_screenshot_artifact_ids: list[str] | None = None
+    workflow_screenshot_artifact_ids: list[str] | None = None
 
     @staticmethod
     def from_task(
         task: Task,
         downloaded_files: list[FileInfo] | None = None,
-        task_screenshots: list[str] | None = None,
-        workflow_screenshots: list[str] | None = None,
+        task_screenshot_artifact_ids: list[str] | None = None,
+        workflow_screenshot_artifact_ids: list[str] | None = None,
     ) -> TaskOutput:
         # For backward compatibility, extract just the URLs from FileInfo objects
         downloaded_file_urls = [file_info.url for file_info in downloaded_files] if downloaded_files else None
@@ -423,8 +425,8 @@ class TaskOutput(BaseModel):
             errors=task.errors,
             downloaded_files=downloaded_files,
             downloaded_file_urls=downloaded_file_urls,
-            task_screenshots=task_screenshots,
-            workflow_screenshots=workflow_screenshots,
+            task_screenshot_artifact_ids=task_screenshot_artifact_ids,
+            workflow_screenshot_artifact_ids=workflow_screenshot_artifact_ids,
         )
 
 

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -944,11 +944,11 @@ class BaseTaskBlock(Block):
                 except asyncio.TimeoutError:
                     LOG.warning("Timeout getting downloaded files", task_id=updated_task.task_id)
 
-                task_screenshots = await app.WORKFLOW_SERVICE.get_recent_task_screenshot_urls(
+                task_screenshot_artifacts = await app.WORKFLOW_SERVICE.get_recent_task_screenshot_artifacts(
                     organization_id=workflow_run.organization_id,
                     task_id=updated_task.task_id,
                 )
-                workflow_screenshots = await app.WORKFLOW_SERVICE.get_recent_workflow_screenshot_urls(
+                workflow_screenshot_artifacts = await app.WORKFLOW_SERVICE.get_recent_workflow_screenshot_artifacts(
                     workflow_run_id=workflow_run_id,
                     organization_id=workflow_run.organization_id,
                 )
@@ -956,8 +956,8 @@ class BaseTaskBlock(Block):
                 task_output = TaskOutput.from_task(
                     updated_task,
                     downloaded_files,
-                    task_screenshots=task_screenshots,
-                    workflow_screenshots=workflow_screenshots,
+                    task_screenshot_artifact_ids=[a.artifact_id for a in task_screenshot_artifacts],
+                    workflow_screenshot_artifact_ids=[a.artifact_id for a in workflow_screenshot_artifacts],
                 )
                 output_parameter_value = task_output.model_dump()
                 await self.record_output_parameter_value(workflow_run_context, workflow_run_id, output_parameter_value)
@@ -1020,11 +1020,11 @@ class BaseTaskBlock(Block):
                 except asyncio.TimeoutError:
                     LOG.warning("Timeout getting downloaded files", task_id=updated_task.task_id)
 
-                task_screenshots = await app.WORKFLOW_SERVICE.get_recent_task_screenshot_urls(
+                task_screenshot_artifacts = await app.WORKFLOW_SERVICE.get_recent_task_screenshot_artifacts(
                     organization_id=workflow_run.organization_id,
                     task_id=updated_task.task_id,
                 )
-                workflow_screenshots = await app.WORKFLOW_SERVICE.get_recent_workflow_screenshot_urls(
+                workflow_screenshot_artifacts = await app.WORKFLOW_SERVICE.get_recent_workflow_screenshot_artifacts(
                     workflow_run_id=workflow_run_id,
                     organization_id=workflow_run.organization_id,
                 )
@@ -1032,8 +1032,8 @@ class BaseTaskBlock(Block):
                 task_output = TaskOutput.from_task(
                     updated_task,
                     downloaded_files,
-                    task_screenshots=task_screenshots,
-                    workflow_screenshots=workflow_screenshots,
+                    task_screenshot_artifact_ids=[a.artifact_id for a in task_screenshot_artifacts],
+                    workflow_screenshot_artifact_ids=[a.artifact_id for a in workflow_screenshot_artifacts],
                 )
                 LOG.warning(
                     f"Task failed with status {updated_task.status}{retry_message}",
@@ -3965,11 +3965,11 @@ class TaskV2Block(Block):
 
         # If continue_on_failure is True, we treat the block as successful even if the task failed
         # This allows the workflow to continue execution despite this block's failure
-        task_screenshots = await app.WORKFLOW_SERVICE.get_recent_task_screenshot_urls(
+        task_screenshot_artifacts = await app.WORKFLOW_SERVICE.get_recent_task_screenshot_artifacts(
             organization_id=organization_id,
             task_v2_id=task_v2.observer_cruise_id,
         )
-        workflow_screenshots = await app.WORKFLOW_SERVICE.get_recent_workflow_screenshot_urls(
+        workflow_screenshot_artifacts = await app.WORKFLOW_SERVICE.get_recent_workflow_screenshot_artifacts(
             workflow_run_id=workflow_run_id,
             organization_id=organization_id,
         )
@@ -3980,8 +3980,8 @@ class TaskV2Block(Block):
             "summary": task_v2.summary,
             "extracted_information": result_dict,
             "failure_reason": failure_reason,
-            "task_screenshots": task_screenshots,
-            "workflow_screenshots": workflow_screenshots,
+            "task_screenshot_artifact_ids": [a.artifact_id for a in task_screenshot_artifacts],
+            "workflow_screenshot_artifact_ids": [a.artifact_id for a in workflow_screenshot_artifacts],
         }
         await self.record_output_parameter_value(workflow_run_context, workflow_run_id, task_v2_output)
         return await self.build_block_result(

--- a/skyvern/services/script_service.py
+++ b/skyvern/services/script_service.py
@@ -638,11 +638,11 @@ async def _update_workflow_block(
             except asyncio.TimeoutError:
                 LOG.warning("Timeout getting downloaded files", task_id=task_id)
 
-            task_screenshots = await app.WORKFLOW_SERVICE.get_recent_task_screenshot_urls(
+            task_screenshot_artifacts = await app.WORKFLOW_SERVICE.get_recent_task_screenshot_artifacts(
                 organization_id=context.organization_id,
                 task_id=task_id,
             )
-            workflow_screenshots = await app.WORKFLOW_SERVICE.get_recent_workflow_screenshot_urls(
+            workflow_screenshot_artifacts = await app.WORKFLOW_SERVICE.get_recent_workflow_screenshot_artifacts(
                 workflow_run_id=context.workflow_run_id,
                 organization_id=context.organization_id,
             )
@@ -650,8 +650,8 @@ async def _update_workflow_block(
             task_output = TaskOutput.from_task(
                 updated_task,
                 downloaded_files,
-                task_screenshots=task_screenshots,
-                workflow_screenshots=workflow_screenshots,
+                task_screenshot_artifact_ids=[a.artifact_id for a in task_screenshot_artifacts],
+                workflow_screenshot_artifact_ids=[a.artifact_id for a in workflow_screenshot_artifacts],
             )
             final_output = task_output.model_dump()
             step_for_billing: Step | None = None


### PR DESCRIPTION
Now stores `task_screenshot_artifact_ids` and `workflow_screenshot_artifact_ids` in DB, generates fresh URLs at response time. from a local run:
<img width="915" height="699" alt="Screenshot 2026-01-20 at 10 18 18 PM" src="https://github.com/user-attachments/assets/c4126131-5c2f-4ac7-a1a5-6ef4c8b0fcb9" />


```
  "task_screenshots": [
    "https://skyvern-artifacts.s3.amazonaws.com/v1/local/o_486530294570550846/tsk_486587699061506714/01_0_stp_486587754896081618/2026-01-21T06%3A09%3A31.629175_a_486587888040068174_screenshot_final.png?AWSAccessKeyId=AKIAWZTLR3KLOPGK5YOU&Signature=Wik1qCD80ROqPPKRfWdfMVh7sfk%3D&Expires=1769062208"
```

that link works to download (local run was clicking first link on hacker news page):
<img width="900" height="603" alt="Screenshot 2026-01-20 at 10 19 19 PM" src="https://github.com/user-attachments/assets/2adacb22-b9c2-45a9-a2c8-683763218ac5" />



<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor screenshot handling to store artifact IDs and generate URLs on demand, ensuring backward compatibility.
> 
>   - **Behavior**:
>     - Store `task_screenshot_artifact_ids` and `workflow_screenshot_artifact_ids` in DB instead of URLs in `tasks.py`.
>     - Generate presigned URLs at response time using `_generate_urls_from_artifact_ids()` in `service.py`.
>     - Backward compatibility: regenerate URLs from `task_id` if only URLs are present.
>   - **Database**:
>     - Add `get_artifacts_by_ids()` in `agent_db.py` to fetch artifacts by ID.
>   - **Workflow Execution**:
>     - Update `execute()` in `block.py` to use artifact IDs and generate URLs.
>     - Modify `TaskOutput.from_task()` to handle artifact IDs instead of URLs.
>   - **Service Methods**:
>     - Add `_refresh_output_screenshot_urls()` in `service.py` to update outputs with fresh URLs.
>     - Rename `get_recent_task_screenshot_urls()` to `get_recent_task_screenshot_artifacts()` in `service.py` and similar for workflow screenshots.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d585dd2bdd722cf6b6aa0ed37778906c7640615b. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented artifact-based screenshot management system for enhanced storage and retrieval.
  * Added automatic refresh mechanism for screenshot URLs to prevent expiration.
  * Enabled backward compatibility with existing screenshot data formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔄 This PR refactors screenshot management to store artifact IDs instead of URLs in the database and generate fresh presigned URLs dynamically at response time. This change addresses the issue of expired presigned URLs while maintaining backward compatibility with existing data.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Database Layer**: Added `get_artifacts_by_ids()` method to fetch multiple artifacts by their IDs in a single query
- **Schema Updates**: Modified `TaskOutput` to store `task_screenshot_artifact_ids` and `workflow_screenshot_artifact_ids` instead of direct URLs
- **Service Layer**: Split screenshot methods into artifact-fetching and URL-generating variants, with new `_generate_urls_from_artifact_ids()` and `_refresh_output_screenshot_urls()` methods
- **Workflow Execution**: Updated all workflow block execution paths to use artifact IDs instead of URLs when storing task outputs

### Technical Implementation
```mermaid
sequenceDiagram
    participant WF as Workflow
    participant SVC as WorkflowService
    participant DB as Database
    participant AM as ArtifactManager
    
    WF->>SVC: get_recent_task_screenshot_artifacts()
    SVC->>DB: get_artifacts_by_entity_id()
    DB-->>SVC: Return Artifact objects
    SVC-->>WF: Return artifacts with IDs
    WF->>WF: Store artifact_ids in TaskOutput
    
    Note over WF,AM: Later, when generating response...
    
    WF->>SVC: _refresh_output_screenshot_urls()
    SVC->>SVC: _generate_urls_from_artifact_ids()
    SVC->>DB: get_artifacts_by_ids()
    DB-->>SVC: Return Artifact objects
    SVC->>AM: get_share_links()
    AM-->>SVC: Return fresh presigned URLs
    SVC-->>WF: Updated output with fresh URLs
```

### Impact
- **URL Freshness**: Eliminates expired presigned URL issues by generating them on-demand at response time
- **Storage Efficiency**: Stores stable artifact IDs instead of time-sensitive URLs in the database
- **Backward Compatibility**: Maintains support for existing data with old URL format through fallback logic in `_refresh_output_screenshot_urls()`
- **Performance**: Batch artifact fetching with `get_artifacts_by_ids()` reduces database queries when processing multiple screenshots

</details>

_Created with [Palmier](https://www.palmier.io)_