### PR TITLE
Fix structlog AttributeError when logging from stdlib loggers

### DIFF
--- a/skyvern/forge/sdk/forge_log.py
+++ b/skyvern/forge/sdk/forge_log.py
@@ -319,9 +319,9 @@ def setup_logger() -> None:
     handler.setFormatter(
         structlog.stdlib.ProcessorFormatter(
             processors=[
-                structlog.stdlib.ProcessorFormatter.remove_processors_meta,
                 structlog.stdlib.add_log_level,
                 structlog.stdlib.add_logger_name,
+                structlog.stdlib.ProcessorFormatter.remove_processors_meta,
                 structlog.processors.TimeStamper(fmt="iso"),
                 structlog.processors.format_exc_info,
                 renderer,


### PR DESCRIPTION
getting these errors in staging logs

```

AttributeError: 'NoneType' object has no attribute 'name'
--
  |   | Feb 05 17:46:12.354 |   | skyvern-staging | ^^^^^^^^^^^
  |   | Feb 05 17:46:12.354 |   | skyvern-staging | event_dict["logger"] = logger.name
```


- Fixes `AttributeError` in structlog by reordering `ProcessorFormatter` processors so that `add_log_level` and `add_logger_name` run **before** `remove_processors_meta`
- `remove_processors_meta` strips the `_record` key from the event dict, but `add_log_level` and `add_logger_name` need that key to extract level/name from stdlib `LogRecord`. Moving `remove_processors_meta` after them prevents the error.