### PR TITLE
fix(frontend): port vitest.setup.ts + wire setupFiles config

### DIFF
--- a/skyvern-frontend/tsconfig.json
+++ b/skyvern-frontend/tsconfig.json
@@ -27,6 +27,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["./src/", "vite-env.d.ts"],
+  "include": ["./src/", "vite-env.d.ts", "vitest.setup.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/skyvern-frontend/vitest.config.ts
+++ b/skyvern-frontend/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       VITE_WSS_BASE_URL: "ws://localhost:8000/api/v1",
       VITE_ENVIRONMENT: "test",
     },
+    setupFiles: "./vitest.setup.ts",
   },
   resolve: {
     alias: {

--- a/skyvern-frontend/vitest.setup.ts
+++ b/skyvern-frontend/vitest.setup.ts
@@ -1,0 +1,47 @@
+type StorageRecord = Record<string, string>;
+
+const createMemoryStorage = (): Storage => {
+  let values: StorageRecord = {};
+
+  return {
+    get length() {
+      return Object.keys(values).length;
+    },
+    clear() {
+      values = {};
+    },
+    getItem(key: string) {
+      return Object.prototype.hasOwnProperty.call(values, key)
+        ? (values[key] ?? null)
+        : null;
+    },
+    key(index: number) {
+      return Object.keys(values)[index] ?? null;
+    },
+    removeItem(key: string) {
+      delete values[key];
+    },
+    setItem(key: string, value: string) {
+      values[key] = String(value);
+    },
+  };
+};
+
+const localStorageNeedsShim =
+  typeof globalThis.localStorage?.clear !== "function" ||
+  typeof window.localStorage?.clear !== "function" ||
+  typeof globalThis.localStorage?.setItem !== "function" ||
+  typeof window.localStorage?.setItem !== "function";
+
+if (localStorageNeedsShim) {
+  const storage = createMemoryStorage();
+
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+}


### PR DESCRIPTION
## Summary

- Adds \`skyvern-frontend/vitest.setup.ts\` (ported verbatim from skyvern-cloud) — a jsdom localStorage shim used by vitest before each suite.
- Wires \`setupFiles: \"./vitest.setup.ts\"\` in \`vitest.config.ts\` so OSS main is self-consistent.

## Why

A previous cloud→OSS sync ported a \`setupFiles\` reference into \`vitest.config.ts\` but \`vitest.setup.ts\` itself wasn't covered by \`.github/sync.yml\` in skyvern-cloud — so the file never crossed. Result: any OSS PR that picked up the synced config (e.g. #6206) errored with \`Cannot find module .../vitest.setup.ts\` and failed all 135 vitest suites before any test ran.

A companion PR in skyvern-cloud (Skyvern-AI/skyvern-cloud#11570) adds \`vitest.setup.ts\` to \`sync.yml\` so this can't recur, but that only takes effect on future syncs — it doesn't backfill the file into OSS. This PR does the one-time backfill.

## Test plan

- [x] \`npx vitest run\` locally — 135 suites, 1127 tests pass.
- [ ] CI green on this PR.
- [ ] After merge: PR #6206 (and any other PR carrying the synced config edit) goes green on rebase.