### PR TITLE
Remove code cache deletion confirmation from backend (#SKY-7370)

### DIFF
--- a/skyvern/exceptions.py
+++ b/skyvern/exceptions.py
@@ -837,11 +837,6 @@ class BrowserProfileNotFound(SkyvernHTTPException):
         super().__init__(message, status_code=status.HTTP_404_NOT_FOUND)
 
 
-class CannotUpdateWorkflowDueToCodeCache(SkyvernException):
-    def __init__(self, workflow_permanent_id: str) -> None:
-        super().__init__(f"No confirmation for code cache deletion on {workflow_permanent_id}.")
-
-
 class APIKeyNotFound(SkyvernHTTPException):
     def __init__(self, organization_id: str) -> None:
         super().__init__(f"No valid API key token found for organization {organization_id}")

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -25,7 +25,6 @@ from skyvern import analytics
 from skyvern._version import __version__
 from skyvern.config import settings
 from skyvern.exceptions import (
-    CannotUpdateWorkflowDueToCodeCache,
     MissingBrowserAddressError,
     SkyvernHTTPException,
 )
@@ -922,7 +921,6 @@ async def update_workflow_legacy(
         ..., description="The ID of the workflow to update. Workflow ID starts with `wpid_`.", examples=["wpid_123"]
     ),
     current_org: Organization = Depends(org_auth_service.get_current_org),
-    delete_code_cache_is_ok: bool = Query(False),
 ) -> Workflow:
     analytics.capture("skyvern-oss-agent-workflow-update")
     # validate the workflow
@@ -938,13 +936,7 @@ async def update_workflow_legacy(
             organization=current_org,
             request=workflow_create_request,
             workflow_permanent_id=workflow_id,
-            delete_code_cache_is_ok=delete_code_cache_is_ok,
         )
-    except CannotUpdateWorkflowDueToCodeCache as e:
-        raise HTTPException(
-            status_code=422,
-            detail=str(e),
-        ) from e
     except WorkflowDefinitionValidationException as e:
         raise e
     except (SkyvernHTTPException, ValidationError) as e:


### PR DESCRIPTION
Synced from cloud PR: https://github.com/Skyvern-AI/skyvern-cloud/pull/8696
Author: @suchintan

## Summary
- Removes the `CannotUpdateWorkflowDueToCodeCache` exception class
- Removes the `delete_code_cache_is_ok` query parameter from the workflow update endpoint
- Cached code is now auto-deleted on workflow save without requiring user confirmation
- This fixes the backend half of a stale closure bug where the frontend confirmation dialog caused infinite 422 errors

## Test plan
- [ ] Save a workflow that has cached code — backend should auto-delete cache without returning 422
- [ ] Verify saving a workflow without cached code still works normally
- [ ] Verify the frontend `delete_code_cache_is_ok` param (if still sent) is harmlessly ignored by FastAPI

> **Note:** This is the backend half of the fix. The frontend PR (#8652) removes the broken confirmation dialog and stops sending the query param.

🤖 Generated with [Claude Code](https://claude.ai/code)