### PR TITLE
feat: add Baidu Qianfan LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,10 +61,17 @@ ENABLE_GEMINI=false
 # GEMINI_API_KEY: Your Gemini API key for accessing models like Gemini 2.5 Pro.
 GEMINI_API_KEY=""
 
+# ENABLE_QIANFAN: Set to true to enable Baidu Qianfan / ERNIE as a language model provider.
+ENABLE_QIANFAN=false
+# QIANFAN_API_KEY: Your Baidu Qianfan API key.
+QIANFAN_API_KEY=""
+# QIANFAN_API_BASE: Optional OpenAI-compatible base URL. Defaults to Baidu's international endpoint.
+QIANFAN_API_BASE="https://api.baiduqianfan.ai/v1"
+
 # LLM_KEY: The chosen language model to use. This should be one of the models
 # provided by the enabled LLM providers (e.g., OPENAI_GPT5_5, OPENAI_GPT5_4,
 # ANTHROPIC_CLAUDE4.7_OPUS, ANTHROPIC_CLAUDE4.6_SONNET, GEMINI_3_PRO,
-# BEDROCK_ANTHROPIC_CLAUDE4.7_OPUS_INFERENCE_PROFILE).
+# BEDROCK_ANTHROPIC_CLAUDE4.7_OPUS_INFERENCE_PROFILE, QIANFAN_ERNIE_5_0).
 # See docs: https://www.skyvern.com/docs/self-hosted/llm-configuration
 LLM_KEY=""
 # a cheaper LLM providers to help finishing some small tasks, like custom selection or svg conversion. If empty, it will be the same as LLM_KEY

