### PR TITLE
Bump version to 1.0.38

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skyvern"
-version = "1.0.37"
+version = "1.0.38"
 description = ""
 authors = [{ name = "Skyvern AI", email = "info@skyvern.com" }]
 requires-python = ">=3.11,<3.14"


### PR DESCRIPTION
## Summary

- Bumps `pyproject.toml` version `1.0.37` → `1.0.38`.
- Triggers `auto-release.yml` → cuts the `v1.0.38` GitHub Release → triggers `build-docker-image.yml` to build & publish both `public.ecr.aws/skyvern/skyvern:v1.0.38` and `public.ecr.aws/skyvern/skyvern-ui:v1.0.38`.
- The UI image is the first OSS release built from the ported `Dockerfile.ui` / `entrypoint-skyvernui.sh` (#5998, SKY-9781), so self-hosters will pick up the leaner multi-stage build and the new runtime-configurable `VITE_*` flags once they pull the new tag.

## Release scope

54 commits since v1.0.37 (2026-05-31). Notable items: critical vitest CVE-2026-47429 fix, captcha timeout circuit breaker, copilot composition-evidence/observation changes, browser-profile session-persist tweaks, OSS workflow schedules. Standard release bundle.

## Test plan

- [ ] After merge, confirm `auto-release.yml` fires and the v1.0.38 release is created.
- [ ] Confirm `build-docker-image.yml` succeeds and `public.ecr.aws/skyvern/skyvern-ui:v1.0.38` is pullable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)