### PR TITLE
Fix LiteLLM callback leak: cache router handlers by llm_key

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -165,6 +165,7 @@ def _convert_allowed_fails_policy(policy: LLMAllowedFailsPolicy | None) -> Allow
 
 class LLMAPIHandlerFactory:
     _custom_handlers: dict[str, LLMAPIHandler] = {}
+    _router_handler_cache: dict[str, LLMAPIHandler] = {}
     _thinking_budget_settings: dict[str, int] | None = None
     _prompt_caching_settings: dict[str, bool] | None = None
 
@@ -389,6 +390,9 @@ class LLMAPIHandlerFactory:
 
     @staticmethod
     def get_llm_api_handler_with_router(llm_key: str) -> LLMAPIHandler:
+        if llm_key in LLMAPIHandlerFactory._router_handler_cache:
+            return LLMAPIHandlerFactory._router_handler_cache[llm_key]
+
         llm_config = LLMConfigRegistry.get_config(llm_key)
         if not isinstance(llm_config, LLMRouterConfig):
             raise InvalidLLMConfigError(llm_key)
@@ -831,6 +835,7 @@ class LLMAPIHandlerFactory:
                     LOG.error("Failed to persist artifacts", exc_info=True)
 
         llm_api_handler_with_router_and_fallback.llm_key = llm_key  # type: ignore[attr-defined]
+        LLMAPIHandlerFactory._router_handler_cache[llm_key] = llm_api_handler_with_router_and_fallback
         return llm_api_handler_with_router_and_fallback
 
     @staticmethod


### PR DESCRIPTION
## Summary

Cache `litellm.Router`-backed handlers per `llm_key` to prevent callback accumulation that was flooding Datadog with ~450K warning logs in 6 hours.

## Investigation

**What was observed:** ~452,737 LiteLLM warning logs in 6 hours in Datadog:

> `Cannot add callback - would exceed MAX_CALLBACKS limit of 30. Current callbacks: 30`

**Why now?** The callback leak has existed for a long time, but the warnings were invisible. Before commit 2acae674, the root logger had no handler — third-party libraries like litellm emitted warnings into the void. That commit added a `StreamHandler` with `ProcessorFormatter` to the root logger (set to WARNING level) to surface third-party warnings in structured JSON. It worked — and surfaced this pre-existing bug.

**Root cause:** Every `litellm.Router()` instantiation registers **4 callbacks** to global litellm lists (async success, sync success, async failure, sync failure). `get_llm_api_handler_with_router()` was creating a **new Router on every call** with no caching:

1. `get_override_llm_api_handler(override_llm_key)` — called on **every LLM request** with a per-org override key
2. → `get_llm_api_handler(override_llm_key)` — detects it's a router config
3. → `get_llm_api_handler_with_router(llm_key)` — creates a **new `litellm.Router`**, leaking 4 callbacks

After just ~8 Router creations (8 × 4 = 32 > 30 limit), LiteLLM hits `MAX_CALLBACKS` and warns on every subsequent LLM call in the process.

**Is this a litellm router misconfiguration?** No. The router configs are correct. The issue is that router instances weren't being reused.

**Organization association:** The LiteLLM warning logs don't carry `@organization_name` — they're emitted by litellm's internal code and are process-global, so they can't be tied to any specific org.

## Fix

Added `_router_handler_cache` dict to `LLMAPIHandlerFactory` that caches the handler (and its enclosed Router) per `llm_key`. Each router config is now instantiated only once per process.

## Test plan

- [x] Existing `test_api_handler_factory.py` tests pass (4/4)
- [ ] Verify warning logs stop appearing in Datadog after deploy
- [ ] Confirm LLM calls with router-based configs still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)