### PR TITLE
Make otp type also selectable in the totp endpoint

### DIFF
--- a/skyvern/forge/prompts/skyvern/parse-otp-login.j2
+++ b/skyvern/forge/prompts/skyvern/parse-otp-login.j2
@@ -1,8 +1,13 @@
-You receive either an email or a text message containing an OTP(like TOTP, Magic Link) to verify the login. Your job is to parse the content, identify the OTP type and value. There should be only one OTP type and one OTP value in the content. The value must be from the content
+You receive either an email or a text message containing an OTP(like TOTP, Magic Link) to verify the login. Your job is to parse the content, identify the OTP type and value. The value must be from the content.
+{% if enforced_otp_type %}
+IMPORTANT: The user has specified they expect a "{{ enforced_otp_type }}" type OTP. You MUST extract the {{ enforced_otp_type }} value from the content, even if other OTP types are present. Ignore any other OTP types in the content. If no {{ enforced_otp_type }} is found, set otp_value_found to false.
+{% else %}
+There should be only one OTP type and one OTP value in the content.
+{% endif %}
 
 You should follow the rules below to identify the OTP type and value:
 - If it's a Magic Link login, the value is usually a link which must be a valid HTTP or HTTPS URL.
-- If it's a TOTP login, The most common value is a code which is a series of digits, although sometimes it may contain letters. 
+- If it's a TOTP login, The most common value is a code which is a series of digits, although sometimes it may contain letters.
 
 MAKE SURE YOU OUTPUT VALID JSON. No text before or after JSON, no trailing commas, no comments (//), no unnecessary quotes, etc.
 

--- a/skyvern/forge/sdk/routes/credentials.py
+++ b/skyvern/forge/sdk/routes/credentials.py
@@ -113,10 +113,10 @@ async def send_totp_code(
         if not workflow_run:
             raise HTTPException(status_code=400, detail=f"Invalid workflow run id: {data.workflow_run_id}")
     content = data.content.strip()
-    otp_value: OTPValue | None = OTPValue(value=content, type=OTPType.TOTP)
+    otp_value: OTPValue | None = OTPValue(value=content, type=data.type or OTPType.TOTP)
     # We assume the user is sending the code directly when the length of code is less than or equal to 10
     if len(content) > 10:
-        otp_value = await parse_otp_login(content, curr_org.organization_id)
+        otp_value = await parse_otp_login(content, curr_org.organization_id, enforced_otp_type=data.type)
 
     if not otp_value:
         LOG.error(

--- a/skyvern/forge/sdk/schemas/totp_codes.py
+++ b/skyvern/forge/sdk/schemas/totp_codes.py
@@ -47,6 +47,11 @@ class TOTPCodeBase(BaseModel):
     )
 
 
+class OTPType(StrEnum):
+    TOTP = "totp"
+    MAGIC_LINK = "magic_link"
+
+
 class TOTPCodeCreate(TOTPCodeBase):
     totp_identifier: str = Field(
         ...,
@@ -58,17 +63,17 @@ class TOTPCodeCreate(TOTPCodeBase):
         description="The content of the TOTP code. It can be the email content that contains the TOTP code, or the sms message that contains the TOTP code. Skyvern will automatically extract the TOTP code from the content.",
         examples=["Hello, your verification code is 123456"],
     )
+    type: OTPType | None = Field(
+        default=None,
+        description="Optional. If provided, forces extraction of this specific OTP type (totp or magic_link). Use this when the content contains multiple OTP types and you want to specify which one to extract.",
+        examples=["totp", "magic_link"],
+    )
 
     @field_validator("content")
     @classmethod
     def sanitize_content(cls, value: str) -> str:
         """Remove NUL (0x00) bytes from content to avoid PostgreSQL DataError."""
         return sanitize_postgres_text(value)
-
-
-class OTPType(StrEnum):
-    TOTP = "totp"
-    MAGIC_LINK = "magic_link"
 
 
 class TOTPCode(TOTPCodeCreate):

--- a/skyvern/services/otp_service.py
+++ b/skyvern/services/otp_service.py
@@ -36,12 +36,20 @@ class OTPResultParsedByLLM(BaseModel):
     otp_value: str | None = Field(None, description="The OTP value.")
 
 
-async def parse_otp_login(content: str, organization_id: str) -> OTPValue | None:
-    prompt = prompt_engine.load_prompt("parse-otp-login", content=content)
+async def parse_otp_login(
+    content: str,
+    organization_id: str,
+    enforced_otp_type: OTPType | None = None,
+) -> OTPValue | None:
+    prompt = prompt_engine.load_prompt(
+        "parse-otp-login",
+        content=content,
+        enforced_otp_type=enforced_otp_type.value if enforced_otp_type else None,
+    )
     resp = await app.SECONDARY_LLM_API_HANDLER(
         prompt=prompt, prompt_name="parse-otp-login", organization_id=organization_id
     )
-    LOG.info("OTP Login Parser Response", resp=resp)
+    LOG.info("OTP Login Parser Response", resp=resp, enforced_otp_type=enforced_otp_type)
     otp_result = OTPResultParsedByLLM.model_validate(resp)
     if otp_result.otp_value_found and otp_result.otp_value:
         return OTPValue(value=otp_result.otp_value, type=otp_result.otp_type)


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for specifying OTP type in TOTP endpoint, enhancing OTP extraction precision.
> 
>   - **Behavior**:
>     - Added `enforced_otp_type` parameter to `parse_otp_login()` in `otp_service.py` to enforce specific OTP type extraction.
>     - Updated `send_totp_code()` in `credentials.py` to use `enforced_otp_type` for OTP parsing.
>   - **Schemas**:
>     - Added `type` field to `TOTPCodeCreate` in `totp_codes.py` to specify OTP type.
>     - Moved `OTPType` enum to top of `totp_codes.py` for better organization.
>   - **Templates**:
>     - Modified `parse-otp-login.j2` to handle `enforced_otp_type` logic for OTP extraction.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for b1b382f46a97989683ca056025ca7859bb4c7d20. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying OTP type during authentication, enabling more accurate parsing of different OTP methods.
  * Enhanced OTP parsing for longer content inputs with explicit type enforcement.

* **Bug Fixes**
  * Improved validation logic to ensure more deterministic OTP parsing results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔧 This PR enhances the TOTP endpoint by adding support for specifying OTP type selection, allowing users to enforce extraction of specific OTP types (TOTP or Magic Link) when content contains multiple authentication methods. The changes improve precision in OTP parsing by introducing an optional `type` parameter that guides the LLM to extract the desired OTP format.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **API Schema Enhancement**: Added optional `type` field to `TOTPCodeCreate` schema allowing users to specify preferred OTP type (TOTP or Magic Link)
- **Prompt Template Logic**: Modified `parse-otp-login.j2` to conditionally enforce specific OTP type extraction when `enforced_otp_type` is provided
- **Service Layer Updates**: Enhanced `parse_otp_login` function to accept and process `enforced_otp_type` parameter
- **Route Handler Modification**: Updated `send_totp_code` endpoint to utilize the new type parameter for OTP processing

### Technical Implementation
```mermaid
sequenceDiagram
    participant Client
    participant API as credentials.py
    participant Service as otp_service.py
    participant LLM as Prompt Engine
    
    Client->>API: POST /totp with content & type
    API->>API: Check content length
    alt Content > 10 chars
        API->>Service: parse_otp_login(content, org_id, enforced_type)
        Service->>LLM: Process with enforced_otp_type prompt
        LLM->>Service: Return parsed OTP
        Service->>API: OTPValue with specified type
    else Content <= 10 chars
        API->>API: Create OTPValue directly with specified type
    end
    API->>Client: Return processed OTP
```

### Impact
- **Improved Accuracy**: Users can now specify which OTP type to extract when content contains multiple authentication methods
- **Enhanced Flexibility**: The endpoint maintains backward compatibility while adding new functionality for type-specific extraction
- **Better User Experience**: Reduces ambiguity in OTP parsing by allowing explicit type specification, especially useful for automated workflows

</details>

_Created with [Palmier](https://www.palmier.io)_