### PR TITLE
Fix live browser stream stuck on about:blank by following the run's active page

### DIFF
--- a/skyvern/forge/sdk/routes/streaming/screencast.py
+++ b/skyvern/forge/sdk/routes/streaming/screencast.py
@@ -71,6 +71,8 @@ async def start_screencast_loop(
     entity_id: str,
     entity_type: str,
     check_finalized: Callable[[], Awaitable[bool]],
+    workflow_run_id: str | None = None,
+    organization_id: str | None = None,
 ) -> None:
     id_key = f"{entity_type}_id"
     cdp_session: CDPSession | None = None
@@ -209,7 +211,7 @@ async def start_screencast_loop(
             data = await frame_queue.get()
             current_url = ""
             try:
-                page = await browser_state.get_working_page()
+                page = await _current_working_page()
                 if page is not None:
                     current_url = page.url
             except Exception:
@@ -247,7 +249,7 @@ async def start_screencast_loop(
         while True:
             await asyncio.sleep(ACTIVE_PAGE_POLL_INTERVAL)
             try:
-                page = await browser_state.get_working_page()
+                page = await _current_working_page()
                 if page is not None and page is not attached_page:
                     await _attach_to_page(page)
             except Exception:
@@ -258,8 +260,21 @@ async def start_screencast_loop(
                     exc_info=True,
                 )
 
+    async def _current_working_page() -> object | None:
+        # A workflow run can swap in a NEW BrowserState for this session after the screencast
+        # started (standalone browser launch -> set_browser_state); the browser_state captured
+        # at connect time then goes stale (idle about:blank). Re-resolve each poll so we follow
+        # the run's live page. (skyvern issue #6703)
+        state = await _resolve_browser_state(entity_id, entity_type, workflow_run_id, organization_id)
+        if state is None:
+            state = browser_state
+        try:
+            return await state.get_working_page()
+        except Exception:
+            return None
+
     try:
-        page = await browser_state.get_working_page()
+        page = await _current_working_page()
         if page is None:
             raise RuntimeError("No working page available for screencast")
 

--- a/skyvern/forge/sdk/routes/streaming/screenshot.py
+++ b/skyvern/forge/sdk/routes/streaming/screenshot.py
@@ -380,6 +380,8 @@ async def _run_local_screencast(
             entity_id=entity_id,
             entity_type=entity_type,
             check_finalized=check_finalized,
+            workflow_run_id=workflow_run_id,
+            organization_id=organization_id,
         )
 
         final_status = await get_current_status()


### PR DESCRIPTION
Fixes #6703.

**Problem** — Starting a run from the editor/builder, the Live Browser pane stays on `about:blank` for the whole run even though the agent is navigating. Opening the same session from **Browsers → Sessions** *after* the run starts renders correctly.

**Root cause** — `start_screencast_loop` (`skyvern/forge/sdk/routes/streaming/screencast.py`) captures the session's `BrowserState` **once**, at connect time. But a workflow run launches a standalone browser and swaps in a **new** `BrowserState` for the session via `PersistentSessionsManager.set_browser_state` (which replaces the stored object). After the swap, the screencast keeps polling `get_working_page()` on the original, now-stale `BrowserState` — whose working page is the idle `about:blank` — so it never attaches to the run's live page. Opening from Browsers → Sessions works only because it connects *after* the swap. (`cdp_input` already rebinds to the active page; only the output screencast doesn't.)

**Fix** — Re-resolve the session's current `BrowserState` on every poll (via the existing `_resolve_browser_state`), mirroring how `cdp_input` rebinds, so the screencast follows the run's live page. Verified on a self-hosted deployment (`BROWSER_STREAMING_MODE=cdp`, `chromium-headful`): the editor live pane follows the agent immediately, with no workaround.
