### PR TITLE
Clear default value state when switching to credential type (#SKY-7820)

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParameterEditPanel.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/panels/WorkflowParameterEditPanel.tsx
@@ -360,6 +360,15 @@ function WorkflowParameterEditPanel({
                       setAzureTotpKey("");
                     }
 
+                    // Clear default value state when switching to credential type
+                    // since credentials don't use default values
+                    if (!wasCredential && isNowCredential) {
+                      setDefaultValueState({
+                        hasDefaultValue: false,
+                        defaultValue: null,
+                      });
+                    }
+
                     if (!isNowCredential) {
                       setDefaultValueState((state) => {
                         return {


### PR DESCRIPTION
## Summary - [SKY-7820](https://linear.app/skyvern/issue/SKY-7820/clear-default-value-when-switching-to-credential-type)

Fixes a state inconsistency bug where switching a parameter type from non-credential to credential did not clear the default value state, leaving stale default value data in the component state.

## Problem

When editing a workflow parameter in the WorkflowParameterEditPanel, if a user selects a non-credential type like "string", checks "Use Default Value", enters a value, and then switches to "credential" type, the defaultValueState remained populated with the previous default value even though credential parameters don't use default values.

While this didn't cause functional issues (the save logic correctly checks isCredentialSelected and doesn't include defaultValue for credential parameters), it created inconsistent state that could cause confusion if defaultValueState is referenced elsewhere in the component.

## What Changed

- Added state cleanup logic in WorkflowParameterEditPanel.tsx when switching from non-credential to credential type
- Clears both hasDefaultValue and defaultValue when the transition occurs
- Positioned the cleanup after credential field clearing but before non-credential default value initialization

## Test plan

- [ ] Open workflow editor and create or edit a parameter
- [ ] Select "string" type and check "Use Default Value", enter a value like "hello"
- [ ] Switch parameter type to "credential"
- [ ] Verify the default value checkbox and input are cleared (not visible for credential types)
- [ ] Switch back to "string" type
- [ ] Verify the default value state is properly reset to the type's default (not retaining "hello")

🤖 Generated with [Claude Code](https://claude.ai/code)