### PR TITLE
fix: disable uvicorn reload on Windows to fix async event loop issue

### DIFF
--- a/skyvern/forge/__main__.py
+++ b/skyvern/forge/__main__.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import structlog
 import uvicorn
@@ -16,7 +17,9 @@ if __name__ == "__main__":
     LOG.info("Agent server starting.", host="0.0.0.0", port=port)
     load_dotenv()
 
-    reload = settings.ENV == "local"
+    # Disable reload on Windows - uvicorn forces WindowsSelectorEventLoopPolicy when reload=True,
+    # but Windows needs WindowsProactorEventLoopPolicy for async subprocess operations
+    reload = settings.ENV == "local" and sys.platform != "win32"
 
     # Configure reload settings
     # Convert TEMP_PATH to relative path if it's absolute to avoid pathlib.glob() issues


### PR DESCRIPTION
	## Summary - [SKY-7678](https://linear.app/skyvern/issue/SKY-7678/async-event-loop-issue-on-windows) - [OSS Issue #3012](https://github.com/Skyvern-AI/skyvern/issues/3012)

Fixes a Windows-specific compatibility issue where uvicorn's hot-reload functionality conflicts with async subprocess operations. When `reload=True`, uvicorn forces the use of `WindowsSelectorEventLoopPolicy`, but Skyvern's workflows require `WindowsProactorEventLoopPolicy` for async subprocess operations. This PR disables hot-reload on Windows while preserving it on Linux and macOS.

## Problem

On Windows, uvicorn's reload mechanism forces the event loop to use `WindowsSelectorEventLoopPolicy`. However, Skyvern's workflow engine uses async subprocess operations that require `WindowsProactorEventLoopPolicy` to function correctly. This mismatch causes runtime errors when workflows attempt to spawn subprocesses asynchronously on Windows.

The conflict only exists on Windows because Linux and macOS use different event loop implementations that don't have this compatibility issue.

## What Changed

- Added `sys.platform != "win32"` check to the reload condition in `skyvern/forge/__main__.py`
- Hot-reload now only enables when `ENV == "local"` AND the platform is not Windows
- Added inline comment explaining the Windows-specific event loop policy conflict
- Linux and macOS development environments retain hot-reload functionality

## Test plan

- [ ] Start Skyvern on Windows in local mode - verify server starts without hot-reload
- [ ] Start Skyvern on Linux/macOS in local mode - verify hot-reload is still enabled
- [ ] Execute workflows with async subprocess operations on Windows - verify they work without event loop errors
- [ ] Verify production deployments (ENV != "local") are unaffected on all platforms

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted development server auto-reload behavior: automatic reload is now enabled only in local development when the platform supports it, and disabled on Windows to avoid compatibility issues with the event loop and async subprocess handling. This reduces crashes and instability during local development.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->