### PR TITLE
Display wait action status as success in UI (#SKY-5901)

### DIFF
--- a/skyvern-frontend/src/routes/tasks/detail/hooks/useActions.ts
+++ b/skyvern-frontend/src/routes/tasks/detail/hooks/useActions.ts
@@ -106,7 +106,11 @@ function useActions({ id }: Props): {
                 confidence: action.confidence_float,
                 input: getActionInput(action),
                 type: action.action_type,
-                success: actionResult?.[0]?.success ?? false,
+                // Wait actions always succeed — they intentionally return ActionFailure
+                // from the backend but completing a wait is expected, not a failure.
+                success:
+                  action.action_type === ActionTypes.wait ||
+                  (actionResult?.[0]?.success ?? false),
                 stepId: step.step_id,
                 index,
                 created_by: action.created_by,
@@ -121,7 +125,9 @@ function useActions({ id }: Props): {
             confidence: action.confidence_float ?? undefined,
             input: action.response ?? "",
             type: action.action_type,
+            // Wait actions always succeed — see comment in legacy path above.
             success:
+              action.action_type === ActionTypes.wait ||
               action.status === Status.Completed ||
               action.status === Status.Skipped,
             stepId: action.step_id ?? "",

--- a/skyvern-frontend/src/routes/workflows/workflowRun/ActionCard.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/ActionCard.tsx
@@ -23,8 +23,12 @@ type Props = {
 };
 
 function ActionCard({ action, onClick, active, index }: Props) {
+  // Wait actions always succeed — they intentionally return ActionFailure
+  // from the backend but completing a wait is expected, not a failure.
   const success =
-    action.status === Status.Completed || action.status === Status.Skipped;
+    action.action_type === ActionTypes.wait ||
+    action.status === Status.Completed ||
+    action.status === Status.Skipped;
 
   const refCallback = useCallback((element: HTMLDivElement | null) => {
     if (element && active) {

--- a/skyvern-frontend/src/routes/workflows/workflowRun/ActionCardMinimal.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/ActionCardMinimal.tsx
@@ -1,5 +1,5 @@
 import { LightningBoltIcon } from "@radix-ui/react-icons";
-import { ActionsApiResponse, Status } from "@/api/types";
+import { ActionsApiResponse, ActionTypes, Status } from "@/api/types";
 import {
   Tooltip,
   TooltipContent,
@@ -14,8 +14,12 @@ type Props = {
 };
 
 function ActionCardMinimal({ action }: Props) {
+  // Wait actions always succeed — they intentionally return ActionFailure
+  // from the backend but completing a wait is expected, not a failure.
   const success =
-    action.status === Status.Completed || action.status === Status.Skipped;
+    action.action_type === ActionTypes.wait ||
+    action.status === Status.Completed ||
+    action.status === Status.Skipped;
 
   return (
     <ItemStatusIndicator failure={!success} success={success} offset="-0.7rem">


### PR DESCRIPTION
Synced from cloud PR: https://github.com/Skyvern-AI/skyvern-cloud/pull/8836
Author: @celalzamanoglu

## Summary - [SKY-5901](https://linear.app/skyvern/issue/SKY-5901/change-wait-action-status-from-fail-to-success-only-in-ui)

Wait actions were displaying with a failure indicator in the UI even though they are an intentional, non-failing action type. This PR fixes the display logic across all action card components so that wait actions always render as successful.

## Problem

The `wait` action type does not have a backend result that marks it as "succeeded" in the traditional sense, so the UI was defaulting to displaying it with a failure indicator (red border, cross icon). This was misleading — a wait action completing is the expected behavior and should be treated as a success from the user's perspective.

## What Changed

- `skyvern-frontend/src/routes/tasks/detail/hooks/useActions.ts`: Updated the `success` computation in both the legacy (step-based) and current (actions API) code paths to treat `ActionTypes.wait` as always successful
- `skyvern-frontend/src/routes/workflows/workflowRun/ActionCard.tsx`: Updated the `success` flag in the workflow run action card to include `ActionTypes.wait`
- `skyvern-frontend/src/routes/workflows/workflowRun/ActionCardMinimal.tsx`: Applied the same fix to the minimal action card variant used in the workflow run timeline view; also imported `ActionTypes` which was previously missing from the import statement

## Test plan

- [ ] Run a task or workflow that includes a wait action and verify it displays with a green/success indicator instead of a red/failure indicator
- [ ] Verify that genuinely failed actions (e.g., a failed click or input) still display with a failure indicator
- [ ] Verify that completed and skipped actions continue to show as successful
- [ ] Check both the task detail view (uses `useActions` hook) and the workflow run view (uses `ActionCard` and `ActionCardMinimal`) to confirm the fix applies consistently in both contexts

🤖 Generated with [Claude Code](https://claude.ai/code)