### PR TITLE
feat: allow custom login prompt when seeding a credential browser profile

### DIFF
--- a/scripts/validate_profile_seed_reuse.py
+++ b/scripts/validate_profile_seed_reuse.py
@@ -1,0 +1,115 @@
+"""Semantic validation for Goal 2: seed a browser profile once, reuse it later.
+
+No Skyvern server / LLM / external account required. It models the mechanism
+the saved "browser profile" relies on (a Playwright *persistent context* directory
+that stores cookies/localStorage) and proves the seed -> reuse flow end to end:
+
+  * SEED  : a persistent context logs in; the session cookie is written into the
+            profile directory (this is what the credential-test endpoint does once
+            the custom login prompt clears 2FA — Goal 2a).
+  * REUSE : a NEW persistent context opened on the SAME profile directory does
+            page.goto(/dashboard) + page.evaluate() and is authenticated, with NO
+            login block — exactly the "EXTRACT-only run bound to the profile" check.
+  * CONTROL: a fresh/empty profile directory lands on the sign-in page.
+
+Run:  uv run python scripts/validate_profile_seed_reuse.py
+Exit 0 == seed-and-reuse validated.
+"""
+
+from __future__ import annotations
+
+import http.server
+import socketserver
+import tempfile
+import threading
+import uuid
+
+from playwright.sync_api import sync_playwright
+
+_SESSIONS: set[str] = set()
+LOGIN_HTML = b"<html><body><h1>Sign in</h1></body></html>"
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+    def _session(self) -> str | None:
+        for part in self.headers.get("Cookie", "").split(";"):
+            if part.strip().startswith("session="):
+                return part.strip()[len("session=") :]
+        return None
+
+    def do_GET(self):
+        if self.path.startswith("/login"):
+            sid = uuid.uuid4().hex
+            _SESSIONS.add(sid)
+            self.send_response(200)
+            self.send_header("Set-Cookie", f"session={sid}; Path=/; Max-Age=86400")
+            self.send_header("Content-Type", "text/html")
+            self.end_headers()
+            self.wfile.write(b"<html><body><h1>Logged in</h1></body></html>")
+        elif self.path.startswith("/dashboard"):
+            sid = self._session()
+            if sid and sid in _SESSIONS:
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(b"<html><body><h1 id='who'>WELCOME authed-user</h1></body></html>")
+            else:
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.end_headers()
+                self.wfile.write(LOGIN_HTML)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+def _authed_on_dashboard(ctx, base: str) -> bool:
+    page = ctx.new_page()
+    page.goto(f"{base}/dashboard")
+    who = page.evaluate("() => document.querySelector('#who') && document.querySelector('#who').textContent")
+    return who is not None and "authed-user" in who
+
+
+def main() -> int:
+    with socketserver.TCPServer(("127.0.0.1", 0), Handler) as httpd:
+        port = httpd.server_address[1]
+        base = f"http://127.0.0.1:{port}"
+        threading.Thread(target=httpd.serve_forever, daemon=True).start()
+
+        seed_dir = tempfile.mkdtemp(prefix="seed_profile_")
+        empty_dir = tempfile.mkdtemp(prefix="empty_profile_")
+
+        with sync_playwright() as p:
+            # SEED: log in inside a persistent profile directory, then close it.
+            seed_ctx = p.chromium.launch_persistent_context(seed_dir, headless=True)
+            sp = seed_ctx.new_page()
+            sp.goto(f"{base}/login")
+            assert "Logged in" in sp.content(), "seed login failed"
+            seed_ctx.close()
+            print("[seed   ]  logged in; session persisted to profile dir")
+
+            # REUSE: brand-new context on the SAME profile dir, no login block.
+            reuse_ctx = p.chromium.launch_persistent_context(seed_dir, headless=True)
+            reuse_authed = _authed_on_dashboard(reuse_ctx, base)
+            reuse_ctx.close()
+            print(f"[reuse  ]  goto(/dashboard)+evaluate() on saved profile -> "
+                  f"{'AUTHED' if reuse_authed else 'SIGN-IN PAGE'} (extract-only run, no login)")
+
+            # CONTROL: empty profile dir -> unauthenticated.
+            ctrl_ctx = p.chromium.launch_persistent_context(empty_dir, headless=True)
+            ctrl_authed = _authed_on_dashboard(ctrl_ctx, base)
+            ctrl_ctx.close()
+            print(f"[control]  goto(/dashboard) on empty profile      -> "
+                  f"{'AUTHED' if ctrl_authed else 'SIGN-IN PAGE'}")
+
+        ok = reuse_authed and not ctrl_authed
+        print("\nRESULT:", "PASS — a seeded profile authenticates a later run without logging in again"
+              if ok else "FAIL")
+        return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skyvern/forge/sdk/routes/credentials.py
+++ b/skyvern/forge/sdk/routes/credentials.py
@@ -533,8 +533,8 @@ async def test_login(
         label=label,
         title=label,
         url=data.url,
-        navigation_goal=_build_navigation_goal(LOGIN_TEST_PROMPT, data.user_context),
-        terminate_criterion=LOGIN_TEST_TERMINATE_CRITERION,
+        navigation_goal=_build_navigation_goal(data.navigation_goal or LOGIN_TEST_PROMPT, data.user_context),
+        terminate_criterion=data.terminate_criterion or LOGIN_TEST_TERMINATE_CRITERION,
         max_steps_per_run=None,
         parameter_keys=[parameter_key],
         totp_verification_url=None,
@@ -704,8 +704,14 @@ async def test_credential(
         has_user_context=bool(data.user_context),
     )
 
-    base_prompt = LOGIN_TEST_PROMPT
+    # A custom navigation_goal/terminate_criterion lets callers reuse the exact prompt
+    # their working `login` block uses, so a site-specific 2FA step (e.g. a masked
+    # phone-number dropdown) can be cleared during profile seeding. The default
+    # LOGIN_TEST_PROMPT/CRITERION terminate as soon as a phone number is requested, which
+    # makes those flows impossible to persist.
+    base_prompt = data.navigation_goal or LOGIN_TEST_PROMPT
     navigation_goal = _build_navigation_goal(base_prompt, data.user_context)
+    terminate_criterion = data.terminate_criterion or LOGIN_TEST_TERMINATE_CRITERION
 
     parameter_key = "credential"
     label = "login"
@@ -724,7 +730,7 @@ async def test_credential(
         title=label,
         url=data.url,
         navigation_goal=navigation_goal,
-        terminate_criterion=LOGIN_TEST_TERMINATE_CRITERION,
+        terminate_criterion=terminate_criterion,
         max_steps_per_run=None,
         parameter_keys=[parameter_key],
         totp_verification_url=None,

--- a/skyvern/forge/sdk/schemas/credentials.py
+++ b/skyvern/forge/sdk/schemas/credentials.py
@@ -294,8 +294,27 @@ class TestCredentialRequest(BaseModel):
         max_length=1000,
         description="Optional user-provided context describing the login sequence (e.g., 'click SSO button first')",
     )
+    navigation_goal: str | None = Field(
+        default=None,
+        max_length=20000,
+        description=(
+            "Optional custom navigation goal that REPLACES the built-in generic login prompt. "
+            "Use the same prompt as your working `login` block when the generic login cannot "
+            "complete a site-specific 2FA step (e.g. a masked phone-number dropdown). "
+            "user_context, if provided, is still appended."
+        ),
+    )
+    terminate_criterion: str | None = Field(
+        default=None,
+        max_length=20000,
+        description=(
+            "Optional custom terminate criterion that REPLACES the built-in one. The default "
+            "criterion terminates as soon as the page asks for a phone number, which blocks "
+            "some legitimate 2FA flows; override it to allow them."
+        ),
+    )
 
-    @field_validator("user_context", mode="before")
+    @field_validator("user_context", "navigation_goal", "terminate_criterion", mode="before")
     @classmethod
     def normalize_user_context(cls, v: str | None) -> str | None:
         return _normalize_optional_str(v)
@@ -346,8 +365,25 @@ class TestLoginRequest(BaseModel):
         max_length=1000,
         description="Optional user-provided context describing the login sequence (e.g., 'click SSO button first')",
     )
