### PR TITLE
fix(docker): force dev deps in UI builder stage to fix "tsc: not found"

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -5,7 +5,9 @@ WORKDIR /app
 
 # Copy dependency files first for better Docker layer caching
 COPY ./skyvern-frontend/package.json ./skyvern-frontend/package-lock.json ./
-RUN npm ci
+# --include=dev keeps tsc/vite installed even if NODE_ENV=production is inherited
+# from the host/build env (npm omits devDependencies otherwise -> "tsc: not found").
+RUN npm ci --include=dev
 
 # Copy source code
 COPY ./skyvern-frontend/ ./


### PR DESCRIPTION
## Problem

Self-hosters building the UI image hit:

```
sh: 1: tsc: not found
```

at the `npm run build` step.

**Root cause:** the frontend build script is `tsc --noEmit && vite build`, but `tsc` (`typescript`) and `vite` live in **devDependencies**. The builder stage in `Dockerfile.ui` used a plain `npm ci`, which **silently omits devDependencies when `NODE_ENV=production` is inherited** from the host shell, a `.env`, docker-compose `environment:`, or CI. With dev deps stripped, `node_modules/.bin/tsc` never exists and the build dies. (The `sh: 1:` prefix is Debian `/bin/sh`, confirming it's the in-image build.)

The Dockerfile never sets `NODE_ENV` itself — it leaks in from the self-hoster's environment — so the stock image build is at the mercy of whatever the host exports.

## Fix

Pin the builder install to `npm ci --include=dev` so the build is immune to an inherited `NODE_ENV=production`. The runtime stage keeps `npm ci --omit=dev`, so the final image stays lean.

```diff
-RUN npm ci
+RUN npm ci --include=dev
```

## Why it's safe

- `--include=dev` only *guarantees* devDependencies are installed in the **builder** stage (where they're required to compile). Behavior is unchanged for any build that wasn't already setting `NODE_ENV=production`.
- The runtime stage's `npm ci --omit=dev` is untouched, so image size is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)