### PR TITLE
security: fix 2 high-severity axios vulnerabilities in skyvern-frontend

### DIFF
--- a/skyvern-frontend/package-lock.json
+++ b/skyvern-frontend/package-lock.json
@@ -41,7 +41,7 @@
         "@uiw/codemirror-theme-tokyo-night-storm": "^4.23.0",
         "@uiw/react-codemirror": "^4.23.0",
         "@xyflow/react": "^12.1.1",
-        "axios": "^1.13.5",
+        "axios": "^1.16.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "cmdk": "^1.0.0",
@@ -3965,6 +3965,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -4149,13 +4161,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -4891,7 +4904,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6270,6 +6282,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {

--- a/skyvern-frontend/package.json
+++ b/skyvern-frontend/package.json
@@ -52,7 +52,7 @@
     "@uiw/codemirror-theme-tokyo-night-storm": "^4.23.0",
     "@uiw/react-codemirror": "^4.23.0",
     "@xyflow/react": "^12.1.1",
-    "axios": "^1.13.5",
+    "axios": "^1.16.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "cmdk": "^1.0.0",


### PR DESCRIPTION
## Ticket

Dependabot alerts #674, #673, #672, #671 in Skyvern-AI/skyvern

## Problem

`axios ^1.13.5` in skyvern-frontend is affected by two high-severity vulnerabilities:
- **CVE-2026-44494** (CVSS 8.7): Prototype Pollution gadget in `config.proxy` — any `Object.prototype` pollution can be escalated into a full MITM attack, intercepting HTTP traffic including auth credentials.
- **CVE-2026-44492** (CVSS 8.6): Related prototype pollution in axios HTTP adapter proxy config.

This is a customer-facing runtime dependency.

## Solution

Updates `axios` from `^1.13.5` to `^1.16.0` (resolves to 1.16.1 in lockfile). Backward-compatible bump — no API changes affect our usage. Also resolves #672 (CVE-2026-44490, CVSS 4.8) and #671 (CVE-2026-44489, CVSS 3.7).

| Alert # | CVE | Severity | CVSS |
|---------|-----|----------|------|
| #674 | CVE-2026-44494 | High | 8.7 |
| #673 | CVE-2026-44492 | High | 8.6 |
| #672 | CVE-2026-44490 | Medium | 4.8 |
| #671 | CVE-2026-44489 | Low | 3.7 |

## How Has This Been Tested?

- `npm install --package-lock-only` confirms axios resolves to 1.16.1 with 0 audit vulnerabilities and no dependency conflicts.
- Pre-commit hooks passed on changed files.
- axios 1.13.x → 1.16.x is a backward-compatible minor bump with no TypeScript API changes affecting our usage.

## Artifacts (if appropriate):

N/A

🤖 Generated with [Claude Code](https://claude.ai/code) via /security-scan