### PR TITLE
chore(frontend): add cta color and collapsible animations to tailwind config

### DIFF
--- a/skyvern-frontend/src/components/SidebarResourceLinks.tsx
+++ b/skyvern-frontend/src/components/SidebarResourceLinks.tsx
@@ -72,7 +72,7 @@ function SidebarResourceLinks({ collapsed }: Props) {
               {
                 "w-7 justify-center": collapsed,
                 "w-full gap-2.5 px-2": !collapsed,
-                "border-cta/30 bg-cta/10 text-cta hover:bg-cta/15 hover:text-cta-hover dark:border-cta/35 dark:bg-cta/15 dark:text-cta-foreground dark:hover:bg-cta/25 dark:hover:text-cta-foreground border shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]":
+                "border border-cta/30 bg-cta/10 text-cta shadow-[inset_0_1px_0_rgba(255,255,255,0.65)] hover:bg-cta/15 hover:text-cta-hover dark:border-cta/35 dark:bg-cta/15 dark:text-cta-foreground dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] dark:hover:bg-cta/25 dark:hover:text-cta-foreground":
                   link.cta,
               },
             )}

--- a/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineBlockItem.tsx
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/WorkflowRunTimelineBlockItem.tsx
@@ -713,7 +713,7 @@ function WorkflowRunTimelineBlockItem({
       {/* Container body — always mounted so open/close transitions animate */}
       {isContainer && (
         <Collapsible open={expanded}>
-          <CollapsibleContent className="motion-safe:data-[state=closed]:animate-collapsible-up-fade motion-safe:data-[state=open]:animate-collapsible-down-fade overflow-hidden">
+          <CollapsibleContent className="overflow-hidden motion-safe:data-[state=closed]:animate-collapsible-up-fade motion-safe:data-[state=open]:animate-collapsible-down-fade">
             {hasActions && (
               <TimelineActionRows
                 block={block}
@@ -960,7 +960,7 @@ function LoopIterationRow({
         </div>
       </div>
       <Collapsible open={expanded}>
-        <CollapsibleContent className="motion-safe:data-[state=closed]:animate-collapsible-up-fade motion-safe:data-[state=open]:animate-collapsible-down-fade overflow-hidden">
+        <CollapsibleContent className="overflow-hidden motion-safe:data-[state=closed]:animate-collapsible-up-fade motion-safe:data-[state=open]:animate-collapsible-down-fade">
           <TimelineSubItems
             items={group.items}
             activeItem={activeItem}

--- a/skyvern-frontend/tailwind.config.js
+++ b/skyvern-frontend/tailwind.config.js
@@ -31,6 +31,11 @@ module.exports = {
           DEFAULT: "hsl(var(--primary))",
           foreground: "hsl(var(--primary-foreground))",
         },
+        cta: {
+          DEFAULT: "hsl(var(--cta))",
+          foreground: "hsl(var(--cta-foreground))",
+          hover: "hsl(var(--cta-hover))",
+        },
         secondary: {
           DEFAULT: "hsl(var(--secondary))",
           foreground: "hsl(var(--secondary-foreground))",
@@ -97,6 +102,28 @@ module.exports = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        "collapsible-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-collapsible-content-height)" },
+        },
+        "collapsible-up": {
+          from: { height: "var(--radix-collapsible-content-height)" },
+          to: { height: "0" },
+        },
+        "collapsible-down-fade": {
+          from: { height: "0", opacity: "0" },
+          to: {
+            height: "var(--radix-collapsible-content-height)",
+            opacity: "1",
+          },
+        },
+        "collapsible-up-fade": {
+          from: {
+            height: "var(--radix-collapsible-content-height)",
+            opacity: "1",
+          },
+          to: { height: "0", opacity: "0" },
+        },
         glow: {
           "0%, 100%": { boxShadow: "0 0 8px 2px rgba(234, 179, 8, 0.3)" },
           "50%": { boxShadow: "0 0 24px 8px rgba(234, 179, 8, 0.6)" },
@@ -105,6 +132,13 @@ module.exports = {
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        "collapsible-down":
+          "collapsible-down 0.22s cubic-bezier(0.22, 1, 0.36, 1)",
+        "collapsible-up": "collapsible-up 0.22s cubic-bezier(0.22, 1, 0.36, 1)",
+        "collapsible-down-fade":
+          "collapsible-down-fade 0.22s cubic-bezier(0.22, 1, 0.36, 1)",
+        "collapsible-up-fade":
+          "collapsible-up-fade 0.22s cubic-bezier(0.22, 1, 0.36, 1)",
         glow: "glow 2.5s ease-in-out infinite",
       },
     },


### PR DESCRIPTION
## Ticket

N/A — internal alignment with the cloud frontend's tailwind theme.

## Problem

The cloud→OSS sync copies `skyvern-frontend/src/` but not `skyvern-frontend/tailwind.config.js`. Cloud's theme defines a `cta` color and four `collapsible-*` animations; OSS's does not. `prettier-plugin-tailwindcss` treats those classes as unknown in OSS, pushes them to the front of the className string, and re-orders synced files into a layout the cloud-side plugin then rejects. Frontend Lint and Build has been failing on sync PRs that touch those classes (#6216 and #6219 hit it with the same three `prettier/prettier` errors in `SidebarResourceLinks.tsx` and `WorkflowRunTimelineBlockItem.tsx`).

## Solution

Add the matching theme entries to OSS `tailwind.config.js`. The plugin then classifies `cta` and `animate-collapsible-*-fade` as known utilities and produces the same canonical class order as cloud, so synced files do not diverge.

### Before

```mermaid
flowchart LR
  A[Cloud src file<br/>cta + collapsible classes] --> B[Cloud prettier plugin<br/>classes known → canonical order]
  B --> C[Sync copies src/]
  C --> D[OSS prettier plugin<br/>classes unknown → pushed to front]
  D --> E[OSS Frontend Lint and Build<br/>prettier/prettier errors]
```

### After

```mermaid
flowchart LR
  A[Cloud src file<br/>cta + collapsible classes] --> B[Cloud prettier plugin<br/>classes known → canonical order]
  B --> C[Sync copies src/]
  C --> D[OSS prettier plugin<br/>classes known → same canonical order]
  D --> E[OSS Frontend Lint and Build<br/>passes]
```

## Description

`skyvern-frontend/tailwind.config.js`: add `cta` color (`DEFAULT`/`foreground`/`hover`) plus four `collapsible-*` keyframes and matching animations.

`skyvern-frontend/src/components/SidebarResourceLinks.tsx`: one className string was sitting in the previous OSS-only permutation; `eslint --fix` reorders it into the new canonical layout (now identical to cloud).

CSS variables for the `cta` color (`--cta`, `--cta-foreground`, `--cta-hover`) are not defined in OSS `index.css`. Lint classification does not need them, so they are out of scope here; the color will currently render as undefined at runtime if the `cta` variant is actually triggered.

## How Has This Been Tested?

- `cd skyvern-frontend && npm ci` resolves `prettier-plugin-tailwindcss@0.8.0` (matches cloud).
- `npm run lint` passes clean (only the pre-existing `delay-[300ms]` ambiguity warning, no errors).
- `npx tsc --noEmit` passes.

## Artifacts (if appropriate):

N/A — tailwind config additions and one auto-fixed className reorder.