### PR TITLE
fix: run code/print blocks against the agent's live authenticated page

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -425,6 +425,44 @@ class Block(BaseModel, abc.ABC):
 
         return browser_state
 
+    async def resolve_live_page(
+        self,
+        workflow_run_id: str,
+        organization_id: str | None = None,
+        browser_session_id: str | None = None,
+    ) -> Page | None:
+        """Return the Playwright page a browser-driving block (code / print) should use.
+
+        In script-execution mode the agent blocks act on a single live
+        ``ScriptSkyvernPage`` held in the script run context. A code/print block
+        that instead re-derives a page via ``get_or_create_browser_state`` ->
+        ``get_working_page`` can end up on a DIFFERENT (unauthenticated)
+        BrowserContext, so ``page.goto(<authed url>)`` bounces to the sign-in page
+        even though every agent block was authenticated. Reuse the agent's live
+        page directly so the block shares the exact same authenticated
+        BrowserContext.
+
+        Falls back to the workflow-run browser for live/agent mode (no script run
+        context exists there).
+        """
+        # Local import avoids a module-load cycle (script_skyvern_page imports
+        # heavily from forge/app, which transitively reaches this module).
+        from skyvern.core.script_generations.script_skyvern_page import script_run_context_manager
+
+        run_ctx = script_run_context_manager.get_run_context()
+        live_page = getattr(getattr(run_ctx, "page", None), "page", None) if run_ctx is not None else None
+        if live_page is not None:
+            return live_page
+
+        browser_state = await self.get_or_create_browser_state(
+            workflow_run_id=workflow_run_id,
+            organization_id=organization_id,
+            browser_session_id=browser_session_id,
+        )
+        if not browser_state:
+            return None
+        return await browser_state.get_working_page()
+
     def format_block_parameter_template_from_workflow_run_context(
         self,
         potential_template: str,
@@ -3411,22 +3449,11 @@ async def wrapper():
     ) -> BlockResult:
         await app.AGENT_FUNCTION.validate_code_block(organization_id=organization_id)
 
