### PR TITLE
Clarify continue_on_failure vs next_loop_on_failure help text in loop blocks

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/helpContent.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/helpContent.ts
@@ -22,9 +22,9 @@ export const baseHelpTooltipContent = {
   totpIdentifier:
     "If you are running multiple workflows at once, you will need to give the block an identifier to know that this TOTP goes with this block.",
   continueOnFailure:
-    "Allow the workflow to continue if it encounters a failure.",
+    "If this block fails, skip the failure and continue to the next block in the current iteration. The remaining blocks in the same iteration will still run.",
   nextLoopOnFailure:
-    "When inside a for loop, continue to the next iteration if this block fails.",
+    "If this block fails, skip the remaining blocks in the current iteration and jump to the next loop iteration.",
   includeActionHistoryInVerification:
     "Include the action history in the completion verification.",
   engine:
@@ -77,7 +77,7 @@ export const helpTooltips = {
     loopValue:
       "Define the values to iterate over. Use a parameter reference or natural language (e.g., 'Extract links of the top 2 posts'). Natural language automatically creates an extraction block that generates a list of string values. Use {{ current_value }} in the loop to get the current iteration value.",
     nextLoopOnFailure:
-      "When enabled, if any block inside the loop fails, the loop will immediately jump to the next iteration instead of stopping.",
+      "If any block inside the loop fails, skip the remaining blocks in the current iteration and jump to the next loop iteration instead of stopping the entire loop.",
   },
   sendEmail: {
     ...baseHelpTooltipContent,


### PR DESCRIPTION
Synced from cloud PR: https://github.com/Skyvern-AI/skyvern-cloud/pull/8745
Author: @suchintan

## Summary
- Updated help text for `continueOnFailure` and `nextLoopOnFailure` to clearly distinguish their behavior inside loop blocks
- `continueOnFailure`: now explains it continues to the **next block** in the same iteration
- `nextLoopOnFailure`: now explains it **skips remaining blocks** and jumps to the next iteration
- Updated both the base block-level tooltips and the loop-specific tooltip

## Test plan
- [ ] Verify tooltip text renders correctly in the workflow editor for blocks inside a loop
- [ ] Verify the loop-level "Next Loop on Failure" tooltip is accurate

🤖 Generated with [Claude Code](https://claude.ai/code)