### PR TITLE
Update artifactServer.js

### DIFF
--- a/skyvern-frontend/artifactServer.js
+++ b/skyvern-frontend/artifactServer.js
@@ -1,10 +1,24 @@
 import express from "express";
 import fs from "fs";
+import path from "path";
 import cors from "cors";
 
 const app = express();
 
 app.use(cors());
+
+export function getRecordingContentType(filePath) {
+  const extension = path.extname(filePath).toLowerCase();
+
+  switch (extension) {
+    case ".webm":
+      return "video/webm";
+    case ".mp4":
+      return "video/mp4";
+    default:
+      return "application/octet-stream";
+  }
+}
 
 // Request logging middleware — logs method, path, status, and duration
 app.use((req, res, next) => {
@@ -28,11 +42,11 @@ app.use((req, res, next) => {
 
 app.get("/artifact/recording", (req, res) => {
   const range = req.headers.range;
-  const path = req.query.path;
-  if (!path || !range) {
+  const filePath = req.query.path;
+  if (!filePath || !range) {
     return res.status(400).send("Missing path or range header");
   }
-  const videoSize = fs.statSync(path).size;
+  const videoSize = fs.statSync(filePath).size;
   const chunkSize = 1 * 1e6;
   const start = Number(range.replace(/\D/g, ""));
   const end = Math.min(start + chunkSize, videoSize - 1);
@@ -41,10 +55,10 @@ app.get("/artifact/recording", (req, res) => {
     "Content-Range": `bytes ${start}-${end}/${videoSize}`,
     "Accept-Ranges": "bytes",
     "Content-Length": contentLength,
-    "Content-Type": "video/mp4",
+    "Content-Type": getRecordingContentType(filePath),
   };
   res.writeHead(206, headers);
-  const stream = fs.createReadStream(path, {
+  const stream = fs.createReadStream(filePath, {
     start,
     end,
   });
@@ -86,8 +100,10 @@ app.use((err, req, res, _next) => {
   res.status(500).send("Internal server error");
 });
 
-app.listen(9090, () => {
-  console.log(
-    `[${new Date().toISOString()}] Artifact server running at http://localhost:9090`,
-  );
-});
+if (process.env.NODE_ENV !== "test") {
+  app.listen(9090, () => {
+    console.log(
+      `[${new Date().toISOString()}] Artifact server running at http://localhost:9090`,
+    );
+  });
+}


### PR DESCRIPTION
## Description

Fixed the recording artifact response so the server no longer hardcodes `video/mp4` for every recording. The `/artifact/recording` route now derives the MIME type from the file extension, returning `video/webm` for `.webm` recordings and `video/mp4` for `.mp4` recordings.

### Changes made
- Updated artifactServer.js to:
  - add a `getRecordingContentType()` helper
  - use the helper when setting `Content-Type` on recording responses
  - avoid auto-starting the server during test imports
- Added a regression test in skyvern-frontend/artifactServer.test.ts to lock in the correct MIME behavior for both `.webm` and `.mp4`.

## How Has This Been Tested?

I verified the fix with a targeted frontend test run:

- Command: `cd /Users/srikantpandey/Personal/skyvern/skyvern-frontend && npm test -- artifactServer.test.ts`
- Result:
  - `1 passed (1)` test file
  - `2 passed (2)` tests

This confirms the recording MIME type logic is now correct for both WebM and MP4 recordings.

## Artifacts (if appropriate)

- Regression test added in skyvern-frontend/artifactServer.test.ts
- Recording MIME logic updated in artifactServer.js