-        browser_state = await self.get_or_create_browser_state(
+        page = await self.resolve_live_page(
             workflow_run_id=workflow_run_id,
             organization_id=organization_id,
             browser_session_id=browser_session_id,
         )
-        if not browser_state:
-            return await self.build_block_result(
-                success=False,
-                failure_reason="No browser found to run the code block",
-                output_parameter_value=None,
-                status=BlockStatus.failed,
-                workflow_run_block_id=workflow_run_block_id,
-                organization_id=organization_id,
-            )
-
-        page = await browser_state.get_working_page()
         if not page:
             return await self.build_block_result(
                 success=False,
@@ -6473,21 +6500,11 @@ class PrintPageBlock(Block):
         if block_context:
             await capture_block_download_baseline(block_context, organization_id or "", workflow_run_id, self.label)
 
-        browser_state = await self.get_or_create_browser_state(
+        page = await self.resolve_live_page(
             workflow_run_id=workflow_run_id,
             organization_id=organization_id,
             browser_session_id=browser_session_id,
         )
-        if not browser_state:
-            return await self.build_block_result(
-                success=False,
-                failure_reason="No browser state available",
-                status=BlockStatus.failed,
-                workflow_run_block_id=workflow_run_block_id,
-                organization_id=organization_id,
-            )
-
-        page = await browser_state.get_working_page()
         if not page:
             return await self.build_block_result(
                 success=False,

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -443,7 +443,10 @@ class Block(BaseModel, abc.ABC):
         BrowserContext.
 
         Falls back to the workflow-run browser for live/agent mode (no script run
-        context exists there).
+        context exists there). Never returns a CLOSED page: if the agent's live page
+        was closed (e.g. user code closed a tab and a persisted session restored the
+        dead context), recover an open page in the same authenticated browser instead
+        of handing back a dead handle, which would raise TargetClosedError.
         """
         # Local import avoids a module-load cycle (script_skyvern_page imports
         # heavily from forge/app, which transitively reaches this module).
@@ -451,9 +454,11 @@ class Block(BaseModel, abc.ABC):
 
         run_ctx = script_run_context_manager.get_run_context()
         live_page = getattr(getattr(run_ctx, "page", None), "page", None) if run_ctx is not None else None
-        if live_page is not None:
+        if live_page is not None and not live_page.is_closed():
             return live_page
 
+        # Script run-context page is missing or CLOSED — recover an OPEN page in the
+        # same authenticated browser rather than returning a closed handle.
         browser_state = await self.get_or_create_browser_state(
             workflow_run_id=workflow_run_id,
             organization_id=organization_id,
@@ -461,7 +466,15 @@ class Block(BaseModel, abc.ABC):
         )
         if not browser_state:
             return None
-        return await browser_state.get_working_page()
+        page = await browser_state.get_working_page()
+        if page is not None and not page.is_closed():
+            return page
+        # No open page left in the authenticated context — open a fresh one; it inherits
+        # the context's cookies, so it stays authenticated.
+        browser_context = getattr(browser_state, "browser_context", None)
+        if browser_context is not None:
+            return await browser_context.new_page()
+        return None
 
     def format_block_parameter_template_from_workflow_run_context(
         self,

--- a/tests/unit/test_code_block_uses_script_runcontext_page.py
+++ b/tests/unit/test_code_block_uses_script_runcontext_page.py
@@ -7,8 +7,9 @@ browser manager could land on a DIFFERENT, unauthenticated BrowserContext, so
 was authenticated.
 
 ``Block.resolve_live_page`` must therefore return the live script run-context page
-(the exact authenticated page the agent used) when a script run is active, and only
-fall back to the workflow-run browser when there is none (live/agent mode).
+(the exact authenticated page the agent used) when a script run is active, only fall
+back to the workflow-run browser when there is none (live/agent mode), and never hand
+back a CLOSED page — instead recovering an open page in the same authenticated context.
 """
 
 from datetime import datetime
@@ -18,6 +19,8 @@ import pytest
 
 from skyvern.forge.sdk.workflow.models.block import CodeBlock, OutputParameter
 from skyvern.forge.sdk.workflow.models.parameter import ParameterType
+
+_MGR = "skyvern.core.script_generations.script_skyvern_page.script_run_context_manager"
 
 
 def _code_block() -> CodeBlock:
@@ -32,23 +35,36 @@ def _code_block() -> CodeBlock:
     return CodeBlock(label="audit_gallery", code="result = 1", output_parameter=output_parameter)
 
 
-@pytest.mark.asyncio
-async def test_resolve_live_page_prefers_script_runcontext_page() -> None:
-    """When a script run is active, use its live page — NOT a re-derived browser."""
-    block = _code_block()
+def _open_page(name: str) -> MagicMock:
+    page = MagicMock(name=name)
+    page.is_closed.return_value = False
+    return page
 
-    agent_page = MagicMock(name="agent_authenticated_playwright_page")
+
+def _closed_page(name: str) -> MagicMock:
+    page = MagicMock(name=name)
+    page.is_closed.return_value = True
+    return page
+
+
+def _run_ctx_with(page: MagicMock | None) -> MagicMock:
     run_ctx = MagicMock()
     run_ctx.page = MagicMock()
-    run_ctx.page.page = agent_page  # underlying Playwright page in the agent's authed context
+    run_ctx.page.page = page
+    return run_ctx
+
+
+@pytest.mark.asyncio
+async def test_resolve_live_page_prefers_script_runcontext_page() -> None:
+    """When a script run is active with an OPEN page, use it — NOT a re-derived browser."""
+    block = _code_block()
+    agent_page = _open_page("agent_authenticated_playwright_page")
 
     with (
-        patch(
-            "skyvern.core.script_generations.script_skyvern_page.script_run_context_manager"
-        ) as mock_mgr,
+        patch(_MGR) as mock_mgr,
         patch.object(CodeBlock, "get_or_create_browser_state", new_callable=AsyncMock) as mock_get_bs,
     ):
-        mock_mgr.get_run_context.return_value = run_ctx
+        mock_mgr.get_run_context.return_value = _run_ctx_with(agent_page)
 
         page = await block.resolve_live_page(workflow_run_id="wr_1", organization_id="o_1")
 
@@ -60,15 +76,12 @@ async def test_resolve_live_page_prefers_script_runcontext_page() -> None:
 async def test_resolve_live_page_falls_back_when_no_script_run() -> None:
     """Live/agent mode (no script run context) falls back to the workflow-run browser."""
     block = _code_block()
-
-    fallback_page = MagicMock(name="workflow_run_working_page")
+    fallback_page = _open_page("workflow_run_working_page")
     browser_state = MagicMock()
     browser_state.get_working_page = AsyncMock(return_value=fallback_page)
 
     with (
-        patch(
-            "skyvern.core.script_generations.script_skyvern_page.script_run_context_manager"
-        ) as mock_mgr,
+        patch(_MGR) as mock_mgr,
         patch.object(CodeBlock, "get_or_create_browser_state", new_callable=AsyncMock) as mock_get_bs,
     ):
         mock_mgr.get_run_context.return_value = None
@@ -83,8 +96,7 @@ async def test_resolve_live_page_falls_back_when_no_script_run() -> None:
 @pytest.mark.asyncio
 async def test_resolve_live_page_falls_back_when_runcontext_has_no_page() -> None:
     block = _code_block()
-
-    fallback_page = MagicMock(name="workflow_run_working_page")
+    fallback_page = _open_page("workflow_run_working_page")
     browser_state = MagicMock()
     browser_state.get_working_page = AsyncMock(return_value=fallback_page)
 
@@ -92,9 +104,7 @@ async def test_resolve_live_page_falls_back_when_runcontext_has_no_page() -> Non
     run_ctx.page = None
 
     with (
-        patch(
-            "skyvern.core.script_generations.script_skyvern_page.script_run_context_manager"
-        ) as mock_mgr,
+        patch(_MGR) as mock_mgr,
         patch.object(CodeBlock, "get_or_create_browser_state", new_callable=AsyncMock) as mock_get_bs,
     ):
         mock_mgr.get_run_context.return_value = run_ctx
@@ -104,3 +114,50 @@ async def test_resolve_live_page_falls_back_when_runcontext_has_no_page() -> Non
 
         assert page is fallback_page
         mock_get_bs.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resolve_live_page_recovers_when_runcontext_page_closed() -> None:
+    """A CLOSED script run-context page (poisoned persisted session) must not be returned;
+    recover an open page from the same authenticated browser instead."""
+    block = _code_block()
+    recovered = _open_page("recovered_open_page")
+    browser_state = MagicMock()
+    browser_state.get_working_page = AsyncMock(return_value=recovered)
+
+    with (
+        patch(_MGR) as mock_mgr,
+        patch.object(CodeBlock, "get_or_create_browser_state", new_callable=AsyncMock) as mock_get_bs,
+    ):
+        mock_mgr.get_run_context.return_value = _run_ctx_with(_closed_page("dead_restored_page"))
+        mock_get_bs.return_value = browser_state
+
+        page = await block.resolve_live_page(workflow_run_id="wr_1", organization_id="o_1")
+
+        assert page is recovered, "must not return the closed page"
+        assert not page.is_closed()
+        mock_get_bs.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resolve_live_page_opens_new_page_when_no_open_page_remains() -> None:
+    """Closed live page AND no open page in the context → open a fresh page in the
+    authenticated context (inherits its cookies)."""
+    block = _code_block()
+    new_page = _open_page("freshly_opened_page")
+    browser_state = MagicMock()
+    browser_state.get_working_page = AsyncMock(return_value=None)
+    browser_state.browser_context = MagicMock()
+    browser_state.browser_context.new_page = AsyncMock(return_value=new_page)
+
+    with (
+        patch(_MGR) as mock_mgr,
+        patch.object(CodeBlock, "get_or_create_browser_state", new_callable=AsyncMock) as mock_get_bs,
+    ):
+        mock_mgr.get_run_context.return_value = _run_ctx_with(_closed_page("dead_restored_page"))
+        mock_get_bs.return_value = browser_state
+
+        page = await block.resolve_live_page(workflow_run_id="wr_1", organization_id="o_1")
+
+        assert page is new_page
+        browser_state.browser_context.new_page.assert_awaited_once()

--- a/tests/unit/test_code_block_uses_script_runcontext_page.py
+++ b/tests/unit/test_code_block_uses_script_runcontext_page.py
@@ -1,0 +1,106 @@
+"""Regression test for the v1.0.34 code-block browser-context split (Goal 1).
+
+In script-execution mode the agent blocks act on a single live ``ScriptSkyvernPage``
+held in the script run context. A code/print block that re-derives a page via the
+browser manager could land on a DIFFERENT, unauthenticated BrowserContext, so
+``page.goto(<authed url>)`` bounced to the sign-in page even though every agent block
+was authenticated.
+
+``Block.resolve_live_page`` must therefore return the live script run-context page
+(the exact authenticated page the agent used) when a script run is active, and only
+fall back to the workflow-run browser when there is none (live/agent mode).
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from skyvern.forge.sdk.workflow.models.block import CodeBlock, OutputParameter
+from skyvern.forge.sdk.workflow.models.parameter import ParameterType
+
+
+def _code_block() -> CodeBlock:
+    output_parameter = OutputParameter(
+        output_parameter_id="op_1",
+        key="code_output",
+        workflow_id="w_1",
+        parameter_type=ParameterType.OUTPUT,
+        created_at=datetime(2026, 1, 1),
+        modified_at=datetime(2026, 1, 1),
+    )
+    return CodeBlock(label="audit_gallery", code="result = 1", output_parameter=output_parameter)
+
+
+@pytest.mark.asyncio
+async def test_resolve_live_page_prefers_script_runcontext_page() -> None:
+    """When a script run is active, use its live page — NOT a re-derived browser."""
+    block = _code_block()
+
+    agent_page = MagicMock(name="agent_authenticated_playwright_page")
+    run_ctx = MagicMock()
+    run_ctx.page = MagicMock()
+    run_ctx.page.page = agent_page  # underlying Playwright page in the agent's authed context
+
+    with (
+        patch(
+            "skyvern.core.script_generations.script_skyvern_page.script_run_context_manager"
+        ) as mock_mgr,
+        patch.object(CodeBlock, "get_or_create_browser_state", new_callable=AsyncMock) as mock_get_bs,
+    ):
+        mock_mgr.get_run_context.return_value = run_ctx
+
+        page = await block.resolve_live_page(workflow_run_id="wr_1", organization_id="o_1")
+
+        assert page is agent_page, "code block must reuse the agent's live script run-context page"
+        mock_get_bs.assert_not_called(), "must not re-derive a separate browser when a script run is active"
+
+
+@pytest.mark.asyncio
+async def test_resolve_live_page_falls_back_when_no_script_run() -> None:
+    """Live/agent mode (no script run context) falls back to the workflow-run browser."""
+    block = _code_block()
+
+    fallback_page = MagicMock(name="workflow_run_working_page")
+    browser_state = MagicMock()
+    browser_state.get_working_page = AsyncMock(return_value=fallback_page)
+
+    with (
+        patch(
+            "skyvern.core.script_generations.script_skyvern_page.script_run_context_manager"
+        ) as mock_mgr,
+        patch.object(CodeBlock, "get_or_create_browser_state", new_callable=AsyncMock) as mock_get_bs,
+    ):
+        mock_mgr.get_run_context.return_value = None
+        mock_get_bs.return_value = browser_state
+
+        page = await block.resolve_live_page(workflow_run_id="wr_1", organization_id="o_1")
+
+        assert page is fallback_page
+        mock_get_bs.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resolve_live_page_falls_back_when_runcontext_has_no_page() -> None:
+    block = _code_block()
+
+    fallback_page = MagicMock(name="workflow_run_working_page")
+    browser_state = MagicMock()
+    browser_state.get_working_page = AsyncMock(return_value=fallback_page)
+
+    run_ctx = MagicMock()
+    run_ctx.page = None
+
+    with (
+        patch(
+            "skyvern.core.script_generations.script_skyvern_page.script_run_context_manager"
+        ) as mock_mgr,
+        patch.object(CodeBlock, "get_or_create_browser_state", new_callable=AsyncMock) as mock_get_bs,
+    ):
+        mock_mgr.get_run_context.return_value = run_ctx
+        mock_get_bs.return_value = browser_state
+
+        page = await block.resolve_live_page(workflow_run_id="wr_1", organization_id="o_1")
+
+        assert page is fallback_page
+        mock_get_bs.assert_awaited_once()


### PR DESCRIPTION
## Description

A workflow **Code Block** (and **Print Page Block**) that runs JS/Python via the Playwright `page` does not execute in the same authenticated `BrowserContext` as the preceding AI agent blocks (login / navigation / extraction) when the workflow runs in **script-execution mode** (`run_with: code`, i.e. a cached script). After the agent blocks authenticate, the code block's `page.goto(<authenticated url>)` lands on the sign-in page, because the block runs against a *different* browser context.

**Root cause.** In script-execution mode the agent blocks act on a single live `ScriptSkyvernPage` held in the script run context (`run_initializer.setup()` → `script_run_context_manager`). But a code block (`skyvern.run_code` → `CodeBlock.execute`) re-derived its page via `get_or_create_browser_state()` → `get_working_page()` instead of using that live page, so it could end up on a different, unauthenticated `BrowserContext`.

**Fix.** Add `Block.resolve_live_page()`: when a script run is active, reuse its live page — the exact authenticated page the agent blocks are using — otherwise fall back to the workflow-run browser (live/agent mode, unchanged). Wire it into `CodeBlock` and `PrintPageBlock`. No flag, no schema/DB change, no public-API change.

**Hardening (included).** `resolve_live_page` never returns a **closed** page. If the agent's live page was closed (e.g. user code closed a tab and a persisted browser session restored the dead context), the block previously got a dead handle and raised `TargetClosedError` on its first page call. Now it recovers an open page in the same authenticated browser: live page (if open) → the context's working page → a freshly opened page in that context (inherits its cookies, so it stays authenticated).

## How Has This Been Tested?

Environment: Python 3.11, `uv sync`, base `v1.0.36`.

- **Unit tests** — `tests/unit/test_code_block_uses_script_runcontext_page.py` (5 tests): the block reuses the script run-context page (and does **not** re-derive a separate browser) when a script run is active; falls back to the workflow-run browser when there is none; a **closed** run-context page is never returned (recovers the context's open working page); when no open page remains, a fresh page is opened in the authenticated context. `uv run pytest tests/unit/test_code_block_uses_script_runcontext_page.py` → 5 passed.
- **Production verification (self-hosted, script mode)** — with `id()`-level tracing at every browser-acquisition site, a real `login → navigation → extraction → code` workflow showed: before, the code block acquired a different `BrowserContext`; after, the code block's context id is identical to the agent blocks', on the warm authenticated page, with auth cookies present. End-to-end the previously-failing run now returns the authenticated content (39 extracted items, HTTP 200). The closed-page recovery was also exercised in production: a persisted session restoring a dead tab previously raised `TargetClosedError`; with this PR the block recovered an open authenticated page and the run completed.

## Artifacts (if appropriate):

Trace excerpt from a self-hosted run (context ids match agent ↔ code block):

```
ScriptSkyvernPage._get_or_create_browser_state  branch=workflow_run  browser_context_id=123283744923472
block reusing script run-context page           block_label=audit_gallery  browser_context_id=123283744923472
code block page state before user code           page_url=https://admin.…/…  cookie_count=31  (auth cookies present)
```
