### PR TITLE
feat: add OrcaRouter as an LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,16 @@ YUTORI_MODEL="n1.5-latest"
 # YUTORI_TOOL_SET: Tool set for Navigator. Options: "" (default core), "browser_tools_core-20260403", "browser_tools_expanded-20260403".
 YUTORI_TOOL_SET=""
 
+# ENABLE_ORCAROUTER: Set to true to enable OrcaRouter as a language model provider.
+ENABLE_ORCAROUTER=false
+# ORCAROUTER_API_KEY: Your OrcaRouter API key (starts with sk-orca-).
+ORCAROUTER_API_KEY=""
+# ORCAROUTER_MODEL: The OrcaRouter model identifier to use. See https://api.orcarouter.ai/v1/models.
+# Examples: "orcarouter/auto", "anthropic/claude-sonnet-4.6", "openai/gpt-5", "google/gemini-3-pro-preview".
+ORCAROUTER_MODEL=""
+# ORCAROUTER_API_BASE: The base URL for the OrcaRouter API.
+ORCAROUTER_API_BASE="https://api.orcarouter.ai/v1"
+
 # LLM_KEY: The chosen language model to use. This should be one of the models
 # provided by the enabled LLM providers (e.g., OPENAI_GPT5_5, OPENAI_GPT5_4,
 # ANTHROPIC_CLAUDE4.7_OPUS, ANTHROPIC_CLAUDE4.6_SONNET, GEMINI_3_PRO,

--- a/skyvern/cli/doctor.py
+++ b/skyvern/cli/doctor.py
@@ -492,6 +492,7 @@ def _check_llm_config() -> CheckResult:
         "BEDROCK": {"enable": "ENABLE_BEDROCK", "key": None},
         "OLLAMA": {"enable": "ENABLE_OLLAMA", "key": None},
         "OPENROUTER": {"enable": "ENABLE_OPENROUTER", "key": "OPENROUTER_API_KEY"},
+        "ORCAROUTER": {"enable": "ENABLE_ORCAROUTER", "key": "ORCAROUTER_API_KEY"},
         "GROQ": {"enable": "ENABLE_GROQ", "key": "GROQ_API_KEY"},
     }
 

--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -433,6 +433,12 @@ class Settings(BaseSettings):
     OPENROUTER_MODEL: str | None = None
     OPENROUTER_API_BASE: str = "https://openrouter.ai/api/v1"
 
+    # ORCAROUTER
+    ENABLE_ORCAROUTER: bool = False
+    ORCAROUTER_API_KEY: str | None = None
+    ORCAROUTER_MODEL: str | None = None
+    ORCAROUTER_API_BASE: str = "https://api.orcarouter.ai/v1"
+
     # GROQ
     ENABLE_GROQ: bool = False
     GROQ_API_KEY: str | None = None

--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -1460,6 +1460,11 @@ class LLMAPIHandlerFactory:
             llm_caller = LLMCaller(llm_key=llm_key, base_parameters=base_parameters)
             return llm_caller.call
 
+        # OrcaRouter talks OpenAI-compatible REST; route through LLMCaller to skip LiteLLM.
+        if llm_key == "ORCAROUTER":
+            llm_caller = LLMCaller(llm_key=llm_key, base_parameters=base_parameters)
+            return llm_caller.call
+
         # For GitHub Copilot via OPENAI_COMPATIBLE, use LLMCaller for a custom header
         if llm_key == "OPENAI_COMPATIBLE" and LLMAPIHandlerFactory.is_github_copilot_endpoint():
             llm_caller = LLMCaller(llm_key=llm_key, base_parameters=base_parameters)
@@ -2081,6 +2086,16 @@ class LLMCaller:
             self.openai_client = AsyncOpenAI(
                 api_key=settings.OPENROUTER_API_KEY,
                 base_url=settings.OPENROUTER_API_BASE,
+                http_client=ForgeAsyncHttpxClientWrapper(),
+            )
+        elif self.llm_key == "ORCAROUTER":
+            # OrcaRouter is an OpenAI-compatible multi-model gateway. Talk to it directly
+            # via AsyncOpenAI (LiteLLM doesn't have a native provider for it). The model id
+            # sent on the wire is the one configured in ORCAROUTER_MODEL.
+            self.llm_key = settings.ORCAROUTER_MODEL or self.llm_key
+            self.openai_client = AsyncOpenAI(
+                api_key=settings.ORCAROUTER_API_KEY,
+                base_url=settings.ORCAROUTER_API_BASE,
                 http_client=ForgeAsyncHttpxClientWrapper(),
             )
         elif self.llm_key == "OPENAI_COMPATIBLE" and LLMAPIHandlerFactory.is_github_copilot_endpoint():
