### PR TITLE
Fix stale litellm httpx client errors in Temporal workers (#SKY-7879)

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -56,6 +56,55 @@ EXTRACT_ACTION_DEFAULT_THINKING_BUDGET = settings.EXTRACT_ACTION_THINKING_BUDGET
 DEFAULT_THINKING_BUDGET = settings.DEFAULT_THINKING_BUDGET
 
 
+def _is_stale_client_error(exc: BaseException) -> bool:
+    """Check if an exception chain contains the httpx 'client has been closed' RuntimeError.
+
+    litellm caches AsyncOpenAI/AsyncAzureOpenAI clients keyed by event loop ID.
+    In long-lived Temporal worker pods the event loop can change (task completion,
+    activity recycling), leaving stale clients whose underlying httpx.AsyncClient
+    is closed.  Subsequent requests through those clients raise:
+        RuntimeError: Cannot send a request, as the client has been closed
+    which litellm wraps as APIConnectionError or InternalServerError.
+    """
+    cur: BaseException | None = exc
+    while cur is not None:
+        if isinstance(cur, RuntimeError) and "client has been closed" in str(cur):
+            return True
+        next_exc = cur.__cause__ or cur.__context__
+        cur = next_exc if next_exc is not cur else None
+    return False
+
+
+async def _acompletion_with_stale_client_retry(
+    acompletion_callable: Any,
+    **kwargs: Any,
+) -> Any:
+    """Call *acompletion_callable* and retry once if the failure is a stale httpx client.
+
+    On first failure the entire ``litellm.in_memory_llm_clients_cache`` is flushed
+    so that the retry creates a fresh client bound to the current event loop.
+    """
+    try:
+        return await acompletion_callable(**kwargs)
+    except Exception as first_err:
+        if not _is_stale_client_error(first_err):
+            raise
+
+        model = kwargs.get("model", "unknown")
+        LOG.warning(
+            "Stale httpx client detected – flushing litellm client cache and retrying",
+            error_type=type(first_err).__name__,
+            model=model,
+        )
+        try:
+            litellm.in_memory_llm_clients_cache.flush_cache()
+        except Exception:
+            LOG.warning("Failed to flush litellm client cache", exc_info=True)
+
+        # Retry once with a fresh client
+        return await acompletion_callable(**kwargs)
+
+
 def _safe_model_dump_json(response: ModelResponse, indent: int = 2) -> str:
     """
     Call model_dump_json() while suppressing Pydantic serialization warnings.
@@ -609,7 +658,8 @@ class LLMAPIHandlerFactory:
                         cache_variant=cache_variant_name,
                     )
                     request_payload_json = await _log_llm_request_artifact(request_model, True)
-                    response = await litellm.acompletion(
+                    response = await _acompletion_with_stale_client_retry(
+                        litellm.acompletion,
                         model=request_model,
                         messages=active_messages,
                         timeout=settings.LLM_CONFIG_TIMEOUT,
@@ -620,7 +670,8 @@ class LLMAPIHandlerFactory:
 
                 async def _call_router_without_cache() -> tuple[ModelResponse, str]:
                     request_payload_json = await _log_llm_request_artifact(llm_key, False)
-                    response = await router.acompletion(
+                    response = await _acompletion_with_stale_client_retry(
+                        router.acompletion,
                         model=main_model_group,
                         messages=messages,
                         timeout=settings.LLM_CONFIG_TIMEOUT,
@@ -1041,7 +1092,8 @@ class LLMAPIHandlerFactory:
                 try:
                     # TODO (kerem): add a retry mechanism to this call (acompletion_with_retries)
                     # TODO (kerem): use litellm fallbacks? https://litellm.vercel.app/docs/tutorials/fallbacks#how-does-completion_with_fallbacks-work
-                    response = await litellm.acompletion(
+                    response = await _acompletion_with_stale_client_retry(
+                        litellm.acompletion,
                         model=model_name,
                         messages=active_messages,
                         drop_params=True,  # Drop unsupported parameters gracefully
@@ -1627,7 +1679,8 @@ class LLMCaller:
         if self.llm_key and "UI_TARS" in self.llm_key:
             return await self._call_ui_tars(messages, tools, timeout, **active_parameters)
 
-        return await litellm.acompletion(
+        return await _acompletion_with_stale_client_retry(
+            litellm.acompletion,
             model=self.llm_config.model_name,
             messages=messages,
             tools=tools,


### PR DESCRIPTION
	## What's happening

Since Jan 30, we've seen a growing spike of "LLM request failed unexpectedly" errors across Temporal worker pods. The error rate has been escalating — from ~4/hr when it first appeared to **354/hr at peak** on Feb 2 — correlating directly with increased GPT-5 mini traffic. Every affected request fails the task entirely with no retry.

The errors affect all OpenAI-family providers (Azure OpenAI and OpenAI direct) across multiple LLM keys: `MASSIVE_AZURE_OPENAI_GPT_5_MINI`, `OPENAI_GPT5_MINI_FLEX`, and others. Vertex/Gemini configs are unaffected because they use a different client mechanism.

## Root cause

litellm caches `AsyncOpenAI` / `AsyncAzureOpenAI` clients in `litellm.in_memory_llm_clients_cache` with a 1-hour TTL. Each cached client holds an `httpx.AsyncClient` bound to the event loop that created it.

In long-lived Temporal worker pods, when event loops change (task completion, activity recycling), those cached clients go stale — their `httpx.AsyncClient` is closed but the cache reference persists. The next request that hits a stale client fails immediately with:

```
RuntimeError: Cannot send a request, as the client has been closed.
→ openai.APIConnectionError: Connection error.
  → litellm.exceptions.APIConnectionError
```

This is fast-failing (1.4–5.3s, not a timeout) and bursts on specific pods — once a stale client is hit, all requests on that pod fail until the cache entry expires. litellm's own retry mechanism doesn't recognize this error chain as retryable.

**Why it wasn't triggered by any deploy or dependency change:** The error is inherent to litellm's client caching design in long-lived processes. It was always possible, but the probability scales with traffic volume. As GPT-5 mini adoption grew, more requests hit the stale client window. We confirmed `litellm`, `openai`, and `httpx` versions were unchanged across v1.0.10 → v1.0.12.

## What this PR does

Adds a targeted retry wrapper that detects the stale httpx client error and recovers:

1. **`_is_stale_client_error(exc)`** — walks the exception `__cause__` chain looking for `RuntimeError` with `"client has been closed"`
2. **`_acompletion_with_stale_client_retry(callable, **kwargs)`** — wraps an acompletion call. On failure, if the error is a stale client:
 - Logs a warning (so we can track frequency in Datadog via "Stale httpx client detected")
 - Flushes the entire `litellm.in_memory_llm_clients_cache` (correct because ALL clients from the old event loop are stale, not just one)
 - Retries exactly once (the retry creates a fresh client on the current event loop — a second failure with the same error isn't possible)
 - Non-stale errors pass through completely unchanged

Applied to all 4 production call sites:
- `_call_primary_with_vertex_cache` → `litellm.acompletion`
- `_call_router_without_cache` → `router.acompletion`
- `llm_api_handler` (direct config path) → `litellm.acompletion`
- `LLMCaller._dispatch_llm_call` → `litellm.acompletion`

Does **not** affect Vertex prompt caching (server-side on Google's infra, completely separate from httpx connection clients).

## Test plan

- [x] `python -m py_compile` passes
- [x] All pre-commit hooks pass
- [x] Grep confirmed no other production `litellm.acompletion` or `router.acompletion` calls need wrapping (remaining hits are in dev scripts/test utilities only)
- [ ] Deploy to staging and confirm "Stale httpx client detected" log lines appear when the retry path triggers
- [ ] Monitor "LLM request failed unexpectedly" error rate drops post-deploy

🤖 Generated with [Claude Code](https://claude.ai/code)