### PR TITLE
Fix script generation race condition causing hardcoded parameter values (#SKY-7653)

### DIFF
--- a/skyvern/forge/sdk/core/skyvern_context.py
+++ b/skyvern/forge/sdk/core/skyvern_context.py
@@ -75,6 +75,10 @@ class SkyvernContext:
     action_ai_overrides: dict[str, dict[int, str]] = field(default_factory=dict)
     action_counters: dict[str, int] = field(default_factory=dict)
 
+    # Track if script generation skipped any actions due to missing data (race condition)
+    # Used to determine if finalize regeneration is needed at workflow completion
+    script_gen_had_incomplete_actions: bool = False
+
     def __repr__(self) -> str:
         return f"SkyvernContext(request_id={self.request_id}, organization_id={self.organization_id}, task_id={self.task_id}, step_id={self.step_id}, workflow_id={self.workflow_id}, workflow_run_id={self.workflow_run_id}, task_v2_id={self.task_v2_id}, max_steps_override={self.max_steps_override}, run_id={self.run_id})"
 

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -967,10 +967,12 @@ async def run_task_v2_helper(
                     context=context,
                     screenshots=completion_screenshots,
                 )
-                await app.WORKFLOW_SERVICE.generate_script_if_needed(
-                    workflow=workflow,
-                    workflow_run=workflow_run,
-                )
+                if task_v2.run_with == "code":
+                    await app.WORKFLOW_SERVICE.generate_script_if_needed(
+                        workflow=workflow,
+                        workflow_run=workflow_run,
+                        finalize=True,  # Force regeneration to ensure field mappings have complete action data
+                    )
                 break
 
         # total step number validation


### PR DESCRIPTION
## Summary

- Fixes a race condition in script generation that causes hardcoded parameter values instead of `context.parameters[field_name]`
- Adds `finalize` parameter to `generate_script_if_needed()` that forces regeneration of all task blocks at workflow completion
- Adds 16 unit tests documenting and replicating the race condition behavior

## Problem

When running a workflow in agent mode, script generation is triggered after each action execution via `post_action_execution`. However, this uses `asyncio.create_task()` which runs in the background. The script generation queries the database for actions, but subsequent actions may not have been executed/saved yet.

This causes a race condition where:
1. Script generation runs with incomplete action data
2. INPUT_TEXT actions aren't found → values get hardcoded instead of using `context.parameters[field_name]`
3. The cached script cannot be reused with different parameters

**Observed timeline:**
```
23:40:54.193 - Script generation: "No field_name_actions found" 
23:41:00.904 - InputTextAction executed (6 seconds LATER!)
```

The generated script had `value = 'Urdaneta'` (hardcoded) instead of `value = context.parameters['facility_name']`.

## Solution Comparison

### Option A: Generate script only at workflow completion

**How it works:** Remove script generation during action execution, only generate once at completion.

| Pros | Cons |
|------|------|
| Simple implementation | No incremental script updates in UI |
| Fewer LLM calls (just 1 at completion) | Users can't see code as it's being generated |
| No race condition possible | - |

**If we don't need to show code in the UI during execution, Option A is the simpler and more efficient solution.**

### Option C: Keep incremental updates + final regeneration (This PR)

**How it works:** Keep existing `post_action_execution` script generation for UI display, add `finalize=True` at completion to force regeneration with complete data.

| Pros | Cons |
|------|------|
| Preserves incremental UI updates | More LLM calls (N during execution + 1 at completion) |
| Shows code as it's being generated | Slightly more complex |
| Ensures final script is correct | Higher cost due to duplicate LLM calls |

**This PR implements Option C** because showing code in the UI as it's generated was mentioned as a requirement. If that requirement changes, Option A would be preferred.

## How the Tests Replicate the Issue

The tests in `tests/unit/test_script_generation_race_condition.py` demonstrate:

1. **`test_race_condition_empty_actions_produces_empty_schema`** - When script generation runs before any INPUT_TEXT actions are saved, it returns an empty schema with no field mappings

2. **`test_hydrate_without_mappings_no_field_name`** - Without field mappings, actions don't get `field_name` added

3. **`test_code_generation_path_without_field_name`** - The code generation logic at `generate_script.py:401-429` checks `act.get("field_name")`:
 - If truthy → generates `context.parameters["field_name"]`
 - If falsy → generates hardcoded `"Urdaneta"`

4. **`test_finalize_forces_block_regeneration`** - Verifies that `finalize=True` adds all task block labels to `blocks_to_update`

5. **`test_demonstrates_race_condition_consequence`** - Documents the full consequence: cached scripts with hardcoded values cannot be reused with different parameters

## Test plan

- [x] All 16 unit tests pass: `pytest tests/unit/test_script_generation_race_condition.py -v`
- [ ] Manual test: Run a workflow with parameters, verify generated script uses `context.parameters[]`
- [ ] Manual test: Run the same workflow with different parameters, verify it works correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete actions during workflow script generation by deferring processing until all action data is available.
  * Fixed race condition that could cause script generation to proceed before action data was persisted.

* **New Features**
  * Enhanced workflow finalization with conditional script regeneration to ensure scripts use complete and accurate action information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes script generation race condition by adding a `finalize` parameter and context tracking for incomplete actions.
> 
>   - **Behavior**:
>     - Fixes race condition in script generation causing hardcoded parameter values instead of `context.parameters[field_name]`.
>     - Adds `finalize` parameter to `generate_script_if_needed()` in `workflow/service.py` to force regeneration at workflow completion.
>     - Skips actions with missing data in `generate_workflow_parameters.py`, marking generation as incomplete.
>   - **Context Tracking**:
>     - Adds `script_gen_had_incomplete_actions` to `SkyvernContext` in `skyvern_context.py` to track incomplete actions.
>   - **Tests**:
>     - Adds 16 unit tests in `tests/unit/test_script_generation_race_condition.py` to replicate and document race condition behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 8ed0dfccfd636b4d3b86a16c3569fe4ddcc9df4d. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR fixes a critical race condition in script generation that was causing hardcoded parameter values instead of proper `context.parameters[field_name]` references. The fix adds intelligent tracking to detect incomplete actions during generation and forces a final regeneration at workflow completion to ensure all field mappings are complete.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Race Condition Detection**: Added `script_gen_had_incomplete_actions` flag to `SkyvernContext` to track when actions are skipped due to missing data
- **Smart Skip Logic**: Modified `generate_workflow_parameters_schema()` to skip actions without data and mark the generation as incomplete
- **Finalization Strategy**: Added `finalize` parameter to `generate_script_if_needed()` that forces regeneration of all task blocks when incomplete actions were detected
- **Selective Regeneration**: Only triggers expensive LLM regeneration when actually needed, avoiding unnecessary costs

### Technical Implementation
```mermaid
sequenceDiagram
    participant WF as Workflow Execution
    participant SG as Script Generation
    participant DB as Database
    participant CTX as Context

    WF->>SG: post_action_execution (async)
    SG->>DB: Query for actions
    Note over DB: Some actions not yet saved (race condition)
    SG->>CTX: Mark script_gen_had_incomplete_actions = True
    SG-->>WF: Return (incomplete script cached)
    
    Note over WF: Continue execution...
    
    WF->>SG: generate_script_if_needed(finalize=True)
    SG->>CTX: Check script_gen_had_incomplete_actions
    alt Incomplete actions detected
        SG->>SG: Force regeneration of all blocks
        SG->>DB: Query for complete action data
        SG-->>WF: Generate correct script with parameters
    else No incomplete actions
        SG-->>WF: Skip regeneration (optimization)
    end
```

### Impact
- **Bug Resolution**: Eliminates hardcoded values like `value = 'Urdaneta'` in favor of proper `value = context.parameters['facility_name']`
- **Script Reusability**: Generated scripts can now be properly reused with different parameter values across workflow runs
- **Cost Optimization**: Only regenerates scripts when actually needed, avoiding unnecessary LLM calls when the initial generation was complete
- **UI Preservation**: Maintains incremental script updates in the UI during execution while ensuring final correctness

</details>

_Created with [Palmier](https://www.palmier.io)_