### PR TITLE
Fix press Enter clearing text on Google search

### DIFF
--- a/skyvern/webeye/actions/actions.py
+++ b/skyvern/webeye/actions/actions.py
@@ -152,6 +152,11 @@ class Action(BaseModel):
     # flag indicating whether the action requires mini-agent mode
     has_mini_agent: bool | None = None
 
+    # When True, the auto-completion Tab hack is skipped because a follow-up
+    # action in the same batch targets the same element or presses a key (e.g. Enter).
+    # Pressing Tab would move focus away and break that next action.
+    skip_auto_complete_tab: bool = False
+
     created_at: datetime | None = None
     modified_at: datetime | None = None
     created_by: str | None = None

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -1512,7 +1512,12 @@ async def handle_input_text_action(
         raise e
     finally:
         # HACK: force to finish missing auto completion input
-        if auto_complete_hacky_flag and await skyvern_element.is_visible() and not await skyvern_element.is_raw_input():
+        if (
+            auto_complete_hacky_flag
+            and await skyvern_element.is_visible()
+            and not await skyvern_element.is_raw_input()
+            and not action.skip_auto_complete_tab
+        ):
             LOG.debug(
                 "Trigger input-selection hack, pressing Tab to choose one",
                 action=action,


### PR DESCRIPTION
## Summary

- Skip the auto-completion Tab hack when the next batched action would be broken by a focus change (e.g. KEYPRESS Enter, or another action on the same element)
- Synced from Skyvern-AI/skyvern-cloud#8724

## Changes

- `skyvern/webeye/actions/actions.py` — New `skip_auto_complete_tab` field on `Action`
- `skyvern/forge/agent.py` — Look-ahead in the action batch to detect when Tab would break the next action
- `skyvern/webeye/actions/handler.py` — Check the flag before pressing Tab

## Test plan

- [x] `py_compile` — all 3 modified files compile cleanly
- [x] Unit tests pass (409 tests)
- [x] MCP browser test: Tab+Enter breaks Google search; Enter alone works
- [x] E2E workflow test: Google search completed successfully

🤖 Generated with [Claude Code](https://claude.ai/code)