### PR TITLE
fix: guard against None message in raw_response path

### DIFF
--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -1240,7 +1240,7 @@ class LLMAPIHandlerFactory:
                         workflow_run_block_id, organization_id, context, llm_cost, prompt_name
                     )
                 if raw_response:
-                    content = response.choices[0].message.content if response.choices else None
+                    content = response.choices[0].message.content if response.choices and response.choices[0].message is not None else None
                     parsed_response = content or ""
                 else:
                     parsed_response = parse_api_response(response, llm_config.add_assistant_prefix, force_dict)
@@ -1778,7 +1778,7 @@ class LLMAPIHandlerFactory:
                         workflow_run_block_id, organization_id, context, llm_cost, prompt_name
                     )
                 if raw_response:
-                    content = response.choices[0].message.content if response.choices else None
+                    content = response.choices[0].message.content if response.choices and response.choices[0].message is not None else None
                     parsed_response = content or ""
                 else:
                     parsed_response = parse_api_response(response, llm_config.add_assistant_prefix, force_dict)


### PR DESCRIPTION
## What

Extend the existing `if response.choices` guard in `api_handler_factory.py` (two locations in the `raw_response` path) to also check `choices[0].message is not None`.

## Why

The current guard:
```python
content = response.choices[0].message.content if response.choices else None
```

protects against an empty `choices` list (which would cause `IndexError`), but not against `choices[0].message` being `None`. Some providers return HTTP 200 with `message: null` on content-filtered responses (Gemini PROHIBITED_CONTENT is the canonical example). When this happens, `choices[0].message.content` throws `AttributeError: 'NoneType' object has no attribute 'content'`.

## Fix

```python
# Before:
content = response.choices[0].message.content if response.choices else None

# After:
content = response.choices[0].message.content if response.choices and response.choices[0].message is not None else None
```

Both occurrences (line ~1243 and line ~1781) are fixed. The change is minimal and backward-compatible — for any well-formed response the behaviour is identical.