### PR TITLE
feat: add curl-based Skyvern server installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -71,14 +71,13 @@ if ! command -v uv >/dev/null 2>&1; then
     # Download then execute (not `curl ... | sh`): POSIX /bin/sh has no
     # pipefail, so curl failures would otherwise be swallowed silently.
     UV_INSTALLER="$(mktemp -t skyvern-uv-installer.XXXXXX)"
+    trap 'rm -f "$UV_INSTALLER"' EXIT
     if ! curl -LsSf https://astral.sh/uv/install.sh -o "$UV_INSTALLER"; then
-        rm -f "$UV_INSTALLER"
         printf 'ERROR: failed to download uv installer from astral.sh.\n' >&2
         printf '       Check your network/proxy. See https://docs.astral.sh/uv/getting-started/installation/\n' >&2
         exit 1
     fi
     sh "$UV_INSTALLER"
-    rm -f "$UV_INSTALLER"
     export PATH="$HOME/.local/bin:$PATH"
     if ! command -v uv >/dev/null 2>&1; then
         printf 'ERROR: uv installer ran but uv is not on PATH.\n' >&2

--- a/install.sh
+++ b/install.sh
@@ -70,7 +70,11 @@ if [ -n "$SKYVERN_VERSION" ]; then
 fi
 
 printf 'installing %s via uv tool install...\n' "$PKG_SPEC"
-uv tool install --force "$PKG_SPEC"
+# Pin Python to a version inside skyvern's `requires-python = ">=3.11,<3.14"`.
+# Without this, uv may pick the host's Python 3.14 (or newer), in which case
+# environment-marker dependencies like playwright (`<'3.14'`) silently drop
+# out of the resolution and the CLI crashes at import time.
+uv tool install --python 3.13 --force "$PKG_SPEC"
 
 if [ "$SKYVERN_RUN_INIT" = "1" ]; then
     printf "\nrunning 'skyvern init' (installs Chromium, ~150MB)...\n"

--- a/install.sh
+++ b/install.sh
@@ -1,28 +1,8 @@
 #!/bin/sh
-# Skyvern installer.
-#
-# Usage:
-#   curl -LsSf https://install.skyvern.com | sh
-#   curl -LsSf https://install.skyvern.com | sh -s -- --no-init
-#   curl -LsSf https://install.skyvern.com | sh -s -- --version 1.0.31
-#
-# Environment overrides:
-#   SKYVERN_RUN_INIT=0   skip `skyvern init` (Chromium browser install)
-#   SKYVERN_VERSION=X    pin a specific PyPI version
-#
-# What this does:
-#   1. Bootstraps `uv` (Astral's Python toolchain) if not already installed.
-#      uv handles Python version management — the host machine doesn't need
-#      a pre-installed Python.
-#   2. Installs the `skyvern` package from PyPI as an isolated tool, exposing
-#      the `skyvern` command on PATH.
-#   3. Runs `skyvern init` to install Chromium for browser automation
-#      (skip with --no-init when running in CI / minimal containers).
+# Skyvern installer. Run `install.sh --help` for usage.
 
 set -eu
 
-# Empty SKYVERN_RUN_INIT means "use the variant's default"; --no-init or
-# `SKYVERN_RUN_INIT=0` overrides to 0; `SKYVERN_RUN_INIT=1` forces it on.
 SKYVERN_RUN_INIT="${SKYVERN_RUN_INIT:-}"
 SKYVERN_VERSION="${SKYVERN_VERSION:-}"
 SKYVERN_VARIANT="${SKYVERN_VARIANT:-server}"
@@ -35,8 +15,8 @@ while [ $# -gt 0 ]; do
         --variant)   SKYVERN_VARIANT="${2:?--variant requires a value}"; shift 2 ;;
         --variant=*) SKYVERN_VARIANT="${1#--variant=}"; shift ;;
         --help|-h)
-            # Self-parsing of "$0" doesn't work when piped (`curl ... | sh`);
-            # `$0` is then the shell name, not a real file. Embed help inline.
+            # Heredoc rather than self-parsing $0: when piped, $0 is the
+            # shell name, not a real file path.
             cat <<'EOF'
 Skyvern installer.
 
@@ -59,13 +39,12 @@ Environment overrides:
   SKYVERN_VERSION=X    same as --version
 
 What this does:
