### PR TITLE
Add DOWNLOAD_FILE action support for cached scripts (#SKY-7656)

### DIFF
--- a/skyvern/core/script_generations/generate_script.py
+++ b/skyvern/core/script_generations/generate_script.py
@@ -181,6 +181,7 @@ ACTION_MAP = {
     "wait": "wait",
     "extract": "extract",
     "complete": "complete",
+    "download_file": "download_file",
 }
 ACTIONS_WITH_XPATH = [
     "click",
@@ -656,6 +657,28 @@ def _action_to_stmt(act: dict[str, Any], task: dict[str, Any], assign_to_output:
                 ),
             )
         )
+    elif method == "download_file":
+        args.append(
+            cst.Arg(
+                keyword=cst.Name("file_name"),
+                value=_value(act.get("file_name", "")),
+                whitespace_after_arg=cst.ParenthesizedWhitespace(
+                    indent=True,
+                    last_line=cst.SimpleWhitespace(INDENT),
+                ),
+            )
+        )
+        if act.get("download_url"):
+            args.append(
+                cst.Arg(
+                    keyword=cst.Name("download_url"),
+                    value=_value(act["download_url"]),
+                    whitespace_after_arg=cst.ParenthesizedWhitespace(
+                        indent=True,
+                        last_line=cst.SimpleWhitespace(INDENT),
+                    ),
+                )
+            )
     elif method == "extract":
         args.append(
             cst.Arg(
@@ -779,7 +802,11 @@ def _build_block_fn(block: dict[str, Any], actions: list[dict[str, Any]]) -> Fun
         body_stmts.append(cst.parse_statement(f"await page.goto({repr(block['url'])})"))
 
     for act in actions:
-        if act["action_type"] in [ActionType.COMPLETE, ActionType.TERMINATE, ActionType.NULL_ACTION]:
+        if act["action_type"] in [
+            ActionType.COMPLETE,
+            ActionType.TERMINATE,
+            ActionType.NULL_ACTION,
+        ]:
             continue
 
         # For extraction blocks, assign extract action results to output variable

--- a/skyvern/webeye/actions/caching.py
+++ b/skyvern/webeye/actions/caching.py
@@ -233,6 +233,7 @@ async def personalize_action(
         ActionType.WAIT,
         ActionType.SOLVE_CAPTCHA,
         ActionType.NULL_ACTION,
+        ActionType.DOWNLOAD_FILE,
     ]:
         return [action]
     elif action.action_type == ActionType.TERMINATE:
@@ -246,7 +247,13 @@ async def personalize_action(
 
 
 def check_for_unsupported_actions(actions: list[Action]) -> None:
-    supported_actions = [ActionType.INPUT_TEXT, ActionType.WAIT, ActionType.CLICK, ActionType.COMPLETE]
+    supported_actions = [
+        ActionType.INPUT_TEXT,
+        ActionType.WAIT,
+        ActionType.CLICK,
+        ActionType.COMPLETE,
+        ActionType.DOWNLOAD_FILE,
+    ]
     supported_actions_with_query = [ActionType.INPUT_TEXT]
     for action in actions:
         query = action.intention


### PR DESCRIPTION
## Summary

Fix `KeyError: <ActionType.DOWNLOAD_FILE: 'download_file'>` errors occurring in production for Signal Advisors workflows.

**Changes:**
1. **Script generation** (`generate_script.py`): Add proper support for `DOWNLOAD_FILE` actions so they are represented in generated cached scripts with `file_name` and `download_url` parameters
2. **SkyvernPage** (`skyvern_page.py`): Add `download_file` method that downloads files from URLs during cached script replay
3. **Caching system** (`caching.py`): Add `DOWNLOAD_FILE` to supported actions to prevent `CachedActionPlanError` when workflows with PDF downloads are replayed

## Root Cause

The `DOWNLOAD_FILE` action (re-enabled in #7817) was not handled in:
1. Script generation - caused `KeyError` when trying to convert action to script code
2. Caching system - would cause `CachedActionPlanError` during cache replay

## Why This Approach

Cached scripts run the generated Python code directly without going through the full agent loop with PDF detection. Therefore, `DOWNLOAD_FILE` actions must be properly represented in the generated scripts so file downloads still occur during replay.

## Datadog Errors Fixed

```
File "/app/skyvern/core/script_generations/generate_script.py", line 346, in _action_to_stmt
  method = ACTION_MAP[act["action_type"]]
KeyError: <ActionType.DOWNLOAD_FILE: 'download_file'>
```

Affected organization: Signal Advisors (`o_399205696085160012`)

## Test plan

- [ ] Verify Signal Advisors workflows with PDF downloads no longer fail script generation
- [ ] Verify DOWNLOAD_FILE actions are represented in generated scripts with proper parameters
- [ ] Verify cached workflows with DOWNLOAD_FILE actions replay correctly and download files

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added file download functionality, allowing downloads from specified URLs with optional custom filenames or automatic filename generation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔧 This PR fixes critical KeyError exceptions in production by adding comprehensive support for DOWNLOAD_FILE actions in Skyvern's cached script generation and replay system, specifically resolving issues affecting Signal Advisors workflows with PDF downloads.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Script Generation**: Added `download_file` to ACTION_MAP and implemented proper code generation for DOWNLOAD_FILE actions with `file_name` and `download_url` parameters
- **SkyvernPage Class**: Implemented new `download_file` method that handles file downloads during cached script replay, with UUID fallback for missing filenames
- **Caching System**: Added DOWNLOAD_FILE to supported actions list to prevent CachedActionPlanError during workflow replay
- **Import Refactoring**: Renamed import to avoid naming conflicts (`download_file` function vs `download_file` method)

### Technical Implementation
```mermaid
sequenceDiagram
    participant WF as Workflow
    participant SG as Script Generator
    participant CS as Cached Script
    participant SP as SkyvernPage
    participant FS as File System

    WF->>SG: Process DOWNLOAD_FILE action
    SG->>SG: Map action to download_file method
    SG->>CS: Generate script with file_name & download_url
    CS->>SP: Execute download_file()
    SP->>FS: Download file from URL
    FS->>SP: Return local file path
    SP->>CS: Return downloaded file path
```

### Impact
- **Production Stability**: Eliminates KeyError exceptions that were breaking Signal Advisors workflows in production
- **Feature Completeness**: Enables full support for file download actions in cached script workflows, maintaining functionality during replay
- **Backward Compatibility**: Changes are additive and don't break existing functionality - workflows without downloads continue to work normally
- **Error Prevention**: Proper validation ensures download_url is required, preventing runtime failures with clear error messages

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for `DOWNLOAD_FILE` action in script generation, SkyvernPage, and caching system to handle file downloads in workflows.
> 
>   - **Behavior**:
>     - Add support for `DOWNLOAD_FILE` action in `generate_script.py` to include `file_name` and `download_url` in cached scripts.
>     - Add `download_file` method in `SkyvernPage` to handle file downloads during cached script replay.
>     - Include `DOWNLOAD_FILE` in supported actions in `caching.py` to prevent `CachedActionPlanError`.
>   - **Error Handling**:
>     - Fix `KeyError` in `generate_script.py` when converting `DOWNLOAD_FILE` action to script code.
>     - Prevent `CachedActionPlanError` in `caching.py` for workflows with `DOWNLOAD_FILE` actions.
>   - **Misc**:
>     - Use `uuid` as fallback for empty `file_name` in `SkyvernPage` `download_file` method.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 660084b7b926c74acab3c4c0db277a351e7106dd. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->