### PR TITLE
Add JSON and URL validation for HTTP Request Block

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/HttpRequestNode/HttpRequestNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/HttpRequestNode/HttpRequestNode.tsx
@@ -39,7 +39,12 @@ import { CodeIcon, PlusIcon, MagicWandIcon } from "@radix-ui/react-icons";
 import { WorkflowBlockParameterSelect } from "../WorkflowBlockParameterSelect";
 import { CurlImportDialog } from "./CurlImportDialog";
 import { QuickHeadersDialog } from "./QuickHeadersDialog";
-import { MethodBadge, UrlValidator, RequestPreview } from "./HttpUtils";
+import {
+  MethodBadge,
+  UrlValidator,
+  RequestPreview,
+  JsonValidator,
+} from "./HttpUtils";
 import { useRerender } from "@/hooks/useRerender";
 import { useRecordingStore } from "@/store/useRecordingStore";
 import { cn } from "@/util/utils";
@@ -271,6 +276,7 @@ function HttpRequestNode({ id, data, type }: NodeProps<HttpRequestNodeType>) {
               minHeight="80px"
               maxHeight="160px"
             />
+            <JsonValidator value={data.headers} />
           </div>
 
           {/* Body Section */}
@@ -312,6 +318,7 @@ function HttpRequestNode({ id, data, type }: NodeProps<HttpRequestNodeType>) {
                 minHeight="100px"
                 maxHeight="200px"
               />
+              <JsonValidator value={data.body} />
             </div>
           )}
 
@@ -333,6 +340,7 @@ function HttpRequestNode({ id, data, type }: NodeProps<HttpRequestNodeType>) {
                 minHeight="80px"
                 maxHeight="160px"
               />
+              <JsonValidator value={data.files} />
             </div>
           )}
 

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/HttpRequestNode/HttpUtils.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/HttpRequestNode/HttpUtils.tsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 import { toast } from "@/components/ui/use-toast";
 import { copyText } from "@/util/copyText";
 import { cn } from "@/util/utils";
+import { validateUrl, validateJson } from "./httpValidation";
 
 // HTTP Method Badge Component
 export function MethodBadge({
@@ -56,23 +57,34 @@ export function MethodBadge({
 
 // URL Validation Component
 export function UrlValidator({ url }: { url: string }) {
-  const isValidUrl = (urlString: string) => {
-    if (!urlString.trim()) return { valid: false, message: "URL is required" };
-
-    try {
-      const url = new URL(urlString);
-      if (!["http:", "https:"].includes(url.protocol)) {
-        return { valid: false, message: "URL must use HTTP or HTTPS protocol" };
-      }
-      return { valid: true, message: "Valid URL" };
-    } catch {
-      return { valid: false, message: "Invalid URL format" };
-    }
-  };
-
-  const validation = isValidUrl(url);
+  const validation = validateUrl(url);
 
   if (!url.trim()) return null;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-1 text-xs",
+        validation.valid
+          ? "text-green-600 dark:text-green-400"
+          : "text-red-600 dark:text-red-400",
+      )}
+    >
+      {validation.valid ? (
+        <CheckCircledIcon className="h-3 w-3" />
+      ) : (
+        <ExclamationTriangleIcon className="h-3 w-3" />
+      )}
+      <span>{validation.message}</span>
+    </div>
+  );
+}
+
+// JSON Validation Component
+export function JsonValidator({ value }: { value: string }) {
+  const validation = validateJson(value);
+
+  if (validation.message === null) return null;
 
   return (
     <div

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/HttpRequestNode/httpValidation.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/HttpRequestNode/httpValidation.ts
@@ -1,0 +1,36 @@
+import { TSON } from "@/util/tson";
+
+// URL Validation Helper
+export function validateUrl(url: string): { valid: boolean; message: string } {
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return { valid: false, message: "URL is required" };
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      return { valid: false, message: "URL must use HTTP or HTTPS protocol" };
+    }
+    return { valid: true, message: "Valid URL" };
+  } catch {
+    return { valid: false, message: "Invalid URL format" };
+  }
+}
+
+// JSON Validation Helper
+export function validateJson(value: string): {
+  valid: boolean;
+  message: string | null;
+} {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === "{}" || trimmed === "[]") {
+    return { valid: true, message: null };
+  }
+
+  const result = TSON.parse(trimmed);
+  if (result.success) {
+    return { valid: true, message: "Valid JSON" };
+  }
+  return { valid: false, message: result.error || "Invalid JSON" };
+}


### PR DESCRIPTION
	## Summary - [SKY-7351](https://linear.app/skyvern/issue/SKY-7351/http-request-block-allows-saving-invalid-json-without-error)

Add validation for HTTP Request Block to prevent saving workflows with invalid JSON or URLs. Users now get real-time feedback while editing and are blocked from saving invalid configurations.

## Problem
The HTTP Request Block allowed users to save workflows with invalid JSON in Headers/Body/Files fields and invalid or empty URLs. Users had no way to know their input was malformed until the workflow failed at runtime.

## What Changed
- Added `JsonValidator` component showing inline validation feedback (green checkmark for valid, red warning for invalid)
- Added save-time validation in `getWorkflowErrors()` for HTTP Request blocks
- URL: required and must be valid http/https format
- Headers/Body/Files: optional, but must be valid JSON if provided
- Uses TSON validation to support Jinja template variables like `{{ parameter }}`

## Test plan
- [ ] Enter invalid JSON in Headers field - verify inline error appears
- [ ] Enter valid JSON - verify green checkmark appears
- [ ] Enter JSON with template variable like `{"key": {{ param }}}` - verify it passes validation
- [ ] Try to save workflow with empty URL - verify save is blocked
- [ ] Try to save workflow with invalid JSON - verify save is blocked
- [ ] Save workflow with valid URL and valid/empty JSON - verify save succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add JSON and URL validation to HTTP Request Block with real-time feedback and save-time checks.
> 
>   - **Validation**:
>     - Added `JsonValidator` and `UrlValidator` components in `HttpUtils.tsx` for inline validation feedback.
>     - Updated `HttpRequestNode.tsx` to use `JsonValidator` for headers, body, and files fields, and `UrlValidator` for URL field.
>     - Enhanced `getWorkflowErrors()` in `workflowEditorUtils.ts` to include JSON and URL validation for HTTP Request blocks.
>   - **Behavior**:
>     - Blocks saving workflows with invalid JSON in headers, body, or files, and invalid or empty URLs.
>     - Supports Jinja template variables in JSON validation using TSON.
>   - **Misc**:
>     - Refactored URL validation logic into `validateUrl()` function in `HttpUtils.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern-cloud&utm_source=github&utm_medium=referral)<sup> for 204b30ca89773811d280133bf7a68f6d9f37a55f. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline JSON validation with feedback for HTTP request headers, body, and file fields.
  * URL validation with visual status and descriptive messages.

* **Enhancements**
  * Workflow-level validation now includes HTTP request URL and JSON checks to surface errors earlier and improve workflow integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->