### PR TITLE
Fix editor showing unsaved changes when switching conditional branches

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -857,9 +857,14 @@ function FlowRenderer({
               doLayout(tempNodes, edges);
             }
 
-            // Only track changes after initial load is complete
+            // Only track changes after initial load is complete and not during internal updates
+            // (e.g., switching conditional branches which is UI state, not workflow data)
+            // Use getState() to get real-time value (not stale closure from render time)
+            const isInternalUpdate =
+              useWorkflowHasChangesStore.getState().isInternalUpdate;
             if (
               !isInitialLoadRef.current &&
+              !isInternalUpdate &&
               changes.some((change) => {
                 return (
                   change.type === "add" ||

--- a/skyvern-frontend/src/store/WorkflowHasChangesStore.ts
+++ b/skyvern-frontend/src/store/WorkflowHasChangesStore.ts
@@ -31,11 +31,13 @@ type WorkflowHasChangesStore = {
   saveIsPending: boolean;
   saidOkToCodeCacheDeletion: boolean;
   showConfirmCodeCacheDeletion: boolean;
+  isInternalUpdate: boolean;
   setGetSaveData: (getSaveData: () => SaveData) => void;
   setHasChanges: (hasChanges: boolean) => void;
   setSaveIsPending: (isPending: boolean) => void;
   setSaidOkToCodeCacheDeletion: (saidOkToCodeCacheDeletion: boolean) => void;
   setShowConfirmCodeCacheDeletion: (show: boolean) => void;
+  setIsInternalUpdate: (isInternalUpdate: boolean) => void;
 };
 
 interface WorkflowSaveOpts {
@@ -48,6 +50,7 @@ const useWorkflowHasChangesStore = create<WorkflowHasChangesStore>((set) => {
     saveIsPending: false,
     saidOkToCodeCacheDeletion: false,
     showConfirmCodeCacheDeletion: false,
+    isInternalUpdate: false,
     getSaveData: () => null,
     setGetSaveData: (getSaveData: () => SaveData) => {
       set({ getSaveData });
@@ -63,6 +66,9 @@ const useWorkflowHasChangesStore = create<WorkflowHasChangesStore>((set) => {
     },
     setShowConfirmCodeCacheDeletion: (show: boolean) => {
       set({ showConfirmCodeCacheDeletion: show });
+    },
+    setIsInternalUpdate: (isInternalUpdate: boolean) => {
+      set({ isInternalUpdate });
     },
   };
 });


### PR DESCRIPTION
## Summary - [SKY-7316](https://linear.app/skyvern/issue/SKY-7316/editor-shows-unsaved-changes-when-switching-branches)

Fixed false positive "unsaved changes" detection in conditional block editor when users switch between branches. The editor was treating branch switching (UI state) as workflow modifications, incorrectly prompting users to save changes when navigating away despite not making actual workflow changes.

## Problem

In the conditional block editor, users can switch between different branches to view their configurations. However, switching branches updates the `activeBranchId` property in node data, which React Flow's change detection interpreted as a workflow modification. This caused the "save changes or continue without saving" dialog to appear when users navigated away from the editor, even though they only changed which branch they were viewing, not the actual workflow data itself.

The issue was compounded by a stale closure problem where the change detection logic in `FlowRenderer.tsx` was checking a hook value captured at render time rather than accessing the real-time store state, preventing proper synchronization with branch switching operations.

## What Changed

- Added `isInternalUpdate` boolean flag to `WorkflowHasChangesStore` to distinguish between UI state changes and actual workflow modifications
- Added `setIsInternalUpdate` setter function to the store interface
- Modified `ConditionalNode.tsx` to wrap branch switching operations with the internal update flag:
- Wrapped `handleSelectBranch` function to set flag before updating `activeBranchId` and clear it after layout completes
- Wrapped initial `activeBranchId` initialization in `useEffect` with the same flag pattern
- Used 50ms timeout to ensure flag is cleared after React Flow's layout operations complete
- Updated `FlowRenderer.tsx` change detection logic to:
- Check `isInternalUpdate` flag using `useWorkflowHasChangesStore.getState().isInternalUpdate` to get real-time state instead of stale closure value
- Skip marking workflow as changed when `isInternalUpdate` is true
- Added explanatory comments about UI state vs workflow data distinction

## Test plan

- [ ] Open a workflow with conditional blocks in the editor
- [ ] Switch between different branches in a conditional block multiple times
- [ ] Navigate away from the editor (e.g., click back to workflows list)
- [ ] Verify no "unsaved changes" dialog appears
- [ ] Make an actual workflow change (add a block, modify a condition, etc.)
- [ ] Navigate away from the editor
- [ ] Verify the "unsaved changes" dialog correctly appears
- [ ] Test with multiple conditional blocks, switching branches across different conditionals
- [ ] Verify branch visibility toggling still works correctly (only active branch nodes are visible)

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix false unsaved changes detection in editor by adding `isInternalUpdate` flag to distinguish UI state changes from workflow modifications.
> 
>   - **Behavior**:
>     - Added `isInternalUpdate` flag to `WorkflowHasChangesStore` to differentiate UI state changes from workflow modifications.
>     - Modified `FlowRenderer.tsx` to check `isInternalUpdate` flag before marking workflow as changed.
>     - Updated `ConditionalNode.tsx` to set `isInternalUpdate` flag during branch switching operations.
>   - **Functions**:
>     - Added `setIsInternalUpdate` function to `WorkflowHasChangesStore`.
>     - Wrapped `handleSelectBranch` and initial `activeBranchId` setup in `ConditionalNode.tsx` with `isInternalUpdate` flag.
>   - **Misc**:
>     - Added comments in `FlowRenderer.tsx` and `ConditionalNode.tsx` explaining UI state vs workflow data distinction.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 893ea8fc46166558c173f6eacc7e613fee132916. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Improved workflow editor change tracking to accurately distinguish between internal UI state updates and actual data modifications, reducing false "unsaved changes" notifications.
* Fixed conditional node branch selection to prevent triggering false change indicators during UI-only state updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

🔧 This PR fixes a false positive "unsaved changes" detection bug in the workflow editor that occurred when users switched between conditional branches. The fix introduces an `isInternalUpdate` flag to distinguish between UI state changes (branch switching) and actual workflow modifications, preventing unnecessary save prompts.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **Store Enhancement**: Added `isInternalUpdate` boolean flag and setter to `WorkflowHasChangesStore` to track internal UI operations
- **Change Detection Logic**: Modified `FlowRenderer.tsx` to check the `isInternalUpdate` flag before marking workflows as changed, using `getState()` to avoid stale closure issues
- **Conditional Node Behavior**: Updated `ConditionalNode.tsx` to wrap branch switching operations with the internal update flag, using 50ms timeouts to ensure proper cleanup after React Flow layout operations

### Technical Implementation
```mermaid
sequenceDiagram
    participant User
    participant ConditionalNode
    participant Store
    participant FlowRenderer
    
    User->>ConditionalNode: Switch branch
    ConditionalNode->>Store: setIsInternalUpdate(true)
    ConditionalNode->>ConditionalNode: update({ activeBranchId })
    ConditionalNode->>FlowRenderer: Triggers change detection
    FlowRenderer->>Store: getState().isInternalUpdate
    Store-->>FlowRenderer: true
    FlowRenderer->>FlowRenderer: Skip marking as changed
    Note over ConditionalNode: 50ms timeout
    ConditionalNode->>Store: setIsInternalUpdate(false)
```

### Impact
- **User Experience**: Eliminates false "unsaved changes" dialogs when switching between conditional branches, reducing user friction
- **Data Integrity**: Maintains proper change detection for actual workflow modifications while ignoring UI state changes
- **Technical Robustness**: Resolves stale closure issues by using real-time store state access instead of render-time hook values

</details>

_Created with [Palmier](https://www.palmier.io)_