### PR TITLE
Add Human Pages integration for human fallback

### DIFF
--- a/integrations/humanpages/README.md
+++ b/integrations/humanpages/README.md
@@ -1,0 +1,116 @@
+# Skyvern + Human Pages
+
+When Skyvern's browser automation hits a blocker it cannot solve — CAPTCHAs, identity verification, phone verification, manual review gates — this integration hands the blocked step to a real human via [Human Pages](https://humanpages.ai) and returns control to Skyvern once the human finishes.
+
+## Installation
+
+```bash
+pip install skyvern-humanpages
+```
+
+## Configuration
+
+Set your Human Pages API key (get one at https://humanpages.ai):
+
+```bash
+export HUMANPAGES_API_KEY="your_api_key"
+```
+
+All settings can be overridden via environment variables with the `HUMANPAGES_` prefix:
+
+| Variable | Default | Description |
+|---|---|---|
+| `HUMANPAGES_API_KEY` | (required) | Your Human Pages agent API key |
+| `HUMANPAGES_BASE_URL` | `https://humanpages.ai` | API base URL |
+| `HUMANPAGES_DEFAULT_PRICE_USDC` | `5.0` | Default job price in USDC |
+| `HUMANPAGES_DEFAULT_DEADLINE_HOURS` | `4` | Default deadline for human to complete |
+| `HUMANPAGES_POLL_INTERVAL_SECONDS` | `30` | How often to check job status |
+| `HUMANPAGES_POLL_TIMEOUT_SECONDS` | `14400` | Maximum wait time (4 hours) |
+
+## Quick start
+
+```python
+import asyncio
+from skyvern_humanpages import HumanFallback
+from skyvern_humanpages.schema import FallbackRequest, BlockerType
+
+fallback = HumanFallback(api_key="your_api_key")
+
+async def main():
+    result = await fallback.handle_blocker(
+        FallbackRequest(
+            url="https://example.com/checkout",
+            blocker_type=BlockerType.CAPTCHA,
+            description="Solve the CAPTCHA on the checkout page so the form can be submitted.",
+        )
+    )
+    print(f"Job {result.job_id} finished with status: {result.status}")
+    print(f"Result: {result.result}")
+
+asyncio.run(main())
+```
+
+## Using the low-level client
+
+If you need finer control, use `HumanPagesClient` directly:
+
+```python
+import asyncio
+from skyvern_humanpages.client import HumanPagesClient
+from skyvern_humanpages.schema import JobCreateRequest
+
+client = HumanPagesClient(api_key="your_api_key")
+
+async def main():
+    # Search for available humans
+    humans = await client.search_humans(skill="web task")
+    print(f"Found {len(humans)} available humans")
+
+    # Create a job
+    job = await client.create_job(
+        JobCreateRequest(
+            humanId=humans[0].id,
+            title="Solve CAPTCHA on example.com",
+            description="Navigate to https://example.com/checkout and solve the CAPTCHA.",
+            priceUsdc=5.0,
+            deadlineHours=2,
+        )
+    )
+    print(f"Created job: {job.id}")
+
+    # Poll for completion
+    status = await client.get_job_status(job.id)
+    print(f"Job status: {status.status}")
+
+    # Read messages
+    messages = await client.get_job_messages(job.id)
+    for msg in messages:
+        print(f"[{msg.sender}] {msg.content}")
+
+asyncio.run(main())
+```
+
+## Supported blocker types
+
+| Type | When to use |
+|---|---|
+| `captcha` | CAPTCHA challenges (reCAPTCHA, hCaptcha, etc.) |
+| `identity_verification` | ID upload, selfie checks, KYC flows |
+| `phone_verification` | SMS or call verification |
+| `manual_review` | Human review gates, approval steps |
+| `login_required` | Login needed with credentials the agent lacks |
+| `other` | Any other blocker Skyvern cannot automate |
+
+## How it works
+
+1. Skyvern detects a blocker it cannot automate
+2. This integration searches Human Pages for an available human with the right skills
+3. A job is created with the blocker details, URL, and optional screenshot
+4. The integration polls until the human completes the task (or it times out)
+5. The result is returned to Skyvern so automation can resume
+
+## Links
+
+- [Human Pages](https://humanpages.ai) — hire real humans for tasks agents cannot do
+- [Human Pages API docs](https://humanpages.ai/docs)
+- [Skyvern](https://github.com/Skyvern-AI/skyvern) — browser automation with AI

--- a/integrations/humanpages/pyproject.toml
+++ b/integrations/humanpages/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "skyvern-humanpages"
+version = "0.1.0"
+description = "Human Pages integration for Skyvern — human fallback for blocked browser tasks"
+authors = [{ name = "Human Pages", email = "github@humanpages.ai" }]
+requires-python = ">=3.11,<3.14"
+readme = "README.md"
+
+dependencies = [
+    "httpx>=0.27.0",
+    "pydantic>=2.0.0",
+    "pydantic-settings>=2.0.0",
+    "python-dotenv>=1.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.sdist]
+include = ["skyvern_humanpages"]
+
+[tool.hatch.build.targets.wheel]
+include = ["skyvern_humanpages"]

--- a/integrations/humanpages/skyvern_humanpages/__init__.py
+++ b/integrations/humanpages/skyvern_humanpages/__init__.py
@@ -1,0 +1,5 @@
+from skyvern_humanpages.client import HumanPagesClient
+from skyvern_humanpages.fallback import HumanFallback
+from skyvern_humanpages.settings import settings
+
+__all__ = ["HumanPagesClient", "HumanFallback", "settings"]

--- a/integrations/humanpages/skyvern_humanpages/client.py
+++ b/integrations/humanpages/skyvern_humanpages/client.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import httpx
+
+from skyvern_humanpages.schema import (
+    HumanSearchResult,
+    JobCreateRequest,
+    JobMessage,
+    JobResponse,
+)
+from skyvern_humanpages.settings import settings
+
+
+class HumanPagesClient:
+    """Low-level async client for the Human Pages REST API."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
+        self.api_key = api_key or settings.api_key
+        self.base_url = (base_url or settings.base_url).rstrip("/")
+        if not self.api_key:
+            raise ValueError(
+                "Human Pages API key is required. "
+                "Set HUMANPAGES_API_KEY or pass api_key=."
+            )
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Content-Type": "application/json",
+            "X-Agent-Key": self.api_key,
+        }
+
+    async def search_humans(
+        self,
+        skill: str = "web task",
+        available: bool = True,
+    ) -> list[HumanSearchResult]:
+        """Search for available humans with a given skill."""
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{self.base_url}/api/humans/search",
+                headers=self._headers(),
+                params={"skill": skill, "available": str(available).lower()},
+            )
+            resp.raise_for_status()
+            return [HumanSearchResult(**h) for h in resp.json()]
+
+    async def create_job(self, request: JobCreateRequest) -> JobResponse:
+        """Create a new job for a human to complete."""
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{self.base_url}/api/jobs",
+                headers=self._headers(),
+                json=request.model_dump(),
+            )
+            resp.raise_for_status()
+            return JobResponse(**resp.json())
+
+    async def get_job_status(self, job_id: str) -> JobResponse:
+        """Check the current status of a job."""
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{self.base_url}/api/jobs/{job_id}",
+                headers=self._headers(),
+            )
+            resp.raise_for_status()
+            return JobResponse(**resp.json())
+
+    async def get_job_messages(self, job_id: str) -> list[JobMessage]:
+        """Retrieve messages exchanged on a job."""
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{self.base_url}/api/jobs/{job_id}/messages",
+                headers=self._headers(),
+            )
+            resp.raise_for_status()
+            return [JobMessage(**m) for m in resp.json()]

--- a/integrations/humanpages/skyvern_humanpages/fallback.py
+++ b/integrations/humanpages/skyvern_humanpages/fallback.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from skyvern_humanpages.client import HumanPagesClient
+from skyvern_humanpages.schema import (
+    BlockerType,
+    FallbackRequest,
+    FallbackResult,
+    JobCreateRequest,
+    JobStatus,
+)
+from skyvern_humanpages.settings import settings
+
+logger = logging.getLogger(__name__)
+
+# Terminal statuses that stop polling
+_TERMINAL = {JobStatus.COMPLETED, JobStatus.CANCELLED, JobStatus.EXPIRED, JobStatus.DISPUTED}
+
+
+class HumanFallback:
+    """High-level helper that delegates a blocked Skyvern step to a real human
+    via Human Pages, then returns control once the human finishes."""
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        price_usdc: float | None = None,
+        deadline_hours: int | None = None,
+        poll_interval: int | None = None,
+        poll_timeout: int | None = None,
+    ) -> None:
+        self.client = HumanPagesClient(api_key=api_key, base_url=base_url)
+        self.price_usdc = price_usdc or settings.default_price_usdc
+        self.deadline_hours = deadline_hours or settings.default_deadline_hours
+        self.poll_interval = poll_interval or settings.poll_interval_seconds
+        self.poll_timeout = poll_timeout or settings.poll_timeout_seconds
+
+    def _build_description(self, request: FallbackRequest) -> str:
+        """Build a human-readable job description from the fallback request."""
+        parts = [
+            f"A browser automation task hit a blocker: {request.blocker_type.value}",
+            f"URL: {request.url}",
+            "",
+            "What the human needs to do:",
+            request.description,
+        ]
+        if request.screenshot_url:
+            parts.append(f"\nScreenshot of the blocked page: {request.screenshot_url}")
+        if request.additional_context:
+            parts.append("\nAdditional context:")
+            for key, value in request.additional_context.items():
+                parts.append(f"  {key}: {value}")
+        return "\n".join(parts)
+
+    def _build_title(self, blocker_type: BlockerType, url: str) -> str:
+        labels = {
+            BlockerType.CAPTCHA: "Solve CAPTCHA",
+            BlockerType.IDENTITY_VERIFICATION: "Complete identity verification",
+            BlockerType.PHONE_VERIFICATION: "Complete phone verification",
+            BlockerType.MANUAL_REVIEW: "Manual review needed",
+            BlockerType.LOGIN_REQUIRED: "Log in to website",
+            BlockerType.OTHER: "Complete blocked browser step",
+        }
+        # Keep the domain for context, truncate if needed
+        domain = url.split("//")[-1].split("/")[0]
+        return f"{labels[blocker_type]} on {domain}"
+
+    async def handle_blocker(self, request: FallbackRequest) -> FallbackResult:
+        """Search for a human, create a job, poll until done, and return the result.
+
+        This is the main entry point. Call it when Skyvern encounters a step it
+        cannot automate (CAPTCHA, identity check, etc.).
+        """
+        logger.info(
+            "Human fallback triggered: blocker=%s url=%s",
+            request.blocker_type.value,
+            request.url,
+        )
+
+        # 1. Find an available human
+        humans = await self.client.search_humans(skill="web task", available=True)
+        if not humans:
+            raise RuntimeError("No humans available on Human Pages for this task")
+
+        human = humans[0]  # pick the first available
+        logger.info("Selected human %s (id=%s)", human.name, human.id)
+
+        # 2. Create the job
+        job = await self.client.create_job(
+            JobCreateRequest(
+                humanId=human.id,
+                title=self._build_title(request.blocker_type, request.url),
+                description=self._build_description(request),
+                priceUsdc=self.price_usdc,
+                deadlineHours=self.deadline_hours,
+            )
+        )
+        logger.info("Created job %s (status=%s)", job.id, job.status.value)
+
+        # 3. Poll until the job reaches a terminal status
+        elapsed = 0
+        while elapsed < self.poll_timeout:
+            await asyncio.sleep(self.poll_interval)
+            elapsed += self.poll_interval
+
+            job = await self.client.get_job_status(job.id)
+            logger.debug("Job %s status: %s (elapsed %ds)", job.id, job.status.value, elapsed)
+
+            if job.status in _TERMINAL:
+                break
+
+        # 4. Gather messages and return
+        messages = await self.client.get_job_messages(job.id)
+
+        if job.status != JobStatus.COMPLETED:
+            logger.warning(
+                "Job %s ended with status %s (not COMPLETED)", job.id, job.status.value
+            )
+
+        return FallbackResult(
+            job_id=job.id,
+            status=job.status,
+            result=job.result,
+            messages=messages,
+        )

--- a/integrations/humanpages/skyvern_humanpages/schema.py
+++ b/integrations/humanpages/skyvern_humanpages/schema.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class JobStatus(str, Enum):
+    PENDING = "PENDING"
+    ACCEPTED = "ACCEPTED"
+    IN_PROGRESS = "IN_PROGRESS"
+    COMPLETED = "COMPLETED"
+    CANCELLED = "CANCELLED"
+    EXPIRED = "EXPIRED"
+    DISPUTED = "DISPUTED"
+
+
+class BlockerType(str, Enum):
+    CAPTCHA = "captcha"
+    IDENTITY_VERIFICATION = "identity_verification"
+    PHONE_VERIFICATION = "phone_verification"
+    MANUAL_REVIEW = "manual_review"
+    LOGIN_REQUIRED = "login_required"
+    OTHER = "other"
+
+
+class HumanSearchResult(BaseModel):
+    id: str
+    name: str | None = None
+    skills: list[str] = []
+    rating: float | None = None
+    available: bool = True
+
+
+class JobCreateRequest(BaseModel):
+    humanId: str
+    title: str
+    description: str
+    priceUsdc: float
+    deadlineHours: int
+
+
+class JobResponse(BaseModel):
+    id: str
+    status: JobStatus
+    humanId: str
+    title: str
+    description: str
+    result: Any | None = None
+
+
+class JobMessage(BaseModel):
+    id: str
+    sender: str
+    content: str
+    createdAt: str
+
+
+class FallbackRequest(BaseModel):
+    url: str
+    blocker_type: BlockerType
+    description: str
+    screenshot_url: str | None = None
+    additional_context: dict[str, Any] | None = None
+
+
+class FallbackResult(BaseModel):
+    job_id: str
+    status: JobStatus
+    result: Any | None = None
+    messages: list[JobMessage] = []

--- a/integrations/humanpages/skyvern_humanpages/settings.py
+++ b/integrations/humanpages/skyvern_humanpages/settings.py
@@ -1,0 +1,18 @@
+from dotenv import load_dotenv
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    api_key: str = ""
+    base_url: str = "https://humanpages.ai"
+    default_price_usdc: float = 5.0
+    default_deadline_hours: int = 4
+    poll_interval_seconds: int = 30
+    poll_timeout_seconds: int = 14400  # 4 hours
+
+    class Config:
+        env_prefix = "HUMANPAGES_"
+
+
+load_dotenv()
+settings = Settings()


### PR DESCRIPTION
## Summary

- Adds `integrations/humanpages/` — a Python package (`skyvern-humanpages`) that delegates blocked browser steps to real humans via the [Human Pages](https://humanpages.ai) API
- When Skyvern hits a blocker it cannot automate (CAPTCHA, identity verification, phone verification, login gates), the integration searches for an available human, creates a job, polls until completion, and returns the result so Skyvern can resume
- Follows the same package structure as the existing langchain and llama_index integrations (pyproject.toml, typed, pydantic schemas, async client)

## Links

- [Human Pages](https://humanpages.ai) — hire real humans for tasks agents cannot do
- [Human Pages API docs](https://humanpages.ai/docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)