### PR TITLE
support passing run_with for run_task endpoint (mostly for task v2)

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -264,6 +264,7 @@ async def run_task(
                 extra_http_headers=run_request.extra_http_headers,
                 browser_session_id=run_request.browser_session_id,
                 browser_address=run_request.browser_address,
+                run_with=run_request.run_with,
             )
         except MissingBrowserAddressError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e

--- a/skyvern/schemas/runs.py
+++ b/skyvern/schemas/runs.py
@@ -437,6 +437,11 @@ class TaskRunRequest(BaseModel):
         description="The CDP address for the task.",
         examples=["http://127.0.0.1:9222", "ws://127.0.0.1:9222/devtools/browser/1234567890"],
     )
+    run_with: str | None = Field(
+        default=None,
+        description="Whether to run the task with agent or code.",
+        examples=["agent", "code"],
+    )
 
     @field_validator("url", "webhook_url", "totp_url")
     @classmethod

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -209,6 +209,7 @@ async def initialize_task_v2(
                 browser_session_id=browser_session_id,
                 extra_http_headers=extra_http_headers,
                 browser_address=browser_address,
+                run_with=run_with,
             ),
             workflow_permanent_id=new_workflow.workflow_permanent_id,
             organization=organization,
@@ -755,10 +756,11 @@ async def run_task_v2_helper(
                     context=context,
                     screenshots=scraped_page.screenshots,
                 )
-                await app.WORKFLOW_SERVICE.generate_script_if_needed(
-                    workflow=workflow,
-                    workflow_run=workflow_run,
-                )
+                if task_v2.run_with == "code":
+                    await app.WORKFLOW_SERVICE.generate_script_if_needed(
+                        workflow=workflow,
+                        workflow_run=workflow_run,
+                    )
                 break
 
             if not plan:


### PR DESCRIPTION
	<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tasks now support an optional execution mode ("agent" or "code").
  * Task runs can specify execution behavior via a new run_with parameter.
  * Script generation during task execution is now conditional on the chosen execution mode when a goal is achieved.
  * The selected execution mode is propagated through the task run context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `run_with` parameter to support optional task execution modes ('agent' or 'code') in task and workflow runs.
> 
>   - **Behavior**:
>     - Add `run_with` parameter to `TaskRunRequest` and `WorkflowRunRequest` in `runs.py` to specify execution mode ('agent' or 'code').
>     - Update `run_task` in `agent_protocol.py` to pass `run_with` to task execution.
>     - Modify `initialize_task_v2` in `task_v2_service.py` to include `run_with` in task initialization.
>     - Conditional script generation in `run_task_v2_helper` in `task_v2_service.py` based on `run_with` value.
>   - **Misc**:
>     - Update docstrings and examples in `runs.py` to reflect new `run_with` parameter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for ff2d8b49d359181421d97248110d4d94c760ba62. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->