### PR TITLE
security: fix HIGH npm vulnerability (form-data CVE-2026-12143)

### DIFF
--- a/skyvern-frontend/package-lock.json
+++ b/skyvern-frontend/package-lock.json
@@ -5973,19 +5973,31 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/forwarded": {


### PR DESCRIPTION
## Ticket

No Linear ticket — automated Dependabot security scan.

## Problem

Dependabot alert #722 (HIGH, CVSS 7.5): form-data 4.0.5 in `skyvern-frontend/package-lock.json` is vulnerable to CRLF injection via unescaped multipart field names and filenames (CVE-2026-12143). form-data is a runtime transitive dependency via axios.

## Solution

Updated `skyvern-frontend/package-lock.json` via `npm update form-data`:

- **Before**: `form-data@4.0.5` (vulnerable)
- **After**: `form-data@4.0.6` (patched)

Only `package-lock.json` changed — no direct dependency version bumps needed, as axios already accepts `^4.0.5` which includes 4.0.6.

## How Has This Been Tested?

- `npm update form-data` resolves form-data to 4.0.6 — PASS
- `npx tsc --noEmit` TypeScript type check — PASS
- package-lock.json diff verified: only form-data and its sub-deps updated

Fixes Dependabot alert #722 in Skyvern-AI/skyvern.

## Artifacts (if appropriate):

N/A — lockfile-only change.

🤖 Generated with [Claude Code](https://claude.ai/code) via /security-scan

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>