### PR TITLE
Bump version to 1.0.42

### DIFF
--- a/packages/skyvern-ui/pyproject.toml
+++ b/packages/skyvern-ui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skyvern-ui"
-version = "1.0.41"
+version = "1.0.42"
 description = "Prebuilt Skyvern UI assets for the Skyvern CLI"
 authors = [{ name = "Skyvern AI", email = "info@skyvern.com" }]
 requires-python = ">=3.11,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skyvern"
-version = "1.0.41"
+version = "1.0.42"
 description = ""
 authors = [{ name = "Skyvern AI", email = "info@skyvern.com" }]
 requires-python = ">=3.11,<3.14"

--- a/skyvern-ts/client/package-lock.json
+++ b/skyvern-ts/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@skyvern/client",
-    "version": "1.0.41",
+    "version": "1.0.42",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@skyvern/client",
-            "version": "1.0.41",
+            "version": "1.0.42",
             "dependencies": {
                 "playwright": "^1.48.0"
             },

--- a/skyvern-ts/client/package.json
+++ b/skyvern-ts/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@skyvern/client",
-    "version": "1.0.41",
+    "version": "1.0.42",
     "private": false,
     "repository": {
         "type": "git",

--- a/uv.lock
+++ b/uv.lock
@@ -5755,7 +5755,7 @@ wheels = [
 
 [[package]]
 name = "skyvern"
-version = "1.0.41"
+version = "1.0.42"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary
Bump Skyvern OSS version to **1.0.42**.

## Changes
- `pyproject.toml` and `packages/skyvern-ui/pyproject.toml`: `1.0.41` → `1.0.42`
- `uv.lock`: sync `skyvern` version
- `skyvern-ts/client/package.json` + `package-lock.json`: bump `@skyvern/client` to `1.0.42`

## Version-only bump (no SDK regeneration)
The OpenAPI spec (`openapi/`) is **unchanged since 1.0.41**, so the generated Python/TS SDK code is byte-identical — only version strings change. No Fern regeneration was needed, and the `skyvern/client` circular-import patches are untouched.

## ⚠️ Release sequencing — read before publishing
This release is intended to ship the UI prebuilt-image fix in **#6683** (prebuilt-aware `npm run start`/`serve` + official Helm chart). The `skyvern-ui` Docker image is built from `main` when the GitHub Release is **published** (`build-docker-image.yml` runs on `release: published`).

**Merge #6683 into `main` before publishing the v1.0.42 release**, otherwise the v1.0.42 `skyvern-ui` image will NOT contain the shim and self-hosters with a `command: ["npm","run","start"]` override will keep crashlooping.

(The PyPI/NPM package publish triggered by merging this bump is independent of #6683 — the shim is not part of the Python/TS SDKs.)

## Deployment
After merge, GitHub Actions will:
- Publish the `skyvern` package to PyPI (version change in `pyproject.toml`)
- Publish `@skyvern/client` to NPM (version change in `package.json`)

## Testing
- [ ] (optional) Python SDK tests
- [x] Verified diff is version-only; TS client JSON validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)