### PR TITLE
chore(ci): add trevor-cheung to OSS sync workflows

### DIFF
--- a/.github/workflows/auto-merge-sync.yml
+++ b/.github/workflows/auto-merge-sync.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   auto-merge:
     if: >
-      contains(join(github.event.pull_request.labels.*.name, ','), 'sync') && contains('suchintan,wintonzheng,LawyZheng,pedrohsdb,marcmuon,celalzamanoglu,AronPerez,andrewneilson,claude[bot],copilot-swe-agent[bot]', github.event.pull_request.user.login)
+      contains(join(github.event.pull_request.labels.*.name, ','), 'sync') && contains('suchintan,wintonzheng,LawyZheng,pedrohsdb,marcmuon,celalzamanoglu,AronPerez,andrewneilson,trevor-cheung,claude[bot],copilot-swe-agent[bot]', github.event.pull_request.user.login)
 
     runs-on: ubuntu-latest
     steps:
@@ -45,6 +45,9 @@ jobs:
               ;;
             andrewneilson)
               echo "GH_PAT=${{ secrets.ANDREW_GH_PAT }}" >> $GITHUB_OUTPUT
+              ;;
+            trevor-cheung)
+              echo "GH_PAT=${{ secrets.TREVOR_GH_PAT }}" >> $GITHUB_OUTPUT
               ;;
             AronPerez)
               echo "GH_PAT=${{ secrets.AARON_GH_PAT }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/sync-skyvern-cloud.yml
+++ b/.github/workflows/sync-skyvern-cloud.yml
@@ -70,6 +70,11 @@ jobs:
               echo "GIT_EMAIL=andrew@skyvern.com" >> $GITHUB_OUTPUT
               echo "GIT_USERNAME=andrewneilson" >> $GITHUB_OUTPUT
               ;;
+            trevor-cheung)
+              echo "GH_PAT=${{ secrets.TREVOR_GH_PAT }}" >> $GITHUB_OUTPUT
+              echo "GIT_EMAIL=trevor@skyvern.com" >> $GITHUB_OUTPUT
+              echo "GIT_USERNAME=Trevor Cheung" >> $GITHUB_OUTPUT
+              ;;
             claude\[bot\])
               echo "GH_PAT=${{ secrets.SKYVERN_CLOUD_GH_PAT }}" >> $GITHUB_OUTPUT
               echo "GIT_EMAIL=209825114+claude[bot]@users.noreply.github.com" >> $GITHUB_OUTPUT

--- a/.github/workflows/sync-skyvern-cloud.yml
+++ b/.github/workflows/sync-skyvern-cloud.yml
@@ -73,7 +73,7 @@ jobs:
             trevor-cheung)
               echo "GH_PAT=${{ secrets.TREVOR_GH_PAT }}" >> $GITHUB_OUTPUT
               echo "GIT_EMAIL=trevor@skyvern.com" >> $GITHUB_OUTPUT
-              echo "GIT_USERNAME=Trevor Cheung" >> $GITHUB_OUTPUT
+              echo "GIT_USERNAME=trevor-cheung" >> $GITHUB_OUTPUT
               ;;
             claude\[bot\])
               echo "GH_PAT=${{ secrets.SKYVERN_CLOUD_GH_PAT }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

Add trevor-cheung to the allowlist and credential switch in both OSS sync workflows so this account can trigger and auto-merge OSS sync PRs using its own GitHub PAT.

## How Has This Been Tested?

Manually reviewed the workflow logic. Will verify end-to-end by triggering an OSS sync PR as trevor-cheung and confirming auto-merge and credential resolution work correctly.

## Artifacts (if appropriate):

N/A