### PR TITLE
Add CLAUDE.md for prompt template sync guidance

### DIFF
--- a/skyvern/forge/prompts/skyvern/CLAUDE.md
+++ b/skyvern/forge/prompts/skyvern/CLAUDE.md
@@ -1,0 +1,9 @@
+# Prompt Templates
+
+Action extraction templates are split for caching optimization:
+
+- `extract-action.j2` — Complete template (static + dynamic)
+- `extract-action-static.j2` — Cacheable prefix
+- `extract-action-dynamic.j2` — Dynamic suffix with runtime variables
+
+When modifying `extract-action.j2`, update the static/dynamic files to match. The static file must exactly match the prefix of the complete file.


### PR DESCRIPTION
## Summary

- Adds a `CLAUDE.md` in `skyvern/forge/prompts/skyvern/` to remind Claude Code that `extract-action.j2` and `extract-action-static.j2` share a prefix and must stay in sync.

## Test plan

- N/A — documentation only

🤖 Generated with [Claude Code](https://claude.ai/code)