### PR TITLE
Add endpoint to update existing credential data (#SKY-7883)

### DIFF
--- a/skyvern/forge/sdk/services/credential/bitwarden_credential_service.py
+++ b/skyvern/forge/sdk/services/credential/bitwarden_credential_service.py
@@ -46,6 +46,45 @@ class BitwardenCredentialVaultService(CredentialVaultService):
 
         return credential
 
+    async def update_credential(self, credential: Credential, data: CreateCredentialRequest) -> Credential:
+        org_collection = await app.DATABASE.get_organization_bitwarden_collection(credential.organization_id)
+
+        if not org_collection:
+            raise HTTPException(status_code=404, detail="Credential account not found. It might have been deleted.")
+
+        # Create new vault item with the updated data
+        new_item_id = await BitwardenService.create_credential_item(
+            collection_id=org_collection.collection_id,
+            name=data.name,
+            credential=data.credential,
+        )
+
+        # Update DB record to point to the new vault item
+        try:
+            updated_credential = await self._update_db_credential(
+                credential=credential,
+                data=data,
+                item_id=new_item_id,
+            )
+        except Exception:
+            LOG.warning(
+                "DB update failed, attempting to clean up new Bitwarden vault item",
+                organization_id=credential.organization_id,
+                new_item_id=new_item_id,
+            )
+            try:
+                await BitwardenService.delete_credential_item(new_item_id)
+            except Exception as cleanup_error:
+                LOG.error(
+                    "Failed to clean up orphaned Bitwarden vault item",
+                    organization_id=credential.organization_id,
+                    new_item_id=new_item_id,
+                    error=str(cleanup_error),
+                )
+            raise
+
+        return updated_credential
+
     async def delete_credential(
         self,
         credential: Credential,
@@ -58,6 +97,21 @@ class BitwardenCredentialVaultService(CredentialVaultService):
 
         await app.DATABASE.delete_credential(credential.credential_id, credential.organization_id)
         await BitwardenService.delete_credential_item(credential.item_id)
+
+    async def post_delete_credential_item(self, item_id: str, organization_id: str | None = None) -> None:
+        try:
+            await BitwardenService.delete_credential_item(item_id)
+            LOG.info(
+                "Successfully deleted credential item from Bitwarden in background",
+                item_id=item_id,
+            )
+        except Exception as e:
+            LOG.warning(
+                "Failed to delete credential item from Bitwarden in background",
+                item_id=item_id,
+                error=str(e),
+                exc_info=True,
+            )
 
     async def get_credential_item(self, db_credential: Credential) -> CredentialItem:
         return await BitwardenService.get_credential_item(db_credential.item_id)


### PR DESCRIPTION
	## Summary

- Adds `POST /credentials/{credential_id}/update` endpoint (and `PUT` on legacy router) to overwrite stored credential data while preserving the same `credential_id`
- Implements update across all three vault backends: Bitwarden (create-before-delete), Azure Key Vault (in-place update), and Custom (create-before-delete)
- Includes rollback logic if DB update fails after vault write (prevents orphaned vault items)
- Adds helper methods to `OrganizationTester` for update operations in tests

## Test plan

- [x] 8 new scenario tests covering:
- Update password credential (DB + vault verification)
- Update credit card credential
- Multiple sequential updates preserve credential_id
- 404 for nonexistent credential
- 404 for soft-deleted credential
- Update isolation (other credentials unaffected)
- Adding TOTP via update
- Credential type change (password -> secret)
- [x] All 14 existing credential tests still pass
- [x] Linter and type checker pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)