### PR TITLE
Add Upload SOP option to workflow editor + button - frontend

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowAddMenu.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowAddMenu.tsx
@@ -1,7 +1,7 @@
-import { SquareIcon, PlusIcon } from "@radix-ui/react-icons";
-import { ReactNode } from "react";
+import { SquareIcon, PlusIcon, UploadIcon } from "@radix-ui/react-icons";
+import { ReactNode, useMemo } from "react";
 
-import { RadialMenu } from "@/components/RadialMenu";
+import { RadialMenu, RadialMenuItem } from "@/components/RadialMenu";
 import { useDebugStore } from "@/store/useDebugStore";
 import { useRecordingStore } from "@/store/useRecordingStore";
 import { useSettingsStore } from "@/store/SettingsStore";
@@ -13,9 +13,11 @@ type WorkflowAddMenuProps = {
   radius?: string;
   rotateText?: boolean;
   startAt?: number;
+  isUploadingSOP?: boolean;
   //   --
   onAdd: () => void;
   onRecord: () => void;
+  onUploadSOP: () => void;
 };
 
 function WorkflowAddMenu({
@@ -25,43 +27,71 @@ function WorkflowAddMenu({
   radius = "80px",
   rotateText = true,
   startAt = 90,
+  isUploadingSOP = false,
   //   --
   onAdd,
   onRecord,
+  onUploadSOP,
 }: WorkflowAddMenuProps) {
   const debugStore = useDebugStore();
   const recordingStore = useRecordingStore();
   const settingsStore = useSettingsStore();
 
-  if (!debugStore.isDebugMode || !settingsStore.isUsingABrowser) {
+  const items = useMemo(() => {
+    const menuItems: Array<RadialMenuItem> = [
+      {
+        id: "1",
+        icon: <PlusIcon className={buttonSize ? "h-3 w-3" : undefined} />,
+        text: "Add Block",
+        onClick: () => {
+          onAdd();
+        },
+      },
+    ];
+
+    // Only show Record Browser when browser is ON
+    if (settingsStore.isUsingABrowser) {
+      menuItems.push({
+        id: "2",
+        icon: <SquareIcon className={buttonSize ? "h-3 w-3" : undefined} />,
+        enabled: !recordingStore.isRecording,
+        text: "Record Browser",
+        onClick: () => {
+          onRecord();
+        },
+      });
+    }
+
+    // Always show Upload SOP option
+    menuItems.push({
+      id: "3",
+      icon: <UploadIcon className={buttonSize ? "h-3 w-3" : undefined} />,
+      text: "Upload SOP",
+      enabled: !isUploadingSOP,
+      onClick: () => {
+        onUploadSOP();
+      },
+    });
+
+    return menuItems;
+  }, [
+    buttonSize,
+    onAdd,
+    onRecord,
+    onUploadSOP,
+    recordingStore.isRecording,
+    settingsStore.isUsingABrowser,
+    isUploadingSOP,
+  ]);
+
+  // Show menu in debug mode regardless of browser state
+  if (!debugStore.isDebugMode) {
     return <>{children}</>;
   }
 
   return (
     <RadialMenu
-      items={[
-        {
-          id: "1",
-          icon: <PlusIcon className={buttonSize ? "h-3 w-3" : undefined} />,
-          text: "Add Block",
-          onClick: () => {
-            onAdd();
-          },
-        },
-        {
-          id: "2",
-          icon: <SquareIcon className={buttonSize ? "h-3 w-3" : undefined} />,
-          enabled: !recordingStore.isRecording && settingsStore.isUsingABrowser,
-          text: "Record Browser",
-          onClick: () => {
-            if (!settingsStore.isUsingABrowser) {
-              return;
-            }
-
-            onRecord();
-          },
-        },
-      ]}
+      items={items}
       buttonSize={buttonSize}
       radius={radius}
       startAt={startAt}

--- a/skyvern-frontend/src/routes/workflows/editor/nodes/NodeAdderNode/NodeAdderNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/NodeAdderNode/NodeAdderNode.tsx
@@ -1,7 +1,9 @@
 import { PlusIcon } from "@radix-ui/react-icons";
 import { Handle, NodeProps, Position, useEdges, useNodes } from "@xyflow/react";
+import { useRef } from "react";
 
 import { useProcessRecordingMutation } from "@/routes/browserSessions/hooks/useProcessRecordingMutation";
+import { useSopToBlocksMutation } from "@/routes/workflows/hooks/useSopToBlocksMutation";
 import { useDebugStore } from "@/store/useDebugStore";
 import {
   BranchContext,
@@ -13,6 +15,7 @@ import { useRecordedBlocksStore } from "@/store/RecordedBlocksStore";
 import { useRecordingStore } from "@/store/useRecordingStore";
 import { useSettingsStore } from "@/store/SettingsStore";
 import { cn } from "@/util/utils";
+import { toast } from "@/components/ui/use-toast";
 
 import type { NodeAdderNode } from "./types";
 import { WorkflowAddMenu } from "../../WorkflowAddMenu";
@@ -32,6 +35,9 @@ function NodeAdderNode({ id, parentId }: NodeProps<NodeAdderNode>) {
   const setRecordedBlocks = useRecordedBlocksStore(
     (state) => state.setRecordedBlocks,
   );
+
+  // SOP upload
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const deriveBranchContext = (previousNodeId: string | undefined) => {
     const previousNode = nodes.find((node) => node.id === previousNodeId);
@@ -123,6 +129,21 @@ function NodeAdderNode({ id, parentId }: NodeProps<NodeAdderNode>) {
     },
   });
 
+  const sopToBlocksMutation = useSopToBlocksMutation({
+    onSuccess: (result) => {
+      // Reuse existing block insertion pattern
+      setRecordedBlocks(result, {
+        previous: previous ?? null,
+        next: id,
+        parent: parentId,
+        connectingEdgeType: "default",
+      });
+    },
+  });
+
+  // Derive upload state directly from mutation to avoid race conditions
+  const isUploadingSOP = sopToBlocksMutation.isPending;
+
   const isProcessing = processRecordingMutation.isPending;
 
   const isBusy =
@@ -181,6 +202,28 @@ function NodeAdderNode({ id, parentId }: NodeProps<NodeAdderNode>) {
     processRecordingMutation.mutate();
   };
 
+  const onUploadSOP = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleSOPFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) {
+      return;
+    }
+    if (!file.name.toLowerCase().endsWith(".pdf")) {
+      toast({
+        variant: "destructive",
+        title: "Invalid file type",
+        description: "Please select a PDF file",
+      });
+      e.target.value = "";
+      return;
+    }
+    sopToBlocksMutation.mutate(file);
+    e.target.value = "";
+  };
+
   const adder = (
     <div
       className={cn("rounded-full bg-slate-50 p-2", {
@@ -206,14 +249,41 @@ function NodeAdderNode({ id, parentId }: NodeProps<NodeAdderNode>) {
     </WorkflowAdderBusy>
   );
 
+  const handleCancelUpload = () => {
+    sopToBlocksMutation.cancel();
+  };
+
+  const sopUploadBusy = (
+    <WorkflowAdderBusy
+      color="#3b82f6"
+      operation="uploading"
+      onComplete={() => {}}
+      onCancel={handleCancelUpload}
+    >
+      {adder}
+    </WorkflowAdderBusy>
+  );
+
   const menu = (
-    <WorkflowAddMenu onAdd={onAdd} onRecord={onRecord}>
+    <WorkflowAddMenu
+      onAdd={onAdd}
+      onRecord={onRecord}
+      onUploadSOP={onUploadSOP}
+      isUploadingSOP={isUploadingSOP}
+    >
       {adder}
     </WorkflowAddMenu>
   );
 
   return (
     <div>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".pdf"
+        className="hidden"
+        onChange={handleSOPFileChange}
+      />
       <Handle
         type="source"
         position={Position.Bottom}
@@ -226,7 +296,13 @@ function NodeAdderNode({ id, parentId }: NodeProps<NodeAdderNode>) {
         id="b"
         className="opacity-0"
       />
-      {isBusy ? busy : isDisabled ? adder : menu}
+      {isUploadingSOP
+        ? sopUploadBusy
+        : isBusy
+          ? busy
+          : isDisabled
+            ? adder
+            : menu}
     </div>
   );
 }

--- a/skyvern-frontend/src/routes/workflows/hooks/useSopToBlocksMutation.ts
+++ b/skyvern-frontend/src/routes/workflows/hooks/useSopToBlocksMutation.ts
@@ -1,0 +1,95 @@
+import { useRef } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { getClient } from "@/api/AxiosClient";
+import { useCredentialGetter } from "@/hooks/useCredentialGetter";
+import { toast } from "@/components/ui/use-toast";
+import { WorkflowBlock, WorkflowParameter } from "../types/workflowTypes";
+
+type SopToBlocksResponse = {
+  blocks: Array<WorkflowBlock>;
+  parameters: Array<WorkflowParameter>;
+};
+
+type UseSopToBlocksMutationOptions = {
+  onSuccess?: (result: SopToBlocksResponse) => void;
+};
+
+function useSopToBlocksMutation({ onSuccess }: UseSopToBlocksMutationOptions) {
+  const credentialGetter = useCredentialGetter();
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async (file: File) => {
+      // Create new AbortController for this request
+      abortControllerRef.current = new AbortController();
+
+      const formData = new FormData();
+      formData.append("file", file);
+      const client = await getClient(credentialGetter);
+      return (
+        await client.post<SopToBlocksResponse>(
+          "/workflows/sop-to-blocks",
+          formData,
+          {
+            headers: {
+              "Content-Type": "multipart/form-data",
+            },
+            signal: abortControllerRef.current.signal,
+          },
+        )
+      ).data;
+    },
+    onSuccess: (result) => {
+      toast({
+        variant: "success",
+        title: "SOP converted",
+        description: `Generated ${result.blocks.length} block${result.blocks.length === 1 ? "" : "s"}`,
+      });
+      onSuccess?.(result);
+    },
+    onError: (error) => {
+      // Don't show error toast if request was cancelled
+      if (error instanceof AxiosError && error.code === "ERR_CANCELED") {
+        toast({
+          variant: "default",
+          title: "Upload cancelled",
+          description: "SOP conversion was cancelled.",
+        });
+        return;
+      }
+
+      // Graceful degradation for 404 (backend not deployed yet)
+      if (error instanceof AxiosError && error.response?.status === 404) {
+        toast({
+          variant: "destructive",
+          title: "Feature not yet available",
+          description:
+            "The Upload SOP feature is being deployed. Please try again later.",
+        });
+      } else {
+        const message =
+          error instanceof AxiosError
+            ? error.response?.data?.detail || error.message
+            : error instanceof Error
+              ? error.message
+              : "Failed to convert SOP";
+        toast({
+          variant: "destructive",
+          title: "Failed to convert SOP",
+          description: message,
+        });
+      }
+    },
+  });
+
+  const cancel = () => {
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+  };
+
+  return { ...mutation, cancel };
+}
+
+export { useSopToBlocksMutation };
+export type { SopToBlocksResponse };


### PR DESCRIPTION
	## Summary - [SKY-7680](https://linear.app/skyvern/issue/SKY-7680)

Adds "Upload SOP" option to the workflow editor's "+" button radial menu, allowing users to upload PDF SOPs and convert them to workflow blocks.

## Changes

### New Feature: Upload SOP
- Added "Upload SOP" option to radial menu (alongside "Add Block" and "Record Browser")
- Menu visibility: Always shows in debug mode, "Record Browser" only when browser is ON
- PDF validation with user-friendly error messages
- Graceful 404 handling when backend endpoint isn't deployed yet

### Loading & Cancel Functionality
- Loading indicator while SOP is being processed (5-15 seconds)
- Cancel button with confirmation dialog
- AbortController support to cancel in-flight requests
- Busy state tooltip shows "uploading" status

### Files Changed
- **WorkflowAddMenu.tsx**: Refactored menu to show conditionally, added `onUploadSOP` prop
- **NodeAdderNode.tsx**: Added file input, upload handler, loading state
- **EdgeWithAddButton.tsx**: Same upload functionality for edge "+" buttons (file input inside EdgeLabelRenderer for portal compatibility)
- **WorkflowAdderBusy.tsx**: Added cancel dialog, `onCancel` prop, "uploading" operation type
- **useSopToBlocksMutation.ts**: New hook with AbortController support, 404 graceful handling

## Test Plan
- [x] Radial menu appears with all 3 options in debug mode
- [x] "Record Browser" only shows when browser is ON
- [x] File picker opens with PDF filter when clicking "Upload SOP"
- [x] Non-PDF file shows error toast
- [x] Valid PDF uploads and blocks are inserted
- [x] Loading indicator shows during processing
- [x] Cancel button works with confirmation dialog
- [x] 404 error shows "Feature not yet available" message
- [x] Works from both NodeAdderNode and EdgeWithAddButton

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SOP (PDF) upload added to the workflow add menu with automatic conversion into workflow blocks and a cancel option.
  * Menu now includes an Upload action and conditionally shows a Record Browser when available.

* **UI/UX Improvements**
  * New "uploading" state with dedicated busy UI and cancel confirmation dialog.
  * PDF validation with clear error messages; upload action disabled while uploading.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds SOP upload feature to workflow editor with PDF validation, error handling, and cancel option.
> 
>   - **New Feature: Upload SOP**
>     - Adds "Upload SOP" option to `WorkflowAddMenu` radial menu.
>     - PDF validation and error messages for non-PDF files.
>     - Handles 404 errors gracefully when backend is unavailable.
>   - **UI/UX Improvements**
>     - `WorkflowAdderBusy` shows "uploading" state with cancel option.
>     - `EdgeWithAddButton` and `NodeAdderNode` support SOP uploads with file input and upload handler.
>   - **New Hook**
>     - `useSopToBlocksMutation` handles SOP to blocks conversion with cancel support and error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 9c251db2469abd4f34dfe7e3b501863fe6a3e7d2. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->