### PR TITLE
docs(llm): upgrade MiniMax default to M3

### DIFF
--- a/docs/developers/self-hosted/llm-configuration.mdx
+++ b/docs/developers/self-hosted/llm-configuration.mdx
@@ -306,15 +306,16 @@ Bedrock inference profile keys (`*_INFERENCE_PROFILE`) use cross-region inferenc
 ```bash .env
 ENABLE_MINIMAX=true
 MINIMAX_API_KEY=your-minimax-api-key
-LLM_KEY=MINIMAX_M2_5
+LLM_KEY=MINIMAX_M3
 ```
 
 ### Available models
 
 | LLM_KEY | Notes |
 |---------|-------|
-| `MINIMAX_M2_5` | |
-| `MINIMAX_M2_5_HIGHSPEED` | Faster variant |
+| `MINIMAX_M3` | |
+| `MINIMAX_M2_7` | |
+| `MINIMAX_M2_7_HIGHSPEED` | Faster variant |
 
 ### Optional settings
 


### PR DESCRIPTION
## Description

Updates the MiniMax section in the self-hosted LLM configuration guide so the recommended `LLM_KEY` and available-models table reflect MiniMax's current M3 lineup instead of the older M2.5 entries.

- `LLM_KEY=MINIMAX_M2_5` -> `LLM_KEY=MINIMAX_M3` in the example `.env`
- Available models table swapped from `MINIMAX_M2_5` / `MINIMAX_M2_5_HIGHSPEED` to `MINIMAX_M3` / `MINIMAX_M2_7` / `MINIMAX_M2_7_HIGHSPEED`

The base URL (`https://api.minimax.io/v1`) and `MINIMAX_API_KEY` / `ENABLE_MINIMAX` env names are untouched.

## How Has This Been Tested?

Docs-only change to `docs/developers/self-hosted/llm-configuration.mdx`. Verified the diff is scoped to the MiniMax subsection.

## Artifacts (if appropriate):

N/A — single doc edit.