### PR TITLE
Expose get_workflow_runs on new API router

### DIFF
--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -2210,6 +2210,25 @@ async def run_workflow_legacy(
     )
 
 
+@base_router.get(
+    "/workflows/runs",
+    response_model=list[WorkflowRun],
+    tags=["Workflows"],
+    description=(
+        "List workflow runs across all workflows for the current organization. "
+        "Results are paginated and can be filtered by status, search key, and error code. "
+        "All filters are combined with AND logic."
+    ),
+    summary="List workflow runs",
+    openapi_extra={
+        "x-fern-sdk-method-name": "get_workflow_runs",
+    },
+)
+@base_router.get(
+    "/workflows/runs/",
+    response_model=list[WorkflowRun],
+    include_in_schema=False,
+)
 @legacy_base_router.get(
     "/workflows/runs",
     response_model=list[WorkflowRun],
@@ -2224,9 +2243,9 @@ async def run_workflow_legacy(
     include_in_schema=False,
 )
 async def get_workflow_runs(
-    page: int = Query(1, ge=1),
-    page_size: int = Query(10, ge=1),
-    status: Annotated[list[WorkflowRunStatus] | None, Query()] = None,
+    page: int = Query(1, ge=1, description="Page number for pagination."),
+    page_size: int = Query(10, ge=1, description="Number of runs to return per page."),
+    status: Annotated[list[WorkflowRunStatus] | None, Query(description="Filter by one or more run statuses.")] = None,
     search_key: str | None = Query(
         None,
         max_length=500,
@@ -2243,10 +2262,10 @@ async def get_workflow_runs(
     current_org: Organization = Depends(org_auth_service.get_current_org),
 ) -> list[WorkflowRun]:
     """
-    Get all workflow runs for the current organization.
+    List workflow runs across all workflows for the current organization.
 
-    Supports filtering by status, parameter search, and error code. All filters
-    are combined with AND logic.
+    Results are paginated and can be filtered by status, search key, and error code.
+    All filters are combined with AND logic.
 
     **Examples:**
     - All failed runs: `?status=failed`


### PR DESCRIPTION
## Summary
- Expose the `GET /workflows/runs` endpoint via the new `base_router` (`/v1/workflows/runs`) in addition to the existing legacy router
- Improve OpenAPI docs for the endpoint: added `description`, `summary`, and per-parameter descriptions
- Fix Fern docs sidebar: add missing `Get Workflow`, `Get Workflow Versions`, and `List Workflow Runs` entries to the Workflows section so they no longer float at the top level

## Test plan
- [ ] Verify `GET /v1/workflows/runs` returns workflow runs (same behavior as `GET /api/v1/workflows/runs`)
- [ ] Verify the endpoint appears under "Workflows" in the Fern API docs sidebar
- [ ] Verify existing `GET /api/v1/workflows/runs` legacy endpoint still works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)