### PR TITLE
Fix navigation blocks with engine skyvern-2.0 losing prompt in UI

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -594,6 +594,7 @@ function convertToNode(
       };
     }
     case "navigation": {
+      const isV2Engine = block.engine === RunEngine.SkyvernV2;
       return {
         ...identifiers,
         ...common,
@@ -616,8 +617,11 @@ function convertToNode(
           engine: block.engine ?? RunEngine.SkyvernV1,
           includeActionHistoryInVerification:
             block.include_action_history_in_verification ?? false,
-          prompt: "",
-          maxSteps: MAX_STEPS_DEFAULT,
+          // When engine is SkyvernV2, use navigation_goal as the prompt
+          prompt: isV2Engine ? block.navigation_goal ?? "" : "",
+          maxSteps: isV2Engine
+            ? block.max_steps_per_run ?? MAX_STEPS_DEFAULT
+            : MAX_STEPS_DEFAULT,
         },
       };
     }


### PR DESCRIPTION
	Synced from cloud PR: https://github.com/Skyvern-AI/skyvern-cloud/pull/8744
Author: @suchintan

## Summary
- When loading a `navigation` block with `engine: skyvern-2.0` from YAML, the `prompt` field was hardcoded to `""`, causing the customer's `navigation_goal` content to not display in the V2 UI
- Maps `navigation_goal` → `prompt` and `max_steps_per_run` → `maxSteps` when the engine is `SkyvernV2` so both Skyvern 2.0 block formats are properly supported:
- **Format 1** (legacy): `block_type: navigation` + `engine: skyvern-2.0` + `navigation_goal`
- **Format 2** (current): `block_type: task_v2` + `prompt`

## Test plan
- [ ] Load a workflow YAML containing a `navigation` block with `engine: skyvern-2.0` and verify the prompt content is displayed in the V2 UI
- [ ] Load a workflow YAML containing a `task_v2` block and verify it still works correctly
- [ ] Edit and save a loaded `navigation` + `engine: skyvern-2.0` block, verify it saves correctly as `task_v2`
- [ ] Create a new Skyvern 2.0 block from the UI, verify it still works end to end
- [ ] TypeScript compilation passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.ai/code)