### PR TITLE
remove credential value type from input parameter dropdown

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParameterEditPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParameterEditPanel.tsx
@@ -46,7 +46,6 @@ const workflowParameterTypeOptions = [
   { label: "integer", value: WorkflowParameterValueType.Integer },
   { label: "boolean", value: WorkflowParameterValueType.Boolean },
   { label: "file", value: WorkflowParameterValueType.FileURL },
-  { label: "credential", value: WorkflowParameterValueType.CredentialId },
   { label: "JSON", value: WorkflowParameterValueType.JSON },
 ];
 


### PR DESCRIPTION
## Summary - [ticket](https://linear.app/skyvern/issue/SKY-7652/remove-credential-value-type-from-input-parameter-dropdown)

Remove the "credential" option from the Value Type dropdown in the Add Input Parameter form to avoid confusion with the dedicated Credential Parameter option.

## What was the problem

The Add Parameter menu has a separate "Credential Parameter" option for configuring credentials, but the Add Input Parameter form also included a "credential" value type in the Value Type dropdown. This was confusing because:

- Users might select "credential" as a value type instead of using the proper "Credential Parameter" option
- The credential value type in input parameters had limited functionality compared to the dedicated Credential Parameter
- Having two ways to add credentials created uncertainty about which approach to use

## What changed

- Removed the `{ label: "credential", value: WorkflowParameterValueType.CredentialId }` option from the `workflowParameterTypeOptions` array in `WorkflowParameterEditPanel.tsx`

Now credential configuration is only available through the dedicated "Credential Parameter" option in the Add Parameter menu.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove `credential` option from `workflowParameterTypeOptions` in `WorkflowParameterEditPanel.tsx` to avoid confusion with dedicated Credential Parameter option.
> 
>   - **Behavior**:
>     - Removed `credential` option from `workflowParameterTypeOptions` in `WorkflowParameterEditPanel.tsx` to prevent confusion with the dedicated "Credential Parameter" option.
>   - **UI**:
>     - Dropdown in Add Input Parameter form no longer includes `credential` as a value type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 45d5a82ff5e310024241c64e7a44741fa5494458. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR removes the "credential" option from the Value Type dropdown in the workflow parameter editor to eliminate user confusion and enforce the use of the dedicated "Credential Parameter" option. The change simplifies the UI by providing a single, clear path for credential configuration.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **UI Simplification**: Removed the `credential` option from `workflowParameterTypeOptions` array in `WorkflowParameterEditPanel.tsx`
- **User Experience**: Eliminated duplicate credential configuration paths that were causing confusion
- **Code Cleanup**: Single line removal that streamlines the parameter type selection interface

### Technical Implementation
```mermaid
flowchart TD
    A[Add Parameter Menu] --> B[Input Parameter]
    A --> C[Credential Parameter]
    B --> D[Value Type Dropdown]
    D --> E[string]
    D --> F[integer]
    D --> G[boolean]
    D --> H[file]
    D --> I[JSON]
    D -.-> J[credential - REMOVED]
    
    style J fill:#ffcccc,stroke:#ff0000,stroke-dasharray: 5 5
    style C fill:#ccffcc,stroke:#00aa00
```

### Impact
- **User Clarity**: Users now have only one clear path for adding credentials through the dedicated "Credential Parameter" option
- **Reduced Confusion**: Eliminates the ambiguity between two different credential configuration methods
- **Consistent UX**: Ensures all credential-related functionality is accessed through the proper dedicated interface with full feature support

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed credential as a selectable parameter type option in workflow parameter configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->