### PR TITLE
Truncate large webhook payloads in log entries

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -3397,7 +3397,7 @@ class ForgeAgent:
                 "Sending task response to webhook callback url",
                 task_id=task.task_id,
                 webhook_callback_url=task.webhook_callback_url,
-                payload=signed_data.signed_payload,
+                payload=signed_data.payload_for_log,
                 headers=signed_data.headers,
             )
 

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -3176,7 +3176,7 @@ class WorkflowService:
             workflow_id=workflow_id,
             workflow_run_id=workflow_run.workflow_run_id,
             webhook_callback_url=workflow_run.webhook_callback_url,
-            payload=signed_data.signed_payload,
+            payload=signed_data.payload_for_log,
             headers=signed_data.headers,
         )
         try:
@@ -3204,7 +3204,7 @@ class WorkflowService:
                     "Webhook failed",
                     workflow_id=workflow_id,
                     workflow_run_id=workflow_run.workflow_run_id,
-                    webhook_data=signed_data.signed_payload,
+                    webhook_data=signed_data.payload_for_log,
                     resp=resp,
                     resp_code=resp.status_code,
                     resp_text=resp.text,


### PR DESCRIPTION
## Summary
- Webhook payloads can be huge and cause Datadog to split logs across multiple lines, making them hard to read.
- Moved truncation logic into `generate_skyvern_webhook_signature` in `security.py` and added a `payload_for_log` field to `WebhookSignature` that caps the logged payload at ~10KB with a truncation suffix showing the original size.
- Updated all webhook log call sites (`agent.py`, `workflow/service.py`) to use `signed_data.payload_for_log` instead of the full `signed_data.signed_payload`.
- The actual HTTP POST still sends the full payload — only the log output is truncated.

## Test plan
- [x] All 3 modified files pass `py_compile`
- [x] All pre-commit hooks pass (ruff, mypy, isort, etc.)
- [ ] Verify in Datadog that webhook log entries are no longer split across multiple lines for large payloads

🤖 Generated with [Claude Code](https://claude.ai/code)

Made with [Cursor](https://cursor.com)