### PR TITLE
Add MCP tool analytics

### DIFF
--- a/skyvern/analytics.py
+++ b/skyvern/analytics.py
@@ -44,7 +44,7 @@ def capture(
 
     distinct_id = settings.ANALYTICS_ID
 
-    payload: dict[str, Any] = data or {}
+    payload: dict[str, Any] = {**analytics_metadata(), **(data or {})}
     try:
         posthog.capture(distinct_id=distinct_id, event=event, properties=payload)
     except Exception as e:

--- a/skyvern/cli/core/result.py
+++ b/skyvern/cli/core/result.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
+from skyvern import analytics
+
 
 class ErrorCode:
     NO_ACTIVE_BROWSER = "NO_ACTIVE_BROWSER"
@@ -63,6 +65,17 @@ def make_result(
     warnings: list[str] | None = None,
     error: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    analytics.capture(
+        "mcp_tool_call",
+        data={
+            "tool": action,
+            "ok": ok,
+            "timing_ms": (timing_ms or {}).get("total"),
+            "error_code": error.get("code") if error else None,
+            "browser_mode": browser_context.mode if browser_context else None,
+            "session_id": browser_context.session_id if browser_context else None,
+        },
+    )
     return {
         "ok": ok,
         "action": action,


### PR DESCRIPTION
## Summary

- Integrate PostHog analytics into `make_result()` — the single function every MCP tool already calls — instead of manually adding `analytics.capture()` to each tool function
- Enrich `analytics.capture()` to always include system metadata (OS, skyvern version, python version, environment)
- Every `mcp_tool_call` event now includes: tool name, success/failure, timing, browser mode, session ID, plus global metadata

## Why this approach

The previous implementation added manual `analytics.capture()` calls to every MCP tool function (235+ lines across 4 files). This approach:
- **2 files, 14 lines** vs 4 files, 235 lines
- **Zero changes** to any tool file (browser.py, workflow.py, session.py, blocks.py)
- **Automatically covers** every future tool — no risk of forgetting
- **Single event name** (`mcp_tool_call`) with tool name as a property — easier to query in PostHog

## Event shape

```
event: "mcp_tool_call"
properties:
  tool: "skyvern_click"
  ok: true
  timing_ms: 1234
  error_code: null
  browser_mode: "cloud_session" | "local" | "cdp" | null
  session_id: "pbs_123" | null
  os: "darwin"
  oss_version: "0.5.2"
  machine: "arm64"
  environment: "local"
```

## Test plan

- [x] `py_compile` passes on both modified files
- [x] All pre-commit hooks pass
- [ ] Verify events appear in PostHog after MCP tool usage

🤖 Generated with [Claude Code](https://claude.ai/code)