### PR TITLE
remove credential type from input parameters

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParameterEditPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParameterEditPanel.tsx
@@ -46,7 +46,6 @@ const workflowParameterTypeOptions = [
   { label: "integer", value: WorkflowParameterValueType.Integer },
   { label: "boolean", value: WorkflowParameterValueType.Boolean },
   { label: "file", value: WorkflowParameterValueType.FileURL },
-  { label: "credential", value: WorkflowParameterValueType.CredentialId },
   { label: "JSON", value: WorkflowParameterValueType.JSON },
 ];
 


### PR DESCRIPTION
### Summary

This PR removes the credential type from "Add Input Parameter" box.
This change was already done in #8324 and got reverted by #8326  
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove `credential` option from `workflowParameterTypeOptions` in `WorkflowParameterEditPanel.tsx`.
> 
>   - **Behavior**:
>     - Removes `credential` option from `workflowParameterTypeOptions` in `WorkflowParameterEditPanel.tsx`.
>   - **Context**:
>     - This change was initially made in PR #8324 and reverted in PR #8326.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for a184a719b6b9a92df7db595882de33db3bb1dcbc. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🔧 This PR removes the "credential" parameter type option from the workflow parameter editor, preventing users from selecting credential types when adding input parameters to workflows.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **UI Parameter Options**: Removed the "credential" option from `workflowParameterTypeOptions` array in `WorkflowParameterEditPanel.tsx`
- **User Interface**: The "Add Input Parameter" dropdown will no longer display "credential" as a selectable type
- **Code Cleanup**: This change re-applies a modification that was previously implemented in PR #8324 but got reverted by PR #8326

### Technical Implementation
```mermaid
flowchart TD
    A[User opens Add Input Parameter] --> B[Parameter Type Dropdown]
    B --> C[Available Options]
    C --> D[string]
    C --> E[integer]
    C --> F[boolean]
    C --> G[file]
    C --> H[JSON]
    C -.-> I[credential - REMOVED]
    
    style I fill:#ffcccc,stroke:#ff0000,stroke-dasharray: 5 5
```

### Impact
- **User Experience**: Users can no longer accidentally or intentionally select credential type for workflow input parameters
- **Security Consideration**: Prevents potential security issues by removing credential handling from input parameters
- **Workflow Design**: Simplifies the parameter type selection process by removing an option that may have been problematic or deprecated

</details>

_Created with [Palmier](https://www.palmier.io)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed credential option from workflow parameter value type selections in the workflow editor.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->