### PR TITLE
Clarify Jinja formatting failures in error_code_mapping

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -29,7 +29,7 @@ import pyotp
 import structlog
 from charset_normalizer import from_bytes
 from email_validator import EmailNotValidError, validate_email
-from jinja2 import StrictUndefined
+from jinja2 import StrictUndefined, TemplateSyntaxError
 from jinja2.sandbox import SandboxedEnvironment
 from opentelemetry import trace as otel_trace
 from playwright.async_api import Page
@@ -797,14 +797,37 @@ class BaseTaskBlock(Block):
         if workflow_error_code_mapping or self.error_code_mapping:
             merged_mapping = dict(workflow_error_code_mapping or {})
             merged_mapping.update(self.error_code_mapping or {})
-            self.error_code_mapping = {
-                self.format_block_parameter_template_from_workflow_run_context(error_code, workflow_run_context): (
-                    self.format_block_parameter_template_from_workflow_run_context(
+            formatted_error_code_mapping: dict[str, str] = {}
+            for error_code, error_description in merged_mapping.items():
+                try:
+                    formatted_error_code = self.format_block_parameter_template_from_workflow_run_context(
+                        error_code, workflow_run_context
+                    )
+                except TemplateSyntaxError as exc:
+                    raise FailedToFormatJinjaStyleParameter(
+                        template=error_code,
+                        msg=(
+                            "Invalid Jinja syntax in error_code_mapping key "
+                            f"'{error_code}': {exc.message} (line {exc.lineno})"
+                        ),
+                    ) from exc
+
+                try:
+                    formatted_error_description = self.format_block_parameter_template_from_workflow_run_context(
                         error_description, workflow_run_context
                     )
-                )
-                for error_code, error_description in merged_mapping.items()
-            }
+                except TemplateSyntaxError as exc:
+                    raise FailedToFormatJinjaStyleParameter(
+                        template=error_description,
+                        msg=(
+                            "Invalid Jinja syntax in error_code_mapping value for key "
+                            f"'{error_code}': {exc.message} (line {exc.lineno})"
+                        ),
+                    ) from exc
+
+                formatted_error_code_mapping[formatted_error_code] = formatted_error_description
+
+            self.error_code_mapping = formatted_error_code_mapping
 
     @staticmethod
     async def get_task_order(workflow_run_id: str, current_retry: int) -> tuple[int, int]:

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -29,7 +29,7 @@ import pyotp
 import structlog
 from charset_normalizer import from_bytes
 from email_validator import EmailNotValidError, validate_email
-from jinja2 import StrictUndefined, TemplateSyntaxError
+from jinja2 import StrictUndefined, TemplateSyntaxError, UndefinedError
 from jinja2.sandbox import SandboxedEnvironment
 from opentelemetry import trace as otel_trace
 from playwright.async_api import Page
@@ -803,12 +803,14 @@ class BaseTaskBlock(Block):
                     formatted_error_code = self.format_block_parameter_template_from_workflow_run_context(
                         error_code, workflow_run_context
                     )
-                except TemplateSyntaxError as exc:
+                except (TemplateSyntaxError, UndefinedError) as exc:
+                    error_detail = exc.message if isinstance(exc, UndefinedError) else exc.message
+                    error_location = "" if isinstance(exc, UndefinedError) else f" (line {exc.lineno})"
                     raise FailedToFormatJinjaStyleParameter(
                         template=error_code,
                         msg=(
-                            "Invalid Jinja syntax in error_code_mapping key "
-                            f"'{error_code}': {exc.message} (line {exc.lineno})"
+                            "Invalid Jinja template in error_code_mapping key "
+                            f"'{error_code}': {error_detail}{error_location}"
                         ),
                     ) from exc
 
@@ -816,12 +818,14 @@ class BaseTaskBlock(Block):
                     formatted_error_description = self.format_block_parameter_template_from_workflow_run_context(
                         error_description, workflow_run_context
                     )
-                except TemplateSyntaxError as exc:
+                except (TemplateSyntaxError, UndefinedError) as exc:
+                    error_detail = exc.message if isinstance(exc, UndefinedError) else exc.message
+                    error_location = "" if isinstance(exc, UndefinedError) else f" (line {exc.lineno})"
                     raise FailedToFormatJinjaStyleParameter(
                         template=error_description,
                         msg=(
-                            "Invalid Jinja syntax in error_code_mapping value for key "
-                            f"'{error_code}': {exc.message} (line {exc.lineno})"
+                            "Invalid Jinja template in error_code_mapping value for key "
+                            f"'{error_code}': {error_detail}{error_location}"
                         ),
                     ) from exc
 

--- a/tests/unit/test_task_block_error_code_mapping_template_errors.py
+++ b/tests/unit/test_task_block_error_code_mapping_template_errors.py
@@ -2,8 +2,11 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
+from jinja2 import StrictUndefined
+from jinja2.sandbox import SandboxedEnvironment
 
 from skyvern.forge.sdk.workflow.exceptions import FailedToFormatJinjaStyleParameter
+from skyvern.forge.sdk.workflow.models import block as block_module
 from skyvern.forge.sdk.workflow.models.block import TaskBlock
 from skyvern.forge.sdk.workflow.models.parameter import OutputParameter, ParameterType
 
@@ -79,3 +82,29 @@ def test_error_code_mapping_key_reports_precise_jinja_syntax_error() -> None:
     error_message = str(exc_info.value)
     assert "error_code_mapping key '{{ error code }}'" in error_message
     assert "expected token 'end of print statement'" in error_message
+
+
+def test_error_code_mapping_value_reports_undefined_variable_in_strict_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    strict_env = SandboxedEnvironment(undefined=StrictUndefined)
+    strict_env.filters["json"] = block_module._json_type_filter
+    monkeypatch.setattr(block_module, "jinja_sandbox_env", strict_env)
+
+    block = TaskBlock(
+        label="block_1",
+        block_type="task",
+        title="Test block",
+        output_parameter=_build_output_parameter(),
+        error_code_mapping={
+            "ACCOUNT_GROUP_NOT_FOUND": "return this error when {{ nonexistent_output }} is missing"
+        },
+    )
+    ctx = _build_mock_context()
+
+    with pytest.raises(FailedToFormatJinjaStyleParameter) as exc_info:
+        block.format_potential_template_parameters(ctx)
+
+    error_message = str(exc_info.value)
+    assert "error_code_mapping value for key 'ACCOUNT_GROUP_NOT_FOUND'" in error_message
+    assert "'nonexistent_output' is undefined" in error_message

--- a/tests/unit/test_task_block_error_code_mapping_template_errors.py
+++ b/tests/unit/test_task_block_error_code_mapping_template_errors.py
@@ -1,0 +1,81 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from skyvern.forge.sdk.workflow.exceptions import FailedToFormatJinjaStyleParameter
+from skyvern.forge.sdk.workflow.models.block import TaskBlock
+from skyvern.forge.sdk.workflow.models.parameter import OutputParameter, ParameterType
+
+
+def _build_output_parameter() -> OutputParameter:
+    now = datetime.now(timezone.utc)
+    return OutputParameter(
+        parameter_type=ParameterType.OUTPUT,
+        key="task_output",
+        description=None,
+        output_parameter_id="output-1",
+        workflow_id="workflow-1",
+        created_at=now,
+        modified_at=now,
+        deleted_at=None,
+    )
+
+
+def _build_mock_context() -> MagicMock:
+    ctx = MagicMock()
+    ctx.values = {}
+    ctx.secrets = {}
+    ctx.include_secrets_in_templates = False
+    ctx.get_block_metadata = MagicMock(return_value={})
+    ctx.workflow_title = "workflow-title"
+    ctx.workflow_id = "workflow-id"
+    ctx.workflow_permanent_id = "workflow-perm-id"
+    ctx.workflow_run_id = "workflow-run-id"
+    ctx.browser_session_id = None
+    ctx.workflow_run_outputs = {}
+    ctx.build_workflow_run_summary = MagicMock(return_value={})
+    ctx.workflow = None
+    return ctx
+
+
+def test_error_code_mapping_value_reports_precise_jinja_syntax_error() -> None:
+    block = TaskBlock(
+        label="block_1",
+        block_type="task",
+        title="Test block",
+        output_parameter=_build_output_parameter(),
+        error_code_mapping={
+            "ACCOUNT_GROUP_NOT_FOUND": (
+                "return this error when {{ current_value.account_number }} and {{account group}} are missing"
+            )
+        },
+    )
+    ctx = _build_mock_context()
+
+    with pytest.raises(FailedToFormatJinjaStyleParameter) as exc_info:
+        block.format_potential_template_parameters(ctx)
+
+    error_message = str(exc_info.value)
+    assert "error_code_mapping value for key 'ACCOUNT_GROUP_NOT_FOUND'" in error_message
+    assert "expected token 'end of print statement'" in error_message
+
+
+def test_error_code_mapping_key_reports_precise_jinja_syntax_error() -> None:
+    block = TaskBlock(
+        label="block_1",
+        block_type="task",
+        title="Test block",
+        output_parameter=_build_output_parameter(),
+        error_code_mapping={
+            "{{ error code }}": "return this error",
+        },
+    )
+    ctx = _build_mock_context()
+
+    with pytest.raises(FailedToFormatJinjaStyleParameter) as exc_info:
+        block.format_potential_template_parameters(ctx)
+
+    error_message = str(exc_info.value)
+    assert "error_code_mapping key '{{ error code }}'" in error_message
+    assert "expected token 'end of print statement'" in error_message


### PR DESCRIPTION
### Motivation
- Improve user-facing diagnostics when Jinja templates in `error_code_mapping` are malformed so failures show a precise, actionable error instead of a generic formatting failure.
- The change targets cases where template syntax errors in either mapping keys or values produced opaque messages during block formatting.

### Description
- Replace the dict-comprehension render path for `error_code_mapping` with an explicit key/value loop that renders each entry individually and collects results into `formatted_error_code_mapping` in `BaseTaskBlock.format_potential_template_parameters` in `skyvern/forge/sdk/workflow/models/block.py`.
- Catch `jinja2.TemplateSyntaxError` separately for keys and values and raise `FailedToFormatJinjaStyleParameter` with contextual messages that include whether the problem was a key or a value, the affected error-code key, and the Jinja parser message and line number.
- Add unit tests `tests/unit/test_task_block_error_code_mapping_template_errors.py` that assert malformed Jinja in both a mapping value and a mapping key produce the clearer `FailedToFormatJinjaStyleParameter` messages.

### Testing
- Ran `python -m compileall skyvern/forge/sdk/workflow/models/block.py tests/unit/test_task_block_error_code_mapping_template_errors.py` which succeeded.
- Ran `pytest -q tests/unit/test_task_block_error_code_mapping_template_errors.py` which failed to run in this environment due to a missing test dependency (`ModuleNotFoundError: No module named 'opentelemetry'`) originating from the test `conftest.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb1431ef14832c98e16721b02f4f35)