@@ -2707,6 +2722,11 @@ class LLMCaller:
     ) -> LLMCallStats:
         empty_call_stats = LLMCallStats()
         if self.original_llm_key.startswith("openrouter/"):
+            return empty_call_stats
+
+        if self.original_llm_key == "ORCAROUTER":
+            # OrcaRouter usage shape varies per upstream model; skip stats accounting
+            # to match the OpenRouter LLMCaller path.
             return empty_call_stats
 
         # Handle OPENAI_COMPATIBLE provider GitHub Copilot

--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -1859,6 +1859,30 @@ if settings.ENABLE_OPENROUTER:
                 ),
             ),
         )
+if settings.ENABLE_ORCAROUTER:
+    # OrcaRouter is wired through LLMAPIHandlerFactory.LLMCaller (see ORCAROUTER branch in
+    # api_handler_factory.LLMCaller.__init__), which calls the OrcaRouter REST API directly
+    # via AsyncOpenAI — LiteLLM is not on the path. We register the bare model id so the
+    # caller sends exactly what OrcaRouter expects (e.g. "anthropic/claude-sonnet-4.6").
+    if settings.ORCAROUTER_MODEL:
+        orcarouter_model_name = settings.ORCAROUTER_MODEL
+        LLMConfigRegistry.register_config(
+            "ORCAROUTER",
+            LLMConfig(
+                orcarouter_model_name,
+                ["ORCAROUTER_API_KEY", "ORCAROUTER_MODEL"],
+                supports_vision=settings.LLM_CONFIG_SUPPORT_VISION,
+                add_assistant_prefix=False,
+                max_completion_tokens=settings.LLM_CONFIG_MAX_TOKENS,
+                litellm_params=LiteLLMParams(
+                    api_key=settings.ORCAROUTER_API_KEY,
+                    api_base=settings.ORCAROUTER_API_BASE,
+                    api_version=None,
+                    model_info={"model_name": orcarouter_model_name},
+                ),
+            ),
+        )
+
 if settings.ENABLE_GROQ:
     # Register Groq model configured in settings
     if settings.GROQ_MODEL:

