### PR TITLE
retry otp webhook call

### DIFF
--- a/skyvern/services/otp_service.py
+++ b/skyvern/services/otp_service.py
@@ -127,7 +127,12 @@ async def _get_otp_value_from_url(
     )
     try:
         json_resp = await aiohttp_post(
-            url=url, str_data=signed_data.signed_payload, headers=signed_data.headers, raise_exception=False
+            url=url,
+            str_data=signed_data.signed_payload,
+            headers=signed_data.headers,
+            raise_exception=False,
+            retry=2,
+            retry_timeout=5,
         )
     except Exception as e:
         LOG.error("Failed to get otp value from url", exc_info=True)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced OTP retrieval reliability with automatic retry logic—up to 2 attempts with 5-second intervals between retries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds retry mechanism to `_get_otp_value_from_url()` in `otp_service.py` for improved OTP delivery reliability.
> 
>   - **Behavior**:
>     - Adds retry mechanism to `_get_otp_value_from_url()` in `otp_service.py` with 2 retries and 5-second timeout for OTP webhook calls.
>   - **Misc**:
>     - Improves OTP delivery reliability by handling failed requests with automatic retries.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 99d5f07eca2523f36b4902800b1211d9ac37016a. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔄 This PR enhances the reliability of OTP webhook calls by adding automatic retry functionality to handle transient network failures and improve delivery success rates.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Retry Logic**: Added `retry=2` parameter to the `aiohttp_post` call in `_get_otp_value_from_url()` function
- **Timeout Configuration**: Introduced `retry_timeout=5` parameter to control the delay between retry attempts
- **Error Resilience**: Enhanced the existing error handling to work in conjunction with the new retry mechanism

### Technical Implementation
```mermaid
sequenceDiagram
    participant OTP as OTP Service
    participant HTTP as aiohttp_post
    participant Webhook as External Webhook
    
    OTP->>HTTP: Initial webhook call
    HTTP->>Webhook: POST request
    Webhook-->>HTTP: Network failure/timeout
    HTTP->>HTTP: Wait 5 seconds
    HTTP->>Webhook: Retry attempt 1
    Webhook-->>HTTP: Network failure/timeout
    HTTP->>HTTP: Wait 5 seconds
    HTTP->>Webhook: Retry attempt 2
    Webhook->>HTTP: Success response
    HTTP->>OTP: Return OTP value
```

### Impact
- **Reliability Improvement**: Reduces OTP delivery failures caused by temporary network issues or webhook endpoint unavailability
- **User Experience**: Minimizes authentication flow interruptions by automatically recovering from transient failures
- **Operational Stability**: Decreases the likelihood of manual intervention needed for OTP-related issues while maintaining reasonable timeout bounds

</details>

_Created with [Palmier](https://www.palmier.io)_