### PR TITLE
Fix direct_searching clearing input after Enter (#SKY-7988)

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -2718,6 +2718,7 @@ async def choose_auto_completion_dropdown(
                 value=text,
             )
             await skyvern_element.press_key("Enter")
+            clear_input = False
             return result
 
         if not element_id:


### PR DESCRIPTION
Synced from cloud PR: https://github.com/Skyvern-AI/skyvern-cloud/pull/8778
Author: @pedrohsdb

## Summary

- **One-line fix**: Set `clear_input = False` in the `direct_searching=True` path of `choose_auto_completion_dropdown()`, preventing the `finally` block from wiping the search input after Enter is pressed.

## Root Cause

In `choose_auto_completion_dropdown()` (`handler.py:2715-2721`), when the LLM returns `direct_searching=True`, the code presses Enter to submit the search but never sets `clear_input = False`. The `finally` block then calls `input_clear()`, wiping the search text before the page can navigate — effectively cancelling the search.

This was introduced in commit `086aee1ed` ("fix search on auto completion (#3468)", Jan 13 2025), which added the `direct_searching` path to handle search bars. The author added the Enter-press logic but missed adding `clear_input = False`, even though the click-suggestion path 30 lines below already had it.

## Why `clear_input = True` exists (and why the fix is safe)

`clear_input = True` is the default because `choose_auto_completion_dropdown()` is called from a **retry loop** in `input_or_auto_complete_input()`. When the auto-completion fails (no match, low relevance, missing element), the typed text needs to be cleared so the caller can retry with different text. The pattern:

| Path | `clear_input` | Why |
|------|--------------|-----|
| **Exception** (no match, low relevance, etc.) | `True` (default) | Failed — clear typed text so caller can retry |
| **Click suggestion** (line 2751) | `False` | Success — clicked an option, don't undo it |
| **Location fast-path** (line 2665) | `False` | Success — clicked single match, don't undo it |
| **`direct_searching`** (line 2720) | was `True` (**BUG**) → now `False` | Success — pressed Enter to search, should not undo it |

The `direct_searching` path is semantically identical to clicking a suggestion — both are "the auto-completion succeeded, we committed to a value." There is no scenario where you'd want to clear the input after successfully pressing Enter to search.

## E2E Verification (Skyvern agent vs mock website)

Created a mock search page (`tests/manual/search_autocomplete_test.html`) with autocomplete dropdown and ran the actual Skyvern agent against it on both main and this branch.

### WITHOUT fix (main) — `direct_searching=True` triggered, input cleared:
```
[20:33:53] Enter key pressed (input has focus, dropdown closed)
[20:33:53] SUBMIT search: "clark county nevada tax assessor official website"
[20:33:53] Input changed: ""
[20:33:53] INPUT CLEARED programmatically (value went from non-empty to empty)  ← BUG
```

### WITH fix (branch) — `direct_searching=True` triggered, input preserved:
```
[20:36:20] Enter key pressed (input has focus, dropdown closed)
[20:36:20] SUBMIT search: "clark county nevada tax assessor official website"
[20:36:21] Enter pressed on page level (activeElement: BODY#)
```
No `INPUT CLEARED` — the fix prevents the `finally` block from wiping the input.

### Dropdown selection (partial text) — works on both:
```
[20:36:21] Clicked suggestion: "clark county nevada property tax search"
[20:36:21] SUBMIT search: "clark county nevada property tax search"
```
The click-suggestion path was already correct (`clear_input = False` at line 2751).

## Original Issue

Amerisave workflow run `wr_495273963449608890`: Skyvern typed "Clark County Nevada tax assessor official website" into Google, the auto-completion handler chose `direct_searching=True` and pressed Enter, but the `finally` block immediately cleared the input, leaving Google's search bar empty and the page stuck on the homepage.

## Test plan

- [x] Compile check: `uv run python -m py_compile skyvern/webeye/actions/handler.py`
- [x] Unit test confirms fix detected: `python tests/manual/test_search_enter_bug.py --unit`
- [x] Playwright tests (3/3 pass): `uv run python -m pytest tests/manual/test_clear_input_playwright.py -v`
- [x] 481 existing unit tests pass: `uv run python -m pytest tests/unit/ -v`
- [x] E2E: Skyvern agent on mock page WITHOUT fix → input cleared (bug confirmed)
- [x] E2E: Skyvern agent on mock page WITH fix → input preserved (fix confirmed)
- [x] E2E: Dropdown selection works correctly on both main and branch

🤖 Generated with [Claude Code](https://claude.ai/code)