### PR TITLE
Fix third-party logger noise flooding stderr after structlog StreamHandler addition

### DIFF
--- a/skyvern/forge/sdk/forge_log.py
+++ b/skyvern/forge/sdk/forge_log.py
@@ -331,7 +331,11 @@ def setup_logger() -> None:
     root_logger = logging.getLogger()
     root_logger.handlers.clear()
     root_logger.addHandler(handler)
-    root_logger.setLevel(LOG_LEVEL_VAL)
+    # Root at WARNING so third-party loggers (temporalio, grpc, litellm, …)
+    # only surface warnings and errors.  Our packages get the configured level.
+    root_logger.setLevel(logging.WARNING)
+    for name in ("skyvern", "cloud", "workers", "scripts", "browser_controller"):
+        logging.getLogger(name).setLevel(LOG_LEVEL_VAL)
 
     uvicorn_error = logging.getLogger("uvicorn.error")
     uvicorn_error.disabled = True


### PR DESCRIPTION
- **Root cause**: PR #8552 added a `StreamHandler` with `ProcessorFormatter` to the root logger so asyncio exceptions would be JSON-formatted. Side effect: ALL third-party library logs (temporalio, grpc, litellm, etc.) at INFO level now flowed to stderr.
- **Fix**: Set root logger to `WARNING` so third-party loggers only surface warnings/errors. Explicitly set our app loggers (`skyvern`, `cloud`, `workers`, `scripts`) to the configured `LOG_LEVEL` (typically `INFO`) so our own logs are preserved.