### PR TITLE
security: fix undici TLS bypass vulnerability (CVE-2026-9697)

### DIFF
--- a/skyvern/cli/mcpb/claude_desktop/package-lock.json
+++ b/skyvern/cli/mcpb/claude_desktop/package-lock.json
@@ -570,6 +570,15 @@
         "mcp-remote-client": "dist/client.js"
       }
     },
+    "node_modules/mcp-remote/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -950,15 +959,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.1.tgz",
-      "integrity": "sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/unpipe": {

--- a/skyvern/cli/mcpb/claude_desktop/package.json
+++ b/skyvern/cli/mcpb/claude_desktop/package.json
@@ -6,5 +6,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "mcp-remote": "0.1.38"
+  },
+  "overrides": {
+    "undici": ">=7.28.0 <8"
   }
 }


### PR DESCRIPTION
## Ticket

No Linear ticket — automated Dependabot security scan (alert #799).

## Problem

Dependabot alert #799 (HIGH, CVSS 7.4): `undici` 7.24.1 in `skyvern/cli/mcpb/claude_desktop/package-lock.json` is vulnerable to TLS certificate validation bypass via CVE-2026-9697. This allows a man-in-the-middle attacker to intercept HTTPS connections made by the MCP bundle.

## Solution

Added `overrides` in `skyvern/cli/mcpb/claude_desktop/package.json` to pin `undici` to `>=7.28.0 <8`, which forces npm to resolve the transitive dependency to 7.28.0 where the vulnerability is patched.

## How Has This Been Tested?

- `npm install` resolves undici to 7.28.0 (patched version) in the lockfile
- `npm audit` no longer reports CVE-2026-9697 after the override is applied

## Artifacts (if appropriate):

Fixes Dependabot alert #799 in skyvern (undici HIGH CVE-2026-9697).