### PR TITLE
chore: bump eslint-plugin-react-refresh to ^0.4.26

### DIFF
--- a/skyvern-frontend/package-lock.json
+++ b/skyvern-frontend/package-lock.json
@@ -82,7 +82,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-react-hooks": "^4.6.0",
-        "eslint-plugin-react-refresh": "^0.4.5",
+        "eslint-plugin-react-refresh": "^0.4.26",
         "lint-staged": "^15.5.2",
         "postcss": "^8.4.37",
         "prettier": "^3.8.1",
@@ -5735,12 +5735,13 @@
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.6.tgz",
-      "integrity": "sha512-NjGXdm7zgcKRkKMua34qVO9doI7VOxZ6ancSvBELJSSoX97jyndXcSoa8XBh69JoB31dNz3EEzlMcizZl7LaMA==",
+      "version": "0.4.26",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
+      "integrity": "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
-        "eslint": ">=7"
+        "eslint": ">=8.40"
       }
     },
     "node_modules/eslint-scope": {

--- a/skyvern-frontend/package.json
+++ b/skyvern-frontend/package.json
@@ -93,7 +93,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-react-refresh": "^0.4.5",
+    "eslint-plugin-react-refresh": "^0.4.26",
     "lint-staged": "^15.5.2",
     "postcss": "^8.4.37",
     "prettier": "^3.8.1",

--- a/skyvern-frontend/src/store/DebugStoreContext.tsx
+++ b/skyvern-frontend/src/store/DebugStoreContext.tsx
@@ -13,6 +13,7 @@ export type DebugStoreContextType = {
   isDebugMode: boolean;
 };
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const DebugStoreContext = createContext<
   DebugStoreContextType | undefined
 >(undefined);


### PR DESCRIPTION
## Summary
- Bumps `eslint-plugin-react-refresh` from `^0.4.5` to `^0.4.26` to align with the cloud repo
- Restores the `eslint-disable-next-line` directive in `DebugStoreContext.tsx` — the newer plugin version correctly flags `createContext` exports, so the suppression is now needed

## Test plan
- [x] `npm run lint` passes locally
- [x] `npm run build` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)