### PR TITLE
Bump version to 1.0.43

### DIFF
--- a/packages/skyvern-ui/pyproject.toml
+++ b/packages/skyvern-ui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skyvern-ui"
-version = "1.0.42"
+version = "1.0.43"
 description = "Prebuilt Skyvern UI assets for the Skyvern CLI"
 authors = [{ name = "Skyvern AI", email = "info@skyvern.com" }]
 requires-python = ">=3.11,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skyvern"
-version = "1.0.41"
+version = "1.0.43"
 description = ""
 authors = [{ name = "Skyvern AI", email = "info@skyvern.com" }]
 requires-python = ">=3.11,<3.14"

--- a/skyvern-ts/client/package-lock.json
+++ b/skyvern-ts/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@skyvern/client",
-    "version": "1.0.42",
+    "version": "1.0.43",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@skyvern/client",
-            "version": "1.0.42",
+            "version": "1.0.43",
             "dependencies": {
                 "playwright": "^1.48.0"
             },

--- a/skyvern-ts/client/package.json
+++ b/skyvern-ts/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@skyvern/client",
-    "version": "1.0.42",
+    "version": "1.0.43",
     "private": false,
     "repository": {
         "type": "git",

--- a/uv.lock
+++ b/uv.lock
@@ -5776,7 +5776,7 @@ wheels = [
 
 [[package]]
 name = "skyvern"
-version = "1.0.41"
+version = "1.0.43"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary
Bump Skyvern OSS version to **1.0.43**.

## Why 1.0.43 (not a re-merge of 1.0.42)
The merged v1.0.42 bump (#6684) was partially clobbered: #6697 carried a stale `pyproject.toml` that knocked `pyproject.toml` + `uv.lock` back to `1.0.41`, while `packages/skyvern-ui/pyproject.toml` and `skyvern-ts/client/*` stayed at `1.0.42` — leaving `main` in a split version state. This PR sets **all** version references to `1.0.43`, reconciling the inconsistency.

## Changes
- `pyproject.toml` (`1.0.41` → `1.0.43`) and `packages/skyvern-ui/pyproject.toml` (`1.0.42` → `1.0.43`)
- `uv.lock`: sync `skyvern` (`1.0.41` → `1.0.43`)
- `skyvern-ts/client/package.json` + `package-lock.json`: `@skyvern/client` (`1.0.42` → `1.0.43`)

## Version-only bump (no SDK regeneration)
The Fern source spec (`openapi/skyvern_openapi.json`) is unchanged since 1.0.41, so the generated Python/TS SDK code is byte-identical — only version strings change. The `skyvern/client` circular-import patches are untouched.

## Release note
The UI prebuilt-image fix (**#6683** — prebuilt-aware `npm run start`/`serve` shim + official `k8s/charts/skyvern-ui`) is **already merged into `main`**, so a v1.0.43 release cut from `main` will include it. No merge-ordering caveat this time.

## Deployment
After merge, GitHub Actions will publish `skyvern` to PyPI and `@skyvern/client` to NPM (version change). Publishing the v1.0.43 GitHub Release builds the `skyvern-ui` Docker image (which will contain the #6683 shim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)