### PR TITLE
fix: resolve #6004 — http://localhost:8080/ is blank window

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,23 @@ DATABASE_STRING="postgresql+psycopg://skyvern@localhost/skyvern"
 # PORT: Port to run the agent on.
 PORT=8000
 
+# =============================================================================
+# FRONTEND (UI) CONFIGURATION
+# =============================================================================
+# These variables are read by the Skyvern UI. The URLs are opened directly from
+# your browser, so they must be reachable from the host you load the UI on. When
+# running in Docker or remotely, use the host's hostname/IP instead of a Docker
+# service name or container-internal address. Leaving these unconfigured causes
+# the UI to render a blank window.
+# VITE_API_BASE_URL: Base URL the UI uses to reach the Skyvern backend API.
+VITE_API_BASE_URL=http://localhost:8000/api/v1
+# VITE_WSS_BASE_URL: WebSocket URL the UI uses for live streaming.
+VITE_WSS_BASE_URL=ws://localhost:8000/api/v1
+# VITE_ARTIFACT_API_BASE_URL: Base URL the UI uses to fetch run artifacts.
+VITE_ARTIFACT_API_BASE_URL=http://localhost:9090
+# VITE_SKYVERN_API_KEY: API key the UI sends with requests to the backend.
+VITE_SKYVERN_API_KEY=
+
 # Analytics configuration:
 # ANALYTICS_ID: Distinct analytics ID (a UUID is generated if left blank).
 ANALYTICS_ID="anonymous"


### PR DESCRIPTION
## Summary

If the frontend depends on env vars that are not represented in .env.example, users copying the example file will start with an unconfigured UI, which presents as a blank window. Making these explicit prevents the misconfiguration that causes this issue

Fixes #6004

## Changes

- `.env.example`

## Why

`.env.example`: If the frontend depends on env vars that are not represented in .env.example, users copying the example file will start with an unconfigured UI, which presents as a blank window. Making these explicit prevents the misconfiguration that causes this issue.
