### PR TITLE
Improve version history icon to better represent document versions (#SKY-7370)

### DIFF
--- a/skyvern-frontend/src/components/icons/VersionHistoryIcon.tsx
+++ b/skyvern-frontend/src/components/icons/VersionHistoryIcon.tsx
@@ -1,0 +1,36 @@
+import { CounterClockwiseClockIcon, FileTextIcon } from "@radix-ui/react-icons";
+
+type Props = {
+  /** Size of the main document icon in pixels */
+  size?: number;
+  /** Additional class names */
+  className?: string;
+};
+
+function VersionHistoryIcon({ size = 24, className = "" }: Props) {
+  // Calculate relative size for the history icon (overlay)
+  const historySize = Math.round(size * 0.6);
+
+  return (
+    <div
+      className={`relative inline-flex items-center justify-center ${className}`}
+      style={{ width: size, height: size }}
+      aria-label="Version History"
+    >
+      {/* Main Document Icon */}
+      <FileTextIcon width={size} height={size} />
+
+      {/* Overlay History Icon - Bottom Left */}
+      <div
+        className="absolute bottom-0 left-0 rounded-full bg-slate-elevation2"
+        style={{
+          transform: "translate(-20%, 20%)",
+        }}
+      >
+        <CounterClockwiseClockIcon width={historySize} height={historySize} />
+      </div>
+    </div>
+  );
+}
+
+export { VersionHistoryIcon };

--- a/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/WorkflowHeader.tsx
@@ -3,7 +3,6 @@ import {
   BookmarkIcon,
   ChevronDownIcon,
   ChevronUpIcon,
-  ClockIcon,
   CodeIcon,
   CopyIcon,
   PlayIcon,
@@ -13,6 +12,7 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { SaveIcon } from "@/components/icons/SaveIcon";
 import { BrowserIcon } from "@/components/icons/BrowserIcon";
+import { VersionHistoryIcon } from "@/components/icons/VersionHistoryIcon";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -386,7 +386,7 @@ function WorkflowHeader({
                         onHistory?.();
                       }}
                     >
-                      <ClockIcon className="size-6" />
+                      <VersionHistoryIcon size={24} />
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>History</TooltipContent>


### PR DESCRIPTION
	## Summary - [SKY-7370](https://linear.app/skyvern/issue/SKY-7370/update-version-history-icon-to-represent-versions)

Replaced the generic clock icon in the workflow editor's version history button with a new composite icon that better represents "document version history" by combining a document icon with a history badge overlay.

## Problem

The version history button in the workflow editor header was using a simple clock icon, which only conveyed the concept of "time" or "history" but didn't clearly represent "versions" or "document history." This made the button's purpose less immediately clear to users who might confuse it with other time-related features.

## What Changed

- **Added** new `VersionHistoryIcon` component in `skyvern-frontend/src/components/icons/VersionHistoryIcon.tsx`
- Composites `FileTextIcon` (document) as the main icon with `CounterClockwiseClockIcon` (history/revert) as a badge overlay
- Overlay positioned at bottom-left with 60% relative sizing for visual balance
- Uses `bg-slate-elevation2` background on the badge for contrast and depth
- Supports configurable size and className props for flexibility
- Includes proper ARIA label for accessibility
- **Updated** `WorkflowHeader.tsx` to use `VersionHistoryIcon` instead of `ClockIcon`
- Removed `ClockIcon` import from `@radix-ui/react-icons`
- Added `VersionHistoryIcon` import and usage with 24px size

## Test plan

- [ ] Verify the version history button in the workflow editor displays the new composite icon (document with history badge)
- [ ] Confirm the icon is visually clear and the badge overlay is properly positioned
- [ ] Test that clicking the button still opens the version history panel
- [ ] Check icon rendering at different screen sizes and zoom levels
- [ ] Verify no console errors or warnings related to the icon component

🤖 Generated with [Claude Code](https://claude.ai/code)