### PR TITLE
Bump version to 1.0.41

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skyvern"
-version = "1.0.40"
+version = "1.0.41"
 description = ""
 authors = [{ name = "Skyvern AI", email = "info@skyvern.com" }]
 requires-python = ">=3.11,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -5732,7 +5732,7 @@ wheels = [
 
 [[package]]
 name = "skyvern"
-version = "1.0.40"
+version = "1.0.41"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Ticket

Follow-up to #6516 / [SKY-10675](https://linear.app/skyvern/issue/SKY-10675) release chain.

## Description

Bump `pyproject.toml` + `uv.lock` from `1.0.40` → `1.0.41`. Version-bump only; no code changes.

## Problem

#6516 (docker self-host UI 403 fix — the injected API key was landing in its own placeholder deny-list, stripping the `x-api-key` header from every authenticated request; broken v1.0.34–v1.0.40) is merged to `main`, but no release carries it yet. Self-hosters keep pulling broken images until a new version is cut.

## Solution

Bump the version so `auto-release.yml` cuts `v1.0.41` — the first release containing the fix. Branch is cut directly off #6516's merge commit. Per #6452, the release should auto-dispatch `build-docker-image` (no manual dispatch needed). Downstream after image publish: one cloud PR bumping Helm `image.tag` `v1.0.39 → v1.0.41` and terraform `skyvern_ui_image_version` `v1.0.38 → v1.0.41`.

## How Has This Been Tested?

Version-only diff (2 files, 2 lines — verified nothing else moved in `uv.lock`). The fix itself was verified end-to-end in #6516 (compose stack + headless-browser `x-api-key` assertions). The resulting image will be verified after publish with a real auth check (deny-list poisoning probe) before any cloud pin moves to it.

## Artifacts (if appropriate):

N/A — version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
