### PR TITLE
Reap idle/abandoned persistent browser sessions to free leaked Chromium + ffmpeg

### DIFF
--- a/skyvern/forge/api_app.py
+++ b/skyvern/forge/api_app.py
@@ -246,6 +246,14 @@ async def lifespan(fastapi_app: FastAPI) -> AsyncGenerator[None, Any]:
     except Exception:
         LOG.exception("Failed to clean up stale browser sessions")
 
+    # Reap expired/abandoned persistent browser sessions so their in-process Chromium + Playwright
+    # ffmpeg recorders don't leak. Upstream renews sessions only on frontend poll / active-workflow
+    # loop and has no timer that closes idle ones; start_reaper() adds that timer.
+    try:
+        forge_app.PERSISTENT_SESSIONS_MANAGER.start_reaper()
+    except Exception:
+        LOG.exception("Failed to start browser session reaper")
+
     # Start cleanup scheduler if enabled
     cleanup_task = start_cleanup_scheduler()
     if cleanup_task:

--- a/skyvern/webeye/default_persistent_sessions_manager.py
+++ b/skyvern/webeye/default_persistent_sessions_manager.py
@@ -30,6 +30,17 @@ from skyvern.webeye.session_cookies import persist_session_cookies
 
 LOG = structlog.get_logger()
 
+# How often the reaper scans for expired persistent browser sessions to close. Upstream has no idle
+# reaper, so abandoned debug/standalone sessions expire in the DB but their in-process Chromium +
+# Playwright record_video ffmpeg encoders are never torn down (one browser + recorder leaked per
+# abandoned session). The reaper closes sessions whose timeout has elapsed.
+REAP_INTERVAL_SECONDS = 60
+# Only reap a session this long AFTER its timeout has elapsed — a safety buffer so the reaper can
+# never race a renewal that is mid-flight. Active sessions are renewed well before expiry (workflow
+# loop every 5 min, frontend polls), so in practice they never reach expiry at all; this is belt-and-
+# suspenders for any clock skew / in-flight-renewal corner case.
+REAP_GRACE_SECONDS = 120
+
 
 @dataclass
 class BrowserSession:
@@ -184,6 +195,7 @@ class DefaultPersistentSessionsManager(PersistentSessionsManager):
     instance: DefaultPersistentSessionsManager | None = None
     _browser_sessions: dict[str, BrowserSession] = dict()
     _background_tasks: set[asyncio.Task[None]] = set()
+    _reaper_task: asyncio.Task[None] | None = None
     database: AgentDB
 
     def __new__(cls, database: AgentDB) -> DefaultPersistentSessionsManager:
@@ -586,6 +598,66 @@ class DefaultPersistentSessionsManager(PersistentSessionsManager):
             await self.database.browser_sessions.archive_browser_session_address(
                 db_session.persistent_browser_session_id, db_session.organization_id
             )
+
+    def start_reaper(self) -> None:
+        """Start the background loop that closes expired persistent browser sessions.
+
+        Idempotent, and gated to cdp streaming mode (browsers run in-process). Without it, an
+        idle/abandoned session (e.g. a debug session whose editor tab was closed, so it stops being
+        renewed) expires in the DB but its in-process Chromium + Playwright record_video ffmpeg
+        encoder are never closed, leaking ~1 browser + recorder per abandoned session.
+        """
+        if settings.BROWSER_STREAMING_MODE != "cdp":
+            return
+        if self._reaper_task is not None and not self._reaper_task.done():
+            return
+        task = asyncio.create_task(self._reap_expired_sessions_loop())
+        self._reaper_task = task
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
+        LOG.info("Persistent browser session reaper started", interval_seconds=REAP_INTERVAL_SECONDS)
+
+    async def _reap_expired_sessions_loop(self) -> None:
+        while True:
+            await asyncio.sleep(REAP_INTERVAL_SECONDS)
+            try:
+                await self._reap_expired_sessions_once()
+            except Exception:
+                LOG.exception("Browser session reaper pass failed")
+
+    async def _reap_expired_sessions_once(self) -> None:
+        sessions = await self.database.browser_sessions.get_all_active_persistent_browser_sessions()
+        now = datetime.now(timezone.utc)
+        for db_session in sessions:
+            # Only reap sessions that have actually started AND are past their timeout. Sessions in
+            # active use are continuously renewed (the workflow renewal loop / frontend polls extend
+            # the timeout), so they never reach expiry here; not-yet-started sessions are still
+            # launching and are left to the existing launch/renewal grace logic.
+            if db_session.started_at is None or db_session.timeout_minutes is None:
+                continue
+            started_at_utc = (
+                db_session.started_at.replace(tzinfo=timezone.utc)
+                if db_session.started_at.tzinfo is None
+                else db_session.started_at
+            )
+            expires_at = started_at_utc + timedelta(minutes=float(db_session.timeout_minutes))
+            if expires_at + timedelta(seconds=REAP_GRACE_SECONDS) > now:
+                continue
+            LOG.info(
+                "Reaping expired persistent browser session",
+                session_id=db_session.persistent_browser_session_id,
+                organization_id=db_session.organization_id,
+            )
+            try:
+                await self.close_session(
+                    db_session.organization_id, db_session.persistent_browser_session_id
+                )
+            except Exception:
+                LOG.exception(
+                    "Failed to reap expired browser session",
+                    session_id=db_session.persistent_browser_session_id,
+                    organization_id=db_session.organization_id,
+                )
 
     @classmethod
     async def close(cls) -> None:


### PR DESCRIPTION
Fixes #6712.

**Problem** — Persistent browser sessions (editor debug sessions + standalone) are renewed only when something pulls on them: the frontend polling `GET /debug-session/{wpid}`, or a workflow run's per-run `_renew_browser_session_loop`. There is **no server-side timer that closes idle/abandoned sessions** (`watch_session_pool()` is a no-op in `DefaultPersistentSessionsManager`). So once a session stops being renewed it expires in the DB, but its in-process Chromium + Playwright `record_video` ffmpeg encoder are never torn down — they accumulate (dozens of orphan browsers + ffmpeg, multiple CPU cores and many GB of RSS at idle) until the pod OOMs.

**Fix** — Add a periodic reaper (`DefaultPersistentSessionsManager.start_reaper` → `_reap_expired_sessions_loop`, started from the API app's startup lifespan, gated to `cdp` mode, 60 s interval) that closes active persistent sessions whose timeout has elapsed, via the existing `close_session()` — which already tears down the context (stopping the ffmpeg recorder), syncs the recording, and releases the CDP port.

**Why it's safe for active sessions** — The reaper only closes sessions whose `started_at + timeout_minutes` is already in the past — the same expiry `renew_or_close_session` already uses to decide a session is non-renewable. Sessions in active use never reach expiry: a workflow run renews every 5 min (`_renew_browser_session_loop`) and an open editor renews via its polls, both keeping the timeout 10–20 min ahead. A **120 s grace margin** (`REAP_GRACE_SECONDS`) adds a buffer so it can't race an in-flight renewal. It deliberately does **not** skip "occupied" sessions — a crashed run that never released its session would otherwise leak forever; the timeout already covers that case.

**Verified** — On a self-hosted `cdp` / `chromium-headful` deployment: created a session with a short timeout, and once it expired the logs showed `Reaping expired persistent browser session` followed by `Closing browser session` (the live in-memory close path), with the session's Chromium + ffmpeg processes reclaimed (down to zero) and the DB row marked `completed`.
