### PR TITLE
Fix workflow add menu layout to use vertical stacking

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowAddMenu.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowAddMenu.tsx
@@ -97,6 +97,7 @@ function WorkflowAddMenu({
       startAt={startAt}
       gap={gap}
       rotateText={rotateText}
+      layout="vertical"
     >
       {children}
     </RadialMenu>


### PR DESCRIPTION
## Summary - [SKY-7738](https://linear.app/skyvern/issue/SKY-7738)

Fixes the workflow editor's add menu layout by introducing a vertical stacking option to the RadialMenu component. Previously, the menu used a radial (circular) layout which looked awkward when displaying 3 options (Add Block, Record Browser, Upload SOP) - they appeared scattered around the + button at different angles. The fix adds a "vertical" layout mode that stacks all options in a neat vertical list to the right of the + button.

## Changes

- Added `layout` prop to `RadialMenu` component supporting "radial" (default) and "vertical" modes
- Vertical layout stacks menu items to the right of center button with proper vertical centering
- Updated `WorkflowAddMenu` to use `layout="vertical"`
- Maintained all existing animations and disabled state handling

## Screenshots
<img width="504" height="334" alt="image" src="https://github.com/user-attachments/assets/2a8329bf-1f80-4e7a-87f2-d5bd74b2858a" />


## Test plan

- [ ] Open workflow editor in debug mode
- [ ] Verify add menu options appear in vertical stack to the right of + button
- [ ] Test menu animations and hover behavior
- [ ] Verify disabled states work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Menu components now support both radial (circular) and vertical (stacked) layout options for improved flexibility in workflow interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces vertical layout option to `RadialMenu` and applies it to `WorkflowAddMenu` for improved menu item arrangement.
> 
>   - **Behavior**:
>     - Added `layout` prop to `RadialMenu` supporting "radial" and "vertical" modes.
>     - `vertical` layout stacks items to the right of the center button with vertical centering.
>     - Updated `WorkflowAddMenu` to use `layout="vertical"`.
>     - Maintained existing animations and disabled state handling.
>   - **Components**:
>     - Modified `RadialMenu` in `RadialMenu.tsx` to handle new layout option.
>     - Updated `WorkflowAddMenu` in `WorkflowAddMenu.tsx` to utilize vertical layout.
>   - **Props**:
>     - Added `layout` prop to `RadialMenuProps` with default "radial".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ba2d55f6ece1ce8573e5975a1d314749260cda36. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🎨 This PR enhances the RadialMenu component by adding a vertical layout option and applies it to the workflow editor's add menu, replacing the awkward circular arrangement of 3 menu items with a clean vertical stack positioned to the right of the trigger button.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **RadialMenu Component Enhancement**: Added a new `layout` prop supporting "radial" (default) and "vertical" modes with comprehensive vertical positioning logic
- **Workflow Add Menu Update**: Modified WorkflowAddMenu to use `layout="vertical"` for improved visual organization
- **Layout Algorithm**: Implemented vertical stacking with proper centering, spacing calculations, and maintained all existing animations and disabled state handling

### Technical Implementation
```mermaid
flowchart TD
    A[RadialMenu Component] --> B{Layout Mode?}
    B -->|radial| C[Calculate Circular Positions]
    B -->|vertical| D[Calculate Vertical Stack]
    C --> E[Position items around circle]
    D --> F[Stack items to right of center]
    F --> G[Center stack vertically]
    G --> H[Apply gap spacing]
    E --> I[Render with animations]
    H --> I
    I --> J[WorkflowAddMenu displays clean vertical list]
```

### Impact
- **User Experience**: Transforms the awkward 3-item circular menu into an intuitive vertical list that's easier to scan and interact with
- **Component Flexibility**: Makes RadialMenu reusable for different UI contexts while maintaining backward compatibility with existing radial implementations
- **Visual Consistency**: Provides a more organized appearance for the workflow editor's add functionality, improving the overall interface polish

</details>

_Created with [Palmier](https://www.palmier.io)_