### PR TITLE
Hide requested API reference pages from Mintlify

### DIFF
--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -2168,6 +2168,7 @@
     },
     "/v1/sdk/run_action": {
       "post": {
+        "x-excluded": true,
         "tags": [
           "SDK"
         ],
@@ -2224,6 +2225,7 @@
     },
     "/api/v1/billing/checkout": {
       "post": {
+        "x-excluded": true,
         "summary": "Create Checkout Session",
         "description": "Create a Stripe Checkout Session for subscribing to a tier.\n\nFrontend should redirect the user to the returned URL.\nAfter successful checkout, Stripe will send a webhook that we handle\nto store the subscription and initialize billing state.\n\nReturns 400 if org already has an active subscription (use portal instead).",
         "operationId": "create_checkout_session_api_v1_billing_checkout_post",

--- a/skyvern/forge/sdk/routes/sdk.py
+++ b/skyvern/forge/sdk/routes/sdk.py
@@ -34,6 +34,7 @@ LOG = structlog.get_logger()
     description="Execute a single SDK action with the specified parameters",
     tags=["SDK"],
     openapi_extra={
+        "x-excluded": True,
         "x-fern-sdk-method-name": "run_sdk_action",
     },
 )


### PR DESCRIPTION
## Summary
- mark only POST /api/v1/billing/checkout and POST /v1/sdk/run_action as x-excluded in the Mintlify docs OpenAPI file
- add x-excluded to the SDK action FastAPI OpenAPI metadata so future API syncs preserve the docs exclusion without removing SDK support

## Verification
- jq empty docs/api-reference/openapi.json
- checked the two target operations return x-excluded=true and the other billing operations remain unset
- python3 -m py_compile skyvern/forge/sdk/routes/sdk.py
- git diff --check -- docs/api-reference/openapi.json skyvern/forge/sdk/routes/sdk.py
- pre-commit hooks passed during commit

## Notes
- This intentionally hides only these two public docs pages:
  - /docs/api-reference/create-checkout-session
  - /docs/api-reference/sdk/run-an-sdk-action
- Live URLs will remain 200 until this merges and Mintlify redeploys.