### PR TITLE
Fix browser session timeout input being uneditable (#SKY-7855)

### DIFF
--- a/skyvern-frontend/src/routes/browserSessions/BrowserSessions.tsx
+++ b/skyvern-frontend/src/routes/browserSessions/BrowserSessions.tsx
@@ -64,7 +64,7 @@ function BrowserSessions() {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [sessionOptions, setSessionOptions] = useState<{
     proxyLocation: ProxyLocation;
-    timeoutMinutes: number;
+    timeoutMinutes: number | null;
   }>({
     proxyLocation: ProxyLocation.Residential,
     timeoutMinutes: 60,
@@ -350,25 +350,31 @@ function BrowserSessions() {
                     <HelpTooltip content="Duration to keep the browser session open. Automatically extends as it is used." />
                   </div>
                   <Input
-                    value={sessionOptions.timeoutMinutes}
+                    type="number"
+                    min={5}
+                    max={1440}
+                    value={sessionOptions.timeoutMinutes ?? ""}
                     placeholder="timeout (minutes)"
                     onChange={(event) => {
                       const value =
                         event.target.value === ""
                           ? null
-                          : Number(event.target.value);
-
-                      if (value) {
-                        setSessionOptions({
-                          ...sessionOptions,
-                          timeoutMinutes: value,
-                        });
-                      }
+                          : parseInt(event.target.value, 10);
+                      setSessionOptions({
+                        ...sessionOptions,
+                        timeoutMinutes: value,
+                      });
                     }}
                   />
                 </div>
                 <Button
-                  disabled={createBrowserSessionMutation.isPending}
+                  disabled={
+                    createBrowserSessionMutation.isPending ||
+                    sessionOptions.timeoutMinutes === null ||
+                    Number.isNaN(sessionOptions.timeoutMinutes) ||
+                    sessionOptions.timeoutMinutes < 5 ||
+                    sessionOptions.timeoutMinutes > 1440
+                  }
                   className="mt-6 w-full"
                   onClick={() => {
                     createBrowserSessionMutation.mutate({


### PR DESCRIPTION
Synced from cloud PR: https://github.com/Skyvern-AI/skyvern-cloud/pull/8835
Author: @celalzamanoglu

## Summary - [SKY-7855](https://linear.app/skyvern/issue/SKY-7855/cannot-change-browser-session-timeout-from-fixed-value-6)

This PR fixes a bug where the browser session timeout input field could not be edited by the user. The timeout was stuck at whatever value was previously set because the `onChange` handler silently discarded updates when the computed value was falsy.

## Problem

The `onChange` handler in the browser session creation drawer wrapped the `setSessionOptions` call in an `if (value)` guard. This check evaluated to `false` whenever the user cleared the field (producing `null`) or typed a transitional falsy value, so the state was never updated. As a result, the input appeared frozen and users could not change the timeout away from the default of 60 minutes — or clear the field at all to retype a new value.

## What Changed

- `skyvern-frontend/src/routes/browserSessions/BrowserSessions.tsx`: Removed the `if (value)` falsy guard from the timeout `onChange` handler so all state updates are applied unconditionally
- Updated the `timeoutMinutes` field type in `sessionOptions` from `number` to `number | null` to correctly reflect that the field can be empty
- Added `type="number"`, `min={5}`, and `max={1440}` attributes to the `<Input>` component to match backend Pydantic constraints (`ge=5`, `le=1440`) and provide browser-native validation
- Changed the `value` prop to `sessionOptions.timeoutMinutes ?? ""` so the input correctly renders an empty string when the value is `null`

## Test plan

- [ ] Open the browser sessions page and click to create a new session
- [ ] Verify the timeout input field defaults to 60 minutes
- [ ] Clear the timeout field completely and confirm the input becomes empty (not stuck)
- [ ] Type a new value (e.g., 30) and confirm it is accepted and reflected in the input
- [ ] Type a value, delete digits one at a time, and confirm each intermediate state is reflected without the input jumping back
- [ ] Attempt to create a session with a valid timeout and confirm it succeeds
- [ ] Attempt to create a session with the field empty and confirm the UI handles the null value gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)