### PR TITLE
feat: add ARTIFACT_AUTH_DISABLED for self-hosted deployments

### DIFF
--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -526,6 +526,19 @@ class Settings(BaseSettings):
     old key in keys until all URLs it signed have expired (12 h), then remove it.
     """
 
+    ARTIFACT_AUTH_DISABLED: bool = False
+    """
+    When True, the ``/artifacts/{id}/content`` endpoint skips authentication
+    checks entirely.  Intended for self-hosted deployments where artifact URLs
+    are accessed directly from the browser (e.g. in ``<img>`` tags) and cannot
+    carry an ``X-API-Key`` header.
+
+    Requires ``SKYVERN_BASE_URL`` to be set to the server\'s external address so
+    that generated artifact URLs point to the same origin.
+
+    Defaults to False.  Has no effect when ``ARTIFACT_CONTENT_HMAC_KEYRING`` is set.
+    """
+
     # Debug Session Settings
     DEBUG_SESSION_TIMEOUT_MINUTES: int = 20
     """

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -1695,7 +1695,10 @@ async def get_artifact_content(
 ) -> Response:
     artifact = None
 
-    if sig is not None and expiry is not None and kid is not None:
+    if settings.ARTIFACT_AUTH_DISABLED:
+        # Unauthenticated path — skip auth entirely (self-hosted convenience).
+        artifact = await app.DATABASE.artifacts.get_artifact_by_id_no_org(artifact_id=artifact_id)
+    elif sig is not None and expiry is not None and kid is not None:
         # HMAC-signed URL path — no org-level API key required.
         if not settings.ARTIFACT_CONTENT_HMAC_KEYRING:
             raise HTTPException(


### PR DESCRIPTION
## Summary

Adds `ARTIFACT_AUTH_DISABLED` config option (default `False`) that skips authentication on the `/artifacts/{id}/content` endpoint. Intended for self-hosted deployments where artifact URLs are loaded directly by the browser (e.g. `<img>` tags) and cannot carry an `X-API-Key` header.

## Motivation

Self-hosted Skyvern instances serve screenshot and recording URLs to the browser. Since browsers cannot add custom headers to `<img>` or `<video>` elements, every artifact request returns 403. The only existing workaround is `ARTIFACT_CONTENT_HMAC_KEYRING`, which requires generating and managing an HMAC signing key — unnecessary complexity for single-tenant self-hosted setups.

## Changes

- **`skyvern/config.py`**: Added `ARTIFACT_AUTH_DISABLED: bool = False` setting
- **`skyvern/forge/sdk/routes/agent_protocol.py`**: In `get_artifact_content`, check `ARTIFACT_AUTH_DISABLED` first — if `True`, look up the artifact without org auth

## Usage

```yaml
environment:
  SKYVERN_BASE_URL: http://localhost:8000
  ARTIFACT_AUTH_DISABLED: "true"
```

Has no effect when `ARTIFACT_CONTENT_HMAC_KEYRING` is set.