### PR TITLE
feat: add per-run llm_api_key override for tasks and workflows

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -678,6 +678,8 @@ class LLMAPIHandlerFactory:
                 )
 
             context = skyvern_context.current()
+            if context and context.llm_api_key:
+                parameters["api_key"] = context.llm_api_key
             is_speculative_step = step.is_speculative if step else False
             should_persist_llm_artifacts, artifact_targets = _get_artifact_targets_and_persist_flag(
                 step, is_speculative_step, task_v2, thought, ai_suggestion
@@ -1278,6 +1280,9 @@ class LLMAPIHandlerFactory:
                 )
 
             context = skyvern_context.current()
+            if context and context.llm_api_key:
+                parameters["api_key"] = context.llm_api_key
+                active_parameters["api_key"] = context.llm_api_key
             is_speculative_step = step.is_speculative if step else False
             should_persist_llm_artifacts, artifact_targets = _get_artifact_targets_and_persist_flag(
                 step, is_speculative_step, task_v2, thought, ai_suggestion
@@ -1862,6 +1867,8 @@ class LLMCaller:
             active_parameters.update(self.llm_config.litellm_params)  # type: ignore
 
         context = skyvern_context.current()
+        if context and context.llm_api_key:
+            active_parameters["api_key"] = context.llm_api_key
         is_speculative_step = step.is_speculative if step else False
         should_persist_llm_artifacts, artifact_targets = _get_artifact_targets_and_persist_flag(
             step, is_speculative_step, task_v2, thought, ai_suggestion

--- a/skyvern/forge/sdk/core/skyvern_context.py
+++ b/skyvern/forge/sdk/core/skyvern_context.py
@@ -56,6 +56,7 @@ class SkyvernContext:
     frame_index_map: dict[Frame, int] = field(default_factory=dict)
     dropped_css_svg_element_map: dict[str, bool] = field(default_factory=dict)
     max_screenshot_scrolls: int | None = None
+    llm_api_key: str | None = None
     browser_container_ip: str | None = None
     browser_container_task_arn: str | None = None
     feature_flag_entries: dict[str, bool | str | None] = field(default_factory=dict)

--- a/skyvern/forge/sdk/executor/async_executor.py
+++ b/skyvern/forge/sdk/executor/async_executor.py
@@ -17,6 +17,7 @@ class AsyncExecutor(abc.ABC):
         max_steps_override: int | None,
         api_key: str | None,
         browser_session_id: str | None,
+        llm_api_key: str | None = None,
         **kwargs: dict,
     ) -> None:
         pass

--- a/skyvern/forge/sdk/executor/background_task_executor.py
+++ b/skyvern/forge/sdk/executor/background_task_executor.py
@@ -29,6 +29,7 @@ class BackgroundTaskExecutor(AsyncExecutor):
         max_steps_override: int | None,
         api_key: str | None,
         browser_session_id: str | None,
+        llm_api_key: str | None = None,
         **kwargs: dict,
     ) -> None:
         LOG.info("Executing task using background task executor", task_id=task_id)
@@ -66,6 +67,7 @@ class BackgroundTaskExecutor(AsyncExecutor):
         context.organization_id = organization_id
         context.max_steps_override = max_steps_override
         context.max_screenshot_scrolls = task.max_screenshot_scrolls
+        context.llm_api_key = llm_api_key
 
         if background_tasks:
             await initialize_skyvern_state_file(task_id=task_id, organization_id=organization_id)

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -235,6 +235,7 @@ async def run_task(
             engine=run_request.engine,
             x_max_steps_override=run_request.max_steps,
             x_api_key=x_api_key,
+            llm_api_key=run_request.llm_api_key,
             request=request,
             background_tasks=background_tasks,
         )
