### PR TITLE
Open workflow copilot by default when no blocks exist

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -248,7 +248,9 @@ function Workspace({
   const [toDeleteCacheKeyValue, setToDeleteCacheKeyValue] = useState<
     string | null
   >(null);
-  const [isCopilotOpen, setIsCopilotOpen] = useState(false);
+  const [isCopilotOpen, setIsCopilotOpen] = useState(
+    () => !initialNodes.some(isWorkflowBlockNode),
+  );
   const [copilotMessageCount, setCopilotMessageCount] = useState(0);
   const copilotButtonRef = useRef<HTMLButtonElement>(null);
   const [


### PR DESCRIPTION
## Summary
- Automatically opens the workflow copilot when a workflow has no blocks (just the start block)
- Helps new users get started building their first workflow by surfacing the AI assistant immediately

## Test plan
- [ ] Create a new workflow and verify the copilot opens automatically
- [ ] Open an existing workflow with blocks and verify the copilot stays closed
- [ ] Delete all blocks from a workflow and reload - copilot should open

🤖 Generated with [Claude Code](https://claude.ai/code)