### PR TITLE
Fix Block Library search to include block descriptions (#SKY-7583)

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx
@@ -348,7 +348,8 @@ function WorkflowNodeLibraryPanel({
 
     return (
       item.nodeType.toLowerCase().includes(term) ||
-      item.title.toLowerCase().includes(term)
+      item.title.toLowerCase().includes(term) ||
+      item.description.toLowerCase().includes(term)
     );
   });
 


### PR DESCRIPTION
## Summary - [SKY-7583](https://linear.app/skyvern/issue/SKY-7583/block-library-search-does-not-match-block-subtitles)

Fixed the Block Library panel search to include block descriptions/subtitles in search results. Previously, searching only matched block titles and node types, which meant searching for terms like "llm" would not find the "Text Prompt Block" even though it has the subtitle "Process text with LLM".

## Problem
In the Workflow Editor's Block Library panel, the search functionality was incomplete. Users could only find blocks by their title or node type, not by the descriptive text explaining what each block does. This made it harder to discover relevant blocks - for example, searching "llm" returned no results even though the Text Prompt Block clearly works with LLMs.

## What Changed
- Added `item.description.toLowerCase().includes(term)` to the search filter logic in `WorkflowNodeLibraryPanel.tsx`
- Block search now checks three fields: node type, title, and description
- File: `skyvern-frontend/src/routes/workflows/editor/panels/WorkflowNodeLibraryPanel.tsx`

## Screenshots
<img width="426" height="297" alt="image" src="https://github.com/user-attachments/assets/74ac2a1d-c8fc-45fb-a060-f8059b77c57a" />


## Test plan
- [x] Open the Workflow Editor and access the Block Library panel
- [x] Search for "llm" - should find Text Prompt Block (subtitle: "Process text with LLM")
- [x] Search for "validation" - should find Validation Block (subtitle: "Add validation rules")
- [x] Verify search still works for block titles (e.g., "action" finds Action Block)
- [x] Verify search still works for node types (e.g., "task" finds task blocks)

🤖 Generated with [Claude Code](https://claude.ai/code)