### PR TITLE
fix(alembic): add nonterminal_status indexes to unblock sync PRs (SKY-9746)

### DIFF
--- a/alembic/versions/2026_05_12_2000-5b15948c8d68_add_status_indexes_for_workflow_runs_and_tasks.py
+++ b/alembic/versions/2026_05_12_2000-5b15948c8d68_add_status_indexes_for_workflow_runs_and_tasks.py
@@ -1,0 +1,45 @@
+"""add status indexes for workflow_runs and tasks to prevent statement timeouts
+
+Revision ID: 5b15948c8d68
+Revises: 78a8db531e69
+Create Date: 2026-05-12 20:00:00.000000+00:00
+
+Mirrors the cloud-side index addition for the equivalent declarations in
+skyvern/forge/sdk/db/models.py. Without this migration, alembic check fails
+because the synced models reference indexes that don't exist in OSS migrations.
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "5b15948c8d68"
+down_revision: Union[str, None] = "78a8db531e69"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET statement_timeout = '3h';")
+        op.execute("""
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_workflow_runs_nonterminal_status
+            ON workflow_runs (status, modified_at, created_at)
+            WHERE status IN ('created', 'queued', 'running', 'paused')
+        """)
+        op.execute("""
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_tasks_nonterminal_status
+            ON tasks (status, modified_at, created_at)
+            WHERE status IN ('created', 'queued', 'running')
+        """)
+        op.execute("RESET statement_timeout;")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("SET statement_timeout = '3h';")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_tasks_nonterminal_status")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_workflow_runs_nonterminal_status")
+        op.execute("RESET statement_timeout;")

--- a/skyvern/forge/sdk/db/models.py
+++ b/skyvern/forge/sdk/db/models.py
@@ -77,7 +77,16 @@ class Base(AsyncAttrs, DeclarativeBase):
 
 class TaskModel(Base):
     __tablename__ = "tasks"
-    __table_args__ = (Index("idx_tasks_org_created", "organization_id", "created_at"),)
+    __table_args__ = (
+        Index("idx_tasks_org_created", "organization_id", "created_at"),
+        Index(
+            "ix_tasks_nonterminal_status",
+            "status",
+            "modified_at",
+            "created_at",
+            postgresql_where=text("status IN ('created', 'queued', 'running')"),
+        ),
+    )
 
     task_id = Column(String, primary_key=True, default=generate_task_id)
     organization_id = Column(String, ForeignKey("organizations.organization_id"))
@@ -406,7 +415,16 @@ class WorkflowTemplateModel(Base):
 
 class WorkflowRunModel(Base):
     __tablename__ = "workflow_runs"
-    __table_args__ = (Index("idx_workflow_runs_org_created", "organization_id", "created_at"),)
+    __table_args__ = (
+        Index("idx_workflow_runs_org_created", "organization_id", "created_at"),
+        Index(
+            "ix_workflow_runs_nonterminal_status",
+            "status",
+            "modified_at",
+            "created_at",
+            postgresql_where=text("status IN ('created', 'queued', 'running', 'paused')"),
+        ),
+    )
 
     workflow_run_id = Column(String, primary_key=True, default=generate_workflow_run_id)
     workflow_id = Column(String, nullable=False)


### PR DESCRIPTION
## Ticket

SKY-9746

## Description

Sync PRs into OSS have been failing `alembic check` since 2026-05-11 (PRs #5948 onward, currently 14 blocked). The cloud migration that added partial indexes on `tasks.status` and `workflow_runs.status` only synced its model changes — not the migration itself, because `.github/sync.yml` covers `skyvern/` but not `alembic/`. So sync-PR branches contain `Index(...)` declarations with no matching migration, and `alembic check` reports "New upgrade operations detected" on every one.

This PR adds:
- An OSS-side migration (`5b15948c8d68`) that creates `ix_tasks_nonterminal_status` and `ix_workflow_runs_nonterminal_status`, mirroring the cloud migration (CONCURRENTLY + autocommit_block + 3h timeout, since these are high-traffic tables).
- The matching `Index(...)` declarations on `TaskModel` and `WorkflowRunModel` so OSS main is internally consistent.

After this lands, every queued sync PR's CI just needs a re-run.

## How Has This Been Tested?

`run_alembic_check.sh` against a freshly created PostgreSQL DB ends with `No new upgrade operations detected.` after this change. Reproduction steps:

```bash
createdb -O skyvern oss_alembic_check
DATABASE_STRING="postgresql+asyncpg://skyvern@localhost/oss_alembic_check" \
  uv run bash run_alembic_check.sh
```

CI on this PR will exercise the same path.

## Artifacts (if appropriate):

n/a — schema-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
