### PR TITLE
fix harfile zstd compression in s3

### DIFF
--- a/skyvern/forge/sdk/artifact/storage/test_s3_storage.py
+++ b/skyvern/forge/sdk/artifact/storage/test_s3_storage.py
@@ -488,14 +488,10 @@ class TestS3StorageHARCompression:
         # Create sample HAR JSON data (easily compressible)
         har_data = b'{"log": {"version": "1.2", "entries": [{"request": {}, "response": {}}]}}'
         artifact = self._create_har_artifact(s3_storage, TEST_STEP_ID)
-        original_uri = artifact.uri
+        assert artifact.uri.endswith(".har.zst")
 
         # Store the artifact
         await s3_storage.store_artifact(artifact, har_data)
-
-        # Verify URI was updated to .har.zst
-        assert artifact.uri.endswith(".har.zst")
-        assert artifact.uri == original_uri.replace(".har", ".har.zst")
 
         # Verify the stored data is compressed
         s3uri = S3Uri(artifact.uri)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compression suffix handling for stored artifacts to consistently apply the ".zst" suffix in artifact URIs, ensuring decompression logic correctly detects compressed data.

* **Tests**
  * Updated artifact compression tests to reflect corrected suffix handling behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update HAR file zstd compression handling in S3 storage to use file extension for detection.
> 
>   - **Behavior**:
>     - In `s3.py`, HAR file compression now determined by `.zst` suffix instead of `ArtifactType`.
>     - `store_artifact()` compresses data if URI ends with `.zst`.
>     - `retrieve_artifact()` decompresses data if URI ends with `.zst`.
>   - **Tests**:
>     - In `test_s3_storage.py`, updated tests to check compression based on URI suffix.
>     - Removed URI mutation checks in `test_store_har_artifact_compresses_with_zstd()`.
>     - Verified compression/decompression in `test_store_har_artifact_compresses_with_zstd()` and `test_retrieve_har_artifact_decompresses_zstd()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for d33f9af51b84de14ea6125f42106ac63c9441074. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes HAR file compression handling in S3 storage by standardizing the compression detection mechanism to use file extensions rather than artifact types, ensuring consistent behavior during both storage and retrieval operations.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Compression Detection**: Introduced `S3_ZSTD_COMPRESSED_SUFFIX` constant and moved compression logic from artifact type checking to URI suffix checking
- **URI Generation**: Modified `build_uri()` to automatically append `.zst` suffix for HAR artifacts at creation time
- **Storage Logic**: Simplified `store_artifact()` to compress based on URI suffix rather than artifact type, eliminating runtime URI mutation
- **Test Updates**: Updated test expectations to verify compression suffix is present from artifact creation rather than after storage

### Technical Implementation
```mermaid
flowchart TD
    A[Create HAR Artifact] --> B[build_uri adds .zst suffix]
    B --> C[store_artifact checks URI suffix]
    C --> D{URI ends with .zst?}
    D -->|Yes| E[Compress with zstd]
    D -->|No| F[Store uncompressed]
    E --> G[Store to S3]
    F --> G
    H[retrieve_artifact] --> I{URI ends with .zst?}
    I -->|Yes| J[Decompress with zstd]
    I -->|No| K[Return raw data]
```

### Impact
- **Consistency**: Eliminates the mismatch between storage and retrieval logic by using the same suffix-based detection mechanism
- **Maintainability**: Reduces complexity by removing runtime URI mutations and centralizing compression logic
- **Reliability**: Ensures HAR files are properly compressed and decompressed without relying on artifact type context during retrieval

</details>

_Created with [Palmier](https://www.palmier.io)_