### PR TITLE
Add `use_current_page` flag to skip initial page navigation

### DIFF
--- a/skyvern/client/types/task_run_request.py
+++ b/skyvern/client/types/task_run_request.py
@@ -147,6 +147,11 @@ class TaskRunRequest(UniversalBaseModel):
     Whether to run the task with agent or code. Null means use the default.
     """
 
+    use_current_page: typing.Optional[bool] = pydantic.Field(default=None)
+    """
+    If True, skip the initial page navigation and LLM URL generation, starting exactly where the browser already is.
+    """
+
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
     else:

--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -737,6 +737,7 @@ class ForgeAgent:
                 and not task.data_extraction_goal
                 and not task.complete_criterion
                 and not task.terminate_criterion
+                and not task.use_current_page
             ):
                 # most likely a GOTO_URL task block
                 page = await browser_state.must_get_working_page()

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -232,7 +232,7 @@ async def run_task(
         data_extraction_schema = run_request.data_extraction_schema
         navigation_goal = run_request.prompt
         navigation_payload = None
-        if not url:
+        if not url and not run_request.use_current_page:
             task_generation = await task_v1_service.generate_task(
                 user_prompt=run_request.prompt,
                 organization=current_org,
@@ -264,6 +264,7 @@ async def run_task(
             max_screenshot_scrolls=run_request.max_screenshot_scrolls,
             extra_http_headers=run_request.extra_http_headers,
             browser_address=run_request.browser_address,
+            use_current_page=run_request.use_current_page,
         )
         task_v1_response = await task_v1_service.run_task(
             task=task_v1_request,

--- a/skyvern/forge/sdk/schemas/tasks.py
+++ b/skyvern/forge/sdk/schemas/tasks.py
@@ -129,6 +129,10 @@ class TaskBase(BaseModel):
         default=True,
         description="If False, omit the scraped page text dump from the extract-information prompt. ExtractionBlock opts out; everything else keeps the default.",
     )
+    use_current_page: bool = Field(
+        default=False,
+        description="If True, skip the initial page navigation and LLM URL generation, starting exactly where the browser already is.",
+    )
 
 
 class TaskRequest(TaskBase):

--- a/skyvern/schemas/runs.py
+++ b/skyvern/schemas/runs.py
@@ -149,6 +149,10 @@ class TaskRunRequest(BaseModel):
         description="Whether to run the task with agent or code. Null means use the default.",
         examples=["agent", "code"],
     )
+    use_current_page: bool = Field(
+        default=False,
+        description="If True, skip the initial page navigation and LLM URL generation, starting exactly where the browser already is.",
+    )
 
     @field_validator("run_with", mode="before")
     @classmethod

--- a/skyvern/webeye/real_browser_manager.py
+++ b/skyvern/webeye/real_browser_manager.py
@@ -121,7 +121,7 @@ class RealBrowserManager(BrowserManager):
                 else:
                     LOG.warning("Organization ID is not set for task", task_id=task.task_id)
                 page = await browser_state.get_working_page()
-                if page:
+                if page and not getattr(task, "use_current_page", False):
                     await browser_state.navigate_to_url(page=page, url=task.url)
                 else:
                     LOG.warning("Browser state has no page", workflow_run_id=task.workflow_run_id)
@@ -163,6 +163,7 @@ class RealBrowserManager(BrowserManager):
             organization_id=task.organization_id,
             extra_http_headers=task.extra_http_headers,
             browser_address=task.browser_address,
+            use_current_page=getattr(task, "use_current_page", False),
         )
         return browser_state
 

--- a/skyvern/webeye/real_browser_state.py
+++ b/skyvern/webeye/real_browser_state.py
@@ -87,6 +87,7 @@ class RealBrowserState(BrowserState):
         extra_http_headers: dict[str, str] | None = None,
         browser_address: str | None = None,
         browser_profile_id: str | None = None,
+        use_current_page: bool = False,
     ) -> None:
         if self.browser_context is None:
             LOG.info("creating browser context")
@@ -128,7 +129,7 @@ class RealBrowserState(BrowserState):
             if not use_existing_page:
                 await self._close_all_other_pages()
 
-            if url and page.url.rstrip("/") != url.rstrip("/"):
+            if url and not use_current_page and page.url.rstrip("/") != url.rstrip("/"):
                 await self.navigate_to_url(page=page, url=url)
 
     async def _wait_for_settle(self) -> None:
@@ -257,6 +258,7 @@ class RealBrowserState(BrowserState):
         extra_http_headers: dict[str, str] | None = None,
         browser_address: str | None = None,
         browser_profile_id: str | None = None,
+        use_current_page: bool = False,
     ) -> Page:
         page = await self.get_working_page()
         if page is not None:
@@ -274,6 +276,7 @@ class RealBrowserState(BrowserState):
                 extra_http_headers=extra_http_headers,
                 browser_address=browser_address,
                 browser_profile_id=browser_profile_id,
+                use_current_page=use_current_page,
             )
         except Exception as e:
             error_message = e.error_message if isinstance(e, FailedToNavigateToUrl) else str(e)
@@ -295,6 +298,7 @@ class RealBrowserState(BrowserState):
                 extra_http_headers=extra_http_headers,
                 browser_address=browser_address,
                 browser_profile_id=browser_profile_id,
+                use_current_page=use_current_page,
             )
         page = await self.__assert_page()
 
@@ -313,6 +317,7 @@ class RealBrowserState(BrowserState):
                 extra_http_headers=extra_http_headers,
                 browser_address=browser_address,
                 browser_profile_id=browser_profile_id,
+                use_current_page=use_current_page,
             )
             page = await self.__assert_page()
         return page


### PR DESCRIPTION
## Summary

Adds a `use_current_page` flag to `TaskRunRequest` and `TaskBase`. When `True`, the agent skips the initial `page.goto()` and the LLM task generation that infers a URL from the prompt. The agent starts exactly where the browser already is — useful when you've pre-navigated the browser and just want to run a task on the current page.

## Changes

| File | Change |
|------|--------|
| `skyvern/forge/sdk/schemas/tasks.py` | Added `use_current_page: bool = False` to `TaskBase` |
| `skyvern/schemas/runs.py` | Added `use_current_page: bool = False` to `TaskRunRequest` |
| `skyvern/client/types/task_run_request.py` | Mirrored in Python SDK client model |
| `skyvern/forge/sdk/routes/agent_protocol.py` | Skip LLM task generation when flag is set; pass flag to `TaskRequest` |
| `skyvern/webeye/real_browser_state.py` | Skip navigation URL check in `check_and_fix_state` and `get_or_create_page` |
| `skyvern/webeye/real_browser_manager.py` | Pass `use_current_page` through to `get_or_create_page`; skip `navigate_to_url` when flag is set |
| `skyvern/forge/agent.py` | Skip GOTO_URL block when flag is set |