### PR TITLE
fix: apply WindowsSelectorEventLoopPolicy on Windows for Playwright subprocess compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ pip install "skyvern[all]"
 skyvern quickstart
 ```
 
+> **Windows users (native, not WSL)**
+> Skyvern handles the required asyncio event loop policy automatically starting
+> from this version. If you're on an older version and hit a `NotImplementedError`
+> during browser launch, add the following at the top of your script:
+>
+> ```python
+> import asyncio, sys
+> if sys.platform == "win32":
+>     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+> ```
+
+
 The pip quickstart uses SQLite by default. For a local Postgres container, run `skyvern quickstart --postgres`.
 
 ### Option B: Docker Compose

--- a/skyvern/__init__.py
+++ b/skyvern/__init__.py
@@ -1,3 +1,10 @@
+import sys
+
+if sys.platform == "win32":
+    import asyncio
+
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
 import typing
 from typing import Any
 

--- a/skyvern/cli/run_commands.py
+++ b/skyvern/cli/run_commands.py
@@ -1,3 +1,11 @@
+# Windows asyncio compatibility — must be set before any event loop is created.
+import sys
+
+if sys.platform == "win32":
+    import asyncio
+
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
 import asyncio
 import atexit
 import json


### PR DESCRIPTION
## Summary

Fixes `NotImplementedError` when using the Skyvern Python SDK or CLI on native Windows 11/10 (not WSL).

Related: #3012, #4666

## Root Cause

Python 3.8+ defaults to `asyncio.ProactorEventLoop` on Windows. `ProactorEventLoop` does not implement `_make_subprocess_transport`, which Playwright requires to spawn Chromium, causing an immediate crash:
```
File "asyncio\base_events.py", line 502, in _make_subprocess_transport
raise NotImplementedError
NotImplementedError
```

This affects every Skyvern entry point on native Windows:
- `from skyvern import Skyvern` → `await skyvern.run_task(...)`
- `skyvern quickstart`
- `skyvern run server`

## Fix

Apply `asyncio.WindowsSelectorEventLoopPolicy` at the two earliest entry points before any event loop is created. Zero-cost guard on Linux/macOS — the `sys.platform == "win32"` check means it never runs outside Windows. Fixes #6494 

## Files Changed

| File | Change |
|---|---|
| `skyvern/__init__.py` | Apply policy at module import time (covers SDK users) |
| `skyvern/cli/run_commands.py` | Apply policy at CLI boot (covers `skyvern run` users) |
| `README.md` | Add Windows callout in quickstart section |

## Testing

Tested on Python 3.11, Windows 11 native. Before this fix, `asyncio.run(skyvern.run_task(...))` raises `NotImplementedError` immediately. After this fix it runs cleanly.

No behaviour change on Linux/macOS.

## Note on pre-commit

`vitest` tests fail locally on Windows due to a missing `@testing-library/dom` peer dependency in `skyvern-frontend/node_modules`, the pre-existing environment issue is unrelated to this PR. All Python hooks pass cleanly.

## Checklist
- [x] Ran `pre-commit run --all-files` — all Python hooks pass cleanly
- [x] Tested on Python 3.11, Windows 11 native
- [x] No changes to Linux/macOS behaviour