### PR TITLE
fix(HttpRequestBlock): apply SSRF protection to workflow HTTP requests

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -47,6 +47,8 @@ from skyvern.constants import (
 )
 from skyvern.exceptions import (
     AzureConfigurationError,
+    BlockedHost,
+    SkyvernHTTPException,
     ConditionalBranchEvaluationError,
     ContextParameterValueNotFound,
     DownloadFileMaxSizeExceeded,
@@ -140,7 +142,7 @@ from skyvern.services.error_detection_service import detect_user_defined_errors_
 from skyvern.utils.strings import generate_random_string
 from skyvern.utils.templating import get_missing_variables
 from skyvern.utils.token_counter import count_tokens
-from skyvern.utils.url_validators import prepend_scheme_and_validate_url
+from skyvern.utils.url_validators import prepend_scheme_and_validate_url, validate_url as _ssrf_validate_url
 from skyvern.webeye.browser_state import BrowserState
 from skyvern.webeye.utils.page import SkyvernFrame
 
@@ -6370,10 +6372,35 @@ class HttpRequestBlock(Block):
                 organization_id=organization_id,
             )
 
-        if not self.validate_url(self.url):
+        try:
+            validated_url = _ssrf_validate_url(self.url)
+            if not validated_url:
+                return await self.build_block_result(
+                    success=False,
+                    failure_reason=f"Invalid URL: {self.url}",
+                    output_parameter_value=None,
+                    status=BlockStatus.failed,
+                    workflow_run_block_id=workflow_run_block_id,
+                    organization_id=organization_id,
+                )
+            self.url = validated_url
+        except BlockedHost as exc:
+            host = getattr(exc, "host", "unknown")
             return await self.build_block_result(
                 success=False,
-                failure_reason=f"Invalid URL format: {self.url}",
+                failure_reason=(
+                    f"URL is blocked by SSRF protection (host: {host}). "
+                    "Add the host to ALLOWED_HOSTS to reach internal endpoints."
+                ),
+                output_parameter_value=None,
+                status=BlockStatus.failed,
+                workflow_run_block_id=workflow_run_block_id,
+                organization_id=organization_id,
+            )
+        except SkyvernHTTPException as exc:
+            return await self.build_block_result(
+                success=False,
+                failure_reason=f"Invalid URL: {getattr(exc, 'message', str(exc))}",
                 output_parameter_value=None,
                 status=BlockStatus.failed,
                 workflow_run_block_id=workflow_run_block_id,


### PR DESCRIPTION
## Problem

`HttpRequestBlock.execute()` validates the user-supplied URL only with a format check (`urlparse` scheme+netloc), then passes it unchanged to `aiohttp_request()`, which has no host filtering. Any authenticated user can create a workflow with an `http_request` block targeting cloud instance metadata endpoints (`http://169.254.169.254/`), loopback, or private-range IPs — the server executes the request and returns the full response body as workflow output.

The project already ships SSRF protection (`url_validators.validate_url` / `is_blocked_host`) used by the webhook test and replay endpoints — but `HttpRequestBlock` bypassed it entirely.

**CVSS v3.1:** AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:N → **8.5 HIGH** (critical in multi-tenant context)

## Fix

Routes `HttpRequestBlock.execute()` through the existing `url_validators.validate_url()` / `is_blocked_host()` SSRF protection layer. Operators who need to reach internal endpoints can use the existing `ALLOWED_HOSTS` config.

## Test Plan
- [ ] Existing test suite passes
- [ ] `http_request` block with `url: http://169.254.169.254/` → returns failure with `URL is blocked by SSRF protection`
- [ ] `http_request` block with `url: http://127.0.0.1:5432/` → blocked
- [ ] `http_request` block with `url: https://webhook.site/test` → succeeds normally
- [ ] Operators with `ALLOWED_HOSTS: ['my-internal-host']` can still reach that host

## Security Note

Severity: Critical on cloud deployments. Filed via GitHub Private Vulnerability Reporting.

<!-- failsafe-scan-id: tob-fallback-2026-06-11 -->