### PR TITLE
security: ignore npm lifecycle scripts in skyvern-ts/client

### DIFF
--- a/skyvern-ts/client/.npmrc
+++ b/skyvern-ts/client/.npmrc
@@ -1,0 +1,5 @@
+# Supply chain protection: do not run lifecycle scripts (preinstall, install,
+# postinstall) on npm install. Blocks worms like "Shai-Hulud" from executing
+# on a compromised dependency before we notice. If a package genuinely needs
+# its install script, use @lavamoat/allow-scripts to allowlist it.
+ignore-scripts=true


### PR DESCRIPTION
## What

Adds `skyvern-ts/client/.npmrc` with `ignore-scripts=true` — the last `package-lock.json` directory in the repo that was still missing one.

## Why

A security alert flagged elevated supply-chain risk: by default npm runs arbitrary `preinstall`/`install`/`postinstall` lifecycle scripts on every install, which is the vector behind worms like "Shai-Hulud 2.0". Disabling lifecycle scripts means a compromised dependency can't auto-execute before we notice it.

This completes the convention already applied in the repo's three other lock-file directories (`skyvern-frontend/`, `tests/sdk/typescript_sdk/`, `skyvern/cli/mcpb/claude_desktop/`) — those `.npmrc` files account for the alert's already-resolved findings; this was the remaining one.

## Note for reviewers

`skyvern-ts/client` is pnpm-managed (`pnpm-lock.yaml`, `packageManager: pnpm@10.14.0`); `ignore-scripts=true` is honored by both npm and pnpm. One dep here, **Playwright**, normally downloads browsers via a `postinstall` script — with scripts ignored that won't run automatically. If a build/CI path relies on it, run `npx playwright install` explicitly (or allowlist via `@lavamoat/allow-scripts`). I did not find such a path in this package's scripts, but flagging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