--- a/README.md
+++ b/README.md
@@ -555,6 +555,7 @@ More extensive documentation can be found on our [📕 docs page](https://www.sk
 | Azure OpenAI | Any GPT models deployed to your Azure subscription |
 | AWS Bedrock | Claude 4.7, Claude 4.6 (Sonnet, Opus), Claude 4.5 (Sonnet, Opus) |
 | Gemini | Gemini 3.1 Pro, Gemini 3 Flash, Gemini 2.5 Pro/Flash |
+| Baidu Qianfan / ERNIE | ERNIE 5.1, ERNIE 5.0, ERNIE 4.5 Turbo |
 | Ollama | Run any locally hosted model via [Ollama](https://github.com/ollama/ollama) |
 | OpenRouter | Access models through [OpenRouter](https://openrouter.ai) |
 | OpenAI-compatible | Any custom API endpoint that follows OpenAI's API format (via [liteLLM](https://docs.litellm.ai/docs/providers/openai_compatible)) |

--- a/docs/developers/self-hosted/llm-configuration.mdx
+++ b/docs/developers/self-hosted/llm-configuration.mdx
@@ -325,6 +325,37 @@ MINIMAX_API_BASE=https://api.minimax.io/v1
 
 ---
 
+## Baidu Qianfan / ERNIE
+
+[Baidu Qianfan](https://intl.cloud.baidu.com/product/qianfan) provides access to ERNIE models through an OpenAI-compatible chat completions API.
+
+```bash .env
+ENABLE_QIANFAN=true
+QIANFAN_API_KEY=your-qianfan-api-key
+LLM_KEY=QIANFAN_ERNIE_5_0
+```
+
+### Available models
+
+| LLM_KEY | Model | Notes |
+|---------|-------|-------|
+| `QIANFAN_ERNIE_5_1` | `ernie-5.1` | |
+| `QIANFAN_ERNIE_5_0` | `ernie-5.0` | Vision support |
+| `QIANFAN_ERNIE_4_5_TURBO_128K` | `ernie-4.5-turbo-128k` | Long-context model |
+| `QIANFAN_ERNIE_4_5_TURBO_VL` | `ernie-4.5-turbo-vl` | Vision support |
+
+### Optional settings
+
+```bash .env
+# Default OpenAI-compatible endpoint from Baidu's international docs
+QIANFAN_API_BASE=https://api.baiduqianfan.ai/v1
+
+# China region alternative
+QIANFAN_API_BASE=https://qianfan.baidubce.com/v2
+```
+
+---
+
 ## VolcEngine (ByteDance Doubao)
 
 [VolcEngine](https://www.volcengine.com/) provides access to ByteDance's Doubao models with vision support.

--- a/skyvern/cli/doctor.py
+++ b/skyvern/cli/doctor.py
@@ -493,6 +493,7 @@ def _check_llm_config() -> CheckResult:
         "OLLAMA": {"enable": "ENABLE_OLLAMA", "key": None},
         "OPENROUTER": {"enable": "ENABLE_OPENROUTER", "key": "OPENROUTER_API_KEY"},
         "GROQ": {"enable": "ENABLE_GROQ", "key": "GROQ_API_KEY"},
+        "QIANFAN": {"enable": "ENABLE_QIANFAN", "key": "QIANFAN_API_KEY"},
     }
 
     enabled = []

--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -285,6 +285,11 @@ class Settings(BaseSettings):
     VOLCENGINE_API_BASE: str = "https://ark.cn-beijing.volces.com/api/v3"
     VOLCENGINE_CUA_LLM_KEY: str = "VOLCENGINE_DOUBAO_1_5_THINKING_VISION_PRO"
 
+    # BAIDU QIANFAN / ERNIE
+    ENABLE_QIANFAN: bool = False
+    QIANFAN_API_KEY: str | None = None
+    QIANFAN_API_BASE: str = "https://api.baiduqianfan.ai/v1"
+
     # OPENAI COMPATIBLE
     OPENAI_COMPATIBLE_MODEL_NAME: str | None = None
     OPENAI_COMPATIBLE_API_KEY: str | None = None

--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -945,6 +945,33 @@ if settings.ENABLE_VOLCENGINE:
         ),
     )
 
+if settings.ENABLE_QIANFAN:
+    qianfan_models = {
+        "QIANFAN_ERNIE_5_1": ("ernie-5.1", False, 65536),
+        "QIANFAN_ERNIE_5_0": ("ernie-5.0", True, 65536),
+        "QIANFAN_ERNIE_4_5_TURBO_128K": ("ernie-4.5-turbo-128k", False, 12288),
+        "QIANFAN_ERNIE_4_5_TURBO_VL": ("ernie-4.5-turbo-vl", True, 16384),
+    }
+
+    for llm_key, (model, supports_vision, max_completion_tokens) in qianfan_models.items():
+        model_name = f"openai/{model}"
+        LLMConfigRegistry.register_config(
+            llm_key,
+            LLMConfig(
+                model_name,
+                ["QIANFAN_API_KEY"],
+                litellm_params=LiteLLMParams(
+                    api_key=settings.QIANFAN_API_KEY,
+                    api_base=settings.QIANFAN_API_BASE,
+                    api_version=None,
+                    model_info={"model_name": model_name},
+                ),
+                supports_vision=supports_vision,
+                add_assistant_prefix=False,
+                max_completion_tokens=max_completion_tokens,
+            ),
+        )
+
 if settings.ENABLE_GEMINI:
     LLMConfigRegistry.register_config(
         "GEMINI_FLASH_2_0",

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -155,6 +155,52 @@ def test_streaming_smoke_test_requires_api_key(monkeypatch: pytest.MonkeyPatch) 
     assert "No API key" in result.detail
 
 
+def test_llm_provider_check_reports_qianfan_missing_api_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text(
+        "\n".join(
+            [
+                "ENABLE_QIANFAN=true",
+                "LLM_KEY=QIANFAN_ERNIE_5_0",
+                "",
+            ]
+        )
+    )
+    monkeypatch.delenv("QIANFAN_API_KEY", raising=False)
+
+    result = doctor_module._check_llm_config()
+
+    assert result.status == "error"
+    assert "Enabled: QIANFAN" in result.detail
+    assert "QIANFAN_API_KEY" in result.detail
+
+
+def test_llm_provider_check_accepts_qianfan_with_api_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text(
+        "\n".join(
+            [
+                "ENABLE_QIANFAN=true",
+                "QIANFAN_API_KEY=test-key",
+                "LLM_KEY=QIANFAN_ERNIE_5_0",
+                "",
+            ]
+        )
+    )
+
+    result = doctor_module._check_llm_config()
+
+    assert result.status == "ok"
+    assert "LLM_KEY=QIANFAN_ERNIE_5_0" in result.detail
+    assert "enabled: QIANFAN" in result.detail
+
+
 def test_compose_database_connection_can_satisfy_database_check(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_qianfan_provider.py
+++ b/tests/unit/test_qianfan_provider.py
@@ -1,0 +1,81 @@
+import importlib
+
+import pytest
+
+from skyvern import config
+from skyvern.config import Settings
+from skyvern.forge.sdk.api.llm import config_registry
+from skyvern.forge.sdk.api.llm.exceptions import MissingLLMProviderEnvVarsError
+from skyvern.forge.sdk.settings_manager import SettingsManager
+
+
+@pytest.fixture(autouse=True)
+def restore_settings_and_registry():
+    original_settings = config.settings
+    yield
+    SettingsManager.set_settings(original_settings)
+    config.settings = original_settings
+    config_registry.LLMConfigRegistry._configs.clear()
+    importlib.reload(config_registry)
+
+
+def _reload_registry(settings: Settings):
+    SettingsManager.set_settings(settings)
+    config.settings = settings
+    config_registry.LLMConfigRegistry._configs.clear()
+    return importlib.reload(config_registry)
+
+
+def test_qianfan_settings_defaults_to_openai_compatible_international_endpoint() -> None:
+    settings = Settings()
+
+    assert settings.ENABLE_QIANFAN is False
+    assert settings.QIANFAN_API_KEY is None
+    assert settings.QIANFAN_API_BASE == "https://api.baiduqianfan.ai/v1"
+
+
+def test_qianfan_registers_expected_ernie_models() -> None:
+    registry_module = _reload_registry(
+        Settings(
+            ENABLE_QIANFAN=True,
+            QIANFAN_API_KEY="test-key",
+            QIANFAN_API_BASE="https://api.baiduqianfan.ai/v1",
+        )
+    )
+
+    expected = {
+        "QIANFAN_ERNIE_5_1": ("openai/ernie-5.1", False, 65536),
+        "QIANFAN_ERNIE_5_0": ("openai/ernie-5.0", True, 65536),
+        "QIANFAN_ERNIE_4_5_TURBO_128K": ("openai/ernie-4.5-turbo-128k", False, 12288),
+        "QIANFAN_ERNIE_4_5_TURBO_VL": ("openai/ernie-4.5-turbo-vl", True, 16384),
+    }
+
+    for llm_key, (model_name, supports_vision, max_tokens) in expected.items():
+        llm_config = registry_module.LLMConfigRegistry.get_config(llm_key)
+
+        assert llm_config.model_name == model_name
+        assert llm_config.required_env_vars == ["QIANFAN_API_KEY"]
+        assert llm_config.supports_vision is supports_vision
+        assert llm_config.add_assistant_prefix is False
+        assert llm_config.max_completion_tokens == max_tokens
+        assert llm_config.litellm_params == {
+            "api_key": "test-key",
+            "api_base": "https://api.baiduqianfan.ai/v1",
+            "api_version": None,
+            "model_info": {"model_name": model_name},
+        }
+
+
+def test_qianfan_registration_requires_api_key() -> None:
+    settings = Settings(ENABLE_QIANFAN=True, QIANFAN_API_KEY=None)
+
+    SettingsManager.set_settings(settings)
+    config.settings = settings
+    config_registry.LLMConfigRegistry._configs.clear()
+
+    try:
+        importlib.reload(config_registry)
+    except MissingLLMProviderEnvVarsError as exc:
+        assert "QIANFAN_API_KEY" in str(exc)
+    else:
+        raise AssertionError("Expected Qianfan registration to require QIANFAN_API_KEY")


### PR DESCRIPTION
## Summary

- Add first-class Baidu Qianfan / ERNIE LLM provider settings with a documented OpenAI-compatible default endpoint.
- Register explicit Qianfan ERNIE model keys through the existing LiteLLM `openai/<model>` path, with conservative vision flags for `ernie-5.0` and `ernie-4.5-turbo-vl`.
- Add Qianfan coverage to `skyvern doctor`, `.env.example`, README, self-hosted LLM docs, and focused unit tests.

## Details

This adds a dedicated Qianfan provider path so users no longer need to configure Baidu Qianfan through the generic `OPENAI_COMPATIBLE` provider.

New environment variables:

```env
ENABLE_QIANFAN=true
QIANFAN_API_KEY=your-qianfan-api-key
QIANFAN_API_BASE=https://api.baiduqianfan.ai/v1
LLM_KEY=QIANFAN_ERNIE_5_0
```

The default `QIANFAN_API_BASE` follows Baidu's international OpenAI-compatible endpoint. The docs also note the China-region alternative:

```env
QIANFAN_API_BASE=https://qianfan.baidubce.com/v2
```

New model keys:

| LLM_KEY | Model | Vision |
|---|---|---|
| `QIANFAN_ERNIE_5_1` | `ernie-5.1` | No |
| `QIANFAN_ERNIE_5_0` | `ernie-5.0` | Yes |
| `QIANFAN_ERNIE_4_5_TURBO_128K` | `ernie-4.5-turbo-128k` | No |
| `QIANFAN_ERNIE_4_5_TURBO_VL` | `ernie-4.5-turbo-vl` | Yes |

## How Has This Been Tested?

- `uv run --extra local pytest tests/unit/test_qianfan_provider.py tests/test_cli_doctor.py::test_llm_provider_check_reports_qianfan_missing_api_key tests/test_cli_doctor.py::test_llm_provider_check_accepts_qianfan_with_api_key -q`
  - `5 passed`
- `uv run --extra local ruff check skyvern/config.py skyvern/forge/sdk/api/llm/config_registry.py skyvern/cli/doctor.py tests/unit/test_qianfan_provider.py tests/test_cli_doctor.py`
  - `All checks passed!`
- Live smoke tested Qianfan with LiteLLM against `https://api.baiduqianfan.ai/v1`:
  - `openai/ernie-5.0` text completion returned the expected token.
  - `openai/ernie-5.0` vision request correctly identified a red JPEG image.
  - `openai/ernie-4.5-turbo-vl` vision request correctly identified a blue JPEG image.

## Artifacts

N/A
