### PR TITLE
Suppress noisy websockets library INFO logs

### DIFF
--- a/skyvern/forge/sdk/forge_log.py
+++ b/skyvern/forge/sdk/forge_log.py
@@ -341,3 +341,9 @@ def setup_logger() -> None:
     uvicorn_error.disabled = True
     uvicorn_access = logging.getLogger("uvicorn.access")
     uvicorn_access.disabled = True
+
+    # Suppress noisy websockets library INFO logs ("connection open", "connection closed")
+    # These are high-volume and not useful for debugging
+    logging.getLogger("websockets").setLevel(logging.WARNING)
+    logging.getLogger("websockets.server").setLevel(logging.WARNING)
+    logging.getLogger("websockets.client").setLevel(logging.WARNING)


### PR DESCRIPTION
## Summary

- Suppress websockets library INFO logs ("connection open", "connection closed") that are generated for every WebSocket connection
- These high-volume logs are wasting indexed logs in Datadog and increasing costs
- Set websockets loggers to WARNING level to allow warnings/errors while suppressing INFO noise

## Test plan

- [ ] Deploy to staging and verify "connection open" / "connection closed" INFO logs no longer appear in Datadog
- [ ] Verify WebSocket functionality still works (VNC streaming, screenshot streaming)
- [ ] Verify websockets WARNING/ERROR logs still appear if there are actual issues

🤖 Generated with [Claude Code](https://claude.ai/code)