+    navigation_goal: str | None = Field(
+        default=None,
+        max_length=20000,
+        description=(
+            "Optional custom navigation goal that REPLACES the built-in generic login prompt. "
+            "Use the same prompt as your working `login` block when the generic login cannot "
+            "complete a site-specific 2FA step. user_context, if provided, is still appended."
+        ),
+    )
+    terminate_criterion: str | None = Field(
+        default=None,
+        max_length=20000,
+        description=(
+            "Optional custom terminate criterion that REPLACES the built-in one (which "
+            "terminates as soon as the page asks for a phone number)."
+        ),
+    )
 
-    @field_validator("user_context", mode="before")
+    @field_validator("user_context", "navigation_goal", "terminate_criterion", mode="before")
     @classmethod
     def normalize_user_context(cls, v: str | None) -> str | None:
         return _normalize_optional_str(v)

--- a/tests/unit/test_credential_test_custom_login_goal.py
+++ b/tests/unit/test_credential_test_custom_login_goal.py
@@ -1,0 +1,128 @@
+"""Regression/feature test for Goal 2: seedable persistent profiles.
+
+The credential-test endpoint (POST /v1/credentials/{id}/test, save_browser_profile=true)
+is the only path that saves a reusable browser profile. It ran a GENERIC login whose
+hardcoded prompt + terminate criterion bail out the instant a site asks for a phone
+number — which is exactly the masked phone-number 2FA step some sites use, so the login
+never completes and the profile is never saved.
+
+Fix: let the caller pass a custom ``navigation_goal`` / ``terminate_criterion`` (the same
+prompt their working ``login`` block uses). These tests assert that, when provided, the
+generated LoginBlock uses them instead of the built-in generic prompt — and that the
+defaults are still used otherwise.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import skyvern.forge.sdk.routes.credentials as credentials_route
+from skyvern.forge.sdk.routes.credentials import (
+    LOGIN_TEST_PROMPT,
+    LOGIN_TEST_TERMINATE_CRITERION,
+)
+from skyvern.forge.sdk.routes.credentials import test_credential as run_test_credential_route
+from skyvern.forge.sdk.schemas.credentials import CredentialType
+from skyvern.forge.sdk.schemas.credentials import TestCredentialRequest as CredentialTestRequest
+
+CUSTOM_GOAL = (
+    "Log in with the provided credentials. When the masked phone-number dropdown appears, "
+    "select a number with the keyboard (Down then Enter), then enter the TOTP code."
+)
+CUSTOM_CRITERION = "Only terminate if the credentials are explicitly rejected."
+
+
+async def _run_test_credential(request: CredentialTestRequest):
+    """Drive the route with all external dependencies mocked; return the
+    WorkflowCreateYAMLRequest captured at create_workflow_from_request."""
+    captured = {}
+
+    credential = MagicMock()
+    credential.credential_type = CredentialType.PASSWORD
+    credential.browser_profile_id = None
+    credential.totp_identifier = "totp-id"
+    credential.name = "Test Credential"
+
+    mock_db = MagicMock()
+    mock_db.credentials.get_credential = AsyncMock(return_value=credential)
+
+    workflow = MagicMock()
+    workflow.workflow_permanent_id = "wpid_1"
+
+    workflow_run = MagicMock()
+    workflow_run.workflow_run_id = "wr_1"
+    workflow_run.workflow_id = "w_1"
+    workflow_run.workflow_permanent_id = "wpid_1"
+
+    async def _capture_create(organization, request):  # noqa: ANN001
+        captured["create_request"] = request
+        return workflow
+
+    mock_wf_service = MagicMock()
+    mock_wf_service.create_workflow_from_request = AsyncMock(side_effect=_capture_create)
+    mock_wf_service.setup_workflow_run = AsyncMock(return_value=workflow_run)
+
+    mock_executor = MagicMock()
+    mock_executor.execute_workflow = AsyncMock()
+
+    org = MagicMock()
+    org.organization_id = "o_1"
+
+    with (
+        patch.object(credentials_route, "app") as mock_app,
+        patch.object(credentials_route, "AsyncExecutorFactory") as mock_factory,
+    ):
+        mock_app.DATABASE = mock_db
+        mock_app.WORKFLOW_SERVICE = mock_wf_service
+        mock_factory.get_executor.return_value = mock_executor
+
+        # save_browser_profile=False so the route does not spawn the polling task.
+        await run_test_credential_route(
+            background_tasks=MagicMock(),
+            credential_id="cred_1",
+            data=request,
+            current_org=org,
+        )
+
+    return captured["create_request"]
+
+
+@pytest.mark.asyncio
+async def test_custom_navigation_goal_and_criterion_used_when_provided() -> None:
+    req = CredentialTestRequest(
+        url="https://account.example.com/sign-in",
+        save_browser_profile=False,
+        navigation_goal=CUSTOM_GOAL,
+        terminate_criterion=CUSTOM_CRITERION,
+    )
+    create_request = await _run_test_credential(req)
+    block = create_request.workflow_definition.blocks[0]
+
+    assert CUSTOM_GOAL in block.navigation_goal, "custom navigation_goal must drive the login block"
+    assert "TERMINATE IMMEDIATELY" not in block.navigation_goal, "built-in phone-number bail-out must be gone"
+    assert block.terminate_criterion == CUSTOM_CRITERION
+
+
+@pytest.mark.asyncio
+async def test_defaults_used_when_not_provided() -> None:
+    req = CredentialTestRequest(url="https://account.example.com/sign-in", save_browser_profile=False)
+    create_request = await _run_test_credential(req)
+    block = create_request.workflow_definition.blocks[0]
+
+    assert block.navigation_goal == LOGIN_TEST_PROMPT
+    assert block.terminate_criterion == LOGIN_TEST_TERMINATE_CRITERION
+
+
+@pytest.mark.asyncio
+async def test_user_context_still_appended_to_custom_goal() -> None:
+    req = CredentialTestRequest(
+        url="https://account.example.com/sign-in",
+        save_browser_profile=False,
+        navigation_goal=CUSTOM_GOAL,
+        user_context="The 'Sign in' button is in the top-right corner.",
+    )
+    create_request = await _run_test_credential(req)
+    block = create_request.workflow_definition.blocks[0]
+
+    assert CUSTOM_GOAL in block.navigation_goal
+    assert "top-right corner" in block.navigation_goal


### PR DESCRIPTION
## Description

`POST /v1/credentials/{id}/test` with `save_browser_profile=true` is the only path that saves a reusable browser profile, but it always runs the **generic** login. The hardcoded `LOGIN_TEST_PROMPT` / `LOGIN_TEST_TERMINATE_CRITERION` bail out the instant a site requests a phone number, so any site whose login is gated behind a phone/2FA step (e.g. a masked phone-number dropdown) can never be seeded: the run ends `terminated` and no profile is saved. `user_context` was only *appended*, so it couldn't override the bail-out.

This adds two optional, backward-compatible fields to `TestCredentialRequest` / `TestLoginRequest`:

- **`navigation_goal`** — REPLACES the built-in generic login prompt; pass the exact prompt your working `login` block uses. `user_context`, if also provided, is still appended.
- **`terminate_criterion`** — REPLACES the built-in criterion.

The `test_credential` / `test_login` routes select the custom value when present, otherwise the existing default. When both are omitted, behavior is byte-identical to today. With a completing login, the existing profile-save path runs and sets `credential.browser_profile_id` — enabling log-in-once / reuse-for-many. No new endpoint, no DB migration, no breaking API change.

```http
POST /v1/credentials/{credential_id}/test
{
  "url": "https://account.example.com/sign-in",
  "save_browser_profile": true,
  "navigation_goal": "<the prompt your login block uses, incl. the 2FA handling>",
  "terminate_criterion": "Only terminate if the credentials are explicitly rejected."
}
```

## How Has This Been Tested?

Environment: Python 3.11, `uv sync`, base `v1.0.36`.

- **Unit tests** — `tests/unit/test_credential_test_custom_login_goal.py` drives the `test_credential` route with external deps mocked and inspects the generated `LoginBlock`: a custom `navigation_goal`/`terminate_criterion` drive the block (the built-in phone-number bail-out is gone); defaults are used when the fields are omitted; `user_context` is still appended to a custom goal. `uv run pytest tests/unit/test_credential_test_custom_login_goal.py` → 3 passed. Existing credential tests still pass.
- **Seed → reuse proof (no account/LLM needed)** — `scripts/validate_profile_seed_reuse.py` seeds a Playwright persistent-context directory by logging in once, then a brand-new context on the same directory loads an authenticated page with no login, while an empty directory lands on sign-in.

## Artifacts (if appropriate):

N/A — covered by the unit tests and the deterministic Playwright proof script above.
