### PR TITLE
Fix HTTP request block overflowing wrapper blocks (#SKY-7486)

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/nodes/HttpRequestNode/HttpRequestNode.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/nodes/HttpRequestNode/HttpRequestNode.tsx
@@ -167,7 +167,7 @@ function HttpRequestNode({ id, data, type }: NodeProps<HttpRequestNodeType>) {
         id="b"
         className="opacity-0"
       />
-      <div className="w-[36rem] space-y-4 rounded-lg bg-slate-elevation3 px-6 py-4">
+      <div className="transform-origin-center w-[30rem] space-y-4 rounded-lg bg-slate-elevation3 px-6 py-4 transition-all">
         <NodeHeader
           blockLabel={label}
           editable={editable}


### PR DESCRIPTION
## Summary - [SKY-7486](https://linear.app/skyvern/issue/SKY-7486/http-request-block-not-fitting-inside-wrapper-blocks)

- **Fixed** the HTTP request block extending beyond the borders of wrapper blocks (conditional and loop blocks) by changing its width from `w-[36rem]` (576px) to `w-[30rem]` (480px), matching the standard width used by all other workflow blocks
- Added `transition-all` class to match the animation pattern used by other block types

## Root Cause

The HTTP request block was created with `w-[36rem]` while every other workflow block uses `w-[30rem]`. Wrapper blocks (loop and conditional) calculate their container width starting at 450px via `getLoopNodeWidth()`, which is not wide enough to contain a 576px child block. The standard 480px width fits correctly.

## Test plan

- [ ] Place an HTTP request block inside a conditional block and verify it fits within the wrapper borders
- [ ] Place an HTTP request block inside a loop block and verify it fits within the wrapper borders
- [ ] Nest a conditional block containing an HTTP request block inside a loop block and verify correct layout
- [ ] Verify the HTTP request block's internal layout (method selector, URL field, headers, body, etc.) renders correctly at the narrower width
- [ ] Verify the HTTP request block still functions correctly (can edit all fields, import cURL, add quick headers, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)