### PR TITLE
Install Tesseract in backend Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN uv pip compile pyproject.toml --extra server --python-version 3.11 -o requir
 FROM python:3.11-slim-bookworm
 WORKDIR /app
 COPY --from=requirements-stage /tmp/requirements.txt /app/requirements.txt
+COPY ./skyvern/forge/sdk/utils/tesseract_languages.py /tmp/tesseract_languages.py
 RUN pip install --upgrade pip setuptools wheel
 # --no-deps: requirements.txt is fully resolved by uv, including the
 # pyproject overrides that loosen litellm's jsonschema==4.23.0 pin.
@@ -18,7 +19,13 @@ RUN pip install --upgrade pip setuptools wheel
 RUN pip install --no-cache-dir --no-deps -r requirements.txt
 RUN playwright install-deps
 RUN playwright install
-RUN apt-get install -y xauth x11-apps netpbm gpg ca-certificates x11vnc && apt-get clean
+RUN apt-get update && \
+    apt-get install -y xauth x11-apps netpbm gpg ca-certificates x11vnc tesseract-ocr $(python /tmp/tesseract_languages.py --apt-packages) && \
+    tesseract --version && \
+    rm /tmp/tesseract_languages.py && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN pip install --no-cache-dir websockify
 
 COPY .nvmrc /app/.nvmrc

--- a/skyvern/forge/sdk/utils/tesseract_languages.py
+++ b/skyvern/forge/sdk/utils/tesseract_languages.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Iterable
+
+DEFAULT_TESSERACT_OCR_LANGUAGE_PACKS = (
+    "eng",
+    "spa",
+    "fra",
+    "deu",
+    "ita",
+    "por",
+    "nld",
+    "pol",
+    "rus",
+    "ukr",
+    "ara",
+    "chi-sim",
+    "chi-tra",
+    "jpn",
+    "kor",
+    "hin",
+)
+
+
+def tesseract_ocr_packages(language_packs: Iterable[str] = DEFAULT_TESSERACT_OCR_LANGUAGE_PACKS) -> list[str]:
+    return [f"tesseract-ocr-{language_pack}" for language_pack in language_packs]
+
+
+def tesseract_language_arg(language_packs: Iterable[str] = DEFAULT_TESSERACT_OCR_LANGUAGE_PACKS) -> str:
+    return "+".join(language_pack.replace("-", "_") for language_pack in language_packs)
+
+
+DEFAULT_FLAT_FILL_OCR_LANGUAGES = tesseract_language_arg()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Print Tesseract language package metadata.")
+    parser.add_argument(
+        "--apt-packages",
+        action="store_true",
+        help="Print Debian OCR language packages for apt-get install.",
+    )
+    parser.add_argument(
+        "--tesseract-languages",
+        action="store_true",
+        help="Print the Tesseract -l language argument.",
+    )
+    args = parser.parse_args()
+
+    if args.apt_packages:
+        print(" ".join(tesseract_ocr_packages()))
+        return
+    if args.tesseract_languages:
+        print(DEFAULT_FLAT_FILL_OCR_LANGUAGES)
+        return
+    parser.error("expected --apt-packages or --tesseract-languages")
+
+
+if __name__ == "__main__":
+    main()

--- a/skyvern/forge/sdk/workflow/models/pdf_fill_block.py
+++ b/skyvern/forge/sdk/workflow/models/pdf_fill_block.py
@@ -32,6 +32,7 @@ from skyvern.forge.sdk.db.exceptions import NotFoundError
 from skyvern.forge.sdk.experimentation.llm_prompt_config import get_llm_handler_for_prompt_type
 from skyvern.forge.sdk.schemas.files import FileInfo
 from skyvern.forge.sdk.utils.pdf_parser import render_pdf_pages_as_images, validate_pdf_file
+from skyvern.forge.sdk.utils.tesseract_languages import DEFAULT_FLAT_FILL_OCR_LANGUAGES
 from skyvern.forge.sdk.workflow.context_manager import WorkflowRunContext
 from skyvern.forge.sdk.workflow.loop_download_filter import filter_downloaded_files_for_current_iteration
 from skyvern.forge.sdk.workflow.models._jinja import render_templates_in_json_value
@@ -60,6 +61,7 @@ FLAT_FILL_OCR_TIMEOUT_SECONDS = 60
 # Outer budget across all pages so a flat PDF can't pin a worker for the full per-page timeout x max pages.
 FLAT_FILL_OCR_TOTAL_TIMEOUT_SECONDS = 300
 FLAT_FILL_MAX_PAGES = 25
+FLAT_FILL_OCR_LANGUAGES = (os.getenv("FLAT_FILL_OCR_LANGUAGES") or DEFAULT_FLAT_FILL_OCR_LANGUAGES).strip()
 
 
 @dataclass(frozen=True)
@@ -511,10 +513,7 @@ class PdfFillBlock(Block):
                 async with aiofiles.open(image_path, "wb") as f:
                     await f.write(image_bytes)
                 process = await asyncio.create_subprocess_exec(
-                    "tesseract",
-                    image_path,
-                    "stdout",
-                    "tsv",
+                    *self._tesseract_command(image_path),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.DEVNULL,
                 )
@@ -531,6 +530,14 @@ class PdfFillBlock(Block):
                     self._parse_tesseract_tsv(stdout.decode("utf-8", errors="replace"), page_index, len(anchors))
                 )
         return anchors
