### PR TITLE
set default browser locale to none

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -126,7 +126,7 @@ class Settings(BaseSettings):
     SMTP_PASSWORD: str = "password"
 
     # browser settings
-    BROWSER_LOCALE: str = "en-US"
+    BROWSER_LOCALE: str | None = None  # "en-US"
     BROWSER_TIMEZONE: str = "America/New_York"
     BROWSER_WIDTH: int = 1920
     BROWSER_HEIGHT: int = 1080

--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -237,7 +237,6 @@ class BrowserContextFactory:
             LOG.info("Extensions added to browser args", extensions=joined_paths)
 
         args = {
-            "locale": settings.BROWSER_LOCALE,
             "color_scheme": "no-preference",
             "args": browser_args,
             "ignore_default_args": [
@@ -251,6 +250,8 @@ class BrowserContextFactory:
             },
             "extra_http_headers": extra_http_headers,
         }
+        if settings.BROWSER_LOCALE:
+            args["locale"] = settings.BROWSER_LOCALE
 
         if settings.ENABLE_PROXY:
             proxy_config = setup_proxy()


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Browser locale configuration is now optional. The system will only apply a locale setting when explicitly configured, allowing the browser to use system defaults when no locale is specified. This provides greater flexibility for different deployment environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🌐 This PR makes browser locale configuration optional by changing the default from "en-US" to None, allowing browsers to use their native default locale instead of forcing English (US) for all users.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Configuration Update**: Modified `BROWSER_LOCALE` in `skyvern/config.py` from a required string defaulting to "en-US" to an optional string that defaults to `None`
- **Browser Factory Logic**: Updated `build_browser_args()` in `skyvern/webeye/browser_factory.py` to conditionally set locale only when explicitly configured
- **Conditional Application**: Locale is now only applied to browser arguments when `settings.BROWSER_LOCALE` has a truthy value

### Technical Implementation
```mermaid
flowchart TD
    A[Browser Initialization] --> B{BROWSER_LOCALE set?}
    B -->|Yes| C[Apply configured locale]
    B -->|No| D[Use browser default locale]
    C --> E[Browser starts with specified locale]
    D --> F[Browser starts with system/default locale]
```

### Impact
- **User Experience**: Users in non-English regions will now see web content in their native browser locale by default instead of being forced into English
- **Configuration Flexibility**: Developers can still explicitly set a locale when needed for testing or specific requirements
- **Backward Compatibility**: Existing configurations that explicitly set BROWSER_LOCALE will continue to work unchanged

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `BROWSER_LOCALE` to optional in `config.py`, modifying `build_browser_args()` in `browser_factory.py` to include locale only if set.
> 
>   - **Behavior**:
>     - `BROWSER_LOCALE` in `config.py` is now optional, defaulting to `None` instead of `en-US`.
>     - In `browser_factory.py`, `build_browser_args()` only includes `locale` if `BROWSER_LOCALE` is set.
>   - **Misc**:
>     - Removed default `locale` argument from `args` in `build_browser_args()` in `browser_factory.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 263f8b7688691c9de70f094aa3060d090dd8cb8c. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->