### PR TITLE
Add SOP-to-blocks endpoint for workflow editor - backend

### DIFF
--- a/skyvern/forge/prompts/skyvern/build-workflow-from-pdf.j2
+++ b/skyvern/forge/prompts/skyvern/build-workflow-from-pdf.j2
@@ -1,5 +1,22 @@
 You are an AI assistant that converts Standard Operating Procedures (SOP) from text into a Skyvern workflow definition in JSON format.
 
+FIRST: Evaluate if this content contains procedural instructions.
+
+A valid SOP MUST contain:
+- Step-by-step instructions telling someone what to DO
+- Action verbs like: go to, click, navigate, enter, fill, submit, download, extract, etc.
+- Sequential steps for completing a task
+
+Note: A document may include reference materials (like sample invoices, screenshots, or examples) alongside instructions - this is still a valid SOP as long as it contains procedural steps.
+
+If the content has NO procedural instructions (just data, information, or documents without steps), return ONLY this JSON:
+{
+  "error": "not_sop",
+  "reason": "This document does not contain procedural instructions or steps to automate."
+}
+
+If the content DOES contain procedural instructions, proceed with the conversion below.
+
 REQUIRED OUTPUT FORMAT:
 Return a JSON object with this structure:
 {
@@ -68,7 +85,7 @@ CRITICAL INSTRUCTIONS - READ CAREFULLY:
 9. **AVOID VALIDATION BLOCKS**: Use "extraction" blocks for data extraction. Only use "validation" if explicitly validating previous extracted data, and always include complete_criterion.
 10. Set continue_on_failure to false for critical steps, true for optional ones
 11. Set engine to "skyvern-1.0" for all blocks that need it
-12. Use clear, descriptive labels that match the SOP terminology
+12. Use SHORT descriptive labels (1-5 words, snake_case): e.g., "login", "extract_date_data", "submit_google_login_form". Avoid long labels.
 
 EXAMPLES OF THOROUGHNESS:
 - If SOP says "Navigate to page X, then click button Y, then fill form Z" → Create 3 separate blocks

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -665,6 +665,76 @@ async def _validate_file_size(file: UploadFile) -> UploadFile:
 
 
 @legacy_base_router.post(
+    "/workflows/sop-to-blocks",
+    response_model=dict[str, Any],
+    include_in_schema=False,
+)
+@legacy_base_router.post(
+    "/workflows/sop-to-blocks/",
+    response_model=dict[str, Any],
+    include_in_schema=False,
+)
+async def convert_sop_to_blocks(
+    file: UploadFile = Depends(_validate_file_size),
+    current_org: Organization = Depends(org_auth_service.get_current_org),
+) -> dict[str, Any]:
+    """Convert a PDF SOP to workflow blocks without creating a workflow."""
+    analytics.capture(
+        "skyvern-oss-workflow-sop-to-blocks",
+        data={"organization_id": current_org.organization_id},
+    )
+
+    # Validate PDF
+    if not file.filename or not file.filename.lower().endswith(".pdf"):
+        raise HTTPException(status_code=400, detail="Only PDF files are supported.")
+
+    try:
+        file_contents = await file.read()
+        file_name = file.filename
+    finally:
+        await file.close()
+
+    # Extract text from PDF
+    sop_text = await asyncio.to_thread(
+        pdf_import_service.extract_text_from_pdf,
+        file_contents,
+        file_name,
+    )
+
+    # Convert to workflow definition via LLM
+    try:
+        result = await pdf_import_service.create_workflow_from_sop_text(sop_text, current_org)
+    except HTTPException:
+        raise
+    except Exception as e:
+        LOG.exception(
+            "Failed to convert SOP to blocks",
+            organization_id=current_org.organization_id,
+            filename=file_name,
+        )
+        raise HTTPException(
+            status_code=422,
+            detail="Failed to convert SOP to workflow blocks. Please verify the PDF content and try again.",
+        ) from e
+
+    workflow_def = result.get("workflow_definition", {})
+
+    # Transform blocks: convert parameter_keys (backend format) to parameters (frontend format)
+    # This is done here rather than in _sanitize_workflow_json because the import-pdf endpoint
+    # needs the backend format for WorkflowCreateYAMLRequest validation
+    # Create shallow copies to avoid mutating shared data structures
+    blocks = [dict(block) for block in workflow_def.get("blocks", [])]
+    for block in blocks:
+        parameter_keys = block.pop("parameter_keys", None) or []
+        block["parameters"] = [{"key": key} for key in parameter_keys]
+
+    return {
+        "blocks": blocks,
+        "parameters": workflow_def.get("parameters", []),
+    }
+
+
+@legacy_base_router.post(
     "/workflows/import-pdf",
     response_model=dict[str, Any],
     tags=["agent"],


### PR DESCRIPTION
## Summary - [SKY-7680](https://linear.app/skyvern/issue/SKY-7680)

Adds a new backend endpoint `POST /workflows/sop-to-blocks` that converts PDF Standard Operating Procedures into workflow blocks without creating a workflow. This enables the workflow editor's "Upload SOP" feature to preview and edit generated blocks before saving.

## Changes

### New Endpoint: `POST /workflows/sop-to-blocks`
- Accepts PDF file upload, returns `{blocks: [...], parameters: [...]}`
- Hidden from API docs (`include_in_schema=False`) - internal use only
- Reuses existing `pdf_import_service` methods for PDF parsing and LLM conversion
- Transforms `parameter_keys` to `parameters` array format for frontend compatibility
- Includes analytics tracking event `skyvern-oss-workflow-sop-to-blocks`

### Non-SOP Content Detection
- LLM prompt first evaluates if content contains procedural instructions
- Documents without actionable steps (invoices, reports, etc.) are rejected with user-friendly error
- Documents with reference materials alongside instructions are still accepted

### Block Label Sanitization
- Replaces whitespace in block labels with underscores (matches frontend behavior)
- Ensures labels are valid identifiers before returning to frontend

### Prompt Improvement
- Updated LLM prompt to generate shorter, snake_case labels (1-5 words)
- Examples: "login", "extract_date_data", "submit_google_login_form"

### Error Handling & Safety
- Try-except around LLM call with proper logging and user-friendly error messages
- Shallow copy of blocks before mutation to avoid modifying shared data structures

## Test Plan
- [x] Upload valid PDF SOP - blocks and parameters returned correctly
- [x] Upload non-SOP document (invoice) - returns appropriate rejection message
- [x] Verify response time is reasonable (5-15 seconds)
- [x] Test invalid file format (non-PDF) - returns 400 error
- [x] Test corrupted PDF - returns appropriate error
- [x] Verify endpoint requires authentication
- [x] Confirm no workflow records created in database
- [x] Verify analytics event is captured
- [x] Block labels are sanitized (no spaces)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to convert PDF documents to workflow definitions via new upload endpoint
  * Automatically generate workflow blocks from uploaded Standard Operating Procedure files

* **Improvements**
  * Enhanced label formatting requirements: now requires concise labels (1-5 words) in snake_case format
  * Improved validation and error handling for PDF uploads
  * Better detection of invalid or non-compliant document content

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->