### PR TITLE
Clarify MCP setup docs for current local bridge flow

### DIFF
--- a/docs/integrations/mcp.mdx
+++ b/docs/integrations/mcp.mdx
@@ -15,6 +15,11 @@ Skyvern MCP currently runs as a local stdio process (`skyvern run mcp`) on your 
 Remote-hosted MCP is planned, but is not the default setup today.
 </Note>
 
+<Note title="Cloud users">
+You do not need to clone the Skyvern OSS repo to use Skyvern Cloud MCP.
+Install `skyvern` locally, configure with your Cloud API key, and run MCP from your local machine.
+</Note>
+
 ## What you can do
 
 The MCP server exposes 31 tools across 5 categories:
@@ -34,7 +39,8 @@ Your AI assistant decides which tools to call based on your instructions. For ex
 ### Option A: Setup wizard (recommended)
 
 ```bash
-pip install skyvern
+python3.11 -m pip install --upgrade pip skyvern
+python3.11 -m skyvern --help
 skyvern init
 ```
 
@@ -71,7 +77,7 @@ Add this to your MCP client's configuration file (including Claude Code manual s
 }
 ```
 
-Replace the `command` value with the exact output of `which python3.11` (or `which python3.12` / `which python3.13`) on your machine. For local mode, set `SKYVERN_BASE_URL` to `http://localhost:8000` and find your API key in the `.env` file after running `skyvern init`.
+Replace the `command` value with the exact output of `python3.11 -c "import sys; print(sys.executable)"` (or `python3.12` / `python3.13`) on your machine. For local mode, set `SKYVERN_BASE_URL` to `http://localhost:8000` and find your API key in the `.env` file after running `skyvern init`.
 
 <Accordion title="Config file locations by client">
 

--- a/fern/integrations/mcp.mdx
+++ b/fern/integrations/mcp.mdx
@@ -16,17 +16,33 @@ You can use MCP with:
 1. **Skyvern Cloud** (`SKYVERN_BASE_URL=https://api.skyvern.com` + your API key)
 2. **Local Skyvern Server** (`SKYVERN_BASE_URL=http://localhost:8000`)
 
+## Cloud-only setup (no OSS clone required)
+
+You do **not** need to clone the Skyvern OSS repo to use Skyvern Cloud MCP.
+You only need Python and the `skyvern` package installed locally.
+
 ## Quickstart
 <Tip title="Supported Python Versions" icon="fa-brands fa-python">
 Python 3.11, 3.12 and 3.13
 </Tip>
 
-1. **Install Skyvern**
+1. **Install Python 3.11+ and verify**
 ```bash
-pip install skyvern
+python3 --version
+```
+If this is not 3.11+ (or you have multiple Python versions), use `python3.11`, `python3.12`, or `python3.13` explicitly in the next steps.
+
+2. **Install Skyvern into that Python**
+```bash
+python3.11 -m pip install --upgrade pip skyvern
 ```
 
-2. **Run the setup wizard**
+3. **Confirm install**
+```bash
+python3.11 -m skyvern --help
+```
+
+4. **Run the setup wizard**
 ```bash
 skyvern init
 ```
@@ -35,12 +51,12 @@ The wizard will:
 - collect/set `SKYVERN_BASE_URL` and `SKYVERN_API_KEY`
 - auto-configure MCP for Claude Desktop, Cursor, and Windsurf
 
-3. **Only for local mode: start the API server**
+5. **Only for local mode: start the API server**
 ```bash
 skyvern run server
 ```
 
-4. **Restart your MCP client app** and ask it to use Skyvern tools.
+6. **Restart your MCP client app** and ask it to use Skyvern tools.
 
 ## Config file locations
 
@@ -72,7 +88,7 @@ Use this if you are setting up a custom MCP client, or Claude Code.
 }
 ```
 
-Set `command` to the exact output of `which python3.11` (or `which python3.12` / `which python3.13`) on the same machine where your MCP client runs.
+Set `command` to the exact output of `python3.11 -c "import sys; print(sys.executable)"` (or `python3.12` / `python3.13`) on the same machine where your MCP client runs.
 
 For local mode:
 - set `SKYVERN_BASE_URL` to `http://localhost:8000`

--- a/integrations/mcp/README.md
+++ b/integrations/mcp/README.md
@@ -18,15 +18,31 @@ You can use MCP with:
 1. **Skyvern Cloud** (`SKYVERN_BASE_URL=https://api.skyvern.com` + your API key)
 2. **Local Skyvern Server** (`SKYVERN_BASE_URL=http://localhost:8000`)
 
+## Cloud-only setup (no OSS clone required)
+
+You do **not** need to clone the Skyvern OSS repo to use Skyvern Cloud MCP.
+You only need Python and the `skyvern` package installed locally.
+
 ## Quickstart
 > Supported Python versions: 3.11, 3.12, 3.13
 
-1. **Install Skyvern**
+1. **Install Python 3.11+ and verify**
 ```bash
-pip install skyvern
+python3 --version
+```
+If this is not 3.11+ (or you have multiple Python versions), use `python3.11`, `python3.12`, or `python3.13` explicitly in the next steps.
+
+2. **Install Skyvern into that Python**
+```bash
+python3.11 -m pip install --upgrade pip skyvern
 ```
 
-2. **Run the setup wizard**
+3. **Confirm install**
+```bash
+python3.11 -m skyvern --help
+```
+
+4. **Run the setup wizard**
 ```bash
 skyvern init
 ```
@@ -35,12 +51,12 @@ The wizard will:
 - collect/set `SKYVERN_BASE_URL` and `SKYVERN_API_KEY`
 - auto-configure MCP for Claude Desktop, Cursor, and Windsurf
 
-3. **Only for local mode: start the API server**
+5. **Only for local mode: start the API server**
 ```bash
 skyvern run server
 ```
 
-4. **Restart your MCP client app** and ask it to use Skyvern tools.
+6. **Restart your MCP client app** and ask it to use Skyvern tools.
 
 ## Config file locations
 
@@ -72,7 +88,7 @@ Use this if you are setting up a custom MCP client, or Claude Code.
 }
 ```
 
-Set `command` to the exact output of `which python3.11` (or `which python3.12` / `which python3.13`) on the same machine where your MCP client runs.
+Set `command` to the exact output of `python3.11 -c "import sys; print(sys.executable)"` (or `python3.12` / `python3.13`) on the same machine where your MCP client runs.
 
 For local mode:
 - set `SKYVERN_BASE_URL` to `http://localhost:8000`


### PR DESCRIPTION
## Summary
- clarify that MCP currently runs as a local stdio bridge (`skyvern run mcp`)
- add explicit note that remote-hosted MCP is planned but not default today
- document exactly which clients `skyvern init` auto-configures
- add explicit Claude Code setup instructions for project (`.mcp.json`) and user/local (`~/.claude.json`) scopes
- align MCP guidance across Fern docs, repo README integration doc, and docs/integrations page

## Why
Customers were getting mixed signals on where MCP config should live and whether cloud users can use MCP without self-hosting. This update makes the current path explicit and avoids giving instructions that won’t work.

## Files
- `fern/integrations/mcp.mdx`
- `integrations/mcp/README.md`
- `docs/integrations/mcp.mdx`
