### PR TITLE
Surface block failure_reason in UI for all block types (#SKY-7620)

### DIFF
--- a/skyvern-frontend/src/routes/workflows/debugger/DebuggerRunOutput.tsx
+++ b/skyvern-frontend/src/routes/workflows/debugger/DebuggerRunOutput.tsx
@@ -12,6 +12,7 @@ import { useWorkflowRunTimelineQuery } from "../hooks/useWorkflowRunTimelineQuer
 import { Status } from "@/api/types";
 import { AutoResizingTextarea } from "@/components/AutoResizingTextarea/AutoResizingTextarea";
 import { isTaskVariantBlock } from "../types/workflowTypes";
+import { statusIsAFailureType } from "@/routes/tasks/types";
 
 function DebuggerRunOutput() {
   const { data: workflowRunTimeline, isLoading: workflowRunTimelineIsLoading } =
@@ -49,6 +50,12 @@ function DebuggerRunOutput() {
     isTaskVariantBlock(activeBlock) &&
     activeBlock.status === Status.Completed;
 
+  const showFailureReason =
+    activeBlock &&
+    activeBlock.status !== null &&
+    (statusIsAFailureType({ status: activeBlock.status }) ||
+      activeBlock.status === Status.Canceled);
+
   const outputs = workflowRun?.outputs;
   const fileUrls = workflowRun?.downloaded_file_urls ?? [];
   const observerOutput = workflowRun?.task_v2?.output;
@@ -72,41 +79,36 @@ function DebuggerRunOutput() {
         <div className="rounded bg-slate-elevation2 p-6">
           <div className="space-y-4">
             <h1 className="text-sm font-bold">Block Outputs</h1>
-            {activeBlock.output === null ? (
-              <div className="text-sm">This block has no outputs</div>
-            ) : isTaskVariantBlock(activeBlock) ? (
+            {showFailureReason ? (
               <div className="space-y-2">
-                <h2 className="text-sm">
-                  {showExtractedInformation
-                    ? "Extracted Information"
-                    : "Failure Reason"}
-                </h2>
-                {showExtractedInformation ? (
-                  <CodeEditor
-                    language="json"
-                    value={JSON.stringify(
-                      (hasExtractedInformation(activeBlock.output) &&
-                        activeBlock.output.extracted_information) ??
-                        null,
-                      null,
-                      2,
-                    )}
-                    minHeight="96px"
-                    maxHeight="200px"
-                    readOnly
-                  />
-                ) : (
-                  <AutoResizingTextarea
-                    value={
-                      activeBlock.status === "canceled"
-                        ? "This block was cancelled"
-                        : activeBlock.failure_reason ?? ""
-                    }
-                    readOnly
-                  />
-                )}
+                <h2 className="text-sm">Failure Reason</h2>
+                <AutoResizingTextarea
+                  value={
+                    activeBlock.status === "canceled"
+                      ? "This block was cancelled"
+                      : activeBlock.failure_reason ?? ""
+                  }
+                  readOnly
+                />
               </div>
-            ) : (
+            ) : showExtractedInformation ? (
+              <div className="space-y-2">
+                <h2 className="text-sm">Extracted Information</h2>
+                <CodeEditor
+                  language="json"
+                  value={JSON.stringify(
+                    (hasExtractedInformation(activeBlock.output) &&
+                      activeBlock.output.extracted_information) ??
+                      null,
+                    null,
+                    2,
+                  )}
+                  minHeight="96px"
+                  maxHeight="200px"
+                  readOnly
+                />
+              </div>
+            ) : activeBlock.output !== null ? (
               <div className="space-y-2">
                 <h2 className="text-sm">Output</h2>
                 <CodeEditor
@@ -117,6 +119,8 @@ function DebuggerRunOutput() {
                   readOnly
                 />
               </div>
+            ) : (
+              <div className="text-sm">This block has no outputs</div>
             )}
           </div>
         </div>

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineItemInfoSection.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineItemInfoSection.tsx
@@ -57,7 +57,9 @@ function WorkflowRunTimelineItemInfoSection({ activeItem }: Props) {
   if (isWorkflowRunBlock(item)) {
     const showExtractedInformationTab = item.status === Status.Completed;
     const showFailureReasonTab =
-      item.status && statusIsAFailureType({ status: item.status });
+      item.status &&
+      (statusIsAFailureType({ status: item.status }) ||
+        item.status === Status.Canceled);
     const defaultTab = showExtractedInformationTab
       ? "extracted_information"
       : showFailureReasonTab
@@ -81,7 +83,7 @@ function WorkflowRunTimelineItemInfoSection({ activeItem }: Props) {
                   Extracted Information
                 </TabsTrigger>
               )}
-              {item.status && statusIsAFailureType({ status: item.status }) && (
+              {showFailureReasonTab && (
                 <TabsTrigger value="failure_reason">Failure Reason</TabsTrigger>
               )}
               <TabsTrigger value="navigation_goal">Navigation Goal</TabsTrigger>
@@ -116,7 +118,7 @@ function WorkflowRunTimelineItemInfoSection({ activeItem }: Props) {
                 />
               </TabsContent>
             )}
-            {item.status && statusIsAFailureType({ status: item.status }) && (
+            {showFailureReasonTab && (
               <TabsContent value="failure_reason">
                 <AutoResizingTextarea
                   value={
@@ -212,12 +214,30 @@ function WorkflowRunTimelineItemInfoSection({ activeItem }: Props) {
       return null;
     }
 
+    const fallbackDefaultTab = showFailureReasonTab
+      ? "failure_reason"
+      : "output";
     return (
       <div className="rounded bg-slate-elevation1 p-4">
-        <Tabs key={item.block_type} defaultValue="output">
+        <Tabs key={item.block_type} defaultValue={fallbackDefaultTab}>
           <TabsList>
+            {showFailureReasonTab && (
+              <TabsTrigger value="failure_reason">Failure Reason</TabsTrigger>
+            )}
             <TabsTrigger value="output">Output</TabsTrigger>
           </TabsList>
+          {showFailureReasonTab && (
+            <TabsContent value="failure_reason">
+              <AutoResizingTextarea
+                value={
+                  item.status === "canceled"
+                    ? "This block was cancelled"
+                    : item.failure_reason ?? ""
+                }
+                readOnly
+              />
+            </TabsContent>
+          )}
           <TabsContent value="output">
             <CodeEditor
               value={JSON.stringify(item.output, null, 2)}


### PR DESCRIPTION
	## Summary - [SKY-7620](https://linear.app/skyvern/issue/SKY-7620/loop-block-failure-lacks-task-id-and-visible-error-reason)

This PR fixes a critical usability issue where block failures within workflow loops were not surfacing failure reasons in the UI. Previously, when a block failed inside a loop (which correctly didn't fail the overall workflow), users had no visibility into why the block failed without digging through workflow_run_outputs JSON. This made debugging and troubleshooting extremely difficult for customers.

## Problem

When a block within a loop failed during workflow execution, two issues prevented effective debugging:

1. The failure reason was present in the backend data but completely hidden from the UI - users could only discover the error by manually inspecting the workflow_run_outputs JSON
2. Non-task blocks (like loop blocks, text prompt blocks, etc.) didn't have a visible "Failure Reason" tab in the timeline info section, even when they failed
3. The Block Outputs section only showed failure reasons for task-variant blocks, leaving other block types without any error visibility

This created a poor user experience where customers had to contact support or dig through raw JSON to understand what went wrong in their workflows.

## What Changed

- Added failure reason display to WorkflowRunTimelineItemInfoSection.tsx for all block types, not just task-variant blocks
- Created a fallback tab rendering section that shows "Failure Reason" tab for any failed or canceled block type (lines 217-251)
- Extended showFailureReasonTab logic to include Status.Canceled in addition to failure statuses
- Updated three WorkflowRunOutput.tsx files (eval, debugger, and main workflow run) to properly render failure reasons:
- Refactored conditional rendering to prioritize showing failure reason when present
- Separated failure reason display logic from extracted information display
- Ensured failure reasons are shown for all block types, not just task blocks
- Applied consistent logic across all three output views to ensure uniform behavior

## Screenshot
<img width="1513" height="930" alt="image" src="https://github.com/user-attachments/assets/2f36ddcc-6131-4848-950d-d92c5c2f5518" />


## Test plan

- [ ] Create a workflow with a loop containing a block that will fail (e.g., navigation to invalid URL)
- [ ] Configure the loop to continue on failure so the workflow completes successfully
- [ ] Run the workflow and verify it completes with one failed block inside the loop
- [ ] Click on the failed block in the timeline
- [ ] Verify the "Failure Reason" tab appears in the info section
- [ ] Verify the failure reason text is visible and descriptive
- [ ] Check the Block Outputs section shows the failure reason (not just "This block has no outputs")
- [ ] Test with different block types (text prompt, validation, etc.) to ensure all show failure reasons
- [ ] Verify canceled blocks also show appropriate messaging
- [ ] Test in all three views: main workflow run output, debugger output, and eval output

🤖 Generated with [Claude Code](https://claude.ai/code)