### PR TITLE
Fix UI line lag when toggling Advanced Settings (#SKY-7702)

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/edges/EdgeWithAddButton.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/edges/EdgeWithAddButton.tsx
@@ -276,6 +276,7 @@ function EdgeWithAddButton({
           style={{
             position: "absolute",
             transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+            transition: "transform 0.2s ease-out",
             fontSize: 12,
             // everything inside EdgeLabelRenderer has no pointer events by default
             // if you have an interactive element, set pointer-events: all

--- a/skyvern-frontend/src/routes/workflows/editor/reactFlowOverrideStyles.css
+++ b/skyvern-frontend/src/routes/workflows/editor/reactFlowOverrideStyles.css
@@ -16,18 +16,18 @@
 
 /* Smooth transitions for node position and size changes */
 .react-flow__node {
-  transition: transform 0.3s ease-in-out;
+  transition: transform 0.2s ease-out;
 }
 
 /* Smooth transitions for edge position updates */
 .react-flow__edge path,
 .react-flow__edge-path {
-  transition: d 0.3s ease-in-out;
+  transition: d 0.2s ease-out;
 }
 
 .react-flow__edge text,
 .react-flow__edge-text {
-  transition: transform 0.3s ease-in-out;
+  transition: transform 0.2s ease-out;
 }
 
 .react-flow__handle-top {


### PR DESCRIPTION
	## Summary - [SKY-7702](https://linear.app/skyvern/issue/SKY-7702/ui-line-lag-when-toggling-advanced-settings-panel)

Fixed visible lag in workflow editor when toggling the Advanced Settings accordion. Edge lines and "+" buttons now smoothly animate in sync with the accordion panel instead of lagging behind.

## Problem

When users toggled the Advanced Settings panel in the workflow editor, the React Flow graph elements (edge lines and add-node buttons) visibly lagged behind the accordion animation. This created a jarring visual experience where:
- The accordion would expand/collapse smoothly
- But the connecting lines and "+" buttons would move with a noticeable delay
- The mismatch was caused by different animation timings between components

Root cause: The accordion uses a 0.2s ease-out transition, while React Flow nodes and edges were configured with 0.3s ease-in-out transitions. This 100ms timing mismatch created the visible lag.

## Reported Video
https://www.loom.com/share/838a8dcea5564d4e96bd162486acdf77

## What Changed

- **`reactFlowOverrideStyles.css`**: Synchronized all React Flow transition timings from `0.3s ease-in-out` to `0.2s ease-out` to match the accordion animation
- Updated `.react-flow__node` transform transition
- Updated `.react-flow__edge path` and `.react-flow__edge-path` transitions
- Updated `.react-flow__edge text` and `.react-flow__edge-text` transform transitions
- **`EdgeWithAddButton.tsx`**: Added explicit `transition: "transform 0.2s ease-out"` to the EdgeLabelRenderer div containing the "+" button, ensuring the add-node button animates smoothly with the graph

## Test plan

- [x] Open the workflow editor
- [x] Toggle the Advanced Settings accordion open and closed multiple times
- [x] Verify edge lines and "+" buttons move in perfect sync with the accordion animation
- [x] Confirm there is no visible lag or delay
- [x] Test on different workflow complexity levels (simple and complex graphs)

🤖 Generated with [Claude Code](https://claude.ai/code)