@@ -414,6 +415,7 @@ async def run_workflow(
             version=None,
             max_steps=x_max_steps_override,
             api_key=x_api_key,
+            llm_api_key=workflow_run_request.llm_api_key,
             request_id=request_id,
             request=request,
             background_tasks=background_tasks,
@@ -2015,6 +2017,7 @@ async def run_task_v1(
         organization=current_org,
         x_max_steps_override=x_max_steps_override,
         x_api_key=x_api_key,
+        llm_api_key=task.llm_api_key,
         request=request,
         background_tasks=background_tasks,
     )

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -143,6 +143,7 @@ class TaskRequest(TaskBase):
     totp_verification_url: str | None = None
     browser_session_id: str | None = None
     model: dict[str, Any] | None = None
+    llm_api_key: str | None = None
 
     @model_validator(mode="after")
     def validate_url(self) -> Self:

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -775,6 +775,7 @@ class WorkflowService:
         workflow_schedule_id: str | None = None,
         ignore_inherited_workflow_system_prompt: bool = False,
         copilot_session_id: str | None = None,
+        llm_api_key: str | None = None,
     ) -> WorkflowRun:
         """
         Create a workflow run and its parameters. Validate the workflow and the organization. If there are missing
@@ -882,6 +883,7 @@ class WorkflowService:
                     workflow_permanent_id=workflow_run.workflow_permanent_id,
                     max_steps_override=max_steps_override,
                     max_screenshot_scrolls=workflow_request.max_screenshot_scrolls,
+                    llm_api_key=llm_api_key,
                     loop_internal_state=copy.deepcopy(context.loop_internal_state) if context else None,
                     copilot_session_id=resolved_copilot_session_id,
                 )

--- a/skyvern/schemas/runs.py
+++ b/skyvern/schemas/runs.py
@@ -144,6 +144,10 @@ class TaskRunRequest(BaseModel):
         description="The CDP address for the task.",
         examples=["http://127.0.0.1:9222", "ws://127.0.0.1:9222/devtools/browser/1234567890"],
     )
+    llm_api_key: str | None = Field(
+        default=None,
+        description="Optional LLM API key to use for this task run instead of the server default.",
+    )
     run_with: str | None = Field(
         default=None,
         description="Whether to run the task with agent or code. Null means use the default.",
@@ -230,6 +234,10 @@ class WorkflowRunRequest(BaseModel):
     ai_fallback: bool | None = Field(
         default=None,
         description="Whether to fallback to AI if the workflow run fails.",
+    )
+    llm_api_key: str | None = Field(
+        default=None,
+        description="Optional LLM API key to use for this workflow run instead of the server default.",
     )
     run_with: str | None = Field(
         default=None,

--- a/skyvern/services/task_v1_service.py
+++ b/skyvern/services/task_v1_service.py
@@ -82,6 +82,7 @@ async def run_task(
     engine: RunEngine = RunEngine.skyvern_v1,
     x_max_steps_override: int | None = None,
     x_api_key: str | None = None,
+    llm_api_key: str | None = None,
     request: Request | None = None,
     background_tasks: BackgroundTasks | None = None,
 ) -> Task:
@@ -118,6 +119,7 @@ async def run_task(
         max_steps_override=x_max_steps_override,
         browser_session_id=task.browser_session_id,
         api_key=x_api_key,
+        llm_api_key=llm_api_key,
     )
     return created_task
 

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -492,6 +492,7 @@ async def run_task_v2(
         run_id=current_run_id,
         request_id=request_id,
         browser_session_id=browser_session_id,
+        llm_api_key=parent_context.llm_api_key if parent_context else None,
         loop_internal_state=copy.deepcopy(parent_context.loop_internal_state) if parent_context else None,
     )
     # SKY-7005: scoped() restores the parent context on exit, preserving

--- a/skyvern/services/workflow_service.py
+++ b/skyvern/services/workflow_service.py
@@ -29,6 +29,7 @@ async def prepare_workflow(
     trigger_type: WorkflowRunTriggerType | None = None,
     ignore_inherited_workflow_system_prompt: bool = False,
     copilot_session_id: str | None = None,
+    llm_api_key: str | None = None,
 ) -> WorkflowRun:
     """
     Prepare a workflow to be run.
@@ -51,6 +52,7 @@ async def prepare_workflow(
         trigger_type=trigger_type,
         ignore_inherited_workflow_system_prompt=ignore_inherited_workflow_system_prompt,
         copilot_session_id=copilot_session_id,
+        llm_api_key=llm_api_key,
     )
 
     workflow = await app.WORKFLOW_SERVICE.get_workflow_by_permanent_id(
@@ -84,6 +86,7 @@ async def run_workflow(
     version: int | None = None,
     max_steps: int | None = None,
     api_key: str | None = None,
+    llm_api_key: str | None = None,
     request_id: str | None = None,
     request: Request | None = None,
     background_tasks: BackgroundTasks | None = None,
@@ -104,6 +107,7 @@ async def run_workflow(
         parent_workflow_run_id=parent_workflow_run_id,
         trigger_type=trigger_type,
         ignore_inherited_workflow_system_prompt=ignore_inherited_workflow_system_prompt,
+        llm_api_key=llm_api_key,
     )
 
     await AsyncExecutorFactory.get_executor().execute_workflow(


### PR DESCRIPTION
## What & Why

Closes #5898

Currently Skyvern uses a single server-configured LLM API key for all runs.
In multi-tenant or BYOK (Bring Your Own Key) deployments, callers need to
supply their own key per run without changing server config.

**Current behavior:** All LLM calls use the server's global API key.  
**Expected behavior:** A caller can pass `llm_api_key` in the request body and Skyvern will use that key for every LLM call within that run.

## Changes

### Schema
- `TaskRunRequest` (`schemas/runs.py`) — new optional `llm_api_key` field
- `TaskRequest` legacy (`forge/sdk/schemas/tasks.py`) — same
- `WorkflowRunRequest` (`schemas/runs.py`) — same

### Propagation chain (tasks)
`POST /run/tasks` → `task_v1_service.run_task()` → `BackgroundTaskExecutor.execute_task()` → `SkyvernContext.llm_api_key`

### Propagation chain (workflows)
`POST /run/workflows` → `workflow_service.run_workflow()` → `WorkflowService.setup_workflow_run()` → `SkyvernContext.llm_api_key`

### Task v2 context inheritance
`task_v2_service.run_task_v2()` copies `llm_api_key` from the parent context so nested runs inherit the key automatically.

### LLM injection (`api_handler_factory.py`)
All three handler paths check `context.llm_api_key` and inject it as `parameters["api_key"]` / `active_parameters["api_key"]` before every `litellm.acompletion` call.

## How to test

1. Start Skyvern with a valid but deliberately wrong server LLM key
2. Call `POST /run/tasks` with `"llm_api_key": "<your-real-key>"` in the body
3. Task should complete successfully — confirming the override is used
4. Omit `llm_api_key` — task should fail with the bad server key
5. Repeat for `POST /run/workflows`
