### PR TITLE
fix: don't crash on Bitwarden login items without a totp field

### DIFF
--- a/skyvern/forge/sdk/services/bitwarden.py
+++ b/skyvern/forge/sdk/services/bitwarden.py
@@ -1139,9 +1139,13 @@ class BitwardenService:
                 credential_type=CredentialType.PASSWORD,
                 name=name,
                 credential=PasswordCredential(
-                    username=login_item["username"] or "",
-                    password=login_item["password"] or "",
-                    totp=login_item["totp"],
+                    # Bitwarden omits the `totp` key entirely for logins without an
+                    # authenticator seed (e.g. text/SMS-delivered 2FA, totp_type="text").
+                    # Index access would raise KeyError: 'totp' and crash run-context init
+                    # before any browser opens, so read these optional fields defensively.
+                    username=login_item.get("username") or "",
+                    password=login_item.get("password") or "",
+                    totp=login_item.get("totp"),
                 ),
             )
         elif response["data"]["type"] == BitwardenItemType.CREDIT_CARD:

--- a/tests/unit/test_bitwarden_credential_item_missing_totp.py
+++ b/tests/unit/test_bitwarden_credential_item_missing_totp.py
@@ -1,0 +1,63 @@
+"""Regression test: a Bitwarden login item without a ``totp`` field must not crash.
+
+Credentials whose 2FA is delivered as text (``totp_type="text"``) have no
+authenticator seed, so the Bitwarden server's ``/object/item/{id}`` response omits
+the ``totp`` key from the ``login`` object. ``_get_credential_item_by_id_using_server``
+read it with ``login_item["totp"]``, raising ``KeyError: 'totp'`` during workflow
+run-context initialization (before any browser opens). It must read the optional
+fields defensively instead.
+"""
+
+import pytest
+
+import skyvern.forge.sdk.services.bitwarden as bitwarden_module
+from skyvern.forge.sdk.schemas.credentials import CredentialType, PasswordCredential
+from skyvern.forge.sdk.services.bitwarden import BitwardenService
+
+
+def _login_response(login: dict) -> dict:
+    # Bitwarden item type is an int enum; LOGIN == 1.
+    return {"success": True, "data": {"type": 1, "name": "Example", "login": login}}
+
+
+@pytest.mark.asyncio
+async def test_login_item_without_totp_key_does_not_raise(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `totp` key entirely absent — the exact shape for text/SMS-delivered 2FA.
+    async def fake_get_json(*args, **kwargs) -> dict:
+        return _login_response({"username": "Gudrun", "password": "pw"})
+
+    monkeypatch.setattr(bitwarden_module, "aiohttp_get_json", fake_get_json)
+
+    item = await BitwardenService._get_credential_item_by_id_using_server("item_1")
+
+    assert item.credential_type == CredentialType.PASSWORD
+    assert isinstance(item.credential, PasswordCredential)
+    assert item.credential.username == "Gudrun"
+    assert item.credential.password == "pw"
+    assert item.credential.totp is None
+
+
+@pytest.mark.asyncio
+async def test_login_item_with_totp_is_preserved(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get_json(*args, **kwargs) -> dict:
+        return _login_response({"username": "u", "password": "p", "totp": "JBSWY3DPEHPK3PXP"})
+
+    monkeypatch.setattr(bitwarden_module, "aiohttp_get_json", fake_get_json)
+
+    item = await BitwardenService._get_credential_item_by_id_using_server("item_1")
+
+    assert item.credential.totp == "JBSWY3DPEHPK3PXP"
+
+
+@pytest.mark.asyncio
+async def test_login_item_with_null_fields_normalizes(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_get_json(*args, **kwargs) -> dict:
+        return _login_response({"username": None, "password": None, "totp": None})
+
+    monkeypatch.setattr(bitwarden_module, "aiohttp_get_json", fake_get_json)
+
+    item = await BitwardenService._get_credential_item_by_id_using_server("item_1")
+
+    assert item.credential.username == ""
+    assert item.credential.password == ""
+    assert item.credential.totp is None


### PR DESCRIPTION
## Description

`_get_credential_item_by_id_using_server` read a Bitwarden login item's fields with hard index access:

```python
credential=PasswordCredential(
    username=login_item["username"] or "",
    password=login_item["password"] or "",
    totp=login_item["totp"],          # KeyError: 'totp' when the key is absent
),
```

Bitwarden **omits the `totp` key entirely** from a login item that has no authenticator seed — e.g. a credential whose 2FA is delivered as text/SMS (`totp_type="text"`). The read then raises `KeyError: 'totp'` inside `get_credential_item`, which surfaces during workflow run-context initialization as `Failed to initialize workflow run context … Unexpected error: 'totp'` and crashes the run **before any browser opens**. Workflows that resolve such a credential cannot run at all.

**Fix.** Read the optional login fields with `.get()`, so a missing `totp` yields `PasswordCredential(totp=None)` — the intended optional shape. `username`/`password` are read defensively too.

## How Has This Been Tested?

Environment: Python 3.11, `uv sync`, base `v1.0.36`.

- **Unit test** — `tests/unit/test_bitwarden_credential_item_missing_totp.py` mocks the Bitwarden server response and covers: login item with **no** `totp` key (must not raise; `totp` is `None`), item **with** a totp seed (preserved), and `null` fields (normalized). `uv run pytest tests/unit/test_bitwarden_credential_item_missing_totp.py` → 3 passed. The test reproduces the exact `KeyError: 'totp'` at the original line without the fix.
- **Production verification (self-hosted)** — credential-bearing workflows that previously failed at run-context init with `Unexpected error: 'totp'` now initialize and run.

## Artifacts (if appropriate):

N/A — covered by the unit test above.