-  1. Bootstraps 'uv' (Astral's Python toolchain) if not already installed.
-     uv handles Python version management — the host machine doesn't need
-     a pre-installed Python.
-  2. Installs the matching PyPI package as an isolated tool, exposing
-     the 'skyvern' command on PATH.
-  3. For variants that need a browser, runs 'skyvern init' to download
-     Chromium (skip with --no-init when running in CI / minimal containers).
+  1. Bootstraps 'uv' if missing — uv manages Python so the host
+     doesn't need one preinstalled.
+  2. Installs the variant's PyPI package as an isolated tool
+     ('skyvern' on PATH).
+  3. For variants that need a browser, runs 'skyvern init' to fetch
+     Chromium (~150MB; skip with --no-init).
 EOF
             exit 0
             ;;
@@ -89,9 +68,8 @@ uv_was_freshly_installed=0
 if ! command -v uv >/dev/null 2>&1; then
     uv_was_freshly_installed=1
     printf 'installing uv (one-time, into ~/.local/bin)...\n'
-    # Download then execute, rather than `curl ... | sh`. POSIX /bin/sh has no
-    # `pipefail`, so a curl failure (captive portal, MITM truncation, 5xx)
-    # would otherwise be silently swallowed and the script would carry on.
+    # Download then execute (not `curl ... | sh`): POSIX /bin/sh has no
+    # pipefail, so curl failures would otherwise be swallowed silently.
     UV_INSTALLER="$(mktemp -t skyvern-uv-installer.XXXXXX)"
     if ! curl -LsSf https://astral.sh/uv/install.sh -o "$UV_INSTALLER"; then
         rm -f "$UV_INSTALLER"
@@ -101,9 +79,6 @@ if ! command -v uv >/dev/null 2>&1; then
     fi
     sh "$UV_INSTALLER"
     rm -f "$UV_INSTALLER"
-    # uv drops binaries in ~/.local/bin and updates shell rc files for future
-    # sessions. Update PATH here so the rest of this script can call uv
-    # directly, then sanity-check the binary actually exists.
     export PATH="$HOME/.local/bin:$PATH"
     if ! command -v uv >/dev/null 2>&1; then
         printf 'ERROR: uv installer ran but uv is not on PATH.\n' >&2
@@ -112,28 +87,17 @@ if ! command -v uv >/dev/null 2>&1; then
     fi
 fi
 
-# Variant policy table. Each variant decides:
-#   PKG_SPEC          which PyPI spec to install
-#   PYTHON_SPEC       which Python range to pin (PEP 440 / 508 specifier)
-#   DEFAULT_RUN_INIT  whether 'skyvern init' (Chromium) runs by default
-#   SUCCESS_HINT      the "what to try next" line printed on success
-#
-# Today only 'server' is accepted. The Skyvern SDK package split (per the
-# March 2026 PRD) will introduce additional variants; when their PyPI
-# targets exist, add cases below — no other code change needed:
-#   sdk: lightweight `skyvern` (no Chromium, no server). DEFAULT_RUN_INIT=0.
-#   mcp: standalone `skyvern-mcp` (SKY-7946).
-#   all: backward-compat alias for today's monolithic install.
+# Variant policy: each variant sets the PyPI spec, the Python range to pin,
+# whether 'skyvern init' runs by default, and the success-message hint.
+# Today only 'server' is accepted; new variants get added at SDK split time.
 case "$SKYVERN_VARIANT" in
     server)
-        # Pre-split: monolithic `skyvern` already includes server, browsers,
-        # and LLM clients. Post-split: change to `skyvern[server]`.
         PKG_SPEC="skyvern"
         PYTHON_SPEC=">=3.11,<3.14"
         DEFAULT_RUN_INIT=1
         SUCCESS_HINT="Try: skyvern --help"
         ;;
-    sdk|mcp|cli|cloud|all)
+    sdk|mcp|all)
         printf "ERROR: --variant '%s' is reserved for the upcoming SDK package split\n" "$SKYVERN_VARIANT" >&2
         printf "       and is not yet available. Use --variant server (the default) for now.\n" >&2
         exit 2
@@ -144,7 +108,6 @@ case "$SKYVERN_VARIANT" in
         ;;
 esac
 
-# Apply --no-init / SKYVERN_RUN_INIT user override; otherwise use variant default.
 [ -n "$SKYVERN_RUN_INIT" ] || SKYVERN_RUN_INIT="$DEFAULT_RUN_INIT"
 
 PKG_SPEC_INSTALL="$PKG_SPEC"
@@ -153,21 +116,17 @@ if [ -n "$SKYVERN_VERSION" ]; then
 fi
 
 printf 'installing %s via uv tool install...\n' "$PKG_SPEC_INSTALL"
-# PYTHON_SPEC is hardcoded per variant. Without this, uv may pick a host
-# Python outside the supported range (e.g., 3.14), in which case
-# environment-marker dependencies like playwright (`<'3.14'`) silently drop
-# out of the resolution and the CLI crashes at import time. Bump this range
-# intentionally when the upstream `requires-python` shifts — it does NOT
-# auto-track. (Filed as a follow-up: CI job that diffs PYTHON_SPEC against
-# the published `requires-python` for the variant.)
+# Pin Python to the variant's supported range. Without this, uv may pick a
+# host Python outside the range and env-marker deps (e.g., playwright with
+# `<'3.14'`) silently drop from the resolution. Bump intentionally when
+# upstream `requires-python` shifts — does NOT auto-track.
 uv tool install --python "$PYTHON_SPEC" --force "$PKG_SPEC_INSTALL"
 
 if [ "$SKYVERN_RUN_INIT" = "1" ]; then
     printf "\nrunning 'skyvern init' (installs Chromium, ~150MB)...\n"
     if ! skyvern init; then
-        # Chromium download can fail behind corporate proxies or on flaky
-        # networks. The CLI is installed regardless; surface the recovery path
-        # instead of returning non-zero from the whole installer.
+        # Chromium download is best-effort: corp proxies often block it. The
+        # CLI is installed regardless; surface a recovery hint and continue.
         printf "\nWARN: 'skyvern init' did not complete. The CLI is installed;\n" >&2
         printf "      re-run 'skyvern init' once your network/proxy is sorted.\n" >&2
     fi
@@ -176,8 +135,6 @@ fi
 printf '\nSkyvern installed. %s\n' "$SUCCESS_HINT"
 
 if [ "$uv_was_freshly_installed" = "1" ]; then
-    printf "\nNote: uv was just installed in ~/.local/bin. To use 'skyvern' in\n"
-    printf '      your current shell session, run:\n'
-    printf '          source ~/.local/bin/env\n'
-    printf '      Or open a new terminal (uv updated your shell rc).\n'
+    printf "\nNote: uv was just installed in ~/.local/bin. Run 'source ~/.local/bin/env'\n"
+    printf "      or open a new terminal to use 'skyvern' in this shell.\n"
 fi

--- a/install.sh
+++ b/install.sh
@@ -21,14 +21,19 @@
 
 set -eu
 
-SKYVERN_RUN_INIT="${SKYVERN_RUN_INIT:-1}"
+# Empty SKYVERN_RUN_INIT means "use the variant's default"; --no-init or
+# `SKYVERN_RUN_INIT=0` overrides to 0; `SKYVERN_RUN_INIT=1` forces it on.
+SKYVERN_RUN_INIT="${SKYVERN_RUN_INIT:-}"
 SKYVERN_VERSION="${SKYVERN_VERSION:-}"
