### PR TITLE
Update API specifications with fern api update

### DIFF
--- a/fern/openapi/skyvern_openapi.json
+++ b/fern/openapi/skyvern_openapi.json
@@ -15169,9 +15169,11 @@
           "generate_metadata",
           "extract_loop_values",
           "generate_task_in_loop",
-          "generate_general_task"
+          "generate_general_task",
+          "termination"
         ],
-        "title": "ThoughtScenario"
+        "title": "ThoughtScenario",
+        "description": "Scenario in which a thought was generated.\n\nNote: Stored as VARCHAR in the database (not a PostgreSQL ENUM), so new values\ncan be added without database migrations. See observer_thoughts.observer_thought_scenario column."
       },
       "ThoughtType": {
         "type": "string",
@@ -15180,9 +15182,11 @@
           "metadata",
           "user_goal_check",
           "internal_plan",
-          "failure_describe"
+          "failure_describe",
+          "termination"
         ],
-        "title": "ThoughtType"
+        "title": "ThoughtType",
+        "description": "Type of thought recorded during task execution.\n\nNote: Stored as VARCHAR in the database (not a PostgreSQL ENUM), so new values\ncan be added without database migrations. See observer_thoughts.observer_thought_type column."
       },
       "TotpType": {
         "type": "string",


### PR DESCRIPTION
Update API specifications by running fern api update.

---

📝 This PR updates the API specifications by adding new enum values and documentation to the ThoughtScenario and ThoughtType schemas in the OpenAPI specification.

<details>
<summary>🔍 <strong>Detailed Analysis</strong></summary>

### Key Changes
- **ThoughtScenario enum**: Added "termination" as a new possible scenario value and comprehensive documentation explaining the database storage approach
- **ThoughtType enum**: Added "termination" as a new thought type value with detailed documentation about database implementation
- **Documentation enhancement**: Both schemas now include descriptions explaining they're stored as VARCHAR (not PostgreSQL ENUM) to allow adding new values without database migrations

### Technical Implementation
```mermaid
flowchart TD
    A[API Specification Update] --> B[ThoughtScenario Schema]
    A --> C[ThoughtType Schema]
    B --> D[Add 'termination' value]
    B --> E[Add database storage documentation]
    C --> F[Add 'termination' value]
    C --> G[Add database storage documentation]
    D --> H[Enhanced API flexibility]
    F --> H
    E --> I[Improved developer understanding]
    G --> I
```

### Impact
- **API extensibility**: The addition of "termination" values expands the system's ability to track task completion scenarios and thought types
- **Developer experience**: New documentation clarifies the database implementation strategy, helping developers understand why VARCHAR is used instead of PostgreSQL ENUMs
- **Future maintenance**: The VARCHAR approach allows for adding new enum values without requiring database migrations, improving system maintainability

</details>

_Created with [Palmier](https://www.palmier.io)_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `skyvern_openapi.json` to include new values and descriptions for `ThoughtScenario` and `ThoughtType`.
> 
>   - **API Specification Update**:
>     - Adds `termination` to `ThoughtScenario` and `ThoughtType` arrays in `skyvern_openapi.json`.
>     - Adds descriptions to `ThoughtScenario` and `ThoughtType` in `skyvern_openapi.json`, explaining storage as VARCHAR and flexibility for new values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Skyvern-AI%2Fskyvern&utm_source=github&utm_medium=referral)<sup> for 310dad54bfdd148c1030c610efeee87a50824e47. You can [customize](https://app.ellipsis.dev/Skyvern-AI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `termination` value to ThoughtScenario and ThoughtType enums, providing new states for thought tracking and categorization.

* **Documentation**
  * Enhanced enum descriptions for ThoughtScenario and ThoughtType with detailed documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->