### PR TITLE
Fix VITE_API_BASE_URL not being used at runtime in Docker

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -8,10 +8,10 @@ COPY ./skyvern-frontend /app
 COPY ./entrypoint-skyvernui.sh /app/entrypoint-skyvernui.sh
 RUN npm install
 
-ENV VITE_API_BASE_URL=http://localhost:8000/api/v1
-ENV VITE_WSS_BASE_URL=ws://localhost:8000/api/v1
-ENV VITE_ARTIFACT_API_BASE_URL=http://localhost:9090
-# Placeholder for runtime injection
+# Placeholders for runtime injection (will be replaced by entrypoint script)
+ENV VITE_API_BASE_URL=__VITE_API_BASE_URL_PLACEHOLDER__
+ENV VITE_WSS_BASE_URL=__VITE_WSS_BASE_URL_PLACEHOLDER__
+ENV VITE_ARTIFACT_API_BASE_URL=__VITE_ARTIFACT_API_BASE_URL_PLACEHOLDER__
 ENV VITE_SKYVERN_API_KEY=__SKYVERN_API_KEY_PLACEHOLDER__
 
 # Build at image time

--- a/entrypoint-skyvernui.sh
+++ b/entrypoint-skyvernui.sh
@@ -2,13 +2,24 @@
 
 set -e
 
-# Extract API key from secrets file
-VITE_SKYVERN_API_KEY=$(sed -n 's/.*cred\s*=\s*"\([^"]*\)".*/\1/p' .streamlit/secrets.toml 2>/dev/null || echo "")
+# Default values for environment variables
+VITE_API_BASE_URL="${VITE_API_BASE_URL:-http://localhost:8000/api/v1}"
+VITE_WSS_BASE_URL="${VITE_WSS_BASE_URL:-ws://localhost:8000/api/v1}"
+VITE_ARTIFACT_API_BASE_URL="${VITE_ARTIFACT_API_BASE_URL:-http://localhost:9090}"
 
-# Inject API key into pre-built JS files (replace placeholder)
-if [ -n "$VITE_SKYVERN_API_KEY" ]; then
-    find /app/dist -name "*.js" -exec sed -i "s/__SKYVERN_API_KEY_PLACEHOLDER__/$VITE_SKYVERN_API_KEY/g" {} \;
+# Extract API key from secrets file if not provided via environment
+if [ -z "$VITE_SKYVERN_API_KEY" ]; then
+    VITE_SKYVERN_API_KEY=$(sed -n 's/.*cred\s*=\s*"\([^"]*\)".*/\1/p' .streamlit/secrets.toml 2>/dev/null || echo "")
 fi
+
+# Inject environment variables into pre-built JS files (replace placeholders)
+# Using | as delimiter since URLs contain /
+find /app/dist -name "*.js" -exec sed -i \
+    -e "s|__VITE_API_BASE_URL_PLACEHOLDER__|${VITE_API_BASE_URL}|g" \
+    -e "s|__VITE_WSS_BASE_URL_PLACEHOLDER__|${VITE_WSS_BASE_URL}|g" \
+    -e "s|__VITE_ARTIFACT_API_BASE_URL_PLACEHOLDER__|${VITE_ARTIFACT_API_BASE_URL}|g" \
+    -e "s|__SKYVERN_API_KEY_PLACEHOLDER__|${VITE_SKYVERN_API_KEY}|g" \
+    {} \;
 
 # Start the servers (no rebuild needed)
 # Tini (configured as ENTRYPOINT) handles signal forwarding and zombie reaping


### PR DESCRIPTION
The commit a71493b moved npm build to Docker image build time for faster startup, but only added runtime placeholder injection for VITE_SKYVERN_API_KEY. The URL environment variables (VITE_API_BASE_URL, VITE_WSS_BASE_URL, and VITE_ARTIFACT_API_BASE_URL) were baked in with hardcoded defaults at build time and never replaced at runtime.

This fix:
- Changes the Dockerfile to use placeholders for all VITE_* URL variables
- Updates the entrypoint script to replace these placeholders with the actual environment variable values at container startup
- Preserves backward compatibility by providing sensible defaults when environment variables are not set

https://claude.ai/code/session_01T27145TMTVUD894o4QsU16