+SKYVERN_VARIANT="${SKYVERN_VARIANT:-server}"
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --no-init)   SKYVERN_RUN_INIT=0; shift ;;
         --version)   SKYVERN_VERSION="${2:?--version requires a value}"; shift 2 ;;
         --version=*) SKYVERN_VERSION="${1#--version=}"; shift ;;
+        --variant)   SKYVERN_VARIANT="${2:?--variant requires a value}"; shift 2 ;;
+        --variant=*) SKYVERN_VARIANT="${1#--variant=}"; shift ;;
         --help|-h)
             # Self-parsing of "$0" doesn't work when piped (`curl ... | sh`);
             # `$0` is then the shell name, not a real file. Embed help inline.
@@ -39,19 +44,28 @@ Usage:
   curl -LsSf https://install.skyvern.com | sh
   curl -LsSf https://install.skyvern.com | sh -s -- --no-init
   curl -LsSf https://install.skyvern.com | sh -s -- --version 1.0.31
+  curl -LsSf https://install.skyvern.com | sh -s -- --variant server
+
+Flags:
+  --variant V    install variant (default: server). Other variants
+                 (sdk, mcp, all) are reserved for the upcoming SDK
+                 package split — currently only 'server' is accepted.
+  --no-init      skip 'skyvern init' (the Chromium browser install).
+  --version X    pin a specific PyPI version (e.g., 1.0.31).
 
 Environment overrides:
-  SKYVERN_RUN_INIT=0   skip 'skyvern init' (Chromium browser install)
-  SKYVERN_VERSION=X    pin a specific PyPI version
+  SKYVERN_VARIANT=V    same as --variant
+  SKYVERN_RUN_INIT=0   same as --no-init
+  SKYVERN_VERSION=X    same as --version
 
 What this does:
   1. Bootstraps 'uv' (Astral's Python toolchain) if not already installed.
      uv handles Python version management — the host machine doesn't need
      a pre-installed Python.
-  2. Installs the 'skyvern' package from PyPI as an isolated tool, exposing
+  2. Installs the matching PyPI package as an isolated tool, exposing
      the 'skyvern' command on PATH.
-  3. Runs 'skyvern init' to install Chromium for browser automation
-     (skip with --no-init when running in CI / minimal containers).
+  3. For variants that need a browser, runs 'skyvern init' to download
+     Chromium (skip with --no-init when running in CI / minimal containers).
 EOF
             exit 0
             ;;
@@ -98,22 +112,55 @@ if ! command -v uv >/dev/null 2>&1; then
     fi
 fi
 
-# When the SDK package split lands (lightweight `skyvern` SDK + full
-# `skyvern[server]` + standalone `skyvern-mcp`), change the next line to:
-#     PKG_SPEC="skyvern[server]"
-# until then, the monolithic `skyvern` package contains the full server.
-PKG_SPEC="skyvern"
+# Variant policy table. Each variant decides:
+#   PKG_SPEC          which PyPI spec to install
+#   PYTHON_SPEC       which Python range to pin (PEP 440 / 508 specifier)
+#   DEFAULT_RUN_INIT  whether 'skyvern init' (Chromium) runs by default
+#   SUCCESS_HINT      the "what to try next" line printed on success
+#
+# Today only 'server' is accepted. The Skyvern SDK package split (per the
+# March 2026 PRD) will introduce additional variants; when their PyPI
+# targets exist, add cases below — no other code change needed:
+#   sdk: lightweight `skyvern` (no Chromium, no server). DEFAULT_RUN_INIT=0.
+#   mcp: standalone `skyvern-mcp` (SKY-7946).
+#   all: backward-compat alias for today's monolithic install.
+case "$SKYVERN_VARIANT" in
+    server)
+        # Pre-split: monolithic `skyvern` already includes server, browsers,
+        # and LLM clients. Post-split: change to `skyvern[server]`.
+        PKG_SPEC="skyvern"
+        PYTHON_SPEC=">=3.11,<3.14"
+        DEFAULT_RUN_INIT=1
+        SUCCESS_HINT="Try: skyvern --help"
+        ;;
+    sdk|mcp|cli|cloud|all)
+        printf "ERROR: --variant '%s' is reserved for the upcoming SDK package split\n" "$SKYVERN_VARIANT" >&2
+        printf "       and is not yet available. Use --variant server (the default) for now.\n" >&2
+        exit 2
+        ;;
+    *)
+        printf "ERROR: unknown variant '%s'. Valid: server (default).\n" "$SKYVERN_VARIANT" >&2
+        exit 2
+        ;;
+esac
+
+# Apply --no-init / SKYVERN_RUN_INIT user override; otherwise use variant default.
+[ -n "$SKYVERN_RUN_INIT" ] || SKYVERN_RUN_INIT="$DEFAULT_RUN_INIT"
+
+PKG_SPEC_INSTALL="$PKG_SPEC"
 if [ -n "$SKYVERN_VERSION" ]; then
-    PKG_SPEC="${PKG_SPEC}==${SKYVERN_VERSION}"
+    PKG_SPEC_INSTALL="${PKG_SPEC}==${SKYVERN_VERSION}"
 fi
 
