### PR TITLE
fix: OSS Docker image build after lightweight wheel split

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,16 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
  && ln -s /root/.local/bin/uv /usr/local/bin/uv
 COPY ./pyproject.toml /tmp/pyproject.toml
 COPY ./uv.lock /tmp/uv.lock
-RUN uv pip compile pyproject.toml -o requirements.txt --no-annotate --no-header
+RUN uv pip compile pyproject.toml --extra server --python-version 3.11 -o requirements.txt --no-annotate --no-header
 
 FROM python:3.11-slim-bookworm
 WORKDIR /app
 COPY --from=requirements-stage /tmp/requirements.txt /app/requirements.txt
 RUN pip install --upgrade pip setuptools wheel
-RUN pip install --no-cache-dir --upgrade -r requirements.txt
+# --no-deps: requirements.txt is fully resolved by uv, including the
+# pyproject overrides that loosen litellm's jsonschema==4.23.0 pin.
+# Letting pip re-resolve here would re-introduce that conflict.
+RUN pip install --no-cache-dir --no-deps -r requirements.txt
 RUN playwright install-deps
 RUN playwright install
 RUN apt-get install -y xauth x11-apps netpbm gpg ca-certificates x11vnc && apt-get clean


### PR DESCRIPTION
## Summary

Fixes the OSS image publisher build, which has been red since the lightweight wheel split landed. Two issues:

1. **`--extra server` missing.** SKY-7947 (#5823) moved server-only deps under `[project.optional-dependencies] server`. `uv pip compile pyproject.toml` now emits only the 9-package lightweight client surface. The resulting image had no litellm / fastapi / sqlalchemy and could not run skyvern. Adding `--extra server` restores the full runtime closure.

2. **pip's resolver re-introduces the litellm/jsonschema conflict.** uv honors the pyproject override `jsonschema>=4.23.0` (which relaxes litellm 1.83.7's exact `jsonschema==4.23.0` pin), so the compiled requirements.txt locks `jsonschema==4.26.0`. A vanilla `pip install -r requirements.txt` re-resolves and aborts because litellm's metadata pin disagrees with the locked version — exactly the failure shown in [run 25236489261](https://github.com/Skyvern-AI/skyvern/actions/runs/25236489261/job/74477991517). Switching to `pip install --no-deps` installs verbatim from the uv-resolved file and skips re-resolution.

3. Also pin `--python-version 3.11` on the compile step so the requirements.txt excludes 3.13-only packages (e.g. pyyaml-ft) regardless of the host Python on the build runner.

## Test plan

- [x] `uv pip compile pyproject.toml --extra server --python-version 3.11` emits 206-package requirements.txt incl. litellm, mcp, fastapi.
- [x] `pip install --no-deps -r requirements.txt` succeeds in a fresh Python 3.11 venv (where the previous `pip install -r` fails with the jsonschema conflict).
- [ ] Manually trigger the `Build Docker Image and Push to ECR` workflow against this branch via `workflow_dispatch` to confirm the multi-arch buildx build is green end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)