### PR TITLE
Fix TypeError comparing offset-naive and offset-aware datetimes (#SKY-7663)

### DIFF
--- a/skyvern/webeye/schemas.py
+++ b/skyvern/webeye/schemas.py
@@ -122,9 +122,11 @@ class BrowserSessionResponse(BaseModel):
                 )
 
             # Sort downloaded files by modified_at in descending order (newest first)
-            downloaded_files.sort(key=lambda x: x.modified_at or datetime.min, reverse=True)
+            # Treat None as "oldest".
+            downloaded_files.sort(key=lambda f: (f.modified_at is not None, f.modified_at), reverse=True)
             # Sort recordings by modified_at in descending order (newest first)
-            recordings.sort(key=lambda x: x.modified_at or datetime.min, reverse=True)
+            # Treat None as "oldest".
+            recordings.sort(key=lambda f: (f.modified_at is not None, f.modified_at), reverse=True)
 
         return cls(
             browser_session_id=browser_session.persistent_browser_session_id,


### PR DESCRIPTION
## Summary

- Fixes `TypeError: can't compare offset-naive and offset-aware datetimes` errors in production
- The error occurred in `BrowserSessionResponse.from_browser_session()` when sorting downloaded files and recordings by `modified_at`

## Root Cause

The code was using `datetime.min` as a fallback value for sorting when `modified_at` was None:

```python
downloaded_files.sort(key=lambda x: x.modified_at or datetime.min, reverse=True)
```

`datetime.min` is offset-naive (no timezone info), but `modified_at` values from S3's `LastModified` are offset-aware (UTC). Python cannot compare naive and aware datetimes.

## Fix

Use the established tuple sorting pattern already used in `local.py`, `s3.py`, and `azure.py`:

```python
# Treat None as "oldest".
downloaded_files.sort(key=lambda f: (f.modified_at is not None, f.modified_at), reverse=True)
```

This pattern:
- Uses tuple sorting where `False` (None values) sorts before `True` (non-None values)
- Places None values last when using `reverse=True`
- Avoids the naive/aware datetime comparison entirely
- Maintains consistency with the rest of the codebase

## Test plan

- [x] Pre-commit hooks pass
- [ ] Deploy and verify Datadog no longer shows these TypeErrors

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sorting of downloaded files and recordings to reliably handle cases where modification dates are unavailable, ensuring proper display order.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix `TypeError` in `from_browser_session()` by changing sorting method to handle naive/aware datetime comparison.
> 
>   - **Bug Fix**:
>     - Fix `TypeError` in `from_browser_session()` in `schemas.py` by changing sorting method for `downloaded_files` and `recordings`.
>     - Use tuple sorting pattern to handle `None` values and avoid naive/aware datetime comparison.
>     - Ensures `None` values are treated as oldest and sorted last with `reverse=True`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 5b3eb84056dbab3296e565e35f80ffb7c26addf1. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🐛 Fixes a TypeError that occurred when comparing offset-naive and offset-aware datetimes during sorting operations in the BrowserSessionResponse class. The PR replaces problematic `datetime.min` fallback values with a tuple-based sorting approach that properly handles None values without timezone comparison issues.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Sorting Logic**: Replaced `datetime.min` fallback with tuple-based sorting `(f.modified_at is not None, f.modified_at)` for both downloaded files and recordings
- **Error Prevention**: Eliminates TypeError when comparing timezone-naive `datetime.min` with timezone-aware S3 `LastModified` timestamps
- **Code Consistency**: Aligns with existing sorting patterns already used in `local.py`, `s3.py`, and `azure.py` modules

### Technical Implementation
```mermaid
flowchart TD
    A[BrowserSessionResponse.from_browser_session] --> B{Sort downloaded_files}
    B --> C[Old: x.modified_at or datetime.min]
    B --> D[New: tuple sorting pattern]
    C --> E[TypeError: naive vs aware datetime]
    D --> F[Success: None treated as oldest]
    
    A --> G{Sort recordings}
    G --> H[Old: x.modified_at or datetime.min]
    G --> I[New: tuple sorting pattern]
    H --> J[TypeError: naive vs aware datetime]
    I --> K[Success: None treated as oldest]
```

### Impact
- **Bug Resolution**: Eliminates production TypeError exceptions that were occurring during file and recording sorting operations
- **Sorting Behavior**: Maintains descending order (newest first) while properly handling None values by treating them as oldest entries
- **Code Maintainability**: Improves consistency across the codebase by using the established tuple sorting pattern used in other storage modules

</details>

_Created with [Palmier](https://www.palmier.io)_