-printf 'installing %s via uv tool install...\n' "$PKG_SPEC"
-# Pin the Python version range to skyvern's `requires-python`. Without this,
-# uv may pick a host Python outside the supported range (e.g., 3.14), in
-# which case environment-marker dependencies like playwright (`<'3.14'`)
-# silently drop out of the resolution and the CLI crashes at import time.
-# The range form tracks `requires-python` automatically as it evolves.
-uv tool install --python '>=3.11,<3.14' --force "$PKG_SPEC"
+printf 'installing %s via uv tool install...\n' "$PKG_SPEC_INSTALL"
+# PYTHON_SPEC is hardcoded per variant. Without this, uv may pick a host
+# Python outside the supported range (e.g., 3.14), in which case
+# environment-marker dependencies like playwright (`<'3.14'`) silently drop
+# out of the resolution and the CLI crashes at import time. Bump this range
+# intentionally when the upstream `requires-python` shifts — it does NOT
+# auto-track. (Filed as a follow-up: CI job that diffs PYTHON_SPEC against
+# the published `requires-python` for the variant.)
+uv tool install --python "$PYTHON_SPEC" --force "$PKG_SPEC_INSTALL"
 
 if [ "$SKYVERN_RUN_INIT" = "1" ]; then
     printf "\nrunning 'skyvern init' (installs Chromium, ~150MB)...\n"
@@ -126,7 +173,7 @@ if [ "$SKYVERN_RUN_INIT" = "1" ]; then
     fi
 fi
 
-printf '\nSkyvern installed. Try: skyvern --help\n'
+printf '\nSkyvern installed. %s\n' "$SUCCESS_HINT"
 
 if [ "$uv_was_freshly_installed" = "1" ]; then
     printf "\nNote: uv was just installed in ~/.local/bin. To use 'skyvern' in\n"

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,29 @@ while [ $# -gt 0 ]; do
         --version)   SKYVERN_VERSION="${2:?--version requires a value}"; shift 2 ;;
         --version=*) SKYVERN_VERSION="${1#--version=}"; shift ;;
         --help|-h)
-            sed -n '2,20p' "$0" | sed -n 's/^# \{0,1\}//p'
+            # Self-parsing of "$0" doesn't work when piped (`curl ... | sh`);
+            # `$0` is then the shell name, not a real file. Embed help inline.
+            cat <<'EOF'
+Skyvern installer.
+
+Usage:
+  curl -LsSf https://install.skyvern.com | sh
+  curl -LsSf https://install.skyvern.com | sh -s -- --no-init
+  curl -LsSf https://install.skyvern.com | sh -s -- --version 1.0.31
+
+Environment overrides:
+  SKYVERN_RUN_INIT=0   skip 'skyvern init' (Chromium browser install)
+  SKYVERN_VERSION=X    pin a specific PyPI version
+
+What this does:
+  1. Bootstraps 'uv' (Astral's Python toolchain) if not already installed.
+     uv handles Python version management — the host machine doesn't need
+     a pre-installed Python.
+  2. Installs the 'skyvern' package from PyPI as an isolated tool, exposing
+     the 'skyvern' command on PATH.
+  3. Runs 'skyvern init' to install Chromium for browser automation
+     (skip with --no-init when running in CI / minimal containers).
+EOF
             exit 0
             ;;
         *)
@@ -53,11 +75,27 @@ uv_was_freshly_installed=0
 if ! command -v uv >/dev/null 2>&1; then
     uv_was_freshly_installed=1
     printf 'installing uv (one-time, into ~/.local/bin)...\n'
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-    # The uv installer drops binaries in ~/.local/bin and updates the user's
-    # shell rc files for future sessions. We update PATH here so the rest of
-    # this script can call uv directly.
+    # Download then execute, rather than `curl ... | sh`. POSIX /bin/sh has no
+    # `pipefail`, so a curl failure (captive portal, MITM truncation, 5xx)
+    # would otherwise be silently swallowed and the script would carry on.
+    UV_INSTALLER="$(mktemp -t skyvern-uv-installer.XXXXXX)"
+    if ! curl -LsSf https://astral.sh/uv/install.sh -o "$UV_INSTALLER"; then
+        rm -f "$UV_INSTALLER"
+        printf 'ERROR: failed to download uv installer from astral.sh.\n' >&2
+        printf '       Check your network/proxy. See https://docs.astral.sh/uv/getting-started/installation/\n' >&2
+        exit 1
+    fi
+    sh "$UV_INSTALLER"
+    rm -f "$UV_INSTALLER"
+    # uv drops binaries in ~/.local/bin and updates shell rc files for future
+    # sessions. Update PATH here so the rest of this script can call uv
+    # directly, then sanity-check the binary actually exists.
     export PATH="$HOME/.local/bin:$PATH"
+    if ! command -v uv >/dev/null 2>&1; then
+        printf 'ERROR: uv installer ran but uv is not on PATH.\n' >&2
+        printf '       See https://docs.astral.sh/uv/getting-started/installation/\n' >&2
+        exit 1
+    fi
 fi
 
 # When the SDK package split lands (lightweight `skyvern` SDK + full
@@ -70,11 +108,12 @@ if [ -n "$SKYVERN_VERSION" ]; then
 fi
 
 printf 'installing %s via uv tool install...\n' "$PKG_SPEC"
-# Pin Python to a version inside skyvern's `requires-python = ">=3.11,<3.14"`.
-# Without this, uv may pick the host's Python 3.14 (or newer), in which case
-# environment-marker dependencies like playwright (`<'3.14'`) silently drop
-# out of the resolution and the CLI crashes at import time.
-uv tool install --python 3.13 --force "$PKG_SPEC"
+# Pin the Python version range to skyvern's `requires-python`. Without this,
+# uv may pick a host Python outside the supported range (e.g., 3.14), in
+# which case environment-marker dependencies like playwright (`<'3.14'`)
+# silently drop out of the resolution and the CLI crashes at import time.
+# The range form tracks `requires-python` automatically as it evolves.
+uv tool install --python '>=3.11,<3.14' --force "$PKG_SPEC"
 
 if [ "$SKYVERN_RUN_INIT" = "1" ]; then
     printf "\nrunning 'skyvern init' (installs Chromium, ~150MB)...\n"

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@ SKYVERN_VARIANT="${SKYVERN_VARIANT:-server}"
 while [ $# -gt 0 ]; do
     case "$1" in
         --no-init)   SKYVERN_RUN_INIT=0; shift ;;
