### PR TITLE
chore(frontend): align tailwind config shape for clean cross-repo sync

### DIFF
--- a/skyvern-frontend/tailwind.config.js
+++ b/skyvern-frontend/tailwind.config.js
@@ -1,11 +1,15 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+import animate from "tailwindcss-animate";
+
+export default {
   darkMode: ["class"],
   content: [
     "./pages/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",
     "./app/**/*.{ts,tsx}",
     "./src/**/*.{ts,tsx}",
+    "./cloud/**/*.{ts,tsx}",
+    "./eval/**/*.{ts,tsx}",
   ],
   prefix: "",
   theme: {
@@ -143,5 +147,5 @@ module.exports = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animate],
 };


### PR DESCRIPTION
## Ticket

N/A — infra cleanup to stop a recurring sync conflict.

## Problem

\`skyvern-frontend/tailwind.config.js\` has been drifting from its downstream sibling on two purely-structural axes:

1. **Module format**: uses CJS (\`module.exports\` / \`require\`) even though \`package.json\` is \`"type": "module"\` and \`postcss.config.js\` is already ESM.
2. **Content globs**: missing \`./cloud/**/*.{ts,tsx}\` and \`./eval/**/*.{ts,tsx}\`.

Neither affects token values or build output here, but every token-addition triggers a sync conflict on those diffs.

## Solution

- Switch to ESM (\`export default\` / \`import animate from "tailwindcss-animate"\`).
- Add the two extra content globs. They are no-ops in this repo — \`cloud/\` and \`eval/\` don't exist here — so the build output is unchanged.

Net diff: 6+/2- on a single file, no theme or plugin changes.

## How Has This Been Tested?

- Tailwind v3.4.x supports both ESM and CJS config files; Vite + PostCSS already load ESM configs in this project (\`postcss.config.js\` is ESM).
- The exact same file shape already runs in production downstream.
- Local: \`npm run build\` and \`npm run dev\` in \`skyvern-frontend/\` produce the same CSS as before.

## Artifacts (if appropriate):

N/A — config refactor with no visual change.