### PR TITLE
Fix credential not clearing when deselected in login block

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/LoginNode/LoginBlockCredentialSelector.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/LoginNode/LoginBlockCredentialSelector.tsx
@@ -145,6 +145,7 @@ function LoginBlockCredentialSelector({ nodeId, value, onChange }: Props) {
   return (
     <>
       <Select
+        key={value ?? "no-credential"}
         value={isCredentialMissing ? undefined : selectedCredentialId ?? value}
         onValueChange={(newValue) => {
           if (newValue === "new") {


### PR DESCRIPTION
## Summary - [SKY-7677](https://linear.app/skyvern/issue/SKY-7677)

Fixed a React rendering bug in the login block credential selector where the selected credential would remain visually displayed even after being removed from the parameter selector.

## Problem
When users removed a credential parameter from the ParametersMultiSelect component in the Advanced Settings of a login block, the credential selector dropdown at the top of the block would not clear visually. The credential name remained displayed in the Select component even though the underlying data had been properly cleared (parameterKeys became empty). This created a confusing UX where the UI showed a credential was selected when none actually was.

The root cause was that React's Select component was not re-rendering when the value changed from a string to undefined. React was reusing the same component instance and not properly updating the displayed value when the credential parameter was removed.

## What Changed
- Added a `key` prop to the Select component in `LoginBlockCredentialSelector.tsx` that forces React to remount the component when the credential selection changes
- The key is set to `value ?? "no-credential"`, which creates a unique key for each credential or a default key when no credential is selected
- This ensures React treats the Select as a new component instance when the credential is cleared, properly displaying the "Select a credential" placeholder

## Test plan
- [x] Open a workflow with a login block
- [x] Select a credential from the credential dropdown at the top of the login block
- [x] Expand Advanced Settings and open the Parameters selector
- [x] Remove the credential parameter from the Parameters selector
- [x] Verify the credential dropdown at the top now shows "Select a credential" placeholder instead of the previously selected credential name
- [x] Re-select a credential and verify it displays correctly
- [x] Switch between different credentials and verify the selector updates properly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the stability and behavior of the credential selector in the login workflow editor to ensure proper state management when changing credential values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes rendering issue in `LoginBlockCredentialSelector.tsx` by adding a `key` prop to `Select` to ensure correct display when credentials are deselected.
> 
>   - **Behavior**:
>     - Fixes rendering issue in `LoginBlockCredentialSelector.tsx` where deselected credentials remained displayed.
>     - Adds `key` prop to `Select` component, set to `value ?? "no-credential"`, forcing remount on credential change.
>     - Ensures "Select a credential" placeholder displays when no credential is selected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 11e45f634b3ae3501547b72dd059212499d33b11. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 Fixes a React rendering bug in the login block credential selector where deselected credentials remained visually displayed in the dropdown. The fix adds a `key` prop to force component re-rendering when credential selection changes, ensuring the UI properly reflects the actual state.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **React Component Fix**: Added `key={value ?? "no-credential"}` prop to the Select component in `LoginBlockCredentialSelector.tsx`
- **State Synchronization**: Forces React to remount the Select component when credential value changes from string to undefined
- **UI Consistency**: Ensures the dropdown placeholder displays correctly when no credential is selected

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant ParametersSelector as Parameters Selector
    participant CredentialDropdown as Credential Dropdown
    participant React as React Renderer

    User->>ParametersSelector: Remove credential parameter
    ParametersSelector->>CredentialDropdown: Update value to undefined
    Note over React: Without key prop: Component reused, display not updated
    CredentialDropdown->>React: Force remount with key prop
    React->>CredentialDropdown: Create new component instance
    CredentialDropdown->>User: Show "Select a credential" placeholder
```

### Impact
- **User Experience**: Eliminates confusing UI state where dropdown showed selected credential when none was actually selected
- **Data Integrity**: Ensures visual representation matches the underlying data state (parameterKeys being empty)
- **Component Reliability**: Leverages React's key prop mechanism to guarantee proper re-rendering behavior for controlled components

</details>

_Created with [Palmier](https://www.palmier.io)_