+
+    @staticmethod
+    def _tesseract_command(image_path: str) -> list[str]:
+        command = ["tesseract", image_path, "stdout"]
+        if FLAT_FILL_OCR_LANGUAGES:
+            command.extend(["-l", FLAT_FILL_OCR_LANGUAGES])
+        command.append("tsv")
+        return command
 
     @staticmethod
     def _tsv_int(row: dict[str, str], key: str) -> int | None:

--- a/tests/unit/test_pdf_fill_block.py
+++ b/tests/unit/test_pdf_fill_block.py
@@ -20,7 +20,9 @@ from pypdf.generic import (
 )
 
 from skyvern.forge import app
+from skyvern.forge.sdk.utils.tesseract_languages import tesseract_language_arg, tesseract_ocr_packages
 from skyvern.forge.sdk.workflow.context_manager import WorkflowRunContext
+from skyvern.forge.sdk.workflow.models import pdf_fill_block
 from skyvern.forge.sdk.workflow.models.block import PdfFillBlock, extract_file_url_from_block_output
 from skyvern.forge.sdk.workflow.models.parameter import OutputParameter
 from skyvern.forge.sdk.workflow.models.pdf_fill_block import FlatPdfAnchor, FlatPlacement, PdfFieldInventory
@@ -587,6 +589,37 @@ def test_parse_tesseract_tsv_skips_malformed_numeric_rows() -> None:
     anchors = PdfFillBlock._parse_tesseract_tsv(tsv, page_index=0, id_offset=0)
 
     assert [a.text for a in anchors] == ["City:"]
+
+
+def test_tesseract_command_includes_configured_languages(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pdf_fill_block, "FLAT_FILL_OCR_LANGUAGES", "eng+spa+fra")
+
+    assert PdfFillBlock._tesseract_command("/tmp/page.png") == [
+        "tesseract",
+        "/tmp/page.png",
+        "stdout",
+        "-l",
+        "eng+spa+fra",
+        "tsv",
+    ]
+
+
+def test_tesseract_command_allows_empty_language_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(pdf_fill_block, "FLAT_FILL_OCR_LANGUAGES", "")
+
+    assert PdfFillBlock._tesseract_command("/tmp/page.png") == ["tesseract", "/tmp/page.png", "stdout", "tsv"]
+
+
+def test_tesseract_language_helpers_share_package_defaults() -> None:
+    language_packs = ("eng", "spa", "chi-sim", "chi-tra")
+
+    assert tesseract_ocr_packages(language_packs) == [
+        "tesseract-ocr-eng",
+        "tesseract-ocr-spa",
+        "tesseract-ocr-chi-sim",
+        "tesseract-ocr-chi-tra",
+    ]
+    assert tesseract_language_arg(language_packs) == "eng+spa+chi_sim+chi_tra"
 
 
 def test_escape_pdf_text() -> None:


### PR DESCRIPTION
## Description

Install the `tesseract` runtime binary and multilingual OCR language data in the backend Docker image so flat PDF fill workflows can run local OCR instead of failing with `tesseract` missing on the host or silently OCRing non-English forms as English-only.

## Solution

- Add a shared `skyvern/forge/sdk/utils/tesseract_languages.py` helper as the single source for default OCR language packs.
- Have the Dockerfile ask that helper for Debian package names during image build instead of duplicating `tesseract-ocr-<lang>` lists.
- Have PDF fill import the same helper for the default Tesseract `-l` string, while still allowing `FLAT_FILL_OCR_LANGUAGES` as a runtime override.
- Install Tesseract plus the explicit language packs used by the runtime default: `eng+spa+fra+deu+ita+por+nld+pol+rus+ukr+ara+chi_sim+chi_tra+jpn+kor+hin`.
- Pass configured languages to Tesseract via `create_subprocess_exec` argv (`-l ...`) so there is no shell interpolation.
- Run `tesseract --version` during image build so missing OCR binaries fail early while building the image.
- Clean apt package lists in the Tesseract install layer.

## How Has This Been Tested?

- `git diff --check` -> passed.
- `uv run python -m pytest tests/unit/test_pdf_fill_block.py::test_tesseract_command_includes_configured_languages tests/unit/test_pdf_fill_block.py::test_tesseract_command_allows_empty_language_override tests/unit/test_pdf_fill_block.py::test_tesseract_language_helpers_share_package_defaults tests/unit/test_pdf_fill_block.py::test_flat_pdf_without_tesseract_fails tests/unit/test_pdf_fill_block.py::test_flat_pdf_overlay_fills_with_ocr_anchors -q` -> `5 passed in 0.09s`.
- `pre-commit run --files Dockerfile skyvern/forge/sdk/workflow/models/pdf_fill_block.py skyvern/forge/sdk/utils/tesseract_languages.py tests/unit/test_pdf_fill_block.py` -> passed.
- Helper smoke: `python skyvern/forge/sdk/utils/tesseract_languages.py --apt-packages` produced the expected package list.
- Docker package solver smoke on `python:3.11-slim-bookworm` with HTTPS Debian mirror workaround: helper-generated package list resolved successfully (`packages-ok`).
- Docker install smoke from the prior pass confirmed Tesseract runs as `tesseract 5.3.0`; the local Docker environment cannot reach `deb.debian.org` over HTTP, so HTTPS was used for package validation.

## Risk / Rollback

Risk: the backend image grows from adding multilingual OCR language data, and OCR can be slower when multiple languages are enabled. This avoids the much larger `tesseract-ocr-all` metapackage by installing only the configured language packs. Roll back by reverting this PR; runtime language breadth can also be reduced by overriding `FLAT_FILL_OCR_LANGUAGES`.

## Artifacts (if appropriate):

Cloud companion PR: https://github.com/Skyvern-AI/skyvern-cloud/pull/12554