### PR TITLE
security: update axios to 1.16.1 (CVE-2026-44494, CVE-2026-44492)

### DIFF
--- a/skyvern-frontend/package-lock.json
+++ b/skyvern-frontend/package-lock.json
@@ -41,7 +41,7 @@
         "@uiw/codemirror-theme-tokyo-night-storm": "^4.23.0",
         "@uiw/react-codemirror": "^4.23.0",
         "@xyflow/react": "^12.1.1",
-        "axios": "^1.13.5",
+        "axios": "^1.16.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "cmdk": "^1.0.0",
@@ -3965,6 +3965,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -4149,13 +4161,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -4891,7 +4904,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6270,6 +6282,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {

--- a/skyvern-frontend/package.json
+++ b/skyvern-frontend/package.json
@@ -52,7 +52,7 @@
     "@uiw/codemirror-theme-tokyo-night-storm": "^4.23.0",
     "@uiw/react-codemirror": "^4.23.0",
     "@xyflow/react": "^12.1.1",
-    "axios": "^1.13.5",
+    "axios": "^1.16.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "cmdk": "^1.0.0",


### PR DESCRIPTION
## Ticket

Dependabot alerts #674 and #673 (Skyvern-AI/skyvern)

## Problem

The `skyvern-frontend` package depends on axios `^1.13.5`, which resolves to axios 1.15.2 — a version affected by two high-severity CVEs. CVE-2026-44494 (CVSS 8.7) allows MITM attacks via prototype pollution in `config.proxy`. CVE-2026-44492 (CVSS 8.6) allows NO_PROXY bypass via IPv4-mapped IPv6 addresses. Both are runtime dependencies in the customer-facing frontend.

## Solution

Updates axios from 1.15.2 to 1.16.1 by bumping the version constraint in `package.json` from `^1.13.5` to `^1.16.0` and regenerating `package-lock.json`. Axios 1.16.0 patches both CVEs. No API changes were introduced; the update is backward-compatible.

## How Has This Been Tested?

- TypeScript type check: `npx tsc --noEmit` — PASS
- `npm audit` in `skyvern-frontend/`: 0 vulnerabilities after update
- `npm install` completed cleanly with no peer dependency conflicts

## Artifacts (if appropriate):

🤖 Generated with [Claude Code](https://claude.ai/code) via /security-scan