### PR TITLE
Use pooled Redis client for notification registry in cloud

### DIFF
--- a/skyvern/forge/forge_app.py
+++ b/skyvern/forge/forge_app.py
@@ -111,15 +111,14 @@ def create_forge_app() -> ForgeApp:
     app.STORAGE = StorageFactory.get_storage()
     app.CACHE = CacheFactory.get_cache()
 
-    if settings.NOTIFICATION_REGISTRY_TYPE == "redis":
+    if settings.NOTIFICATION_REGISTRY_TYPE == "redis" and settings.NOTIFICATION_REDIS_URL:
         from redis.asyncio import from_url as redis_from_url
 
         from skyvern.forge.sdk.notification.factory import NotificationRegistryFactory
         from skyvern.forge.sdk.notification.redis import RedisNotificationRegistry
         from skyvern.forge.sdk.redis.factory import RedisClientFactory
 
-        redis_url = settings.NOTIFICATION_REDIS_URL or settings.REDIS_URL
-        redis_client = redis_from_url(redis_url, decode_responses=True)
+        redis_client = redis_from_url(settings.NOTIFICATION_REDIS_URL, decode_responses=True)
         RedisClientFactory.set_client(redis_client)
         NotificationRegistryFactory.set_registry(RedisNotificationRegistry(redis_client))
     app.ARTIFACT_MANAGER = ArtifactManager()


### PR DESCRIPTION
Synced from cloud PR: https://github.com/Skyvern-AI/skyvern-cloud/pull/8863
Author: @wintonzheng

## Summary
- Consolidate Redis client usage for `RedisNotificationRegistry` in cloud environment
- Override the open-source notification registry setup to use `async_redis_client` from `cloud/clients/redis.py`
- The cloud Redis client has proper connection pooling (`BlockingConnectionPool`), retry logic, SSL support, and health checks
- Previously, the notification registry was creating its own Redis client via `redis_from_url()` without connection pooling

## Test plan
- [ ] Verify backend starts successfully with `NOTIFICATION_REGISTRY_TYPE=redis`
- [ ] Test notification pub/sub functionality in cloud environment
- [ ] Confirm Redis connection pooling is being used (check Redis connections count)

🤖 Generated with [Claude Code](https://claude.ai/code)