### PR TITLE
Fix ActionDragPath subscript error in CUA drag action parsing (#SKY-7774)

### DIFF
--- a/skyvern/webeye/actions/parse_actions.py
+++ b/skyvern/webeye/actions/parse_actions.py
@@ -370,12 +370,13 @@ async def parse_cua_actions(
                             intention=reasoning,
                         )
                     else:
-                        start_x, start_y = whole_path[0][0], whole_path[0][1]
+                        # ActionDragPath objects have x and y attributes
+                        start_x, start_y = whole_path[0].x, whole_path[0].y
                         reasoning = reasoning or f"Drag action path: {whole_path}"
                         action = DragAction(
                             start_x=start_x,
                             start_y=start_y,
-                            path=whole_path[1:],
+                            path=[(p.x, p.y) for p in whole_path[1:]],
                             reasoning=reasoning,
                             intention=reasoning,
                         )


### PR DESCRIPTION
## Summary

- Fixed `TypeError: 'ActionDragPath' object is not subscriptable` error in CUA drag action parsing
- The OpenAI CUA drag action returns `path` as `List[ActionDragPath]` where each `ActionDragPath` is an object with `.x` and `.y` attributes, not a subscriptable list/tuple
- Updated code to access `ActionDragPath` attributes using `.x` and `.y` instead of subscript operators `[0]` and `[1]`
- Convert `ActionDragPath` objects to tuples for `DragAction.path` field which expects `list[tuple[int, int]]`

## Test plan

- [ ] Verify CUA drag actions are parsed correctly without errors
- [ ] Test drag operations in browser automation tasks

🤖 Generated with [Claude Code](https://claude.ai/code)