### PR TITLE
Fix React error #185 when copy-pasting content between blocks (#SKY-7638)

### DIFF
--- a/skyvern-frontend/src/components/AutoResizingTextarea/AutoResizingTextarea.tsx
+++ b/skyvern-frontend/src/components/AutoResizingTextarea/AutoResizingTextarea.tsx
@@ -1,6 +1,6 @@
 import { Textarea } from "@/components/ui/textarea";
 import type { ChangeEventHandler, HTMLAttributes } from "react";
-import { forwardRef, useEffect, useRef, useCallback } from "react";
+import { forwardRef, useRef, useCallback, useLayoutEffect } from "react";
 import { cn } from "@/util/utils";
 
 type Props = {
@@ -30,6 +30,7 @@ const AutoResizingTextarea = forwardRef<HTMLTextAreaElement, Props>(
     forwardedRef,
   ) => {
     const innerRef = useRef<HTMLTextAreaElement | null>(null);
+    const lastHeightRef = useRef<string>("");
     const getTextarea = useCallback(() => innerRef.current, []);
 
     const setRefs = (element: HTMLTextAreaElement | null) => {
@@ -43,13 +44,25 @@ const AutoResizingTextarea = forwardRef<HTMLTextAreaElement, Props>(
       }
     };
 
-    useEffect(() => {
+    useLayoutEffect(() => {
       const textareaElement = getTextarea();
       if (!textareaElement) {
         return;
       }
+
+      // Temporarily set to auto to measure scrollHeight accurately
       textareaElement.style.height = "auto";
-      textareaElement.style.height = `${textareaElement.scrollHeight + 2}px`;
+      const newHeight = `${textareaElement.scrollHeight + 2}px`;
+
+      // Only apply the final height if it differs from the last applied height
+      // This prevents unnecessary dimension change events in React Flow
+      if (lastHeightRef.current !== newHeight) {
+        lastHeightRef.current = newHeight;
+        textareaElement.style.height = newHeight;
+      } else {
+        // Restore the previous height since nothing changed
+        textareaElement.style.height = lastHeightRef.current;
+      }
     }, [getTextarea, value]);
 
     return (


### PR DESCRIPTION
## Summary - [SKY-7638](https://linear.app/skyvern/issue/SKY-7638)

Fixed React error #185 (Maximum update depth exceeded) that occurred when copy-pasting text content between workflow blocks in the editor. The error was caused by an infinite loop cascade where textarea dimension changes triggered immediate layout operations, which triggered more dimension changes.

## Problem

When users copy-pasted text content from one block's input field to another, React threw error #185: "Maximum update depth exceeded." The root cause was a cascade of rapid state updates:

1. Pasting text into a textarea causes `AutoResizingTextarea` to measure and set a new height
2. The height change triggers a React Flow dimension change event
3. `FlowRenderer` receives the dimension change and immediately runs layout, which repositions nodes
4. Node repositioning triggers more dimension change events
5. Loop continues until React's update depth limit is hit

## What Changed

**AutoResizingTextarea component**
- Added `lastHeightRef` to track the last applied height value
- Switched from `useEffect` to `useLayoutEffect` for synchronous DOM measurements
- Only apply height changes when the calculated height differs from the last applied height

**FlowRenderer component**
- Added `isLayoutingRef` flag to track when layout operations are in progress
- Implemented `debouncedLayoutForDimensions` (50ms debounce) to batch rapid dimension changes
- Added guard to skip dimension change processing when already in a layout operation
- Added actual change detection — only trigger layout if dimensions truly changed

## Test plan

- [ ] Open the workflow editor and create a few blocks with text content
- [ ] Copy text from one block's input field and paste it into another block's input field
- [ ] Verify no React error #185 appears in the console
- [ ] Paste large amounts of text into a block's textarea and verify auto-resize works smoothly
- [ ] Paste text rapidly between different blocks to stress-test the debouncing
- [ ] Type in a textarea within a workflow block and verify auto-resize still works
- [ ] Verify viewport auto-pan still works when typing extends beyond the viewport
- [ ] Verify workflow editor performance feels responsive during normal editing

🤖 Generated with [Claude Code](https://claude.ai/code)