+        --run-init|--run-setup) SKYVERN_RUN_INIT=1; shift ;;
         --version)   SKYVERN_VERSION="${2:?--version requires a value}"; shift 2 ;;
         --version=*) SKYVERN_VERSION="${1#--version=}"; shift ;;
         --variant)   SKYVERN_VARIANT="${2:?--variant requires a value}"; shift 2 ;;
@@ -23,28 +24,31 @@ Skyvern installer.
 Usage:
   curl -LsSf https://install.skyvern.com | sh
   curl -LsSf https://install.skyvern.com | sh -s -- --no-init
-  curl -LsSf https://install.skyvern.com | sh -s -- --version 1.0.31
+  curl -LsSf https://install.skyvern.com | sh -s -- --run-setup
+  curl -LsSf https://install.skyvern.com | sh -s -- --version 1.0.35
   curl -LsSf https://install.skyvern.com | sh -s -- --variant server
 
 Flags:
-  --variant V    install variant (default: server). Other variants
-                 (sdk, mcp, all) are reserved for the upcoming SDK
-                 package split — currently only 'server' is accepted.
-  --no-init      skip 'skyvern init' (the Chromium browser install).
-  --version X    pin a specific PyPI version (e.g., 1.0.31).
+  --variant V    install variant (default: server). This curl installer is
+                 intentionally for the self-hosted CLI/server path. For SDKs,
+                 use pip inside your project: 'skyvern' or 'skyvern[local]'.
+  --run-setup    run the setup wizard after install (requires a terminal).
+  --run-init     alias for --run-setup.
+  --no-init      skip the post-install setup wizard.
+  --version X    pin a specific PyPI version (e.g., 1.0.35).
 
 Environment overrides:
   SKYVERN_VARIANT=V    same as --variant
   SKYVERN_RUN_INIT=0   same as --no-init
+  SKYVERN_RUN_INIT=1   same as --run-setup
   SKYVERN_VERSION=X    same as --version
 
 What this does:
   1. Bootstraps 'uv' if missing — uv manages Python so the host
      doesn't need one preinstalled.
-  2. Installs the variant's PyPI package as an isolated tool
+  2. Installs the self-hosted PyPI package as an isolated tool
      ('skyvern' on PATH).
-  3. For variants that need a browser, runs 'skyvern init' to fetch
-     Chromium (~150MB; skip with --no-init).
+  3. Prints the next setup command. Use --run-setup to run it immediately.
 EOF
             exit 0
             ;;
@@ -86,19 +90,28 @@ if ! command -v uv >/dev/null 2>&1; then
     fi
 fi
 
-# Variant policy: each variant sets the PyPI spec, the Python range to pin,
-# whether 'skyvern init' runs by default, and the success-message hint.
-# Today only 'server' is accepted; new variants get added at SDK split time.
+# Variant policy: the curl installer is for isolated CLI/server installs.
+# SDK installs belong in the user's project environment, not a uv tool venv.
 case "$SKYVERN_VARIANT" in
     server)
-        PKG_SPEC="skyvern"
+        PKG_SPEC="skyvern[server]"
         PYTHON_SPEC=">=3.11,<3.14"
-        DEFAULT_RUN_INIT=1
-        SUCCESS_HINT="Try: skyvern --help"
+        DEFAULT_RUN_INIT=0
+        SUCCESS_HINT="Next: skyvern quickstart"
         ;;
-    sdk|mcp|all)
-        printf "ERROR: --variant '%s' is reserved for the upcoming SDK package split\n" "$SKYVERN_VARIANT" >&2
-        printf "       and is not yet available. Use --variant server (the default) for now.\n" >&2
+    sdk|cloud|base)
+        printf "ERROR: --variant '%s' is not installed by this curl installer.\n" "$SKYVERN_VARIANT" >&2
+        printf "       Use 'pip install skyvern' inside your Python project instead.\n" >&2
+        exit 2
+        ;;
+    local|embedded)
+        printf "ERROR: --variant '%s' is not installed by this curl installer.\n" "$SKYVERN_VARIANT" >&2
+        printf "       Use 'pip install \"skyvern[local]\"' inside your Python project instead.\n" >&2
+        exit 2
+        ;;
+    mcp|all)
+        printf "ERROR: --variant '%s' is not available from this installer.\n" "$SKYVERN_VARIANT" >&2
+        printf "       Use --variant server for the self-hosted CLI/server tool.\n" >&2
         exit 2
         ;;
     *)
@@ -108,6 +121,13 @@ case "$SKYVERN_VARIANT" in
 esac
 
 [ -n "$SKYVERN_RUN_INIT" ] || SKYVERN_RUN_INIT="$DEFAULT_RUN_INIT"
+case "$SKYVERN_RUN_INIT" in
+    0|1) ;;
+    *)
+        printf "ERROR: SKYVERN_RUN_INIT must be 0 or 1.\n" >&2
+        exit 2
+        ;;
+esac
 
 PKG_SPEC_INSTALL="$PKG_SPEC"
 if [ -n "$SKYVERN_VERSION" ]; then
@@ -121,13 +141,22 @@ printf 'installing %s via uv tool install...\n' "$PKG_SPEC_INSTALL"
 # upstream `requires-python` shifts — does NOT auto-track.
 uv tool install --python "$PYTHON_SPEC" --force "$PKG_SPEC_INSTALL"
 
+SETUP_COMMAND="skyvern quickstart"
+if skyvern quickstart --help 2>/dev/null | grep -q -- "--install-type"; then
+    SETUP_COMMAND="skyvern quickstart --install-type server"
+fi
+SUCCESS_HINT="Next: $SETUP_COMMAND"
+
 if [ "$SKYVERN_RUN_INIT" = "1" ]; then
