### PR TITLE
Fix auto-release not triggering Docker build workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -93,4 +93,6 @@ jobs:
           prerelease: false
           generate_release_notes: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Using PAT instead of GITHUB_TOKEN to trigger downstream workflows (e.g., build-docker-image)
+          # GITHUB_TOKEN events don't trigger other workflows to prevent infinite loops
+          GITHUB_TOKEN: ${{ secrets.SKYVERN_OSS_GITHUB_TOKEN }}

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -2,6 +2,12 @@ name: Build Docker Image and Push to ECR
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name for the release (e.g., v1.0.11)'
+        required: true
+        type: string
 env:
   AWS_REGION: us-east-1
   ECR_BACKEND_REPOSITORY: skyvern
@@ -50,10 +56,10 @@ jobs:
           cache-to: type=gha,mode=max
           tags: |
             ${{ env.ECR_REGISTRY}}/${{ env.REGISTRY_ALIAS }}/${{ env.ECR_BACKEND_REPOSITORY }}:${{ github.sha }}
-            ${{ env.ECR_REGISTRY}}/${{ env.REGISTRY_ALIAS }}/${{ env.ECR_BACKEND_REPOSITORY }}:${{ github.event.release.tag_name }}
+            ${{ env.ECR_REGISTRY}}/${{ env.REGISTRY_ALIAS }}/${{ env.ECR_BACKEND_REPOSITORY }}:${{ inputs.tag_name || github.event.release.tag_name }}
             ${{ env.ECR_REGISTRY}}/${{ env.REGISTRY_ALIAS }}/${{ env.ECR_BACKEND_REPOSITORY }}:latest
             ${{ env.DOCKERHUB_USERNAME }}/${{ env.ECR_BACKEND_REPOSITORY }}:${{ github.sha }}
-            ${{ env.DOCKERHUB_USERNAME }}/${{ env.ECR_BACKEND_REPOSITORY }}:${{ github.event.release.tag_name }}
+            ${{ env.DOCKERHUB_USERNAME }}/${{ env.ECR_BACKEND_REPOSITORY }}:${{ inputs.tag_name || github.event.release.tag_name }}
             ${{ env.DOCKERHUB_USERNAME }}/${{ env.ECR_BACKEND_REPOSITORY }}:latest
       - name: Build, tag, and push ui image to Amazon Public ECR and Docker Hub
         id: build-ui-image
@@ -71,8 +77,8 @@ jobs:
           push: true
           tags: |
             ${{ env.ECR_REGISTRY}}/${{ env.REGISTRY_ALIAS }}/${{ env.ECR_UI_REPOSITORY }}:${{ github.sha }}
-            ${{ env.ECR_REGISTRY}}/${{ env.REGISTRY_ALIAS }}/${{ env.ECR_UI_REPOSITORY }}:${{ github.event.release.tag_name }}
+            ${{ env.ECR_REGISTRY}}/${{ env.REGISTRY_ALIAS }}/${{ env.ECR_UI_REPOSITORY }}:${{ inputs.tag_name || github.event.release.tag_name }}
             ${{ env.ECR_REGISTRY}}/${{ env.REGISTRY_ALIAS }}/${{ env.ECR_UI_REPOSITORY }}:latest
             ${{ env.DOCKERHUB_USERNAME }}/${{ env.ECR_UI_REPOSITORY }}:${{ github.sha }}
-            ${{ env.DOCKERHUB_USERNAME }}/${{ env.ECR_UI_REPOSITORY }}:${{ github.event.release.tag_name }}
+            ${{ env.DOCKERHUB_USERNAME }}/${{ env.ECR_UI_REPOSITORY }}:${{ inputs.tag_name || github.event.release.tag_name }}
             ${{ env.DOCKERHUB_USERNAME }}/${{ env.ECR_UI_REPOSITORY }}:latest


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` to `build-docker-image.yml` for manual triggering
- Use `SKYVERN_OSS_GITHUB_TOKEN` instead of `GITHUB_TOKEN` in `auto-release.yml`

## Root Cause
When workflows use `GITHUB_TOKEN` to create events (like releases), those events **do not trigger other workflows**. This is a GitHub security feature to prevent infinite workflow loops.

## Changes

### 1. Manual trigger for `build-docker-image.yml`
Added `workflow_dispatch` with a `tag_name` input so builds can be triggered manually:
- Go to Actions → "Build Docker Image and Push to ECR"
- Click "Run workflow"
- Enter the tag name (e.g., `v1.0.11`)

### 2. Use PAT in `auto-release.yml`
Changed from `GITHUB_TOKEN` to `SKYVERN_OSS_GITHUB_TOKEN` so release events can trigger downstream workflows.

## Test plan
- [ ] Manually trigger `build-docker-image.yml` with tag `v1.0.11` to verify the manual trigger works
- [ ] Verify next auto-release triggers the Docker build workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)