### PR TITLE
Expose run usage ledger in run responses

### DIFF
--- a/skyvern/forge/sdk/workflow/models/workflow.py
+++ b/skyvern/forge/sdk/workflow/models/workflow.py
@@ -20,7 +20,7 @@ from skyvern.forge.sdk.workflow.models.run_limits import (
     reject_bool_max_elapsed_time_minutes,
 )
 from skyvern.forge.sdk.workflow.models.validators import normalize_run_metadata, normalize_run_with
-from skyvern.schemas.runs import ProxyLocationInput, ScriptRunResponse
+from skyvern.schemas.runs import ProxyLocationInput, RunUsageResponse, ScriptRunResponse
 from skyvern.schemas.workflows import WorkflowStatus
 from skyvern.utils.secret_headers import mask_header_values
 from skyvern.utils.url_validators import validate_url
@@ -368,6 +368,7 @@ class WorkflowRunResponseBase(BaseModel):
     )
     credits_used: int = 0
     cached_credits_used: int = 0
+    usage: RunUsageResponse | None = None
     task_v2: TaskV2 | None = None
     workflow_title: str | None = None
     browser_session_id: str | None = None

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -130,6 +130,7 @@ from skyvern.schemas.runs import (
     ProxyLocationInput,
     RunStatus,
     RunType,
+    RunUsageResponse,
     WorkflowRunRequest,
     WorkflowRunResponse,
 )
@@ -163,6 +164,21 @@ from skyvern.webeye.browser_state import BrowserState
 from skyvern.webeye.session_cookies import persist_session_cookies
 
 LOG = structlog.get_logger()
+
+
+def build_workflow_usage_response(
+    credits_used: int | None,
+    cached_credits_used: int | None,
+) -> RunUsageResponse:
+    billable_credits = credits_used or 0
+    cached_credits = cached_credits_used or 0
+    return RunUsageResponse(
+        source="workflow_run",
+        billable_credits_used=billable_credits,
+        cached_credits_used=cached_credits,
+        total_credits_used=billable_credits + cached_credits,
+    )
+
 
 DEFAULT_FIRST_BLOCK_LABEL = "block_1"
 DEFAULT_WORKFLOW_TITLE = "New Workflow"
@@ -5646,6 +5662,7 @@ class WorkflowService:
             total_cost=None,
             credits_used=workflow_run.credits_used,
             cached_credits_used=workflow_run.cached_credits_used,
+            usage=build_workflow_usage_response(workflow_run.credits_used, workflow_run.cached_credits_used),
             workflow_title=workflow.title,
             browser_session_id=workflow_run.browser_session_id,
             browser_profile_id=workflow_run.browser_profile_id,

--- a/skyvern/schemas/runs.py
+++ b/skyvern/schemas/runs.py
@@ -383,6 +383,28 @@ class UploadFileResponse(BaseModel):
     presigned_url: str = Field(description="Presigned URL to access the uploaded file")
 
 
