### PR TITLE
ci: add quickstart wheel-install + Bug 1 reproduction smoke (gated)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,3 +128,69 @@ jobs:
         run: npm run lint
       - name: Run build
         run: npm run build
+  pip-install-and-migrate-smoke:
+    name: Pip-install wheel + reproduce stale-settings migration path
+    if: false # ACTIVATED in PR A.2.1 after deps are fixed
+    runs-on: ubuntu-latest
+    needs: test
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: skyvern
+          POSTGRES_DB: skyvern
+          POSTGRES_HOST_AUTH_METHOD: trust
+        options: >-
+          --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.11"
+      - name: Install uv (build only)
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Build wheel
+        run: |
+          uv build
+          ls -la dist/
+      - name: Install wheel via plain pip (Bug 2 regression test)
+        run: |
+          python -m venv /tmp/pip-venv
+          /tmp/pip-venv/bin/pip install --upgrade pip
+          /tmp/pip-venv/bin/pip install ./dist/skyvern-*.whl
+          /tmp/pip-venv/bin/python -c "import skyvern, litellm, fastmcp, dotenv; print('OK')"
+      - name: Reproduce Bug 1 stale-settings path
+        run: |
+          rm -rf ~/.skyvern && mkdir -p ~/.skyvern
+          touch ~/.skyvern/data.db
+          SQLITE_SIZE_BEFORE=$(stat -c %s ~/.skyvern/data.db 2>/dev/null || stat -f %z ~/.skyvern/data.db)
+          mkdir -p /tmp/smoke && cd /tmp/smoke && rm -f .env && touch .env
+          unset DATABASE_STRING
+          /tmp/pip-venv/bin/python <<'PY'
+          # Cache Settings BEFORE setup_postgresql writes DATABASE_STRING
+          # (mirrors the quickstart import order that produced the original bug).
+          from skyvern.config import Settings, settings  # noqa: F401
+          from skyvern.cli.llm_setup import update_or_add_env_var
+          from skyvern.utils import migrate_db
+          update_or_add_env_var("DATABASE_STRING", "postgresql+psycopg://skyvern@localhost/skyvern")
+          migrate_db()
+          PY
+          SQLITE_SIZE_AFTER=$(stat -c %s ~/.skyvern/data.db 2>/dev/null || stat -f %z ~/.skyvern/data.db)
+          echo "SQLite size before/after: $SQLITE_SIZE_BEFORE / $SQLITE_SIZE_AFTER"
+          if [ "$SQLITE_SIZE_BEFORE" != "$SQLITE_SIZE_AFTER" ]; then
+            echo "FAIL: migration ran against SQLite — stale-settings reload regression"
+            exit 1
+          fi
+      - name: Verify Postgres schema (deterministic post-check)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client
+          psql -h localhost -U skyvern -d skyvern -c "SELECT 1 FROM organizations LIMIT 0"
+          psql -h localhost -U skyvern -d skyvern -t -c "SELECT version_num FROM alembic_version" \
+            | grep -E '[a-f0-9]+'


### PR DESCRIPTION
## Summary

Adds a CI smoke job to `ci.yml` that gates PyPI publish against:
- pip-resolvable wheel (currently broken due to litellm/fastmcp `python-dotenv` conflict)
- the original `skyvern quickstart` SQLite-fallback bug (Settings caching across setup_postgresql + migrate_db)

Gated `if: false` initially. Will be activated in a follow-up PR after the dep fix lands so the smoke can pass on its own branch.

## Why now (and not bundled with the dep fix)

`sdk-release.yml`'s path filter is `pyproject.toml` only. A pyproject change triggers publish using whatever `ci.yml` is on main at that moment. If we land the dep fix and the smoke as one PR, the pyproject change publishes BEFORE the smoke gate exists.

Sequencing instead: smoke skeleton (`if: false`) lands first as a no-op → dep fix lands → smoke gets activated → version bump triggers publish, with the smoke as the gate.

## Test plan

- [x] YAML parses (`python -m yaml`)
- [ ] CI green on PR branch (smoke is `if: false`, so it doesn't run)
- [ ] PR merge does NOT trigger sdk-release.yml (no pyproject change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)