-    printf "\nrunning 'skyvern init' (installs Chromium, ~150MB)...\n"
-    if ! skyvern init; then
-        # Chromium download is best-effort: corp proxies often block it. The
-        # CLI is installed regardless; surface a recovery hint and continue.
-        printf "\nWARN: 'skyvern init' did not complete. The CLI is installed;\n" >&2
-        printf "      re-run 'skyvern init' once your network/proxy is sorted.\n" >&2
+    if [ ! -t 0 ]; then
+        printf "\nWARN: not running setup because stdin is not an interactive terminal.\n" >&2
+        printf "      Run '%s' from your shell when ready.\n" "$SETUP_COMMAND" >&2
+    else
+        printf "\nrunning '%s'...\n" "$SETUP_COMMAND"
+        if ! sh -c "$SETUP_COMMAND"; then
+            printf "\nWARN: '%s' did not complete. The CLI is installed;\n" "$SETUP_COMMAND" >&2
+            printf "      re-run '%s' once the issue is sorted.\n" "$SETUP_COMMAND" >&2
+        fi
     fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# Skyvern installer.
+#
+# Usage:
+#   curl -LsSf https://install.skyvern.com | sh
+#   curl -LsSf https://install.skyvern.com | sh -s -- --no-init
+#   curl -LsSf https://install.skyvern.com | sh -s -- --version 1.0.31
+#
+# Environment overrides:
+#   SKYVERN_RUN_INIT=0   skip `skyvern init` (Chromium browser install)
+#   SKYVERN_VERSION=X    pin a specific PyPI version
+#
+# What this does:
+#   1. Bootstraps `uv` (Astral's Python toolchain) if not already installed.
+#      uv handles Python version management — the host machine doesn't need
+#      a pre-installed Python.
+#   2. Installs the `skyvern` package from PyPI as an isolated tool, exposing
+#      the `skyvern` command on PATH.
+#   3. Runs `skyvern init` to install Chromium for browser automation
+#      (skip with --no-init when running in CI / minimal containers).
+
+set -eu
+
+SKYVERN_RUN_INIT="${SKYVERN_RUN_INIT:-1}"
+SKYVERN_VERSION="${SKYVERN_VERSION:-}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --no-init)   SKYVERN_RUN_INIT=0; shift ;;
+        --version)   SKYVERN_VERSION="${2:?--version requires a value}"; shift 2 ;;
+        --version=*) SKYVERN_VERSION="${1#--version=}"; shift ;;
+        --help|-h)
+            sed -n '2,20p' "$0" | sed -n 's/^# \{0,1\}//p'
+            exit 0
+            ;;
+        *)
+            printf 'unknown option: %s (try --help)\n' "$1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+case "$(uname -s)" in
+    Darwin|Linux) ;;
+    *)
+        printf 'unsupported OS: %s\n' "$(uname -s)" >&2
+        printf "For Windows, use WSL or 'pip install skyvern' from a Python environment.\n" >&2
+        exit 1
+        ;;
+esac
+
+uv_was_freshly_installed=0
+if ! command -v uv >/dev/null 2>&1; then
+    uv_was_freshly_installed=1
+    printf 'installing uv (one-time, into ~/.local/bin)...\n'
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    # The uv installer drops binaries in ~/.local/bin and updates the user's
+    # shell rc files for future sessions. We update PATH here so the rest of
+    # this script can call uv directly.
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# When the SDK package split lands (lightweight `skyvern` SDK + full
+# `skyvern[server]` + standalone `skyvern-mcp`), change the next line to:
+#     PKG_SPEC="skyvern[server]"
+# until then, the monolithic `skyvern` package contains the full server.
+PKG_SPEC="skyvern"
+if [ -n "$SKYVERN_VERSION" ]; then
+    PKG_SPEC="${PKG_SPEC}==${SKYVERN_VERSION}"
+fi
+
+printf 'installing %s via uv tool install...\n' "$PKG_SPEC"
+uv tool install --force "$PKG_SPEC"
+
+if [ "$SKYVERN_RUN_INIT" = "1" ]; then
+    printf "\nrunning 'skyvern init' (installs Chromium, ~150MB)...\n"
+    if ! skyvern init; then
+        # Chromium download can fail behind corporate proxies or on flaky
+        # networks. The CLI is installed regardless; surface the recovery path
+        # instead of returning non-zero from the whole installer.
+        printf "\nWARN: 'skyvern init' did not complete. The CLI is installed;\n" >&2
+        printf "      re-run 'skyvern init' once your network/proxy is sorted.\n" >&2
+    fi
+fi
+
+printf '\nSkyvern installed. Try: skyvern --help\n'
+
+if [ "$uv_was_freshly_installed" = "1" ]; then
+    printf "\nNote: uv was just installed in ~/.local/bin. To use 'skyvern' in\n"
+    printf '      your current shell session, run:\n'
+    printf '          source ~/.local/bin/env\n'
+    printf '      Or open a new terminal (uv updated your shell rc).\n'
+fi

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Smoke-test install.sh against fresh Docker base images.
+#
+# Verifies the curl installer works on machines with:
+#   - no Python preinstalled (ubuntu:22.04, ubuntu:24.04, debian:12-slim)
+#   - Python preinstalled but no uv (python:3.11-slim, python:3.13-slim)
+#
+# Usage:
+#   scripts/test-install.sh                # default matrix, --no-init
+#   scripts/test-install.sh --with-init    # full e2e including Chromium download
+#   IMAGES="ubuntu:22.04" scripts/test-install.sh   # subset
+#
+# Requires Docker on the host.
+
+set -eu
+
+WITH_INIT=0
+[ "${1:-}" = "--with-init" ] && WITH_INIT=1
+
+DEFAULT_IMAGES="ubuntu:22.04 ubuntu:24.04 debian:12-slim python:3.11-slim python:3.13-slim"
+IMAGES="${IMAGES:-$DEFAULT_IMAGES}"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+[ -f "$INSTALL_SH" ] || { printf 'install.sh not found at %s\n' "$INSTALL_SH" >&2; exit 1; }
+
+init_flag="--no-init"
+[ "$WITH_INIT" = "1" ] && init_flag=""
+
+failed=""
+for img in $IMAGES; do
+    printf '\n=== %s ===\n' "$img"
+    if docker run --rm -v "$INSTALL_SH:/tmp/install.sh:ro" "$img" sh -c "
+        set -e
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -qq >/dev/null
+        apt-get install -qq -y curl ca-certificates >/dev/null
+        sh /tmp/install.sh $init_flag
+        export PATH=\"\$HOME/.local/bin:\$PATH\"
+        skyvern --version
+    "; then
+        printf 'PASS: %s\n' "$img"
+    else
+        printf 'FAIL: %s\n' "$img"
+        failed="$failed $img"
+    fi
+done
+
+if [ -n "$failed" ]; then
+    printf '\nFAILED:%s\n' "$failed" >&2
+    exit 1
+fi
+
+printf '\nAll images passed.\n'

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -31,17 +31,21 @@ failed=""
 for variant in $VARIANTS; do
     for img in $IMAGES; do
         printf '\n=== %s / variant=%s ===\n' "$img" "$variant"
