### PR TITLE
Fix AttributeError in _wait_for_page_ready_before_action

### DIFF
--- a/skyvern/core/script_generations/script_skyvern_page.py
+++ b/skyvern/core/script_generations/script_skyvern_page.py
@@ -546,10 +546,11 @@ class ScriptSkyvernPage(SkyvernPage):
         3. DOM stability (no significant mutations for 300ms)
         """
         try:
-            if not self._page:
+            # Note: SkyvernPage uses self.page, not self._page
+            if not self.page:
                 return
 
-            skyvern_frame = await SkyvernFrame.create_instance(frame=self._page)
+            skyvern_frame = await SkyvernFrame.create_instance(frame=self.page)
             await skyvern_frame.wait_for_page_ready(
                 network_idle_timeout_ms=settings.PAGE_READY_NETWORK_IDLE_TIMEOUT_MS,
                 loading_indicator_timeout_ms=settings.PAGE_READY_LOADING_INDICATOR_TIMEOUT_MS,

--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -2456,8 +2456,23 @@ class ForgeAgent:
                     break
                 except (FailedToTakeScreenshot, ScrapingFailed) as e:
                     if idx < len(SCRAPE_TYPE_ORDER) - 1:
+                        LOG.warning(
+                            "Scrape attempt failed, will retry with next strategy",
+                            attempt=idx + 1,
+                            scrape_type=scrape_type.value if hasattr(scrape_type, "value") else str(scrape_type),
+                            error_type=e.__class__.__name__,
+                            url=task.url,
+                        )
                         continue
-                    LOG.exception(f"{e.__class__.__name__} happened in two normal attempts and reload-page retry")
+                    LOG.error(
+                        "All scrape attempts failed",
+                        total_attempts=len(SCRAPE_TYPE_ORDER),
+                        error_type=e.__class__.__name__,
+                        url=task.url,
+                        step_order=step.order,
+                        step_retry=step.retry_index,
+                        exc_info=True,
+                    )
                     raise e
 
         if scraped_page is None:


### PR DESCRIPTION
## Summary

- Fix critical bug where `self._page` was used instead of `self.page` in `_wait_for_page_ready_before_action`
- **Added diagnostic logging** for screenshot timeouts to help debug Flinks issues

## Bug Fix

The `SkyvernPage` class uses `self.page` but `_wait_for_page_ready_before_action` was checking `self._page` which doesn't exist. This caused every cached script action to log:
```
AttributeError: 'ScriptSkyvernPage' object has no attribute '_page'
```

## Added Logging for Screenshot Diagnostics

### Screenshot timeout now logs context:
```
Screenshot timeout | timeout_ms=3000 | url=https://... | viewport=1920x1080 | full_page=False | mode=detailed
```

### Scrape retry attempts now logged:
```
Scrape attempt failed, will retry with next strategy | attempt=1 | scrape_type=normal | error_type=FailedToTakeScreenshot | url=...
Scrape attempt failed, will retry with next strategy | attempt=2 | scrape_type=normal | error_type=FailedToTakeScreenshot | url=...
All scrape attempts failed | total_attempts=3 | error_type=FailedToTakeScreenshot | url=... | step_order=0 | step_retry=1
```

This will help identify:
- **Which URLs** are causing timeouts
- **What timeout value** is actually being used
- **Page viewport size** (large pages may timeout)
- **Which retry attempt** failed
- **Step context** (order and retry index)

## Test plan

- [ ] Deploy to staging and verify logs appear correctly
- [ ] Have Nick deploy and check if new logs provide insight into slowness
- [ ] Monitor for patterns in failing URLs/viewport sizes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error logging for screenshot and scraping operations with improved diagnostic context.

* **Chores**
  * Internal refactoring to improve code consistency and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix `AttributeError` in `ScriptSkyvernPage` and enhance logging for screenshot and scrape diagnostics.
> 
>   - **Bug Fix**:
>     - Fix `AttributeError` in `ScriptSkyvernPage._wait_for_page_ready_before_action` by using `self.page` instead of `self._page`.
>   - **Logging Enhancements**:
>     - Add detailed logging for screenshot timeouts in `_current_viewpoint_screenshot_helper()` in `page.py`.
>     - Log scrape retry attempts and failures in `build_and_record_step_prompt()` in `agent.py` with context like URL and error type.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 48c131a02fcf5391b3aaf9643524da04b9bacdb8. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🐛 This PR fixes a critical AttributeError in the `_wait_for_page_ready_before_action` method by correcting the page attribute reference from `self._page` to `self.page`. Additionally, it enhances diagnostic logging for screenshot timeouts and scraping retry attempts to improve debugging capabilities for performance issues.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Bug Fix**: Corrected attribute reference in `ScriptSkyvernPage._wait_for_page_ready_before_action` from non-existent `self._page` to proper `self.page`
- **Enhanced Logging**: Added comprehensive diagnostic logging for screenshot timeouts with URL, viewport, and timeout context
- **Scraping Diagnostics**: Improved logging for scrape retry attempts and failures with detailed error context and step information

### Technical Implementation
```mermaid
sequenceDiagram
    participant SP as ScriptSkyvernPage
    participant SF as SkyvernFrame
    participant Page as Browser Page
    
    SP->>SP: _wait_for_page_ready_before_action()
    SP->>SP: Check if self.page exists (fixed from self._page)
    SP->>SF: create_instance(frame=self.page)
    SF->>Page: wait_for_page_ready()
    Page-->>SF: Ready state
    SF-->>SP: Completion
    
    Note over SP: Previously failed with AttributeError
    Note over SP: Now works correctly with self.page
```

### Impact
- **Stability Improvement**: Eliminates AttributeError exceptions that were occurring on every cached script action
- **Enhanced Debugging**: Screenshot timeouts now log comprehensive context including URL, viewport size, timeout values, and error details
- **Better Monitoring**: Scraping retry attempts are now properly logged with attempt counts, error types, and step context for easier troubleshooting
- **Operational Visibility**: Teams can now identify patterns in failing URLs, viewport sizes, and timeout scenarios to optimize performance

</details>

_Created with [Palmier](https://www.palmier.io)_