--- a/tests/unit_tests/test_orcarouter_integration.py
+++ b/tests/unit_tests/test_orcarouter_integration.py
@@ -1,0 +1,148 @@
+import importlib
+import json
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from skyvern import config
+from skyvern.forge import app
+from skyvern.forge.forge_app_initializer import start_forge_app
+from skyvern.forge.sdk.api.llm import api_handler_factory, config_registry
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_forge_app():
+    start_forge_app()
+    yield
+
+
+class DummyResponse(dict):
+    def __init__(self, content: str):
+        super().__init__({"choices": [{"message": {"content": content}}], "usage": {}})
+        self.choices = [types.SimpleNamespace(message=types.SimpleNamespace(content=content))]
+
+    def model_dump_json(self, indent: int = 2):
+        return json.dumps(self, indent=indent)
+
+    def model_dump(self):
+        return self
+
+
+class DummyArtifactManager:
+    async def create_llm_artifact(self, *args, **kwargs):
+        return None
+
+    async def bulk_create_artifacts(self, *args, **kwargs):
+        return None
+
+
+def _apply_orcarouter_settings(monkeypatch, *, model: str = "anthropic/claude-sonnet-4.6") -> None:
+    """Patch the live settings object so config_registry reload sees the new values.
+
+    importlib.reload rebuilds the LLMConfigRegistry class, but api_handler_factory still
+    holds a reference to the pre-reload class. Rebind it after reload so the handler
+    factory and the test see the same registry instance.
+    """
+    monkeypatch.setattr(config.settings, "ENABLE_ORCAROUTER", True)
+    monkeypatch.setattr(config.settings, "ORCAROUTER_API_KEY", "key")
+    monkeypatch.setattr(config.settings, "ORCAROUTER_MODEL", model)
+    monkeypatch.setattr(config.settings, "ORCAROUTER_API_BASE", "https://api.orcarouter.ai/v1")
+    monkeypatch.setattr(config.settings, "LLM_KEY", "ORCAROUTER")
+
+    config_registry.LLMConfigRegistry._configs.clear()
+    importlib.reload(config_registry)
+    monkeypatch.setattr(api_handler_factory, "LLMConfigRegistry", config_registry.LLMConfigRegistry)
+
+
+def test_orcarouter_config_registration(monkeypatch):
+    """ORCAROUTER registers with the raw model id — no LiteLLM provider prefix."""
+    _apply_orcarouter_settings(monkeypatch, model="anthropic/claude-sonnet-4.6")
+
+    cfg = config_registry.LLMConfigRegistry.get_config("ORCAROUTER")
+    assert cfg.model_name == "anthropic/claude-sonnet-4.6"
+    assert cfg.litellm_params["api_key"] == "key"
+    assert cfg.litellm_params["api_base"] == "https://api.orcarouter.ai/v1"
+    assert cfg.litellm_params["model_info"]["model_name"] == "anthropic/claude-sonnet-4.6"
+
+
+def test_orcarouter_skipped_when_model_unset(monkeypatch):
+    """Mirrors the OpenRouter/Groq guard: registration is skipped when ORCAROUTER_MODEL is empty."""
+    monkeypatch.setattr(config.settings, "ENABLE_ORCAROUTER", True)
+    monkeypatch.setattr(config.settings, "ORCAROUTER_API_KEY", "key")
+    monkeypatch.setattr(config.settings, "ORCAROUTER_MODEL", "")
+    monkeypatch.setattr(config.settings, "ORCAROUTER_API_BASE", "https://api.orcarouter.ai/v1")
+
+    config_registry.LLMConfigRegistry._configs.clear()
+    importlib.reload(config_registry)
+
+    assert not config_registry.LLMConfigRegistry.is_registered("ORCAROUTER")
+
+
+def test_orcarouter_llmcaller_bypasses_litellm(monkeypatch):
+    """LLMCaller for ORCAROUTER should set up AsyncOpenAI against the OrcaRouter base URL
+    and rewrite self.llm_key to the configured model id (no LiteLLM in the path)."""
+    _apply_orcarouter_settings(monkeypatch, model="anthropic/claude-sonnet-4.6")
+
+    captured_kwargs: dict = {}
+
+    def _fake_async_openai(**kwargs):
+        captured_kwargs.update(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr(api_handler_factory, "AsyncOpenAI", _fake_async_openai)
+
+    caller = api_handler_factory.LLMCaller(llm_key="ORCAROUTER")
+    assert caller.openai_client is not None
+    assert caller.llm_key == "anthropic/claude-sonnet-4.6"
+    assert caller.original_llm_key == "ORCAROUTER"
+    assert captured_kwargs["api_key"] == "key"
+    assert captured_kwargs["base_url"] == "https://api.orcarouter.ai/v1"
+
+
+@pytest.mark.asyncio
+async def test_orcarouter_basic_completion(monkeypatch):
+    """End-to-end: ORCAROUTER handler should hit the OrcaRouter AsyncOpenAI client with
+    the configured model id, and never touch litellm.acompletion."""
+    _apply_orcarouter_settings(monkeypatch)
+
+    monkeypatch.setattr(app, "ARTIFACT_MANAGER", DummyArtifactManager())
+
+    completions_mock = AsyncMock(return_value=DummyResponse('{"result": "ok"}'))
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = completions_mock
+    monkeypatch.setattr(api_handler_factory, "AsyncOpenAI", lambda **kwargs: mock_client)
+
+    # Guard: litellm.acompletion must not be invoked on this path.
+    sentinel_litellm = AsyncMock(side_effect=AssertionError("litellm.acompletion should not be called"))
+    monkeypatch.setattr(api_handler_factory.litellm, "acompletion", sentinel_litellm)
+
+    handler = api_handler_factory.LLMAPIHandlerFactory.get_llm_api_handler("ORCAROUTER")
+    result = await handler("hi", "test")
+
+    assert result == {"result": "ok"}
+    completions_mock.assert_called_once()
+    sentinel_litellm.assert_not_called()
+    assert completions_mock.call_args.kwargs["model"] == "anthropic/claude-sonnet-4.6"
+
+
+@pytest.mark.asyncio
+async def test_orcarouter_error_propagation(monkeypatch):
+    """Upstream API errors should surface as LLMProviderError, matching other LLMCaller paths."""
+    _apply_orcarouter_settings(monkeypatch)
+
+    monkeypatch.setattr(app, "ARTIFACT_MANAGER", DummyArtifactManager())
+
+    class DummyAPIError(Exception):
+        pass
+
+    async def _raise(*args, **kwargs):
+        raise DummyAPIError("boom")
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create = _raise
+    monkeypatch.setattr(api_handler_factory, "AsyncOpenAI", lambda **kwargs: mock_client)
+
+    handler = api_handler_factory.LLMAPIHandlerFactory.get_llm_api_handler("ORCAROUTER")
+    with pytest.raises(api_handler_factory.LLMProviderError):
+        await handler("hi", "test")


### PR DESCRIPTION
## Description

Adds [OrcaRouter](https://api.orcarouter.ai/v1) as a first-class LLM provider. OrcaRouter fronts 160+ upstream models (Anthropic / OpenAI / Google / etc.) behind a single OpenAI-compatible endpoint, so the configured `ORCAROUTER_MODEL` (e.g. `anthropic/claude-sonnet-4.6`, `openai/gpt-5`, `orcarouter/auto`) is forwarded verbatim to the gateway.

**Important:** OrcaRouter requests are dispatched through `LLMCaller`'s `AsyncOpenAI` path — **LiteLLM is not on the request path**. LiteLLM has no native OrcaRouter provider; routing through `openai/` as a compatibility shim would force a misleading model prefix on the wire. The dedicated `LLMCaller` branch mirrors how OpenRouter's dynamic-key path works today.

### Changes

- **`skyvern/config.py`** — new `ENABLE_ORCAROUTER`, `ORCAROUTER_API_KEY`, `ORCAROUTER_MODEL`, `ORCAROUTER_API_BASE` settings (mirrors the OpenRouter shape).
- **`skyvern/forge/sdk/api/llm/config_registry.py`** — register `ORCAROUTER` with the bare model id when `ORCAROUTER_MODEL` is set; skipped when empty (consistent with OpenRouter / Groq).
- **`skyvern/forge/sdk/api/llm/api_handler_factory.py`**
  - `get_llm_api_handler` routes `ORCAROUTER` to `LLMCaller`.
  - `LLMCaller.__init__` adds an `ORCAROUTER` branch that builds an `AsyncOpenAI` client against `ORCAROUTER_API_BASE` and rewrites `self.llm_key` to `ORCAROUTER_MODEL` so the wire model name matches the gateway's catalog.
  - `get_call_stats` short-circuits to empty stats for `ORCAROUTER`, matching the OpenRouter `LLMCaller` behavior (usage shape varies per upstream model).
- **`skyvern/cli/doctor.py`** — surface `ORCAROUTER` in the provider health check so misconfiguration is reported.
- **`.env.example`** — document the four new variables.
- **`tests/unit_tests/test_orcarouter_integration.py`** — new unit suite.

## How Has This Been Tested?

### Unit tests (new file: `tests/unit_tests/test_orcarouter_integration.py`)

5 cases, all green:

1. `test_orcarouter_config_registration` — registry stores the bare model id (no LiteLLM prefix).
2. `test_orcarouter_skipped_when_model_unset` — empty `ORCAROUTER_MODEL` skips registration.
3. `test_orcarouter_llmcaller_bypasses_litellm` — `LLMCaller` builds `AsyncOpenAI` against the OrcaRouter base URL and rewrites `llm_key` to the configured model id.
4. `test_orcarouter_basic_completion` — end-to-end through the handler hits `AsyncOpenAI.chat.completions.create` with the right model, and a sentinel asserts `litellm.acompletion` is **never** called on this path.
5. `test_orcarouter_error_propagation` — upstream `AsyncOpenAI` failures surface as `LLMProviderError`.

```
$ uv run pytest tests/unit_tests/test_orcarouter_integration.py tests/unit_tests/test_openrouter_integration.py
======================== 8 passed, 4 warnings in 4.24s =========================
```

No regression in the existing `test_openrouter_integration.py` suite.

### Lint / format

```
$ uv run ruff check ... && uv run ruff format --check ...
All checks passed!
5 files already formatted
```

### Manual smoke test

```
$ curl -s -X POST https://api.orcarouter.ai/v1/chat/completions \
    -H "Authorization: Bearer sk-orca-***" -H "Content-Type: application/json" \
    -d '{"model":"anthropic/claude-sonnet-4.6","messages":[{"role":"user","content":"Reply with exactly: pong"}],"max_tokens":20}'
{"id":"...","model":"claude-sonnet-4-6",...,"choices":[{"index":0,"message":{"role":"assistant","content":"pong"},"finish_reason":"stop"}],...}
```

Confirms the gateway honors the model id we register and returns the expected OpenAI-compatible shape that `LLMCaller`'s `AsyncOpenAI` path consumes.

## Artifacts (if appropriate)

N/A — backend-only change with no UI surface.