+class RunUsageResponse(BaseModel):
+    source: Literal["task_run", "workflow_run"] = Field(
+        description="Where the usage numbers were read from.",
+        examples=["task_run", "workflow_run"],
+    )
+    duration_ms: int | None = Field(default=None, description="Recorded run duration in milliseconds.")
+    total_cost_usd: float | None = Field(
+        default=None,
+        description="Total known USD cost recorded for task runs. Null when exact cost is not recorded.",
+    )
+    compute_cost_usd: float | None = Field(default=None, description="Recorded browser compute cost in USD.")
+    llm_cost_usd: float | None = Field(default=None, description="Recorded LLM cost in USD.")
+    proxy_cost_usd: float | None = Field(default=None, description="Recorded proxy cost in USD.")
+    captcha_cost_usd: float | None = Field(default=None, description="Recorded captcha-solving cost in USD.")
+    billable_credits_used: int | None = Field(default=None, description="Non-cached credits charged for this run.")
+    cached_credits_used: int | None = Field(default=None, description="Cached credits consumed for this run.")
+    total_credits_used: int | None = Field(
+        default=None,
+        description="Sum of billable and cached credits when credit counters are available.",
+    )
+
+
 class BaseRunResponse(BaseModel):
     run_id: str = Field(
         description="Unique identifier for this run. Run ID starts with `tsk_` for task runs and `wr_` for workflow runs.",
@@ -442,6 +464,10 @@ class BaseRunResponse(BaseModel):
     step_count: int | None = Field(
         default=None,
         description="Total number of steps executed in this run",
+    )
+    usage: RunUsageResponse | None = Field(
+        default=None,
+        description="Run usage ledger for API clients that need spend, credit, or duration visibility.",
     )
 
 

--- a/skyvern/services/run_service.py
+++ b/skyvern/services/run_service.py
@@ -12,6 +12,7 @@ from skyvern.schemas.runs import (
     BulkCancelRunsResponse,
     RunEngine,
     RunResponse,
+    RunUsageResponse,
     RunType,
     TaskRunRequest,
     TaskRunResponse,
@@ -20,6 +21,45 @@ from skyvern.schemas.webhooks import RunWebhookReplayResponse
 from skyvern.services import task_v1_service, task_v2_service, webhook_service, workflow_service
 
 LOG = structlog.get_logger()
+
+
+def _as_float(value: object) -> float | None:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _build_task_run_usage(run: object) -> RunUsageResponse | None:
+    compute_cost = _as_float(getattr(run, "compute_cost", None))
+    llm_cost = _as_float(getattr(run, "llm_cost", None))
+    proxy_cost = _as_float(getattr(run, "proxy_cost", None))
+    captcha_cost = _as_float(getattr(run, "captcha_cost", None))
+    duration_ms = getattr(run, "duration_ms", None)
+
+    costs = [cost for cost in [compute_cost, llm_cost, proxy_cost, captcha_cost] if cost is not None]
+    if not costs and duration_ms is None:
+        return None
+
+    return RunUsageResponse(
+        source="task_run",
+        duration_ms=duration_ms,
+        total_cost_usd=sum(costs) if costs else None,
+        compute_cost_usd=compute_cost,
+        llm_cost_usd=llm_cost,
+        proxy_cost_usd=proxy_cost,
+        captcha_cost_usd=captcha_cost,
+    )
+
+
+def _with_task_run_usage(response: RunResponse | None, run: object) -> RunResponse | None:
+    if response is None:
+        return None
+
+    usage = _build_task_run_usage(run)
+    if usage is None:
+        return response
+
+    return response.model_copy(update={"usage": usage})
 
 
 async def get_run_response(run_id: str, organization_id: str | None = None) -> RunResponse | None:
@@ -57,7 +97,7 @@ async def get_run_response(run_id: str, organization_id: str | None = None) -> R
         elif run.task_run_type == RunType.yutori_navigator:
             run_engine = RunEngine.yutori_navigator
 
-        return TaskRunResponse(
+        response = TaskRunResponse(
             run_id=run.run_id,
             run_type=run.task_run_type,
             status=str(task_v1_response.status),
@@ -89,11 +129,13 @@ async def get_run_response(run_id: str, organization_id: str | None = None) -> R
             errors=task_v1_response.errors,
             step_count=task_v1_response.step_count,
         )
+        return _with_task_run_usage(response, run)
     elif run.task_run_type == RunType.task_v2:
         task_v2 = await app.DATABASE.observer.get_task_v2(run.run_id, organization_id=organization_id)
         if not task_v2:
             return None
-        return await task_v2_service.build_task_v2_run_response(task_v2)
+        response = await task_v2_service.build_task_v2_run_response(task_v2)
+        return _with_task_run_usage(response, run)
     elif run.task_run_type == RunType.workflow_run:
         return await workflow_service.get_workflow_run_response(run.run_id, organization_id=organization_id)
     raise ValueError(f"Invalid task run type: {run.task_run_type}")

--- a/skyvern/services/workflow_service.py
+++ b/skyvern/services/workflow_service.py
@@ -10,9 +10,23 @@ from skyvern.forge.sdk.executor.factory import AsyncExecutorFactory
 from skyvern.forge.sdk.schemas.organizations import Organization
 from skyvern.forge.sdk.workflow.exceptions import InvalidTemplateWorkflowPermanentId
 from skyvern.forge.sdk.workflow.models.workflow import WorkflowRequestBody, WorkflowRun
-from skyvern.schemas.runs import RunStatus, RunType, WorkflowRunRequest, WorkflowRunResponse
+from skyvern.schemas.runs import RunStatus, RunType, RunUsageResponse, WorkflowRunRequest, WorkflowRunResponse
 
 LOG = structlog.get_logger(__name__)
+
+
+def build_workflow_run_usage(
+    credits_used: int | None,
+    cached_credits_used: int | None,
+) -> RunUsageResponse:
+    billable_credits = credits_used or 0
+    cached_credits = cached_credits_used or 0
+    return RunUsageResponse(
+        source="workflow_run",
+        billable_credits_used=billable_credits,
+        cached_credits_used=cached_credits,
+        total_credits_used=billable_credits + cached_credits,
+    )
 
 
 async def prepare_workflow(
@@ -141,6 +155,7 @@ async def get_workflow_run_response(
         include_step_count=True,
     )
     app_url = f"{settings.SKYVERN_APP_URL.rstrip('/')}/runs/{workflow_run.workflow_run_id}"
+    status_usage = getattr(workflow_run_resp, "usage", None)
     return WorkflowRunResponse(
         run_id=workflow_run_id,
         run_type=RunType.workflow_run,
@@ -179,4 +194,7 @@ async def get_workflow_run_response(
         ),
         errors=workflow_run_resp.errors,
         step_count=workflow_run_resp.total_steps,
+        usage=status_usage
+        if isinstance(status_usage, RunUsageResponse)
+        else build_workflow_run_usage(workflow_run.credits_used, workflow_run.cached_credits_used),
     )

--- a/tests/unit/services/test_get_workflow_run_response_passthrough.py
+++ b/tests/unit/services/test_get_workflow_run_response_passthrough.py
@@ -35,6 +35,8 @@ async def test_get_workflow_run_response_passes_through_all_fields() -> None:
         queued_at=now,
         started_at=now,
         finished_at=now,
+        credits_used=9,
+        cached_credits_used=4,
     )
 
     status_resp = MagicMock(
@@ -72,5 +74,9 @@ async def test_get_workflow_run_response_passes_through_all_fields() -> None:
     assert resp.run_with == "code"
     assert resp.status == RunStatus.completed
     assert resp.step_count == 4
+    assert resp.usage is not None
+    assert resp.usage.billable_credits_used == 9
+    assert resp.usage.cached_credits_used == 4
+    assert resp.usage.total_credits_used == 13
     assert resp.run_request is not None
     assert resp.run_request.browser_session_id == "pbs_123"

--- a/tests/unit/test_run_response_usage.py
+++ b/tests/unit/test_run_response_usage.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+
+from skyvern.forge.sdk.workflow.service import build_workflow_usage_response
+from skyvern.schemas.runs import RunUsageResponse
+from skyvern.services.run_service import _build_task_run_usage
+from skyvern.services.workflow_service import build_workflow_run_usage
+
+
+def test_build_task_run_usage_sums_recorded_cost_columns() -> None:
+    usage = _build_task_run_usage(
+        SimpleNamespace(
+            duration_ms=12_345,
+            compute_cost=0.42,
+            llm_cost=1.15,
+            proxy_cost=None,
+            captcha_cost=0.08,
+        )
+    )
+
+    assert usage == RunUsageResponse(
+        source="task_run",
+        duration_ms=12_345,
+        total_cost_usd=1.65,
+        compute_cost_usd=0.42,
+        llm_cost_usd=1.15,
+        proxy_cost_usd=None,
+        captcha_cost_usd=0.08,
+    )
+
+
+def test_build_task_run_usage_keeps_duration_without_costs() -> None:
+    usage = _build_task_run_usage(
+        SimpleNamespace(
+            duration_ms=2500,
+            compute_cost=None,
+            llm_cost=None,
+            proxy_cost=None,
+            captcha_cost=None,
+        )
+    )
+
+    assert usage == RunUsageResponse(source="task_run", duration_ms=2500)
+
+
+def test_build_task_run_usage_omits_empty_rows() -> None:
+    usage = _build_task_run_usage(
+        SimpleNamespace(
+            duration_ms=None,
+            compute_cost=None,
+            llm_cost=None,
+            proxy_cost=None,
+            captcha_cost=None,
+        )
+    )
+
+    assert usage is None
+
+
+def test_workflow_usage_reports_billable_and_cached_credit_ledger() -> None:
+    usage = build_workflow_run_usage(credits_used=7, cached_credits_used=3)
+
+    assert usage == RunUsageResponse(
+        source="workflow_run",
+        billable_credits_used=7,
+        cached_credits_used=3,
+        total_credits_used=10,
+    )
+
+
+def test_sdk_workflow_usage_normalizes_null_credit_counters() -> None:
+    usage = build_workflow_usage_response(credits_used=None, cached_credits_used=None)
+
+    assert usage == RunUsageResponse(
+        source="workflow_run",
+        billable_credits_used=0,
+        cached_credits_used=0,
+        total_credits_used=0,
+    )


### PR DESCRIPTION
## Summary

Adds a structured usage ledger to public run responses so API clients can inspect recorded spend and credit usage without scraping the UI or relying on the deprecated top-level cost field.

This covers two paths:

- task runs expose recorded duration plus compute, LLM, proxy, and captcha cost columns when present
- workflow runs expose billable, cached, and total credits from the workflow run counters

The same ledger is included on both the unified /runs/{run_id} response and the workflow run status response, while keeping existing fields unchanged for compatibility.

This is related to issue #6226, where API consumers asked for usage visibility through the API.

## Validation

- uv run ruff check skyvern/schemas/runs.py skyvern/services/run_service.py skyvern/services/workflow_service.py skyvern/forge/sdk/workflow/models/workflow.py skyvern/forge/sdk/workflow/service.py tests/unit/test_run_response_usage.py tests/unit/services/test_get_workflow_run_response_passthrough.py
- uv run ruff format --check skyvern/schemas/runs.py skyvern/services/run_service.py skyvern/services/workflow_service.py skyvern/forge/sdk/workflow/models/workflow.py skyvern/forge/sdk/workflow/service.py tests/unit/test_run_response_usage.py tests/unit/services/test_get_workflow_run_response_passthrough.py
- uv run python -m py_compile skyvern/schemas/runs.py skyvern/services/run_service.py skyvern/services/workflow_service.py skyvern/forge/sdk/workflow/models/workflow.py skyvern/forge/sdk/workflow/service.py tests/unit/test_run_response_usage.py tests/unit/services/test_get_workflow_run_response_passthrough.py

I tried the focused pytest command for the new tests, but this local checkout hung during Skyvern service import/bootstrap before producing test output. I stopped that process and left the compile plus ruff checks above as the local signal.