### PR TITLE
copilot: stamp gen_ai.usage.cost on Agents SDK spans (SKY-9246)

### DIFF
--- a/skyvern/forge/sdk/copilot/tracing_setup.py
+++ b/skyvern/forge/sdk/copilot/tracing_setup.py
@@ -103,6 +103,55 @@ def ensure_tracing_initialized() -> None:
         LOG.info("Initialized copilot tracing", exporter="logfire")
 
 
+def _usage_field(obj: Any, *keys: str) -> Any:
+    """Return the first present field by key on a usage object/dict."""
+    if obj is None:
+        return None
+    for key in keys:
+        if isinstance(obj, dict):
+            if key in obj:
+                return obj[key]
+        else:
+            value = getattr(obj, key, None)
+            if value is not None:
+                return value
+    return None
+
+
+def _attach_cost_attr(attrs: dict[str, Any], usage: Any, model: str | None) -> None:
+    """Stamp gen_ai.usage.cost on GenerationSpanData so Logfire's AI Agents dashboard populates.
+
+    Silent on any failure: telemetry must never break the copilot path.
+    """
+    if not model or usage is None:
+        return
+    input_tokens = _usage_field(usage, "input_tokens", "prompt_tokens")
+    output_tokens = _usage_field(usage, "output_tokens", "completion_tokens")
+    if not isinstance(input_tokens, (int, float)) or not isinstance(output_tokens, (int, float)):
+        return
+    # OpenAI reports cached prompt tokens nested under input_tokens_details; pull
+    # them out so cost reflects the cache discount instead of full input pricing.
+    cached_tokens = _usage_field(
+        _usage_field(usage, "input_tokens_details", "prompt_tokens_details"),
+        "cached_tokens",
+    )
+    cache_read = int(cached_tokens) if isinstance(cached_tokens, (int, float)) and cached_tokens > 0 else 0
+    try:
+        import litellm
+
+        prompt_cost, completion_cost = litellm.cost_per_token(
+            model=model,
+            prompt_tokens=int(input_tokens),
+            completion_tokens=int(output_tokens),
+            cache_read_input_tokens=cache_read,
+        )
+    except Exception:
+        return
+    total = float(prompt_cost) + float(completion_cost)
+    if total > 0:
+        attrs["gen_ai.usage.cost"] = total
+
+
 def _patch_agent_span_attributes() -> None:
     """Patch logfire to emit OTel GenAI semantic convention attributes on agent spans.
 
@@ -147,6 +196,7 @@ def _patch_agent_span_attributes() -> None:
                     attrs["gen_ai.request.model"] = model
             elif isinstance(span_data, GenerationSpanData):
                 attrs.setdefault("gen_ai.operation.name", "chat")
+                _attach_cost_attr(attrs, getattr(span_data, "usage", None), getattr(span_data, "model", None))
             elif isinstance(span_data, FunctionSpanData):
                 attrs.setdefault("gen_ai.operation.name", "execute_tool")
                 if "name" in attrs:


### PR DESCRIPTION
## Description

Logfire's built-in AI Agents dashboard computes cost from `gen_ai.usage.cost` on `Chat completion with {model}` spans. The OpenAI-Agents-SDK path emits these spans with `gen_ai.usage.input_tokens` / `output_tokens` but no cost attribute, so Cost Over Time and Cost Per Run render as `<$0.01` even when several million tokens have flowed through.

This patch computes cost inside the existing `_patch_agent_span_attributes` hook via `litellm.cost_per_token`, reading `input_tokens` / `output_tokens` / `input_tokens_details.cached_tokens` off `GenerationSpanData.usage`. Cache-read tokens are threaded through so the cost reflects the OpenAI prompt-cache discount.

Linear: [SKY-9246](https://linear.app/skyvern/issue/SKY-9246)

## How Has This Been Tested?

Unit-level smoke test of the helper against the usage shape the Agents SDK produces:

| Case | Expected | Observed |
|---|---|---|
| gpt-5-mini-2025-08-07, 23430 in / 2328 out, 10000 cached | cached discount applied | \`gen_ai.usage.cost = 0.0082635\` |
| gpt-5-nano-2025-08-07, same counts | cached discount applied | \`gen_ai.usage.cost = 0.0016527\` |
| gpt-5-mini, 1000 in / 200 out, no details dict | full input pricing | \`gen_ai.usage.cost = 0.00065\` |
| unknown model id | silent no-op | \`{}\` |
| \`usage=None\` | silent no-op | \`{}\` |
| \`model=None\` | silent no-op | \`{}\` |

End-to-end verification against Logfire is pending — will be done on the \`copilot-evals\` branch by running one eval case and confirming the next \`Chat completion%\` span in the \`workflow-copilot-oai\` project has a non-null \`gen_ai.usage.cost\`, and that the AI Agents Cost panels populate.