### PR TITLE
Deprecate 'task' block type in MCP tools — steer toward navigation/extraction

### DIFF
--- a/skyvern/cli/mcp_tools/workflow.py
+++ b/skyvern/cli/mcp_tools/workflow.py
@@ -346,8 +346,10 @@ async def skyvern_workflow_create(
     """Create a new Skyvern workflow from a YAML or JSON definition. Use when you need to save
     a new automation workflow that can be run repeatedly with different parameters.
 
-    Best practice: use one task block per logical step with a short focused prompt (2-3 sentences).
-    Common block types: task, for_loop, conditional, code, text_prompt, extraction, action, navigation, wait, login.
+    Best practice: use one block per logical step with a short focused prompt (2-3 sentences).
+    Use "navigation" blocks for actions (filling forms, clicking) and "extraction" blocks for pulling data.
+    Do NOT use the deprecated "task" block type.
+    Common block types: navigation, extraction, task_v2, for_loop, conditional, code, text_prompt, action, wait, login.
     Call skyvern_block_schema() for the full list with schemas and examples.
 
     Example JSON definition (multi-block EIN application):
@@ -361,17 +363,21 @@ async def skyvern_workflow_create(
               {"parameter_type": "workflow", "key": "owner_ssn", "workflow_parameter_type": "string"}
             ],
             "blocks": [
-              {"block_type": "task", "label": "select_entity_type",
+              {"block_type": "navigation", "label": "select_entity_type",
                "url": "https://sa.www4.irs.gov/modiein/individual/index.jsp",
-               "engine": "skyvern-2.0",
+               "title": "Select Entity Type",
                "navigation_goal": "Select 'Sole Proprietor' as the entity type and click Continue."},
-              {"block_type": "task", "label": "enter_business_info", "engine": "skyvern-2.0",
-               "navigation_goal": "Fill in the business name as '{{business_name}}' and click Continue."},
-              {"block_type": "task", "label": "enter_owner_info", "engine": "skyvern-2.0",
-               "navigation_goal": "Enter the responsible party name '{{owner_name}}' and SSN '{{owner_ssn}}'. Click Continue."},
-              {"block_type": "task", "label": "confirm_and_submit", "engine": "skyvern-2.0",
-               "navigation_goal": "Review the information on the confirmation page and click Submit.",
-               "data_extraction_goal": "Extract the assigned EIN number",
+              {"block_type": "navigation", "label": "enter_business_info",
+               "title": "Enter Business Info",
+               "navigation_goal": "Fill in the business name as '{{business_name}}' and click Continue.",
+               "parameter_keys": ["business_name"]},
+              {"block_type": "navigation", "label": "enter_owner_info",
+               "title": "Enter Owner Info",
+               "navigation_goal": "Enter the responsible party name '{{owner_name}}' and SSN '{{owner_ssn}}'. Click Continue.",
+               "parameter_keys": ["owner_name", "owner_ssn"]},
+              {"block_type": "extraction", "label": "extract_ein",
+               "title": "Extract EIN",
+               "data_extraction_goal": "Extract the assigned EIN number from the confirmation page",
                "data_schema": {"type": "object", "properties": {"ein": {"type": "string"}}}}
             ]
           }

--- a/skyvern/forge/prompts/skyvern/workflow-copilot.j2
+++ b/skyvern/forge/prompts/skyvern/workflow-copilot.j2
@@ -78,11 +78,12 @@ IMPORTANT RULES:
 * Always generate valid YAML that conforms to the Skyvern workflow schema
 * Preserve existing blocks unless the user explicitly asks to modify or remove them
 * Use appropriate block types based on the user's intent:
-   - Use "task_v2" blocks for complex, multi-step workflows (may be slightly slower)
-   - Use "task" blocks for combined navigation and extraction (faster, but less flexible)
-   - Use "goto_url" blocks for pure navigation without data extraction
-   - Use "extraction" blocks for data extraction from the current page
+   - Use "navigation" blocks for actions: filling forms, clicking buttons, navigating flows (most common)
+   - Use "extraction" blocks for extracting structured data from the current page
+   - Use "task_v2" blocks for complex tasks requiring deep thinking and natural language prompts
+   - Use "goto_url" blocks for navigating directly to a URL without additional instructions
    - Use "login" blocks for authentication flows
+   - Do NOT use "task" blocks — they are deprecated. Use "navigation" instead.
 * Include all required fields for each block type (label, next_block_label, block_type, etc.)
 * Use descriptive, unique labels for blocks (snake_case format)
 * Reference parameters using Jinja2 syntax: {% raw %}{{ parameters.param_key }}{% endraw %}


### PR DESCRIPTION
## Summary

- LLMs were defaulting to the legacy `task` block type when creating workflows via MCP tools. This updates all MCP tool surfaces to recommend `navigation` (for actions) and `extraction` (for data extraction) instead.
- Soft backward-compatible redirect: `skyvern_block_schema(block_type="task")` returns the `navigation` schema with a deprecation warning rather than breaking.
- Updated MCP server instructions, block examples/summaries, `skyvern_workflow_create` docstring, and the `workflow-copilot.j2` prompt template.

You can see from a test run it now correctly builds a navigation and extraction browser task in the generated YAML associated to the generated workflow after site exploration with the skyvern actions

<img width="741" height="750" alt="Screenshot 2026-02-11 at 3 30 28 PM" src="https://github.com/user-attachments/assets/05a64c14-3bd7-470f-a022-6950367d6792" />


## Files changed

| File | What |
|------|------|
| `skyvern/cli/mcp_tools/__init__.py` | MCP server instructions: block type recommendations, deprecation notice, prefer-tools-over-scripts rule |
| `skyvern/cli/mcp_tools/blocks.py` | Schema tool redirect, updated summaries/examples/hints, validation deprecation warning |
| `skyvern/cli/mcp_tools/workflow.py` | `skyvern_workflow_create` docstring + example using navigation/extraction |
| `skyvern/forge/prompts/skyvern/workflow-copilot.j2` | Copilot prompt: recommend navigation/extraction, deprecate task |

🤖 Generated with [Claude Code](https://claude.ai/code)