-        if docker run --rm -v "$INSTALL_SH:/tmp/install.sh:ro" "$img" sh -c "
+        if docker run --rm \
+            -v "$INSTALL_SH:/tmp/install.sh:ro" \
+            -e "VARIANT=$variant" \
+            -e "INIT_FLAG=$init_flag" \
+            "$img" sh -c '
             set -e
             export DEBIAN_FRONTEND=noninteractive
             apt-get update -qq >/dev/null
             apt-get install -qq -y curl ca-certificates >/dev/null
-            sh /tmp/install.sh --variant '$variant' $init_flag
-            export PATH=\"\$HOME/.local/bin:\$PATH\"
+            sh /tmp/install.sh --variant "$VARIANT" $INIT_FLAG
+            export PATH="$HOME/.local/bin:$PATH"
             # --help exit 0 proves the package imports cleanly (the CLI
             # has no --version flag).
             skyvern --help >/dev/null
-        "; then
+        '; then
             printf 'PASS: %s / variant=%s\n' "$img" "$variant"
         else
             printf 'FAIL: %s / variant=%s\n' "$img" "$variant"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,13 +1,9 @@
 #!/bin/sh
 # Smoke-test install.sh against fresh Docker base images.
 #
-# Verifies the curl installer works on machines with:
-#   - no Python preinstalled (ubuntu:22.04, ubuntu:24.04, debian:12-slim)
-#   - Python preinstalled but no uv (python:3.11-slim, python:3.13-slim)
-#
 # Usage:
 #   scripts/test-install.sh                # default matrix, --no-init
-#   scripts/test-install.sh --with-init    # full e2e including Chromium download
+#   scripts/test-install.sh --with-init    # full e2e (downloads Chromium)
 #   IMAGES="ubuntu:22.04" scripts/test-install.sh   # subset
 #
 # Requires Docker on the host.
@@ -20,9 +16,7 @@ WITH_INIT=0
 DEFAULT_IMAGES="ubuntu:22.04 ubuntu:24.04 debian:12-slim python:3.11-slim python:3.13-slim"
 IMAGES="${IMAGES:-$DEFAULT_IMAGES}"
 
-# Variant matrix. Today only 'server' is accepted by install.sh; the loop
-# scaffolding is in place so that split day is a data-only change — append
-# 'sdk', 'mcp', 'all' once their PyPI targets exist.
+# Today only 'server' is valid; append other variants when they exist.
 DEFAULT_VARIANTS="server"
 VARIANTS="${VARIANTS:-$DEFAULT_VARIANTS}"
 
@@ -44,9 +38,8 @@ for variant in $VARIANTS; do
             apt-get install -qq -y curl ca-certificates >/dev/null
             sh /tmp/install.sh --variant '$variant' $init_flag
             export PATH=\"\$HOME/.local/bin:\$PATH\"
-            # skyvern's CLI exposes no '--version' flag; --help exiting 0
-            # proves the package imports cleanly (including playwright for
-            # variants that pull it in).
+            # --help exit 0 proves the package imports cleanly (the CLI
+            # has no --version flag).
             skyvern --help >/dev/null
         "; then
             printf 'PASS: %s / variant=%s\n' "$img" "$variant"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -20,6 +20,12 @@ WITH_INIT=0
 DEFAULT_IMAGES="ubuntu:22.04 ubuntu:24.04 debian:12-slim python:3.11-slim python:3.13-slim"
 IMAGES="${IMAGES:-$DEFAULT_IMAGES}"
 
+# Variant matrix. Today only 'server' is accepted by install.sh; the loop
+# scaffolding is in place so that split day is a data-only change — append
+# 'sdk', 'mcp', 'all' once their PyPI targets exist.
+DEFAULT_VARIANTS="server"
+VARIANTS="${VARIANTS:-$DEFAULT_VARIANTS}"
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 INSTALL_SH="$REPO_ROOT/install.sh"
 [ -f "$INSTALL_SH" ] || { printf 'install.sh not found at %s\n' "$INSTALL_SH" >&2; exit 1; }
@@ -28,24 +34,27 @@ init_flag="--no-init"
 [ "$WITH_INIT" = "1" ] && init_flag=""
 
 failed=""
