### PR TITLE
Preserve field names for unchanged blocks during schema regeneration (#SKY-7434)

### DIFF
--- a/skyvern/forge/prompts/skyvern/generate-workflow-parameters.j2
+++ b/skyvern/forge/prompts/skyvern/generate-workflow-parameters.j2
@@ -8,6 +8,9 @@ Given a list of input_text, upload_file and select_option actions with their int
 3. If multiple actions use the same text value, they should map to the same field name
 4. Field names should be concise but clear about what data they represent
 5. Avoid generic names like "field1", "input1" - use meaningful names based on the intention
+{% if has_existing_fields %}
+6. CRITICAL: Some actions have existing field names that MUST be preserved exactly as specified. These field names are used by cached code and changing them will break the workflow. You MUST use the exact existing field name for these actions.
+{% endif %}
 
 ## Actions:
 {% for action in custom_field_actions %}
@@ -15,6 +18,8 @@ Action {{ loop.index }}:
 - Action type: "{{ action.action_type }}"
 - Value: "{{ action.value }}"
 - Intention: "{{ action.intention }}"
+{% if action.existing_field_name %}- EXISTING FIELD NAME (MUST PRESERVE): "{{ action.existing_field_name }}"
+{% endif %}
 {% endfor %}
 
 ## Expected Output:
@@ -32,7 +37,7 @@ Return a JSON object with the following structure:
       "description": "Description of what this field represents"
     },
     "field_name_2": {
-      "type": "str", 
+      "type": "str",
       "description": "Description of what this field represents"
     },
     ...
@@ -44,5 +49,7 @@ Where:
 - `field_mappings` maps each action index (1-based) to its corresponding field name
 - `schema_fields` defines each unique field with its type and description
 - Actions with the same text value should map to the same field name
+{% if has_existing_fields %}- Actions with an existing field name MUST use that exact field name in both `field_mappings` and `schema_fields`
+{% endif %}
 
 Generate the field names now:


### PR DESCRIPTION
	## Summary
- Fixes cache issue where login block schema mismatches when cache is regenerated
- When a user adds a new block but keeps existing blocks unchanged, the LLM was generating new field names for all actions, causing mismatches with cached code that referenced the old field names
- Now passes existing field names from cached blocks to the LLM prompt, instructing it to preserve those exact names

## Changes
- `generate_workflow_parameters.py`: Accept `existing_field_assignments` parameter to pass preserved field names
- `generate-workflow-parameters.j2`: Updated prompt to include existing field names with "MUST PRESERVE" instructions
- `generate_script.py`: Added `_build_existing_field_assignments()` helper to collect field names from unchanged cached blocks

## Test plan
- [ ] Deploy to staging and test with a workflow that has cached blocks
- [ ] Add a new block to an existing workflow with cached login block
- [ ] Verify the login block's field names are preserved in the regenerated schema

Linear: https://linear.app/skyvern/issue/SKY-7434

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Preserves existing field names for unchanged blocks during schema regeneration to prevent mismatches with cached code.
> 
>   - **Behavior**:
>     - Preserves existing field names for unchanged blocks during schema regeneration to prevent mismatches with cached code.
>     - Updates LLM prompt in `generate-workflow-parameters.j2` to include instructions for preserving existing field names.
>   - **Functions**:
>     - Adds `_build_existing_field_assignments()` in `generate_script.py` to map action indices to existing field names.
>     - Modifies `generate_workflow_parameters_schema()` in `generate_workflow_parameters.py` to accept `existing_field_assignments`.
>   - **Misc**:
>     - Updates `generate_workflow_parameters.py` to handle existing field names in `_generate_field_names_with_llm()`.
>     - Minor updates to docstrings and comments for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 571255581826bd75236c9846e298a105187d408d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preservation of existing external field names when regenerating workflow schemas so prior field names are reused exactly.

* **Bug Fixes**
  * Prevents schema/code mismatches with cached or unchanged blocks and improves consistency of parameter assignments across regenerations.

* **Tests**
  * Added tests covering field-name preservation and end-to-end regeneration behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->