### PR TITLE
change sidebar expand/collapse icon from pin to chevron

### DIFF
--- a/skyvern-frontend/src/routes/root/SidebarContent.tsx
+++ b/skyvern-frontend/src/routes/root/SidebarContent.tsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 import { SideNav } from "./SideNav";
 import { cn } from "@/util/utils";
 import { Button } from "@/components/ui/button";
-import { PinLeftIcon, PinRightIcon } from "@radix-ui/react-icons";
+import { ChevronLeftIcon, ChevronRightIcon } from "@radix-ui/react-icons";
 
 type Props = {
   useCollapsedState?: boolean;
@@ -37,9 +37,9 @@ function SidebarContent({ useCollapsedState }: Props) {
           }}
         >
           {collapsed ? (
-            <PinRightIcon className="h-6 w-6" />
+            <ChevronRightIcon className="h-6 w-6" />
           ) : (
-            <PinLeftIcon className="hidden h-6 w-6 lg:block" />
+            <ChevronLeftIcon className="hidden h-6 w-6 lg:block" />
           )}
         </Button>
       </div>


### PR DESCRIPTION
## Summary - [SKY-7582](https://linear.app/skyvern/issue/SKY-7582/update-sidebar-toggle-icon-to-chevrons)

This PR updates icon on the bottom of Sidebar that is controlling the expand/collapse action. The icon is changed from PinLeft/Right to ChevronLeft/Right

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the sidebar collapse/expand button icons.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Change sidebar toggle icon from pin to chevron in `SidebarContent.tsx` for improved visual feedback.
> 
>   - **UI Change**:
>     - Replaces `PinLeftIcon` and `PinRightIcon` with `ChevronLeftIcon` and `ChevronRightIcon` in `SidebarContent.tsx`.
>     - The chevron icon changes based on the `collapsed` state for better visual feedback.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 150ce9564975ba2702c4815ea27c0d605098353b. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

---

🎨 This PR updates the sidebar toggle icons from pin icons to chevron icons for better visual clarity and user experience consistency in the Skyvern frontend application.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Icon Replacement**: Changed from `PinLeftIcon`/`PinRightIcon` to `ChevronLeftIcon`/`ChevronRightIcon` in the sidebar toggle button
- **Import Updates**: Updated the import statement from Radix UI to use chevron icons instead of pin icons
- **Visual Consistency**: Maintained the same conditional rendering logic where chevron direction indicates the action (right chevron when collapsed, left chevron when expanded)

### Technical Implementation
```mermaid
flowchart TD
    A[Sidebar Collapsed State] --> B{Is Collapsed?}
    B -->|Yes| C[Show ChevronRightIcon]
    B -->|No| D[Show ChevronLeftIcon]
    C --> E[Click to Expand]
    D --> F[Click to Collapse]
    E --> G[Sidebar Expands]
    F --> H[Sidebar Collapses]
```

### Impact
- **User Experience**: Chevron icons provide clearer directional indication of the toggle action compared to pin icons
- **Visual Consistency**: Aligns with common UI patterns where chevrons indicate expand/collapse functionality
- **No Functional Changes**: The behavior remains identical - only the visual representation has been updated
- **Backward Compatibility**: No breaking changes as this is purely a visual/styling update

</details>

_Created with [Palmier](https://www.palmier.io)_