### PR TITLE
Reduce frequency of thinking budget optimization logs

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -289,7 +289,7 @@ class LLMAPIHandlerFactory:
             else:
                 # Other reasoning-capable models (Deepseek, etc.) - use "low" for all budget values
                 parameters["reasoning_effort"] = "low"
-                LOG.info(
+                LOG.debug(
                     "Applied thinking budget optimization (reasoning_effort)",
                     prompt_name=prompt_name,
                     budget=new_budget,
@@ -320,7 +320,7 @@ class LLMAPIHandlerFactory:
             if model_label is None and isinstance(llm_config, LLMRouterConfig):
                 model_label = getattr(llm_config, "main_model_group", "router")
 
-            LOG.info(
+            LOG.debug(
                 "Applied thinking budget optimization (reasoning_effort)",
                 prompt_name=prompt_name,
                 budget=new_budget,
@@ -338,7 +338,7 @@ class LLMAPIHandlerFactory:
             if model_label is None and isinstance(llm_config, LLMRouterConfig):
                 model_label = getattr(llm_config, "main_model_group", "router")
 
-            LOG.info(
+            LOG.debug(
                 "Applied thinking budget optimization (thinking)",
                 prompt_name=prompt_name,
                 budget=new_budget,
@@ -366,7 +366,7 @@ class LLMAPIHandlerFactory:
                 thinking_payload["type"] = "enabled"
             parameters["thinking"] = thinking_payload
 
-        LOG.info(
+        LOG.debug(
             "Applied thinking budget optimization (budget_tokens)",
             prompt_name=prompt_name,
             budget=new_budget,


### PR DESCRIPTION
Change LOG.info to LOG.debug for "Applied thinking budget optimization" messages. These logs appear on every LLM call with thinking optimization, creating excessive noise in production logs.

The logs are still available at debug level for troubleshooting.

Slack thread: https://skyvern.slack.com/archives/C095XG26XQW/p1770995804075809?thread_ts=1770995492.515429&cid=C095XG26XQW

https://claude.ai/code/session_01ENsWLNuGAgJtwfMsJ4YbqA