### PR TITLE
fix workflow version comparison to show older version on left

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowHistoryPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowHistoryPanel.tsx
@@ -67,7 +67,11 @@ function WorkflowHistoryPanel({ workflowPermanentId, onCompare }: Props) {
 
   const handleCompare = (mode: "visual" | "json" = "visual") => {
     if (selectedVersions.size === 2 && versions) {
-      const selectedVersionsArray = Array.from(selectedVersions);
+      // Sort ascending so older version (lower number) is first, newer is second
+      // This matches standard diff convention: old on left, new on right
+      const selectedVersionsArray = Array.from(selectedVersions).sort(
+        (a, b) => a - b,
+      );
       const version1 = versions.find(
         (v) => v.version === selectedVersionsArray[0],
       );


### PR DESCRIPTION
## Summary - [ticket](https://linear.app/skyvern/issue/SKY-7649/reverse-order-of-workflow-history-comparison-panels)
Reverses the order of workflow version comparison panels so older versions appear on the left and newer versions on the right, matching standard diff tool conventions.



## Problem
In the workflow version comparison view, the newer version was displayed on the left and the older version on the right. This is counterintuitive since most diff tools show the base/older version on the left and the changed/newer version on the right. 


## What Changed:
- Modified WorkflowHistoryPanel.tsx to sort selected versions ascending by version number before passing to the comparison drawer
- This ensures version1 (left panel) is always the older version and version2 (right panel) is always the newer version, regardless of selection order
## Screenshots
### Before

<img width="2698" height="1752" alt="image" src="https://github.com/user-attachments/assets/b6e8bb48-0ca8-48c5-a730-75d4fbf73bbe" />

### After


<img width="1921" height="736" alt="image" src="https://github.com/user-attachments/assets/9bb070e0-62a7-4f67-a77d-d4e173fd7322" />
<img width="1919" height="874" alt="image" src="https://github.com/user-attachments/assets/8a617d7b-d679-4eea-8030-8dbbece9c31b" />
<img width="1941" height="590" alt="image" src="https://github.com/user-attachments/assets/f0bed4c6-2815-436d-801d-d27ac0386694" />

---

🔄 This PR fixes the workflow version comparison display order to follow standard diff conventions by ensuring older versions appear on the left panel and newer versions on the right panel. The change sorts selected versions in ascending order before comparison, regardless of the user's selection order.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Version Sorting Logic**: Added ascending sort `(a, b) => a - b` to the selected versions array before comparison
- **UI Convention Alignment**: Ensures version1 (left panel) is always the older version and version2 (right panel) is the newer version
- **User Experience**: Maintains consistent diff presentation regardless of which version the user selects first

### Technical Implementation
```mermaid
flowchart TD
    A[User selects 2 versions] --> B[selectedVersions Set]
    B --> C[Convert to Array]
    C --> D[Sort ascending by version number]
    D --> E[version1 = lower number<br/>version2 = higher number]
    E --> F[Display: Old on Left, New on Right]
    
    style D fill:#e1f5fe
    style F fill:#c8e6c9
```

### Impact
- **User Experience**: Aligns with standard diff tool conventions (git diff, IDE comparisons, etc.) making it more intuitive
- **Consistency**: Eliminates confusion about which version is being compared as the "base" vs "changed"
- **Backward Compatibility**: No breaking changes - existing functionality remains intact, only the display order is corrected

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes version comparison order in `WorkflowHistoryPanel.tsx` to display older version on the left, aligning with diff tool conventions.
> 
>   - **Behavior**:
>     - In `WorkflowHistoryPanel.tsx`, modified `handleCompare()` to sort `selectedVersions` in ascending order by version number.
>     - Ensures older version is always on the left and newer version on the right in comparison view.
>   - **Misc**:
>     - Added comments in `handleCompare()` to explain sorting logic and its purpose.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for f5323c6d5aa6e244e0186deecdf00abaf4955c2c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version comparison in workflow history to ensure consistent ordering during diffs, with the older version always displayed first.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->