### PR TITLE
Fix ForLoop blocks not executing with cached scripts (#SKY-7751)

### DIFF
--- a/skyvern/core/script_generations/CLAUDE.md
+++ b/skyvern/core/script_generations/CLAUDE.md
@@ -1,0 +1,32 @@
+# Script Generation Context
+
+## Key Constants
+
+- `SCRIPT_TASK_BLOCKS` - Block types that have task_id and actions (task, navigation, extraction, etc.)
+- `BLOCK_TYPES_THAT_SHOULD_BE_CACHED` in `workflow/service.py` - Block types eligible for caching (includes for_loop)
+
+## Script Block Requirements for `run_with: code`
+
+For a workflow to execute with cached scripts (`run_with: code`), ALL top-level blocks must have:
+1. A `script_block` database entry
+2. A non-null `run_signature` field
+
+Without these, the system falls back to `run_with: agent`.
+
+## Adding New Cacheable Block Types
+
+When adding a new block type that should support cached execution:
+1. Add to `BLOCK_TYPES_THAT_SHOULD_BE_CACHED` in `workflow/service.py`
+2. Add handling in `generate_workflow_script_python_code()` with BOTH:
+   - `create_or_update_script_block()` - stores metadata in database
+   - `append_block_code(block_code)` - adds code to generated script output
+3. Ensure `run_signature` is set (the code statement to execute the block)
+
+**CRITICAL**: Every block type needs BOTH database entry AND script output. Missing `append_block_code()` causes runtime failures even if database entries exist.
+
+## Block Processing Order in generate_script.py
+
+1. `task_v1_blocks` - Blocks in `SCRIPT_TASK_BLOCKS`
+2. `task_v2_blocks` - task_v2 blocks with child blocks
+3. `for_loop_blocks` - ForLoop container blocks
+4. `__start_block__` - Workflow entry point


### PR DESCRIPTION
## Summary

- **Root Cause**: ForLoop blocks were excluded from script_block database entry creation, causing workflows with ForLoop blocks to always fall back to `run_with: agent` instead of `run_with: code`
- **Fix**: Add explicit handling for `for_loop` blocks in `generate_workflow_script_python_code()` to create script_block entries with `run_signature`
- **Added**: CLAUDE.md in script_generations folder documenting the script block requirements for cached execution

## Investigation Findings

Datadog logs showed that Middesk's CA EDD workflow (`wpid_465679359287789630`):
- ✅ Scripts were being generated ("Generating script for workflow")
- ✅ Scripts were found on subsequent runs ("Found cached script for workflow")  
- ✅ Script blocks were loaded ("Loading script blocks for workflow execution")
- ❌ All runs showed `run_with: agent` instead of `run_with: code`

The decision at `service.py:985` requires `script_blocks_by_label` to be non-empty:
```python
run_with = "code" if script and is_script_run and script_blocks_by_label else "agent"
```

ForLoop blocks were missing from `script_blocks_by_label` because:
1. `SCRIPT_TASK_BLOCKS` only includes task, navigation, extraction, etc. - not `for_loop`
2. Script block creation only iterated over blocks in `SCRIPT_TASK_BLOCKS` and `task_v2`
3. ForLoop blocks never got a `run_signature` stored in the database
4. When loading script blocks, only entries with `run_signature` are added to `script_blocks_by_label`

## Test plan

- [x] All existing ForLoop tests pass (12 tests)
- [x] All script generation race condition tests pass (23 tests)
- [x] Pre-commit hooks pass
- [ ] Deploy to staging and verify ForLoop workflows run with `run_with: code`
- [ ] Monitor Datadog for `@run_with:code @block_type:for_loop` logs

🤖 Generated with [Claude Code](https://claude.ai/code)