-for img in $IMAGES; do
-    printf '\n=== %s ===\n' "$img"
-    if docker run --rm -v "$INSTALL_SH:/tmp/install.sh:ro" "$img" sh -c "
-        set -e
-        export DEBIAN_FRONTEND=noninteractive
-        apt-get update -qq >/dev/null
-        apt-get install -qq -y curl ca-certificates >/dev/null
-        sh /tmp/install.sh $init_flag
-        export PATH=\"\$HOME/.local/bin:\$PATH\"
-        # skyvern's CLI exposes no '--version' flag; --help exiting 0 proves
-        # the package imports cleanly (including playwright).
-        skyvern --help >/dev/null
-    "; then
-        printf 'PASS: %s\n' "$img"
-    else
-        printf 'FAIL: %s\n' "$img"
-        failed="$failed $img"
-    fi
+for variant in $VARIANTS; do
+    for img in $IMAGES; do
+        printf '\n=== %s / variant=%s ===\n' "$img" "$variant"
+        if docker run --rm -v "$INSTALL_SH:/tmp/install.sh:ro" "$img" sh -c "
+            set -e
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update -qq >/dev/null
+            apt-get install -qq -y curl ca-certificates >/dev/null
+            sh /tmp/install.sh --variant '$variant' $init_flag
+            export PATH=\"\$HOME/.local/bin:\$PATH\"
+            # skyvern's CLI exposes no '--version' flag; --help exiting 0
+            # proves the package imports cleanly (including playwright for
+            # variants that pull it in).
+            skyvern --help >/dev/null
+        "; then
+            printf 'PASS: %s / variant=%s\n' "$img" "$variant"
+        else
+            printf 'FAIL: %s / variant=%s\n' "$img" "$variant"
+            failed="$failed $img(variant=$variant)"
+        fi
+    done
 done
 
 if [ -n "$failed" ]; then

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -37,7 +37,9 @@ for img in $IMAGES; do
         apt-get install -qq -y curl ca-certificates >/dev/null
         sh /tmp/install.sh $init_flag
         export PATH=\"\$HOME/.local/bin:\$PATH\"
-        skyvern --version
+        # skyvern's CLI exposes no '--version' flag; --help exiting 0 proves
+        # the package imports cleanly (including playwright).
+        skyvern --help >/dev/null
     "; then
         printf 'PASS: %s\n' "$img"
     else

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   scripts/test-install.sh                # default matrix, --no-init
-#   scripts/test-install.sh --with-init    # full e2e (downloads Chromium)
+#   scripts/test-install.sh --with-init    # run post-install setup when possible
 #   IMAGES="ubuntu:22.04" scripts/test-install.sh   # subset
 #
 # Requires Docker on the host.
@@ -16,7 +16,8 @@ WITH_INIT=0
 DEFAULT_IMAGES="ubuntu:22.04 ubuntu:24.04 debian:12-slim python:3.11-slim python:3.13-slim"
 IMAGES="${IMAGES:-$DEFAULT_IMAGES}"
 
-# Today only 'server' is valid; append other variants when they exist.
+# This installer is intentionally server-only; SDK/local installs belong in a
+# project environment via pip, not a uv tool venv.
 DEFAULT_VARIANTS="server"
 VARIANTS="${VARIANTS:-$DEFAULT_VARIANTS}"
 


### PR DESCRIPTION
## Ticket

https://linear.app/skyvern/issue/SKY-9476/add-curl-installer-for-skyvern

## Description

Adds a one-line curl installer for the self-hosted Skyvern CLI/server path:

```sh
curl -LsSf https://install.skyvern.com | sh
```

The installer now targets the post-split package contract:

- `pip install skyvern` remains the lightweight Cloud/API SDK path and belongs in a project environment.
- `pip install "skyvern[local]"` remains the embedded local SDK path and belongs in a project environment.
- The curl installer is intentionally for the isolated CLI/server tool and installs `skyvern[server]` with `uv tool install --python '>=3.11,<3.14'`.

The script bootstraps `uv` if missing, installs the server extra as an isolated tool, and prints the next setup command. It no longer runs interactive setup by default because the canonical `curl | sh` invocation does not provide a real interactive stdin. Users can opt in with `--run-setup` / `--run-init`; when stdin is not a TTY the script skips setup and prints the command to run manually.

## Quickstart compatibility

This is compatible with the incoming quickstart install-type selector from Skyvern Cloud PR #10976. After installation, the script checks whether `skyvern quickstart --help` exposes `--install-type`:

- If available, it prints/runs `skyvern quickstart --install-type server`.
- Otherwise, it falls back to `skyvern quickstart`.

That keeps this PR independent of the exact OSS sync order while still using the narrower server quickstart once it lands.

## Hosting note

The script should be hosted from the OSS repo, not skyvern-cloud, because it installs the public OSS PyPI package. Suggested public endpoint: `install.skyvern.com` via Cloudflare Pages/Worker or Vercel pointed at this repo's `install.sh` on `main`. Raw GitHub can be a temporary fallback, but should not be the promoted URL.

## How Has This Been Tested?

- `sh -n install.sh scripts/test-install.sh`
- `git diff --check`
- `pre-commit run --files install.sh scripts/test-install.sh` -> shellcheck and generic hooks passed
- `sh install.sh --help`
- `sh install.sh --variant local --no-init` -> rejects with `pip install "skyvern[local]"` guidance
- `SKYVERN_RUN_INIT=wat sh install.sh --variant server --version 0` -> rejects invalid env override before install
- Mocked `PATH` smoke: verifies the installer calls `uv tool install --python >=3.11,<3.14 --force skyvern[server]`
- Mocked quickstart detection: verifies the success hint becomes `skyvern quickstart --install-type server` when that flag exists, and `skyvern quickstart` otherwise
- `uv pip install --python <temp venv python> --dry-run 'skyvern[server]'` -> resolved published `skyvern==1.0.35` server extra successfully

## Not tested

- Full Docker matrix in `scripts/test-install.sh`.
- Real `uv tool install 'skyvern[server]'`, to avoid replacing the local user-level `skyvern` tool during review.
