### PR TITLE
fix: ci: install copilot extra so copilot unit tests run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,17 +55,17 @@ jobs:
         with:
           path: .venv
           key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version || '3.11' }}-${{ hashFiles('**/uv.lock') }}
-      # Create/refresh the environment (installs main + dev groups)
+      # Create/refresh the environment (installs main + dev groups + copilot extra)
       - name: Sync deps with uv
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
           uv lock
-          uv sync --group dev
+          uv sync --group dev --extra copilot
       # Ensure venv is current even on cache hit (cheap no-op if up to date)
       - name: Ensure environment is up to date
         if: steps.cache-venv.outputs.cache-hit == 'true'
         run: |
-          uv sync --group dev
+          uv sync --group dev --extra copilot
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:


### PR DESCRIPTION
## Summary

Issue introduced to OSS likely with #5512. This will be reversed once the whole feature is merged in.

- Add `--extra copilot` to both `uv sync --group dev` calls in CI so the `openai-agents` package is installed during test runs.

The copilot test files synced from skyvern-cloud (`tests/unit/test_copilot_action_fingerprint.py`, `test_copilot_cancel_helpers.py`, `test_copilot_session_injection.py`) import from `skyvern.forge.sdk.copilot.tools` which does `from agents import function_tool` at the top level. The `openai-agents` package is declared as the `copilot` optional extra in `pyproject.toml` but CI was only running `uv sync --group dev`, so these tests failed with `ModuleNotFoundError: No module named 'agents'` during collection.

## Test plan

- [x] CI on this PR should pass (the copilot tests that were failing should now collect and run)