### PR TITLE
Reduce frequency of thinking budget optimization logs

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -289,7 +289,7 @@ class LLMAPIHandlerFactory:
             else:
                 # Other reasoning-capable models (Deepseek, etc.) - use "low" for all budget values
                 parameters["reasoning_effort"] = "low"
-                LOG.info(
+                LOG.debug(
                     "Applied thinking budget optimization (reasoning_effort)",
                     prompt_name=prompt_name,
                     budget=new_budget,
@@ -320,7 +320,7 @@ class LLMAPIHandlerFactory:
             if model_label is None and isinstance(llm_config, LLMRouterConfig):
                 model_label = getattr(llm_config, "main_model_group", "router")
 
-            LOG.info(
+            LOG.debug(
                 "Applied thinking budget optimization (reasoning_effort)",
                 prompt_name=prompt_name,
                 budget=new_budget,
@@ -338,7 +338,7 @@ class LLMAPIHandlerFactory:
             if model_label is None and isinstance(llm_config, LLMRouterConfig):
                 model_label = getattr(llm_config, "main_model_group", "router")
 
-            LOG.info(
+            LOG.debug(
                 "Applied thinking budget optimization (thinking)",
                 prompt_name=prompt_name,
                 budget=new_budget,
@@ -366,7 +366,7 @@ class LLMAPIHandlerFactory:
                 thinking_payload["type"] = "enabled"
             parameters["thinking"] = thinking_payload
 
-        LOG.info(
+        LOG.debug(
             "Applied thinking budget optimization (budget_tokens)",
             prompt_name=prompt_name,
             budget=new_budget,


### PR DESCRIPTION
Synced from cloud PR: https://github.com/Skyvern-AI/skyvern-cloud/pull/8780
Author: @pedrohsdb

## Summary

- Change `LOG.info` → `LOG.debug` for all four "Applied thinking budget optimization" messages in `api_handler_factory.py`
- These logs fire on **every LLM call** with thinking optimization enabled, creating excessive noise in production logs
- Logs remain available at debug level for troubleshooting

Replaces open-source PR https://github.com/Skyvern-AI/skyvern/pull/4742 (which was opened in the wrong repo — merging here will auto-sync to OSS).

🤖 Generated with [Claude Code](https://claude.ai/code)