### PR TITLE
chore(security): add .npmrc ignore-scripts to remaining npm workspaces

### DIFF
--- a/skyvern-frontend/.npmrc
+++ b/skyvern-frontend/.npmrc
@@ -1,0 +1,5 @@
+# Supply chain protection: do not run lifecycle scripts (preinstall, install,
+# postinstall) on npm install. Blocks worms like "Shai-Hulud" from executing
+# on a compromised dependency before we notice. If a package genuinely needs
+# its install script, use @lavamoat/allow-scripts to allowlist it.
+ignore-scripts=true

--- a/skyvern-ts/client/.npmrc
+++ b/skyvern-ts/client/.npmrc
@@ -1,0 +1,5 @@
+# Supply chain protection: do not run lifecycle scripts (preinstall, install,
+# postinstall) on npm install. Blocks worms like "Shai-Hulud" from executing
+# on a compromised dependency before we notice. If a package genuinely needs
+# its install script, use @lavamoat/allow-scripts to allowlist it.
+ignore-scripts=true

--- a/tests/sdk/typescript_sdk/.npmrc
+++ b/tests/sdk/typescript_sdk/.npmrc
@@ -1,0 +1,5 @@
+# Supply chain protection: do not run lifecycle scripts (preinstall, install,
+# postinstall) on npm install. Blocks worms like "Shai-Hulud" from executing
+# on a compromised dependency before we notice. If a package genuinely needs
+# its install script, use @lavamoat/allow-scripts to allowlist it.
+ignore-scripts=true


### PR DESCRIPTION
## Summary
- Follow-up to #5600. Adds `.npmrc` with `ignore-scripts=true` to the three remaining `package-lock.json` locations flagged by the security scanner: `skyvern-frontend/`, `skyvern-ts/client/`, and `tests/sdk/typescript_sdk/`.
- Disables npm lifecycle scripts (`preinstall`, `install`, `postinstall`) at install time to block supply-chain worms like "Shai-Hulud" from executing on a compromised dependency before we notice.
- If a dependency genuinely needs its install script (e.g. esbuild's native binary in `skyvern-frontend`), the follow-up is to wire up `@lavamoat/allow-scripts` and run `npx --no allow-scripts` after `npm ci` in CI — see https://github.com/lavamoat/allow-scripts. Not done in this PR; flagging for follow-up if local `npm install` breaks.

## Test plan
- [ ] `npm ci` still succeeds in `skyvern-frontend/` (watch for esbuild postinstall breakage)
- [ ] `npm ci` still succeeds in `skyvern-ts/client/`
- [ ] `npm ci` still succeeds in `tests/sdk/typescript_sdk/`
- [ ] Frontend dev server (`npm run dev`) boots and renders
- [ ] Frontend prod build (`npm run build`) completes
- [ ] If anything breaks, set up `@lavamoat/allow-scripts` for the affected workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)