### PR TITLE
Fix debugger loop block visual overlap when status row appears (#SKY-7310)

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/FlowRenderer.tsx
@@ -36,7 +36,7 @@ import {
 import "@xyflow/react/dist/style.css";
 import { nanoid } from "nanoid";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useBlocker } from "react-router-dom";
+import { useBlocker, useParams } from "react-router-dom";
 import {
   AWSSecretParameter,
   debuggableWorkflowBlockTypes,
@@ -308,6 +308,7 @@ function FlowRenderer({
   onContainerResize,
   onRequestDeleteNode,
 }: Props) {
+  const { blockLabel: targettedBlockLabel } = useParams();
   const reactFlowInstance = useReactFlow();
   const debugStore = useDebugStore();
   const { title, initializeTitle } = useWorkflowTitleStore();
@@ -356,11 +357,11 @@ function FlowRenderer({
 
   const doLayout = useCallback(
     (nodes: Array<AppNode>, edges: Array<Edge>) => {
-      const layoutedElements = layout(nodes, edges);
+      const layoutedElements = layout(nodes, edges, targettedBlockLabel);
       setNodes(layoutedElements.nodes);
       setEdges(layoutedElements.edges);
     },
-    [setNodes, setEdges],
+    [setNodes, setEdges, targettedBlockLabel],
   );
 
   useEffect(() => {
@@ -369,6 +370,15 @@ function FlowRenderer({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [nodesInitialized]);
+
+  // Re-layout when the targetted block changes to account for the status row
+  // that appears when a block is being debugged
+  useEffect(() => {
+    if (nodesInitialized && targettedBlockLabel) {
+      doLayout(nodes, edges);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [targettedBlockLabel]);
 
   useEffect(() => {
     const topLevelBlocks = getWorkflowBlocks(nodes, edges);

--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -708,11 +708,11 @@ function Workspace({
 
   const doLayout = useCallback(
     (nodes: Array<AppNode>, edges: Array<Edge>) => {
-      const layoutedElements = layout(nodes, edges);
+      const layoutedElements = layout(nodes, edges, blockLabel);
       setNodes(layoutedElements.nodes);
       setEdges(layoutedElements.edges);
     },
-    [setNodes, setEdges],
+    [setNodes, setEdges, blockLabel],
   );
 
   // Listen for conditional branch changes to trigger re-layout
@@ -724,7 +724,7 @@ function Workspace({
         const currentNodes = getNodes() as Array<AppNode>;
         const currentEdges = getEdges();
 
-        const layoutedElements = layout(currentNodes, currentEdges);
+        const layoutedElements = layout(currentNodes, currentEdges, blockLabel);
         setNodes(layoutedElements.nodes);
         setEdges(layoutedElements.edges);
       }, 10); // Small delay to ensure visibility updates complete
@@ -737,7 +737,7 @@ function Workspace({
         handleBranchChange,
       );
     };
-  }, [getNodes, getEdges, setNodes, setEdges]);
+  }, [getNodes, getEdges, setNodes, setEdges, blockLabel]);
 
   function addNode({
     nodeType,

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -262,9 +262,13 @@ function getNestingLevel(node: AppNode, nodes: Array<AppNode>): number {
   return level;
 }
 
+// Extra margin to add when a block is being debugged and shows the status row
+const TARGETTED_BLOCK_EXTRA_MARGIN = 48;
+
 function layout(
   nodes: Array<AppNode>,
   edges: Array<Edge>,
+  targettedBlockLabel?: string,
 ): { nodes: Array<AppNode>; edges: Array<Edge> } {
   const loopNodes = nodes.filter(
     (node) => node.type === "loop" && !node.hidden,
@@ -288,12 +292,18 @@ function layout(
       ...n,
       position: { x: 0, y: 0 },
     }));
+    // Check if this loop node is the targetted block (being debugged)
+    // If so, add extra margin to account for the status row that appears
+    const nodeLabel = isWorkflowBlockNode(node) ? node.data.label : undefined;
+    const isTargetted =
+      targettedBlockLabel && nodeLabel === targettedBlockLabel;
+    const marginy = isTargetted ? 225 + TARGETTED_BLOCK_EXTRA_MARGIN : 225;
     const layouted = layoutUtil(
       childNodesWithResetPositions,
       childEdges,
       {
         marginx: (loopNodeWidth - maxChildWidth) / 2,
-        marginy: 225,
+        marginy,
       },
       nodes,
     );
@@ -337,12 +347,18 @@ function layout(
       position: { x: 0, y: 0 },
     }));
 
+    // Check if this conditional node is the targetted block (being debugged)
+    // If so, add extra margin to account for the status row that appears
+    const nodeLabel = isWorkflowBlockNode(node) ? node.data.label : undefined;
+    const isTargetted =
+      targettedBlockLabel && nodeLabel === targettedBlockLabel;
+    const marginy = isTargetted ? 225 + TARGETTED_BLOCK_EXTRA_MARGIN : 225;
     const layouted = layoutUtil(
       childNodesWithResetPositions,
       childEdges,
       {
         marginx: (conditionalNodeWidth - maxChildWidth) / 2,
-        marginy: 225,
+        marginy,
       },
       nodes,
     );


### PR DESCRIPTION
## Summary - [SKY-7310](https://linear.app/skyvern/issue/SKY-7310/fix-debugger-loop-jank)

Fixes visual overlap issue in the workflow editor debugger where child blocks inside loop and conditional blocks would overlap with the status row that appears when debugging a block. The status row (showing rerun button, date info, and status badge) adds 48px of height but child blocks were not repositioning to account for this, causing UI jank.

## Problem

When running a loop or conditional block in the debugger, a status row appears at the top of the block container showing debug information (rerun button, execution date, status badge). This status row adds visual height to the container, but the layout system was not accounting for this extra space. As a result:

- Child blocks inside the debugged block would overlap with the status row
- The container height wouldn't adjust properly
- Sibling blocks below the container wouldn't reposition
- This created a poor visual experience during debugging sessions

## What Changed

- **Modified `layout` function in `workflowEditorUtils.ts`**: Added optional `targettedBlockLabel` parameter to identify which block is being debugged
- **Added `TARGETTED_BLOCK_EXTRA_MARGIN` constant**: Defines 48px of extra margin to compensate for the status row height
- **Enhanced loop node layout logic**: Checks if loop node matches targetted block label and adds extra margin (225px → 273px) when debugging
- **Enhanced conditional node layout logic**: Same check and margin adjustment for conditional blocks being debugged
- **Updated `FlowRenderer.tsx`**: Extracts `blockLabel` from URL params via `useParams()` and passes it to layout function
- **Added re-layout effect in `FlowRenderer.tsx`**: Triggers layout recalculation when targetted block changes to immediately apply margin adjustments
- **Updated `Workspace.tsx`**: Passes `blockLabel` to all `layout()` calls and includes it in dependency arrays

The fix works through a cascading effect: increased child node margins → child positions adjust downward → container height increases to fit children → sibling blocks reposition below the expanded container.

## Test plan

- [ ] Open a workflow in the editor that contains a loop block with child blocks inside
- [ ] Click the debug button on the loop block to enter debug mode
- [ ] Verify that child blocks inside the loop do not overlap with the status row at the top
- [ ] Verify that blocks below the loop reposition correctly to account for the increased height
- [ ] Repeat the test with a conditional block instead of a loop block
- [ ] Navigate away from the debugged block and verify layout returns to normal (no extra margin)
- [ ] Test with nested loops/conditionals to ensure margin is only applied to the directly targetted block

🤖 Generated with [Claude Code](https://claude.ai/code)