### PR TITLE
fix: restore DESC order in get_tasks_actions for timeline UI

### DIFF
--- a/skyvern/core/script_generations/transform_workflow_run.py
+++ b/skyvern/core/script_generations/transform_workflow_run.py
@@ -101,8 +101,9 @@ async def transform_workflow_run_to_code_gen_input(workflow_run_id: str, organiz
             task_count=len(tasks),
         )
 
-        # Single query for all actions
+        # Single query for all actions (returns desc order for timeline; reverse for chronological)
         all_actions = await app.DATABASE.get_tasks_actions(task_ids=task_ids_list, organization_id=organization_id)
+        all_actions.reverse()
         for action in all_actions:
             if action.task_id:
                 actions_by_task_id[action.task_id].append(action)

--- a/skyvern/forge/sdk/db/CLAUDE.md
+++ b/skyvern/forge/sdk/db/CLAUDE.md
@@ -1,0 +1,11 @@
+# Database Layer
+
+## `get_tasks_actions` — Sort Order is DESC (Intentional)
+
+`get_tasks_actions()` returns actions in **descending** `created_at` order. This is intentional — do NOT change it to ascending.
+
+**Why:** The primary consumer is `get_workflow_run_timeline()` in `service.py`, which feeds the frontend timeline UI. The frontend renders actions with `index={actions.length - index}` and expects newest-first (DESC) ordering for correct display numbering.
+
+**Script generation** (`transform_workflow_run.py`) needs chronological (ascending) order for code generation. It reverses the result with `all_actions.reverse()` after fetching.
+
+**History:** PR #8551 changed this to ASC for script gen correctness but broke the timeline. PR #8606 synced the change to cloud. This was fixed by reverting to DESC and reversing in the script gen caller instead.

--- a/skyvern/forge/sdk/db/agent_db.py
+++ b/skyvern/forge/sdk/db/agent_db.py
@@ -577,10 +577,9 @@ class AgentDB(BaseAlchemyDB):
                     select(ActionModel)
                     .filter(ActionModel.organization_id == organization_id)
                     .filter(ActionModel.task_id.in_(task_ids))
-                    .order_by(ActionModel.created_at)
+                    .order_by(ActionModel.created_at.desc())
                 )
                 actions = (await session.scalars(query)).all()
-                # Must match get_task_actions_hydrated: no empty_element_id so None element_ids stay None
                 return [hydrate_action(action) for action in actions]
 
         except SQLAlchemyError:


### PR DESCRIPTION
## Summary

- Restore `get_tasks_actions()` to its original DESC sort order, which the timeline UI depends on
- Reverse actions in `transform_workflow_run.py` to get chronological (ASC) order for script generation
- Add `CLAUDE.md` in `skyvern/forge/sdk/db/` documenting why DESC order must be preserved

## Context

PR #8551 changed `get_tasks_actions` from `order_by(created_at.desc())` to `order_by(created_at)` to fix script generation ordering. PR #8606 synced this to cloud. However, the original caller — `get_workflow_run_timeline()` in `service.py` — was designed around DESC order. The frontend renders actions with `index={actions.length - index}` expecting newest-first ordering.

**Impact without this fix:** Timeline UI shows actions with inverted numbering (first action labeled with highest number).

## Fix

- Revert `get_tasks_actions` to `order_by(created_at.desc())` (its original behavior)
- Add `all_actions.reverse()` in `transform_workflow_run.py` before grouping by task_id
- Update tests to mock DESC input and verify ASC output

## Test plan

- [x] `python -m pytest tests/unit/test_batch_action_queries.py -v` — 3 tests pass
- [x] `python -m pytest tests/unit/test_forloop_script_generation.py -v` — 12 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)