### PR TITLE
fix: stop the docker UI from filtering out its own injected API key (403 "Invalid credentials" on self-host)

### DIFF
--- a/entrypoint-skyvernui.sh
+++ b/entrypoint-skyvernui.sh
@@ -28,8 +28,11 @@ VITE_ENABLE_2FA_NOTIFICATIONS="${VITE_ENABLE_2FA_NOTIFICATIONS:-false}"
 # 1. Environment variable (from .env file or docker-compose environment),
 #    but only if it's not a placeholder/sentinel value. Both the Dockerfile
 #    default (__SKYVERN_API_KEY_PLACEHOLDER__) and the .env.example default
-#    (YOUR_API_KEY) can leak through if users skip configuration. Keep this
-#    filter list aligned with the frontend's PLACEHOLDER_VALUES.
+#    (YOUR_API_KEY) can leak through if users skip configuration. Keep these
+#    sentinels aligned with the frontend's placeholder check in
+#    skyvern-frontend/src/util/env.ts (which matches the Docker sentinel by
+#    its _PLACEHOLDER__ suffix — the sed below rewrites every occurrence of
+#    the full sentinel in the bundle, so the frontend must never spell it out).
 # 2. Generated credentials file from the backend first-run setup
 #    (volume-mounted at /app/.skyvern/credentials.toml in docker-compose)
 VITE_SKYVERN_API_KEY="${VITE_SKYVERN_API_KEY:-}"

--- a/skyvern-frontend/src/util/env.test.ts
+++ b/skyvern-frontend/src/util/env.test.ts
@@ -1,3 +1,6 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 async function loadEnv(apiKey: string | null = null, streamingMode = "") {
@@ -41,6 +44,53 @@ describe("getCredentialParam", () => {
 
     expect(params.has("apikey")).toBe(false);
     expect(params.get("token")).toBe("Bearer clerk token");
+  });
+});
+
+describe("getRuntimeApiKey", () => {
+  // Built via join so this test file never contains the sentinel verbatim
+  // either — entrypoint-skyvernui.sh sed-replaces every occurrence in built
+  // assets, and the source guard below must stay meaningful.
+  const dockerSentinel = ["__SKYVERN_API_KEY", "_PLACEHOLDER__"].join("");
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    window.sessionStorage.clear();
+  });
+
+  it("returns the build-time API key", async () => {
+    const { getRuntimeApiKey } = await loadEnv("eyJhbGciOiJIUzI1NiJ9.real.key");
+
+    expect(getRuntimeApiKey()).toBe("eyJhbGciOiJIUzI1NiJ9.real.key");
+  });
+
+  it("treats the .env.example placeholder as missing", async () => {
+    const { getRuntimeApiKey } = await loadEnv("YOUR_API_KEY");
+
+    expect(getRuntimeApiKey()).toBe(null);
+  });
+
+  it("treats an un-replaced docker placeholder as missing", async () => {
+    const { getRuntimeApiKey } = await loadEnv(dockerSentinel);
+
+    expect(getRuntimeApiKey()).toBe(null);
+  });
+
+  // Regression guard for the v1.0.34–v1.0.40 docker auth outage:
+  // entrypoint-skyvernui.sh sed-replaces EVERY occurrence of the docker
+  // sentinel in the built bundle with the real API key. When the full
+  // sentinel appeared verbatim in this module (inside the placeholder
+  // deny-list), the real key replaced it there too, so the key became a
+  // member of its own deny-list and the UI sent no x-api-key header at all
+  // (403 "Invalid credentials" on every request).
+  it("never spells out the full docker placeholder sentinel in module source", async () => {
+    const source = await readFile(
+      path.join(process.cwd(), "src/util/env.ts"),
+      "utf-8",
+    );
+
+    expect(source.includes(dockerSentinel)).toBe(false);
   });
 });
 

