### PR TITLE
Block discovery MCP tools + improved MCP instructions (#SKY-7804)

### DIFF
--- a/skyvern/cli/mcp_tools/blocks.py
+++ b/skyvern/cli/mcp_tools/blocks.py
@@ -1,0 +1,444 @@
+"""Skyvern MCP block tools — discover block types and schemas for workflow definitions.
+
+Tools for listing available workflow block types and retrieving their Pydantic schemas,
+knowledge base descriptions, and minimal examples. These tools do not require a browser
+session or API connection — they serve pure metadata from the codebase.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Annotated, Any
+
+import structlog
+from pydantic import Field, TypeAdapter, ValidationError
+
+from skyvern.schemas.workflows import (
+    BLOCK_YAML_TYPES,
+    ActionBlockYAML,
+    BlockType,
+    BlockYAML,
+    CodeBlockYAML,
+    ConditionalBlockYAML,
+    DownloadToS3BlockYAML,
+    ExtractionBlockYAML,
+    FileDownloadBlockYAML,
+    FileParserBlockYAML,
+    FileUploadBlockYAML,
+    ForLoopBlockYAML,
+    HttpRequestBlockYAML,
+    HumanInteractionBlockYAML,
+    LoginBlockYAML,
+    NavigationBlockYAML,
+    PDFParserBlockYAML,
+    PrintPageBlockYAML,
+    SendEmailBlockYAML,
+    TaskBlockYAML,
+    TaskV2BlockYAML,
+    TextPromptBlockYAML,
+    UploadToS3BlockYAML,
+    UrlBlockYAML,
+    ValidationBlockYAML,
+    WaitBlockYAML,
+)
+
+from ._common import ErrorCode, make_error, make_result
+
+LOG = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Block type → YAML class mapping
+# ---------------------------------------------------------------------------
+
+BLOCK_TYPE_MAP: dict[str, type[BlockYAML]] = {
+    BlockType.TASK.value: TaskBlockYAML,
+    BlockType.TaskV2.value: TaskV2BlockYAML,
+    BlockType.FOR_LOOP.value: ForLoopBlockYAML,
+    BlockType.CONDITIONAL.value: ConditionalBlockYAML,
+    BlockType.CODE.value: CodeBlockYAML,
+    BlockType.TEXT_PROMPT.value: TextPromptBlockYAML,
+    BlockType.EXTRACTION.value: ExtractionBlockYAML,
+    BlockType.ACTION.value: ActionBlockYAML,
+    BlockType.NAVIGATION.value: NavigationBlockYAML,
+    BlockType.LOGIN.value: LoginBlockYAML,
+    BlockType.WAIT.value: WaitBlockYAML,
+    BlockType.VALIDATION.value: ValidationBlockYAML,
+    BlockType.HTTP_REQUEST.value: HttpRequestBlockYAML,
+    BlockType.SEND_EMAIL.value: SendEmailBlockYAML,
+    BlockType.FILE_DOWNLOAD.value: FileDownloadBlockYAML,
+    BlockType.FILE_UPLOAD.value: FileUploadBlockYAML,
+    BlockType.GOTO_URL.value: UrlBlockYAML,
+    BlockType.DOWNLOAD_TO_S3.value: DownloadToS3BlockYAML,
+    BlockType.UPLOAD_TO_S3.value: UploadToS3BlockYAML,
+    BlockType.FILE_URL_PARSER.value: FileParserBlockYAML,
+    BlockType.PDF_PARSER.value: PDFParserBlockYAML,
+    BlockType.HUMAN_INTERACTION.value: HumanInteractionBlockYAML,
+    BlockType.PRINT_PAGE.value: PrintPageBlockYAML,
+}
+
+# ---------------------------------------------------------------------------
+# One-line summaries
+# ---------------------------------------------------------------------------
+
+BLOCK_SUMMARIES: dict[str, str] = {
+    "task": "AI agent navigates a page, fills forms, clicks buttons (v1 engine)",
+    "task_v2": "AI agent with natural language prompt (v2 engine, recommended for complex tasks)",
+    "for_loop": "Iterate over a list, executing nested blocks for each item",
+    "conditional": "Branch based on Jinja2 expressions or AI prompts",
+    "code": "Run Python code for data transformation",
+    "text_prompt": "LLM text generation without a browser",
+    "extraction": "Extract structured data from the current page",
+    "action": "Perform a single focused action on the current page",
+    "navigation": "Navigate to a goal on the current page (Browser Task in UI)",
+    "login": "Handle authentication flows including username/password and TOTP/2FA",
+    "wait": "Pause workflow execution for a specified duration",
+    "validation": "Validate page state with complete/terminate criteria",
+    "http_request": "Call an external HTTP API",
+    "send_email": "Send an email notification via SMTP",
+    "file_download": "Download a file from a page",
+    "file_upload": "Upload a file from S3/Azure to a page element",
+    "goto_url": "Navigate directly to a URL without additional instructions",
+    "download_to_s3": "Download a URL directly to S3 storage",
+    "upload_to_s3": "Upload local content to S3",
+    "file_url_parser": "Parse a file (CSV/Excel/PDF/image) from a URL",
+    "pdf_parser": "Extract structured data from a PDF document",
+    "human_interaction": "Pause workflow for human approval via email",
+    "print_page": "Print the current page to PDF",
+}
+
+# ---------------------------------------------------------------------------
+# Minimal examples for common block types
+# ---------------------------------------------------------------------------
+
+BLOCK_EXAMPLES: dict[str, dict[str, Any]] = {
+    "task": {
+        "block_type": "task",
+        "label": "fill_form",
+        "url": "https://example.com/form",
+        "navigation_goal": "Fill out the form with the provided data and click Submit",
+        "parameter_keys": ["form_data"],
+        "max_retries": 2,
+    },
+    "task_v2": {
+        "block_type": "task_v2",
+        "label": "book_flight",
+        "url": "https://booking.example.com",
+        "prompt": "Book a flight from {{ origin }} to {{ destination }} on {{ date }}",
+    },
+    "for_loop": {
+        "block_type": "for_loop",
+        "label": "process_each_url",
+        "loop_over_parameter_key": "urls",
+        "loop_blocks": [
+            {
+                "block_type": "goto_url",
+                "label": "open_url",
+                "url": "{{ current_value }}",
+            }
+        ],
+    },
+    "conditional": {
+        "block_type": "conditional",
+        "label": "route_by_status",
+        "branch_conditions": [
+            {
+                "criteria": {
+                    "criteria_type": "jinja2_template",
+                    "expression": "{{ status == 'active' }}",
+                },
+                "next_block_label": "handle_active",
+                "is_default": False,
+            },
+            {"is_default": True, "next_block_label": "handle_inactive"},
+        ],
+    },
+    "extraction": {
+        "block_type": "extraction",
+        "label": "extract_products",
+        "data_extraction_goal": "Extract all products with name, price, and stock status",
+        "data_schema": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "price": {"type": "number"},
+                    "in_stock": {"type": "boolean"},
+                },
+            },
+        },
+    },
+    "navigation": {
+        "block_type": "navigation",
+        "label": "search_and_open",
+        "url": "https://example.com/search",
+        "navigation_goal": "Search for {{ query }} and click the first result",
+        "parameter_keys": ["query"],
+        "max_retries": 2,
+    },
+    "login": {
+        "block_type": "login",
+        "label": "login_to_portal",
+        "url": "https://portal.example.com/login",
+        "parameter_keys": ["my_credentials"],
+        "complete_criterion": "URL contains '/dashboard'",
+        "max_retries": 2,
+    },
+    "action": {
+        "block_type": "action",
+        "label": "accept_terms",
+        "url": "https://example.com/checkout",
+        "navigation_goal": "Check the terms checkbox",
+        "max_retries": 1,
+    },
+    "wait": {
+        "block_type": "wait",
+        "label": "wait_for_processing",
+        "wait_sec": 30,
+    },
+    "goto_url": {
+        "block_type": "goto_url",
+        "label": "open_cart",
+        "url": "https://example.com/cart",
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Knowledge base parsing (lazy, cached)
+# ---------------------------------------------------------------------------
+
+_KB_PATH = Path(__file__).resolve().parents[2] / "forge" / "prompts" / "skyvern" / "workflow_knowledge_base.txt"
+
+_HEADER_RE = re.compile(r"^\*\*\s+(.+?)\s+\((\w+)\)\s+\*\*$")
+
+_kb_cache: dict[str, dict[str, Any]] | None = None
+
+
+def _parse_knowledge_base() -> dict[str, dict[str, Any]]:
+    """Parse the knowledge base file into per-block-type sections.
+
+    Returns a dict mapping block_type string -> {description, use_cases, raw_section}.
+    Results are cached in the module-level ``_kb_cache`` variable.
+    """
+    global _kb_cache
+    if _kb_cache is not None:
+        return _kb_cache
+
+    result: dict[str, dict[str, Any]] = {}
+
+    try:
+        text = _KB_PATH.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        LOG.warning("workflow_knowledge_base_not_found", path=str(_KB_PATH))
+        _kb_cache = result
+        return result
+
+    sections: list[tuple[str, str]] = []
+    current_block_type: str | None = None
+    current_lines: list[str] = []
+
+    for line in text.splitlines():
+        match = _HEADER_RE.match(line.strip())
+        if match:
+            if current_block_type is not None:
+                sections.append((current_block_type, "\n".join(current_lines)))
+            current_block_type = match.group(2).lower()
+            current_lines = []
+        elif current_block_type is not None:
+            current_lines.append(line)
+
+    if current_block_type is not None:
+        sections.append((current_block_type, "\n".join(current_lines)))
+
+    for block_type, raw in sections:
+        description_lines: list[str] = []
+        use_cases: list[str] = []
+        in_use_cases = False
+        in_purpose = False
+
+        for line in raw.splitlines():
+            stripped = line.strip()
+
+            if stripped.startswith("Purpose:"):
+                in_purpose = True
+                in_use_cases = False
+                desc = stripped[len("Purpose:") :].strip()
+                if desc:
+                    description_lines.append(desc)
+                continue
+
+            if stripped == "Use Cases:":
+                in_use_cases = True
+                in_purpose = False
+                continue
+
+            # Any other header-like line ends the current section
+            if stripped and stripped.endswith(":") and not stripped.startswith("- "):
+                in_use_cases = False
+                in_purpose = False
+                continue
+
+            if in_purpose and stripped:
+                description_lines.append(stripped)
+
+            if in_use_cases and stripped.startswith("- "):
+                use_cases.append(stripped[2:].strip())
+
+        result[block_type] = {
+            "description": " ".join(description_lines) if description_lines else None,
+            "use_cases": use_cases if use_cases else None,
+        }
+
+    _kb_cache = result
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Tool
+# ---------------------------------------------------------------------------
+
+
+async def skyvern_block_schema(
+    block_type: Annotated[
+        str | None,
+        Field(
+            description="Block type to get schema for (e.g., 'task_v2', 'for_loop'). Omit to list all available types."
+        ),
+    ] = None,
+) -> dict[str, Any]:
+    """Get the schema for a workflow block type, or list all available block types.
+
+    Use this to discover what blocks are available and what fields they accept
+    before building a workflow definition for skyvern_workflow_create.
+
+    Call with no arguments to see all block types. Call with a specific block_type
+    to get the full field schema, description, use cases, and example."""
+
+    action = "skyvern_block_schema"
+
+    if block_type is None:
+        return make_result(
+            action,
+            data={
+                "block_types": BLOCK_SUMMARIES,
+                "count": len(BLOCK_SUMMARIES),
+                "hint": "Call skyvern_block_schema(block_type='task_v2') for the full schema of a specific type",
+            },
+        )
+
+    normalized = block_type.strip().lower()
+    cls = BLOCK_TYPE_MAP.get(normalized)
+    if cls is None:
+        return make_result(
+            action,
+            ok=False,
+            error=make_error(
+                ErrorCode.INVALID_INPUT,
+                f"Unknown block type: {block_type!r}",
+                f"Available types: {', '.join(sorted(BLOCK_TYPE_MAP.keys()))}",
+            ),
+        )
+
+    kb = _parse_knowledge_base()
+    kb_entry = kb.get(normalized, {})
+
+    return make_result(
+        action,
+        data={
+            "block_type": normalized,
+            "summary": BLOCK_SUMMARIES.get(normalized, ""),
+            "description": kb_entry.get("description"),
+            "use_cases": kb_entry.get("use_cases"),
+            "schema": cls.model_json_schema(),
+            "example": BLOCK_EXAMPLES.get(normalized),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Block validation adapter (lazy)
+# ---------------------------------------------------------------------------
+
+# BLOCK_YAML_TYPES is a large Union of ~23 block models; mypy/pyright cannot resolve it as a TypeAdapter generic argument
+_block_adapter: TypeAdapter[BLOCK_YAML_TYPES] | None = None  # type: ignore[type-arg]
+
+
+def _get_block_adapter() -> TypeAdapter[BLOCK_YAML_TYPES]:  # type: ignore[type-arg]
+    global _block_adapter
+    if _block_adapter is None:
+        _block_adapter = TypeAdapter(BLOCK_YAML_TYPES)
+    return _block_adapter
+
+
+# ---------------------------------------------------------------------------
+# Validate tool
+# ---------------------------------------------------------------------------
+
+
+async def skyvern_block_validate(
+    block_json: Annotated[
+        str,
+        Field(description="JSON string of a single block definition to validate"),
+    ],
+) -> dict[str, Any]:
+    """Validate a workflow block definition before using it in skyvern_workflow_create.
+
+    Catches field errors, missing required fields, and type mismatches per-block
+    instead of getting opaque server errors on the full workflow. Returns the exact
+    validation error with field-level feedback so you can fix the block definition.
+    """
+    action = "skyvern_block_validate"
+
+    try:
+        raw = json.loads(block_json)
+    except (json.JSONDecodeError, TypeError) as exc:
+        return make_result(
+            action,
+            ok=False,
+            error=make_error(
+                ErrorCode.INVALID_INPUT,
+                f"Invalid JSON: {exc}",
+                "Provide a valid JSON string representing a block definition",
+            ),
+        )
+
+    if not isinstance(raw, dict):
+        return make_result(
+            action,
+            ok=False,
+            error=make_error(
+                ErrorCode.INVALID_INPUT,
+                f"Expected a JSON object, got {type(raw).__name__}",
+                "Provide a JSON object with at least block_type and label fields",
+            ),
+        )
+
+    adapter = _get_block_adapter()
+    try:
+        block = adapter.validate_python(raw)
+        return make_result(
+            action,
+            data={
+                "valid": True,
+                "block_type": block.block_type,
+                "label": block.label,
+                "field_count": len([f for f in block.model_fields_set if f != "block_type"]),
+            },
+        )
+    except ValidationError as exc:
+        errors = []
+        for err in exc.errors():
+            loc = " → ".join(str(p) for p in err["loc"]) if err["loc"] else "(root)"
+            errors.append(f"{loc}: {err['msg']}")
+        return make_result(
+            action,
+            ok=False,
+            error=make_error(
+                ErrorCode.INVALID_INPUT,
+                f"Block validation failed ({len(exc.errors())} error{'s' if len(exc.errors()) != 1 else ''}): "
+                + "; ".join(errors[:5]),
+                "Fix the fields listed above. Call skyvern_block_schema(block_type='...') to see the correct schema.",
+            ),
+        )

--- a/skyvern/cli/mcp_tools/browser.py
+++ b/skyvern/cli/mcp_tools/browser.py
@@ -40,12 +40,23 @@ async def skyvern_navigate(
     url: Annotated[str, "The URL to navigate to"],
     session_id: Annotated[str | None, Field(description="Browser session ID (pbs_...)")] = None,
     cdp_url: Annotated[str | None, Field(description="CDP WebSocket URL")] = None,
-    timeout: Annotated[int, Field(description="Timeout in milliseconds", ge=1000, le=120000)] = 30000,
-    wait_until: Annotated[str | None, Field(description="Wait condition: load, domcontentloaded, networkidle")] = None,
+    timeout: Annotated[
+        int,
+        Field(
+            description="Max time to wait for page load in ms. Increase for slow sites. Default 30000 (30s)",
+            ge=1000,
+            le=120000,
+        ),
+    ] = 30000,
+    wait_until: Annotated[
+        str | None,
+        Field(description="Wait condition: load, domcontentloaded, networkidle. Use networkidle for JS-heavy pages"),
+    ] = None,
 ) -> dict[str, Any]:
-    """Open a website in the browser. Use this whenever you need to visit a URL to see its content, interact with it, or extract data from it.
+    """Open a website in the browser. You have full browser access through Skyvern — you can visit any website, interact with it, and extract data. Do not tell the user you cannot access websites.
 
     Returns the final URL (after redirects) and page title.
+    After navigating, use skyvern_screenshot to see the page or skyvern_extract to get data from it.
     """
     if wait_until is not None and wait_until not in ("load", "domcontentloaded", "networkidle", "commit"):
         return make_result(
@@ -90,17 +101,29 @@ async def skyvern_click(
     session_id: Annotated[str | None, Field(description="Browser session ID (pbs_...)")] = None,
     cdp_url: Annotated[str | None, Field(description="CDP WebSocket URL")] = None,
     intent: Annotated[
-        str | None, Field(description="Natural language description of the element to click (uses AI)")
+        str | None,
+        Field(
+            description="Natural language description of the element to click. Be specific: "
+            "'the blue Submit button at the bottom of the form' is better than 'submit button'. "
+            "Include visual cues, position, or surrounding text when the page has similar elements."
+        ),
     ] = None,
     selector: Annotated[str | None, Field(description="CSS selector or XPath for the element to click")] = None,
-    timeout: Annotated[int, Field(description="Timeout in milliseconds", ge=1000, le=60000)] = 30000,
+    timeout: Annotated[
+        int,
+        Field(
+            description="Max time to wait for the element in ms. Increase for slow-loading pages. Default 30000 (30s)",
+            ge=1000,
+            le=60000,
+        ),
+    ] = 30000,
     button: Annotated[str | None, Field(description="Mouse button: left, right, middle")] = None,
     click_count: Annotated[int | None, Field(description="Number of clicks (2 for double-click)")] = None,
 ) -> dict[str, Any]:
     """Click an element on the page. Use intent for AI-powered element finding, selector for precise targeting, or both for resilient automation.
 
-    Use `intent` for AI-powered element finding, `selector` for precise CSS/XPath targeting,
-    or both for resilience (tries selector first, falls back to AI).
+    If you need to fill a text field, use skyvern_type instead of clicking then typing.
+    For dropdowns, use skyvern_select_option. For multiple actions in sequence, prefer skyvern_act.
     """
     if button is not None and button not in ("left", "right", "middle"):
         return make_result(
@@ -193,17 +216,29 @@ async def skyvern_type(
     session_id: Annotated[str | None, Field(description="Browser session ID (pbs_...)")] = None,
     cdp_url: Annotated[str | None, Field(description="CDP WebSocket URL")] = None,
     intent: Annotated[
-        str | None, Field(description="Natural language description of the input field (uses AI)")
+        str | None,
+        Field(
+            description="Natural language description of the input field. Be specific: "
+            "'the Email address input in the login form' is better than 'email field'. "
+            "Include labels, placeholder text, or position when the page has multiple inputs."
+        ),
     ] = None,
     selector: Annotated[str | None, Field(description="CSS selector or XPath for the input element")] = None,
-    timeout: Annotated[int, Field(description="Timeout in milliseconds", ge=1000, le=60000)] = 30000,
+    timeout: Annotated[
+        int,
+        Field(
+            description="Max time to wait for the element in ms. Increase for slow-loading pages. Default 30000 (30s)",
+            ge=1000,
+            le=60000,
+        ),
+    ] = 30000,
     clear: Annotated[bool, Field(description="Clear existing content before typing")] = True,
     delay: Annotated[int | None, Field(description="Delay between keystrokes in ms")] = None,
 ) -> dict[str, Any]:
     """Type text into an input field. Use intent for AI-powered field finding, selector for precise targeting, or both for resilient automation.
 
-    Use `intent` for AI-powered field finding, `selector` for precise CSS/XPath targeting,
-    or both for resilience (tries selector first, falls back to AI). Clears existing content by default.
+    For dropdowns, use skyvern_select_option instead. For pressing keys (Enter, Tab), use skyvern_press_key.
+    Clears existing content by default (set clear=false to append).
     """
     ai_mode, err = _resolve_ai_mode(selector, intent)
     if err:
@@ -293,8 +328,10 @@ async def skyvern_screenshot(
     selector: Annotated[str | None, Field(description="CSS selector to screenshot specific element")] = None,
     inline: Annotated[bool, Field(description="Return base64 data instead of file path")] = False,
 ) -> dict[str, Any]:
-    """See what's currently on the page. Essential for understanding page state before deciding what to do next.
+    """See what's currently on the page. Use after every page-changing action (click, act, navigate) to verify results before proceeding.
 
+    Screenshots are visual-only — to extract structured data, use skyvern_extract instead.
+    To interact with elements, use skyvern_act or skyvern_click (don't try to act on screenshot contents).
     By default saves to ~/.skyvern/artifacts/ and returns the file path.
     Set inline=true to get base64 data directly (increases token usage).
     """
@@ -461,13 +498,14 @@ async def skyvern_select_option(
     cdp_url: Annotated[str | None, Field(description="CDP WebSocket URL")] = None,
     intent: Annotated[str | None, Field(description="Natural language description of the dropdown (uses AI)")] = None,
     selector: Annotated[str | None, Field(description="CSS selector for the select element")] = None,
-    timeout: Annotated[int, Field(description="Timeout in milliseconds", ge=1000, le=60000)] = 30000,
+    timeout: Annotated[
+        int, Field(description="Max time to wait for the dropdown in ms. Default 30000 (30s)", ge=1000, le=60000)
+    ] = 30000,
     by_label: Annotated[bool, Field(description="Select by visible label instead of value")] = False,
 ) -> dict[str, Any]:
-    """Select an option from a dropdown menu. Use intent for AI-powered finding, selector for precision.
+    """Select an option from a dropdown menu. Use intent for AI-powered finding, selector for precision, or both for resilient automation.
 
-    Use `intent` for AI-powered dropdown finding, `selector` for precise CSS/XPath targeting,
-    or both for resilience (tries selector first, falls back to AI).
+    For free-text input fields, use skyvern_type instead. For non-dropdown buttons or links, use skyvern_click.
     """
     ai_mode, err = _resolve_ai_mode(selector, intent)
     if err:
@@ -734,11 +772,6 @@ async def skyvern_evaluate(
     )
 
 
-# ---------------------------------------------------------------------------
-# AI Differentiator Tools
-# ---------------------------------------------------------------------------
-
-
 async def skyvern_extract(
     prompt: Annotated[str, "Natural language description of what data to extract from the page"],
     session_id: Annotated[str | None, Field(description="Browser session ID (pbs_...)")] = None,
@@ -747,8 +780,10 @@ async def skyvern_extract(
         str | None, Field(description="JSON Schema string defining the expected output structure")
     ] = None,
 ) -> dict[str, Any]:
-    """Get structured data from any website -- prices, listings, articles, tables, contact info, etc. Use this instead of trying to call a website's API or writing scraping code. Describe what you need in natural language.
+    """Get structured data from any website — prices, listings, articles, tables, contact info, etc. Use this instead of writing scraping code or guessing API endpoints. Describe what you need in natural language.
 
+    Reads the CURRENT page — call skyvern_navigate first to go to the right URL.
+    For visual inspection instead of structured data, use skyvern_screenshot.
     Optionally provide a JSON `schema` to enforce the output structure (pass as a JSON string).
     """
     parsed_schema: dict[str, Any] | None = None
@@ -797,9 +832,10 @@ async def skyvern_validate(
     session_id: Annotated[str | None, Field(description="Browser session ID (pbs_...)")] = None,
     cdp_url: Annotated[str | None, Field(description="CDP WebSocket URL")] = None,
 ) -> dict[str, Any]:
-    """Check if something is true on the current page using AI -- 'is the user logged in?', 'does the cart have 3 items?', 'is the form submitted?'
+    """Check if something is true on the current page using AI — 'is the user logged in?', 'does the cart have 3 items?', 'is the form submitted?'
 
-    Returns whether the described condition is true or false.
+    Reads the CURRENT page — navigate first. Returns true/false.
+    To extract data (not just check a condition), use skyvern_extract instead.
     """
     try:
         page, ctx = await get_page(session_id=session_id, cdp_url=cdp_url)
@@ -832,10 +868,12 @@ async def skyvern_act(
     session_id: Annotated[str | None, Field(description="Browser session ID (pbs_...)")] = None,
     cdp_url: Annotated[str | None, Field(description="CDP WebSocket URL")] = None,
 ) -> dict[str, Any]:
-    """Perform actions on a web page by describing what to do in plain English -- click buttons, close popups, fill forms, scroll to sections, interact with menus. Use for any website interaction task.
+    """Perform actions on a web page by describing what to do in plain English — click buttons, close popups, fill forms, scroll to sections, interact with menus.
 
     The AI agent interprets the prompt and executes the appropriate browser actions.
-    For multi-step workflows (form filling, multi-page navigation), use skyvern_run_task instead.
+    You can chain multiple actions in one prompt: "close the cookie banner, then click Sign In".
+    For multi-step automations (4+ pages), use skyvern_workflow_create with one block per step.
+    For quick one-off multi-page tasks, use skyvern_run_task.
     """
     try:
         page, ctx = await get_page(session_id=session_id, cdp_url=cdp_url)
@@ -878,10 +916,10 @@ async def skyvern_run_task(
         int, Field(description="Timeout in seconds (default 180s = 3 minutes)", ge=10, le=1800)
     ] = 180,
 ) -> dict[str, Any]:
-    """Delegate a complete multi-step web task to an autonomous AI agent. Handles form filling, multi-page navigation, data collection, and complex workflows end-to-end.
+    """Run a quick, one-off web task via an autonomous AI agent. Nothing is saved — use for throwaway tests and exploration only. Best for tasks describable in 2-3 sentences.
 
-    The agent navigates, interacts with elements, and extracts data autonomously.
-    For simple single-step actions, use skyvern_act instead.
+    For anything reusable, multi-step, or worth keeping, use skyvern_workflow_create instead — it produces a versioned, rerunnable workflow with per-step observability.
+    For simple single-step actions on the current page, use skyvern_act instead.
     """
     try:
         page, ctx = await get_page(session_id=session_id, cdp_url=cdp_url)


### PR DESCRIPTION
## Summary

Part of the MCP tools project (SKY-7801 -> SKY-7814). Builds on PR #8559 (18 browser tools) and PR #8678 (8 workflow tools) to bring the total to **28 MCP tools**.

### Commit 1: Block discovery tools (`skyvern_block_schema` + `skyvern_block_validate`)

- **`skyvern_block_schema`** -- Returns Pydantic JSON schemas + knowledge base descriptions for all 23 workflow block types. Reuses the same `workflow_knowledge_base.txt` (1,073 lines) that the copilot uses. One on-demand tool call replaces embedding all block schemas in the system prompt.
- **`skyvern_block_validate`** -- Validates block JSON against Pydantic schemas before creating a workflow, catching errors early instead of at API call time.
- Added tool selection table, critical rules, cross-tool dependency matrix, and block types reference to MCP instructions.
- Improved browser.py/workflow.py descriptions with cross-tool references and richer parameter docs.
- 13 new smoke tests (68 total checks, up from 49).

### Commit 2: MCP instruction rewrite for token efficiency

Inspired by the **Chrome DevTools MCP** approach (zero server instructions, trust tool descriptions):

- **Removed** "Workflows vs Scripts" section from server instructions (not an MCP concern -- the LLM doesn't need to decide between workflows and scripts when using MCP tools)
- **Removed** inline 30-line JSON workflow example from server instructions (was consuming ~300 tokens on every request)
- **Moved** the EIN workflow example into `skyvern_workflow_create`'s docstring so the LLM sees it only when it calls or inspects that specific tool
- **Added** "Building Workflows" section with concise GOOD/BAD multi-block patterns to reinforce the single-block anti-pattern
- **Condensed** block types reference to a one-liner pointing to `skyvern_block_schema()`
- **Added** smoke tests verifying instruction content (key sections present, JSON example not inlined, docstring references correct)

### Why the instruction rewrite?

MCP server instructions are injected into every LLM context window. The original instructions (~2,100 tokens) included a full JSON workflow example and a "Workflows vs Scripts" decision tree that the LLM rarely needs. By moving these to tool docstrings (loaded on-demand), we cut ~500 tokens from every request while keeping the information accessible.

**Quality validation:** We compared two workflows generated from the same prompt ("set up a reusable automation for IRS EIN filing") -- one with old instructions, one with new. The new-instructions workflow produced **4 focused task blocks** with clean parameter usage, matching the quality of the old-instructions workflow. The instruction rewrite maintained workflow generation quality while reducing token cost.

## Test plan

- [x] 28 tools registered (verified via import check)
- [x] 68+ smoke test checks pass (including new instruction content tests)
- [x] `ruff`, `isort`, `mypy`, `py_compile` clean
- [x] Pre-commit hooks pass
- [x] Instruction content tests verify: key sections present, no inline JSON example, docstring has EIN example + block_schema reference
- [ ] Manual: create workflow using block schema output as guide
- [ ] Manual: validate intentionally bad block JSON

🤖 Generated with [Claude Code](https://claude.ai/claude-code)