### PR TITLE
Add webhook notification when cleanup task is triggered

### DIFF
--- a/skyvern/services/cleanup_service.py
+++ b/skyvern/services/cleanup_service.py
@@ -272,7 +272,7 @@ async def send_cleanup_webhooks(
         try:
             # Get API key for signature
             api_key_obj = await app.DATABASE.get_valid_org_auth_token(
-                org.organization_id, OrganizationAuthTokenType.api
+                org.organization_id, OrganizationAuthTokenType.api.value
             )
             if not api_key_obj:
                 LOG.debug(


### PR DESCRIPTION
## Summary
- Send webhook notifications to organizations when cleanup scheduler runs
- Webhook URL is retrieved from organization settings (`webhook_callback_url`)
- Organizations without webhook URL are skipped
- Webhook payload includes cleanup metrics (temp files removed, processes killed, stale tasks/workflows count)
- Uses signed payloads with HMAC-SHA256 for security (same as existing task webhooks)

## Test plan
- [ ] Enable cleanup cron (`ENABLE_CLEANUP_CRON=true`)
- [ ] Configure an organization with a webhook URL
- [ ] Wait for cleanup scheduler to trigger (or manually call `run_cleanup()`)
- [ ] Verify webhook is received with correct payload format:
  ```json
  {
    "event": "cleanup_triggered",
    "timestamp": "2026-02-19T...",
    "metrics": {
      "temp_files_removed": 0,
      "processes_killed": 0,
      "stale_tasks": 0,
      "stale_workflows": 0
    }
  }
  ```
- [ ] Verify organizations without webhook URL are skipped (no errors)
- [ ] Verify signature headers are present (`x-skyvern-timestamp`, `x-skyvern-signature`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)