--- a/skyvern-frontend/src/util/env.ts
+++ b/skyvern-frontend/src/util/env.ts
@@ -80,12 +80,13 @@ function getRuntimeApiKey(): string | null {
 
   // Treat placeholder / example values as missing so they are never sent
   // as real credentials (e.g. from .env.example or an un-replaced Docker placeholder).
-  const PLACEHOLDER_VALUES = [
-    "YOUR_API_KEY",
-    "__SKYVERN_API_KEY_PLACEHOLDER__",
-  ];
-  runtimeApiKey =
-    candidate && PLACEHOLDER_VALUES.includes(candidate) ? null : candidate;
+  // The Docker sentinel is matched by its suffix on purpose: the prebuilt-image
+  // entrypoint sed-replaces every occurrence of the full sentinel in the bundle
+  // with the real API key, so spelling it out here would put the real key in its
+  // own deny-list and strip the x-api-key header from every request.
+  const isPlaceholder =
+    candidate === "YOUR_API_KEY" || candidate?.endsWith("_PLACEHOLDER__");
+  runtimeApiKey = candidate && isPlaceholder ? null : candidate;
   return runtimeApiKey;
 }
 


### PR DESCRIPTION
## Problem

Since v1.0.34 (introduced in 2bfb42f10, #5960), every docker self-host deployment of the UI fails all authenticated requests with **403 "Invalid credentials"** — the UI sends no `x-api-key` header at all, no matter how the key is configured (`VITE_SKYVERN_API_KEY` env var or the generated `.skyvern/credentials.toml` fallback). Reported by Flinks on v1.0.38 and v1.0.40; #6401 fixed a different symptom (restart re-injection) and did not resolve this.

## Root cause

The prebuilt UI image (`Dockerfile.ui` + `entrypoint-skyvernui.sh`) injects runtime config by sed-replacing **every** occurrence of `__SKYVERN_API_KEY_PLACEHOLDER__` in the built bundle with the real API key. The frontend's placeholder deny-list in `src/util/env.ts` spelled out that same sentinel verbatim:

```ts
const PLACEHOLDER_VALUES = [
  "YOUR_API_KEY",
  "__SKYVERN_API_KEY_PLACEHOLDER__",   // ← sed rewrites this too
];
```

After injection the minified bundle literally contains `["YOUR_API_KEY","eyJhbGciOiJIUzI1..."]` — the real key becomes a member of its own deny-list, `getRuntimeApiKey()` returns `null`, and no `x-api-key` is attached. Dev builds never hit this because there is no sed step.

## Fix

- Match the docker sentinel by its `_PLACEHOLDER__` suffix instead of spelling out the full string, so the sentinel never appears in the bundle outside the env value slot. (Suffix matching rather than string concatenation because esbuild constant-folds concatenated literals, which would reintroduce the verbatim sentinel.)
- Add a source-guard test that fails if the full sentinel is ever reintroduced into `env.ts`, plus behavior tests for the placeholder filtering.
- Update the stale cross-reference comment in `entrypoint-skyvernui.sh`.

## Reproduction & verification

Reproduced end-to-end with the published images (docker compose, postgres + backend + UI, headless-browser assertions on `/workflows`):

| Setup | Result |
|---|---|
| UI v1.0.24, valid key in `skyvern-frontend/.env` | `x-api-key` sent, all 200 ✅ |
| UI v1.0.40, same key/backend/DB | `x-api-key: NONE`, all 403 "Invalid credentials" ❌ |
| v1.0.40 bundle with poisoned deny-list entry removed in place | all 200 ✅ (isolates the mechanism) |
| **This branch**: `npm run build` with docker placeholder env values → entrypoint sed applied → served against the same backend | `x-api-key` sent, all 200 ✅ |

After the fix the sentinel appears exactly once in the bundle (the value slot), and the compiled filter is sed-proof:

```js
n=e==="YOUR_API_KEY"||(e==null?void 0:e.endsWith("_PLACEHOLDER__"))
```

`vitest run src/util/env.test.ts`: 8/8 passing. Lint and prettier clean.

Diagnostic note for support: backend 403 detail `Invalid credentials` on `/workflows` means the request carried **no** `x-api-key` header; a malformed key produces `Could not validate credentials` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)