### PR TITLE
chore(frontend): bump prettier-plugin-tailwindcss to ^0.8.0

### DIFF
--- a/skyvern-frontend/package-lock.json
+++ b/skyvern-frontend/package-lock.json
@@ -91,7 +91,7 @@
         "lint-staged": "^15.5.2",
         "postcss": "^8.4.37",
         "prettier": "^3.8.1",
-        "prettier-plugin-tailwindcss": "^0.6.5",
+        "prettier-plugin-tailwindcss": "^0.8.0",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.5.3",
         "vite": "^6.4.2",
@@ -7731,13 +7731,13 @@
       }
     },
     "node_modules/prettier-plugin-tailwindcss": {
-      "version": "0.6.14",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.14.tgz",
-      "integrity": "sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.8.0.tgz",
+      "integrity": "sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14.21.3"
+        "node": ">=20.19"
       },
       "peerDependencies": {
         "@ianvs/prettier-plugin-sort-imports": "*",
@@ -7750,14 +7750,12 @@
         "prettier": "^3.0",
         "prettier-plugin-astro": "*",
         "prettier-plugin-css-order": "*",
-        "prettier-plugin-import-sort": "*",
         "prettier-plugin-jsdoc": "*",
         "prettier-plugin-marko": "*",
         "prettier-plugin-multiline-arrays": "*",
         "prettier-plugin-organize-attributes": "*",
         "prettier-plugin-organize-imports": "*",
         "prettier-plugin-sort-imports": "*",
-        "prettier-plugin-style-order": "*",
         "prettier-plugin-svelte": "*"
       },
       "peerDependenciesMeta": {
@@ -7788,9 +7786,6 @@
         "prettier-plugin-css-order": {
           "optional": true
         },
-        "prettier-plugin-import-sort": {
-          "optional": true
-        },
         "prettier-plugin-jsdoc": {
           "optional": true
         },
@@ -7807,9 +7802,6 @@
           "optional": true
         },
         "prettier-plugin-sort-imports": {
-          "optional": true
-        },
-        "prettier-plugin-style-order": {
           "optional": true
         },
         "prettier-plugin-svelte": {

--- a/skyvern-frontend/package.json
+++ b/skyvern-frontend/package.json
@@ -102,7 +102,7 @@
     "lint-staged": "^15.5.2",
     "postcss": "^8.4.37",
     "prettier": "^3.8.1",
-    "prettier-plugin-tailwindcss": "^0.6.5",
+    "prettier-plugin-tailwindcss": "^0.8.0",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.5.3",
     "vite": "^6.4.2",


### PR DESCRIPTION
## Ticket
N/A — internal alignment with skyvern-cloud.

## Problem
`skyvern-frontend/package.json` pins `prettier-plugin-tailwindcss` at `^0.6.5`, while the corresponding cloud frontend pins `^0.8.0`. The version skew makes prettier-only cherry-picks between the two repos produce class-reordering churn that won't apply cleanly on the other side.

## Solution
Bump `prettier-plugin-tailwindcss` to `^0.8.0` in `skyvern-frontend/`. The newer plugin happens to emit identical output to the older one for the current tree, so no source files need to change — only `package.json` + `package-lock.json` are touched.

## How Has This Been Tested?
- `npm install` succeeds; `node_modules/prettier-plugin-tailwindcss` resolves to `0.8.0`.
- `npm run format` after the bump touches zero source files — diff is limited to `package.json` and `package-lock.json`.
- Will rely on CI to confirm lint/build/tests still pass.

## Artifacts (if appropriate):
N/A — config-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)