### PR TITLE
[CLI] Improve quickstart secret prompt feedback

### DIFF
--- a/skyvern/cli/init_command.py
+++ b/skyvern/cli/init_command.py
@@ -16,6 +16,7 @@ from .browser import setup_browser_config
 from .console import console
 from .database import setup_postgresql
 from .llm_setup import setup_llm_providers, update_or_add_env_var
+from .masked_prompt import ask_secret
 
 
 def init_env(
@@ -131,10 +132,10 @@ def init_env(
             console.print("1. Create an account at [link]https://app.skyvern.com[/link]")
             console.print("2. Go to [bold cyan]Settings[/bold cyan]")
             console.print("3. [bold green]Copy your API key[/bold green]")
-            api_key = Prompt.ask("Enter your Skyvern API key", password=True)
+            api_key = ask_secret("Enter your Skyvern API key")
             if not api_key:
                 console.print("[red]API key is required.[/red]")
-                api_key = Prompt.ask("Please re-enter your Skyvern API key", password=True)
+                api_key = ask_secret("Please re-enter your Skyvern API key")
                 if not api_key:
                     console.print("[bold red]Error: API key cannot be empty. Aborting initialization.[/bold red]")
                     return False

--- a/skyvern/cli/llm_setup.py
+++ b/skyvern/cli/llm_setup.py
@@ -8,6 +8,7 @@ from skyvern.analytics import capture_setup_event
 from skyvern.utils.env_paths import resolve_backend_env_path
 
 from .console import console
+from .masked_prompt import ask_secret
 
 DEFAULT_POSTGRES_DATABASE_STRING = "postgresql+psycopg://skyvern@localhost:5432/skyvern"
 
@@ -70,7 +71,7 @@ def setup_llm_providers() -> None:
     console.print("To enable OpenAI, you must have an OpenAI API key.")
     enable_openai = Confirm.ask("Do you want to enable OpenAI?")
     if enable_openai:
-        openai_api_key = Prompt.ask("Enter your OpenAI API key", password=True)
+        openai_api_key = ask_secret("Enter your OpenAI API key")
         if not openai_api_key:
             console.print("[red]Error: OpenAI API key is required. OpenAI will not be enabled.[/red]")
         else:
@@ -91,7 +92,7 @@ def setup_llm_providers() -> None:
     console.print("To enable Anthropic, you must have an Anthropic API key.")
     enable_anthropic = Confirm.ask("Do you want to enable Anthropic?")
     if enable_anthropic:
-        anthropic_api_key = Prompt.ask("Enter your Anthropic API key", password=True)
+        anthropic_api_key = ask_secret("Enter your Anthropic API key")
         if not anthropic_api_key:
             console.print("[red]Error: Anthropic API key is required. Anthropic will not be enabled.[/red]")
         else:
@@ -115,7 +116,7 @@ def setup_llm_providers() -> None:
     enable_azure = Confirm.ask("Do you want to enable Azure?")
     if enable_azure:
         azure_deployment = Prompt.ask("Enter your Azure deployment name")
-        azure_api_key = Prompt.ask("Enter your Azure API key", password=True)
+        azure_api_key = ask_secret("Enter your Azure API key")
         azure_api_base = Prompt.ask("Enter your Azure API base URL")
         azure_api_version = Prompt.ask("Enter your Azure API version")
         if not all([azure_deployment, azure_api_key, azure_api_base, azure_api_version]):
@@ -135,7 +136,7 @@ def setup_llm_providers() -> None:
     console.print("To enable Gemini, you must have a Gemini API key.")
     enable_gemini = Confirm.ask("Do you want to enable Gemini?")
     if enable_gemini:
-        gemini_api_key = Prompt.ask("Enter your Gemini API key", password=True)
+        gemini_api_key = ask_secret("Enter your Gemini API key")
         if not gemini_api_key:
             console.print("[red]Error: Gemini API key is required. Gemini will not be enabled.[/red]")
         else:

--- a/skyvern/cli/masked_prompt.py
+++ b/skyvern/cli/masked_prompt.py
@@ -15,6 +15,45 @@ _BACKSPACE_CHARS = {"\b", "\x7f"}
 _CTRL_C = "\x03"
 _CTRL_D = "\x04"
 _CTRL_U = "\x15"
+_ESCAPE = "\x1b"
+_OSC_TERMINATOR = "\x07"
+
+
+def _is_csi_final_byte(char: str) -> bool:
+    return "\x40" <= char <= "\x7e"
+
+
+def _consume_escape_sequence(read_char: Callable[[], str]) -> str | None:
+    """Consume a terminal escape sequence and return a newline if one ended it."""
+    char = read_char()
+    if char == "":
+        raise EOFError
+    if char in {"\r", "\n"}:
+        return char
+
+    if char == "[":
+        while True:
+            char = read_char()
+            if char == "":
+                raise EOFError
+            if char in {"\r", "\n"}:
+                return char
+            if _is_csi_final_byte(char):
+                return None
+
+    if char == "]":
+        previous_char = ""
+        while True:
+            char = read_char()
+            if char == "":
+                raise EOFError
+            if char in {"\r", "\n"}:
+                return char
+            if char == _OSC_TERMINATOR or (previous_char == _ESCAPE and char == "\\"):
+                return None
+            previous_char = char
+
+    return None
 
 
 def _read_masked_line(
@@ -28,6 +67,11 @@ def _read_masked_line(
 
     while True:
         char = read_char()
+        if char == _ESCAPE:
+            escaped_char = _consume_escape_sequence(read_char)
+            if escaped_char is None:
+                continue
+            char = escaped_char
         if char == "":
             raise EOFError
         if char in {"\r", "\n"}:
@@ -92,10 +136,12 @@ def _read_masked_tty_unix(output: TextIO, *, mask: str) -> str:
 def _read_masked_tty_windows(output: TextIO, *, mask: str) -> str:
     import msvcrt
 
+    get_wide_char: Callable[[], str] = getattr(msvcrt, "getwch")
+
     def read_char() -> str:
-        char = msvcrt.getwch()
+        char = get_wide_char()
         if char in {"\x00", "\xe0"}:
-            msvcrt.getwch()
+            get_wide_char()
             return "\x00"
         return char
 

--- a/skyvern/cli/masked_prompt.py
+++ b/skyvern/cli/masked_prompt.py
@@ -1,0 +1,142 @@
+"""Masked CLI prompt helpers for secret input."""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Callable
+from typing import Any, TextIO
+
+from rich.console import Console
+from rich.prompt import Prompt
+from rich.text import TextType
+
+_BACKSPACE_CHARS = {"\b", "\x7f"}
+_CTRL_C = "\x03"
+_CTRL_D = "\x04"
+_CTRL_U = "\x15"
+
+
+def _read_masked_line(
+    read_char: Callable[[], str],
+    write: Callable[[str], None],
+    *,
+    mask: str = "*",
+) -> str:
+    """Read one line while echoing a mask character for each entered character."""
+    value: list[str] = []
+
+    while True:
+        char = read_char()
+        if char == "":
+            raise EOFError
+        if char in {"\r", "\n"}:
+            write("\n")
+            return "".join(value)
+        if char == _CTRL_C:
+            write("\n")
+            raise KeyboardInterrupt
+        if char == _CTRL_D:
+            write("\n")
+            raise EOFError
+        if char in _BACKSPACE_CHARS:
+            if value:
+                value.pop()
+                write("\b \b")
+            continue
+        if char == _CTRL_U:
+            write("\b \b" * len(value))
+            value.clear()
+            continue
+        if char < " ":
+            continue
+
+        value.append(char)
+        write(mask)
+
+
+def _read_masked_tty(output: TextIO, *, mask: str = "*") -> str:
+    if os.name == "nt":
+        return _read_masked_tty_windows(output, mask=mask)
+    return _read_masked_tty_unix(output, mask=mask)
+
+
+def _read_masked_tty_unix(output: TextIO, *, mask: str) -> str:
+    import termios
+    import tty
+
+    input_file = sys.stdin
+    fd = input_file.fileno()
+    old_settings = termios.tcgetattr(fd)
+    wrote_newline = False
+
+    def write(text: str) -> None:
+        nonlocal wrote_newline
+        if text.endswith("\n"):
+            wrote_newline = True
+        output.write(text)
+        output.flush()
+
+    try:
+        tty.setcbreak(fd)
+        try:
+            return _read_masked_line(lambda: input_file.read(1), write, mask=mask)
+        except (EOFError, KeyboardInterrupt):
+            if not wrote_newline:
+                write("\n")
+            raise
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+
+
+def _read_masked_tty_windows(output: TextIO, *, mask: str) -> str:
+    import msvcrt
+
+    def read_char() -> str:
+        char = msvcrt.getwch()
+        if char in {"\x00", "\xe0"}:
+            msvcrt.getwch()
+            return "\x00"
+        return char
+
+    def write(text: str) -> None:
+        output.write(text)
+        output.flush()
+
+    return _read_masked_line(read_char, write, mask=mask)
+
+
+def _read_secret_with_mask(
+    console: Console,
+    prompt: TextType,
+    *,
+    stream: TextIO | None = None,
+    mask: str = "*",
+) -> str:
+    console.print(prompt, end="")
+    if stream is not None:
+        return stream.readline().rstrip("\r\n")
+    if not sys.stdin.isatty():
+        return sys.stdin.readline().rstrip("\r\n")
+    return _read_masked_tty(console.file, mask=mask)
+
+
+class MaskedPrompt(Prompt):
+    """Rich prompt that displays ``*`` feedback for secret input."""
+
+    @classmethod
+    def get_input(
+        cls,
+        console: Console,
+        prompt: TextType,
+        password: bool,
+        stream: TextIO | None = None,
+    ) -> str:
+        if password:
+            return _read_secret_with_mask(console, prompt, stream=stream)
+        return super().get_input(console, prompt, password, stream=stream)
+
+
+def ask_secret(prompt: TextType, **kwargs: Any) -> str:
+    """Prompt for a secret and echo ``*`` characters as feedback."""
+    return MaskedPrompt.ask(prompt, password=True, **kwargs)

--- a/tests/unit/test_masked_prompt.py
+++ b/tests/unit/test_masked_prompt.py
@@ -30,6 +30,26 @@ def test_read_masked_line_backspace_removes_last_character() -> None:
     assert "".join(output) == "***\b \b*\n"
 
 
+def test_read_masked_line_ignores_bracketed_paste_markers() -> None:
+    chars = iter("\x1b[200~sk-abc\x1b[201~\n")
+    output: list[str] = []
+
+    result = _read_masked_line(lambda: next(chars), output.append)
+
+    assert result == "sk-abc"
+    assert "".join(output) == "******\n"
+
+
+def test_read_masked_line_ignores_arrow_key_sequences() -> None:
+    chars = iter("ab\x1b[D\n")
+    output: list[str] = []
+
+    result = _read_masked_line(lambda: next(chars), output.append)
+
+    assert result == "ab"
+    assert "".join(output) == "**\n"
+
+
 def test_ask_secret_reads_stream_without_echoing_secret() -> None:
     stream = StringIO("secret-value\n")
     output = StringIO()

--- a/tests/unit/test_masked_prompt.py
+++ b/tests/unit/test_masked_prompt.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from io import StringIO
+
+from rich.console import Console
+
+from skyvern.cli.masked_prompt import _read_masked_line, ask_secret
+
+
+def test_read_masked_line_echoes_one_mask_per_pasted_character() -> None:
+    secret = "sk-test-secret"
+    chars = iter(f"{secret}\n")
+    output: list[str] = []
+
+    result = _read_masked_line(lambda: next(chars), output.append)
+
+    rendered = "".join(output)
+    assert result == secret
+    assert rendered == "*" * len(secret) + "\n"
+    assert secret not in rendered
+
+
+def test_read_masked_line_backspace_removes_last_character() -> None:
+    chars = iter("abc\x7fd\n")
+    output: list[str] = []
+
+    result = _read_masked_line(lambda: next(chars), output.append)
+
+    assert result == "abd"
+    assert "".join(output) == "***\b \b*\n"
+
+
+def test_ask_secret_reads_stream_without_echoing_secret() -> None:
+    stream = StringIO("secret-value\n")
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, color_system=None)
+
+    result = ask_secret("Enter API key", console=console, stream=stream)
+
+    rendered = output.getvalue()
+    assert result == "secret-value"
+    assert "Enter API key:" in rendered
+    assert "secret-value" not in rendered


### PR DESCRIPTION
## Summary
- Add a masked secret prompt helper that echoes `*` characters while preserving secret input values.
- Use the helper for quickstart/init LLM and Skyvern API key prompts.
- Cover paste masking, backspace behavior, and stream handling with focused unit tests.

## Root Cause
Rich/Typer password prompts delegate to `getpass`, which intentionally echoes nothing. That makes pasted API keys look like they were not accepted during quickstart.

## Validation
- `ruff check skyvern/cli/masked_prompt.py skyvern/cli/llm_setup.py skyvern/cli/init_command.py tests/unit/test_masked_prompt.py`
- `ruff format --check skyvern/cli/masked_prompt.py skyvern/cli/llm_setup.py skyvern/cli/init_command.py tests/unit/test_masked_prompt.py`
- `uv run --extra server --group dev pytest tests/unit/test_masked_prompt.py`
- PTY smoke test for masked terminal input
