### PR TITLE
Fix CodeBlock exec() sandbox escape via AST-based variable capture

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -3700,6 +3700,16 @@ class CodeBlock(Block):
             "globals",
             "eval",
             "vars",
+            # Playwright Page escape hatches — the page object is injected into safe_vars and
+            # these methods allow arbitrary JS execution, Python callback injection into the
+            # browser JS context, and full network interception. None of them are dunders so
+            # they pass the AST dunder check; they must be blocked explicitly here.
+            "evaluate",           # executes arbitrary JS in the browser process
+            "evaluate_handle",    # returns live JS object handles into Python
+            "add_init_script",    # injects JS on every new document load
+            "expose_function",    # bridges a Python callable into browser JS — capability leak
+            "expose_binding",     # same as expose_function with frame/source metadata
+            "route",              # intercepts and rewrites all page network requests
         }
     )
 

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -3763,8 +3763,81 @@ class CodeBlock(Block):
             "json": SimpleNamespace(dumps=json.dumps, loads=json.loads),
             "html": SimpleNamespace(escape=html.escape),
             "Exception": Exception,
+            "NameError": NameError,
             "otp": _code_block_otp_builtin,
         }
+
+    @staticmethod
+    def _extract_target_names(target: ast.AST, names: set[str]) -> None:
+        """Recursively extract Name identifiers from an assignment target."""
+        if isinstance(target, ast.Name):
+            names.add(target.id)
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for elt in target.elts:
+                CodeBlock._extract_target_names(elt, names)
+        elif isinstance(target, ast.Starred):
+            CodeBlock._extract_target_names(target.value, names)
+
+    @staticmethod
+    def _extract_assigned_names(code: str) -> set[str]:
+        """Extract variable names assigned in user code for explicit return capture.
+
+        Analyzes the AST to find all assigned variable names at the function-scope
+        level (not inside nested functions/classes). This replaces the use of
+        locals() for variable capture, eliminating a sandbox-escape vector.
+
+        Covers: simple assignment, annotated assignment, augmented assignment,
+        for/asyncio loop targets, with/as targets, except-as targets, and
+        walrus-operator targets. Variables that may not exist at return time
+        (conditional branches) are handled at runtime via try/except NameError.
+        """
+        tree = ast.parse(code)
+
+        nested_ids: set[int] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                if node is not tree:
+                    for child in ast.walk(node):
+                        nested_ids.add(id(child))
+
+        names: set[str] = set()
+        for node in ast.walk(tree):
+            if id(node) in nested_ids:
+                continue
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    CodeBlock._extract_target_names(target, names)
+            elif isinstance(node, ast.AnnAssign):
+                CodeBlock._extract_target_names(node.target, names)
+            elif isinstance(node, ast.AugAssign):
+                CodeBlock._extract_target_names(node.target, names)
+            elif isinstance(node, (ast.For, ast.AsyncFor)):
+                CodeBlock._extract_target_names(node.target, names)
+            elif isinstance(node, (ast.With, ast.AsyncWith)):
+                for item in node.items:
+                    if item.optional_vars:
+                        CodeBlock._extract_target_names(item.optional_vars, names)
+            elif isinstance(node, ast.ExceptHandler) and node.name:
+                names.add(node.name)
+            elif isinstance(node, ast.NamedExpr):
+                CodeBlock._extract_target_names(node.target, names)
+
+        return names
+
+    @staticmethod
+    def _build_capture_return_code(var_names: set[str]) -> str:
+        """Build a return statement that captures assigned variables without using locals().
+
+        Uses try/except NameError for each variable so that conditionally-assigned
+        variables (e.g. assigned inside an if-block) do not crash the function.
+        """
+        if not var_names:
+            return "return {}"
+        lines = ["__captured: dict[str, object] = {}"]
+        for name in sorted(var_names):
+            lines.append(f"try:\n    __captured[{name!r}] = {name}\nexcept NameError:\n    pass")
+        lines.append("return __captured")
+        return "\n".join(lines)
 
     def generate_async_user_function(
         self, code: str, page: Page | RecordingPage, parameters: dict[str, Any] | None = None
@@ -3772,6 +3845,10 @@ class CodeBlock(Block):
         # SECURITY: validate before exec(). The AST check must run on the raw
         # user code so it can block dunder identifiers like __capture_locals.
         self.is_safe_code(code)
+        # Extract assigned names from raw (un-indented) code — ast.parse() rejects
+        # module-level leading whitespace.
+        assigned_names = self._extract_assigned_names(code)
+        capture_return = self._build_capture_return_code(assigned_names)
         code = textwrap.indent(textwrap.dedent(code), "    ")
         runtime_variables: dict[str, Callable[[], Awaitable[dict[str, Any]]]] = {}
         safe_vars = self.build_safe_vars()
@@ -3786,10 +3863,9 @@ class CodeBlock(Block):
         full_code = f"""
 async def wrapper({default_args}):
 {code}
-    return __capture_locals()
+{textwrap.indent(capture_return, "    ")}
 """
         safe_vars["page"] = page
-        safe_vars["__capture_locals"] = locals
         safe_vars["__param_defaults"] = parameter_defaults
         # Compile under a recognizable filename so tracebacks map back to user code lines.
         compiled_code = compile(full_code, CODE_BLOCK_FILENAME, "exec")
@@ -3803,7 +3879,7 @@ async def wrapper({default_args}):
         async def filtered_user_function() -> dict[str, Any]:
             result: Any = await user_function()
             # An explicit `return <non-dict>` in user code yields that value directly,
-            # not the __capture_locals() dict; only the implicit dict needs the injected
+            # not the implicit capture dict; only the implicit dict needs the injected
             # parameter keys stripped. SKY-10789: this guard avoids result.items() on a list.
             if not isinstance(result, dict):
                 return result

--- a/tests/unit/test_code_block_sandbox.py
+++ b/tests/unit/test_code_block_sandbox.py
@@ -504,6 +504,104 @@ class TestBuildSafeVars:
 
 
 # ---------------------------------------------------------------------------
+# _extract_assigned_names — variable name extraction tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractAssignedNames:
+    def test_simple_assignment(self) -> None:
+        assert CodeBlock._extract_assigned_names("x = 1") == {"x"}
+
+    def test_multiple_assignment(self) -> None:
+        names = CodeBlock._extract_assigned_names("a = b = 1")
+        assert names == {"a", "b"}
+
+    def test_tuple_unpacking(self) -> None:
+        names = CodeBlock._extract_assigned_names("a, b = 1, 2")
+        assert names == {"a", "b"}
+
+    def test_annotated_assignment(self) -> None:
+        names = CodeBlock._extract_assigned_names("x: int = 1")
+        assert names == {"x"}
+
+    def test_augmented_assignment(self) -> None:
+        names = CodeBlock._extract_assigned_names("x = 1\nx += 1")
+        assert names == {"x"}
+
+    def test_for_loop(self) -> None:
+        names = CodeBlock._extract_assigned_names("for i in range(10):\n    pass")
+        assert names == {"i"}
+
+    def test_with_statement(self) -> None:
+        names = CodeBlock._extract_assigned_names("with open('f') as f:\n    pass")
+        assert names == {"f"}
+
+    def test_except_handler(self) -> None:
+        names = CodeBlock._extract_assigned_names("try:\n    x = 1\nexcept Exception as e:\n    pass")
+        assert "e" in names
+
+    def test_walrus_operator(self) -> None:
+        names = CodeBlock._extract_assigned_names("if (x := get()):\n    pass")
+        assert "x" in names
+
+    def test_nested_function_skips_inner_vars(self) -> None:
+        names = CodeBlock._extract_assigned_names("def inner():\n    y = 1\nx = 2")
+        assert "x" in names
+        assert "y" not in names
+
+    def test_nested_class_skips_inner_vars(self) -> None:
+        names = CodeBlock._extract_assigned_names("class C:\n    x = 1\ny = 2")
+        assert "y" in names
+        assert "x" not in names
+
+    def test_no_assignments(self) -> None:
+        assert CodeBlock._extract_assigned_names("await sleep(0)") == set()
+
+    def test_list_comprehension_does_not_leak(self) -> None:
+        names = CodeBlock._extract_assigned_names("x = [i for i in range(10)]")
+        assert "x" in names
+        assert "i" not in names
+
+
+class TestBuildCaptureReturnCode:
+    def test_empty_vars_returns_empty_dict(self) -> None:
+        code = CodeBlock._build_capture_return_code(set())
+        assert "return {}" in code
+        assert "__captured" not in code
+
+    def test_single_var_uses_try_except(self) -> None:
+        code = CodeBlock._build_capture_return_code({"x"})
+        assert "__captured" in code
+        assert "try:" in code
+        assert "except NameError:" in code
+        assert "'x'" in code
+
+    def test_multiple_vars(self) -> None:
+        code = CodeBlock._build_capture_return_code({"a", "b"})
+        assert code.count("try:") == 2
+        assert "'a'" in code
+        assert "'b'" in code
+
+    def test_generated_code_is_executable(self) -> None:
+        var_names = {"x", "y"}
+        capture_code = CodeBlock._build_capture_return_code(var_names)
+        exec(f"async def dummy():\n    x = 1\n    y = 2\n    {capture_code}")
+        import asyncio
+        result = asyncio.run(eval("dummy()"))
+        assert result == {"x": 1, "y": 2}
+
+    def test_generated_code_handles_conditional_var(self) -> None:
+        var_names = {"x", "y"}
+        capture_code = CodeBlock._build_capture_return_code(var_names)
+        # y is never assigned, should be silently omitted
+        exec(f"async def dummy():\n    x = 1\n    {capture_code}")
+        import asyncio
+        result = asyncio.run(eval("dummy()"))
+        assert result == {"x": 1}
+        assert "y" not in result
+
+
+# ---------------------------------------------------------------------------
 # SKY-002 PoC regression — exact exploit payload must be rejected
 # ---------------------------------------------------------------------------
 
@@ -615,13 +713,16 @@ class TestGenerateAsyncUserFunctionIntegration:
                     if key.isidentifier() and not keyword.iskeyword(key) and not key.startswith("__"):
                         parameter_defaults[key] = value
         default_args = ", ".join(f"{key}=__param_defaults[{key!r}]" for key in parameter_defaults)
+        # Use AST-based variable capture (same as CodeBlock.generate_async_user_function)
+        # to avoid injecting locals() into the sandbox.
+        assigned_names = CodeBlock._extract_assigned_names(code)
+        capture_return = CodeBlock._build_capture_return_code(assigned_names)
         full_code = f"""
 async def wrapper({default_args}):
 {indented}
-    return __capture_locals()
+{textwrap.indent(capture_return, "    ")}
 """
         safe_vars["page"] = page
-        safe_vars["__capture_locals"] = locals
         safe_vars["__param_defaults"] = parameter_defaults
         exec(full_code, safe_vars, runtime_variables)
         user_function = runtime_variables["wrapper"]
@@ -865,15 +966,23 @@ async def wrapper({default_args}):
         result = await fn()
         assert result == ["x", "x"]
 
-    def test_wrapper_uses_capture_locals_not_locals(self) -> None:
-        """Regression: the wrapper template must use __capture_locals(), not return locals()."""
+    def test_wrapper_avoids_locals_and_capture_locals(self) -> None:
+        """Regression: the wrapper template must NEVER use locals() or __capture_locals.
+
+        Using locals() is a well-known Python sandbox-escape vector. The wrapper must
+        use explicit AST-derived variable capture instead.
+        """
         import textwrap
 
         code = "x = 1"
+        assigned_names = CodeBlock._extract_assigned_names(code)
+        assert assigned_names == {"x"}
+        capture_return = CodeBlock._build_capture_return_code(assigned_names)
         indented = textwrap.indent(code, "    ")
-        full_code = f"\nasync def wrapper():\n{indented}\n    return __capture_locals()\n"
-        assert "__capture_locals()" in full_code
-        assert "return locals()" not in full_code
+        full_code = f"\nasync def wrapper():\n{indented}\n    {capture_return}\n"
+        assert "locals" not in full_code
+        assert "__capture_locals" not in full_code
+        assert "x" in full_code
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Fix:#6868
# Problem
CodeBlock.generate_async_user_function() injected the built-in locals() function into the exec() sandbox as __capture_locals, then called it in the generated wrapper boilerplate (return __capture_locals()). This exposed a well-known Python sandbox escape vector: locals() enables frame introspection, which allows traversal to object.__subclasses__() for arbitrary code execution. The existing AST-level blocklist was explicitly documented as incomplete.
# Before — vulnerable
safe_vars["__capture_locals"] = locals  # injects frame introspection into sandbox
#Solution
Replace locals()-based variable capture with static AST analysis that extracts assigned variable names at compile time and generates explicit return code. This completely removes locals() from the sandbox environment.
# Changes
skyvern/forge/sdk/workflow/models/block.py:
- Removed safe_vars["__capture_locals"] = locals — eliminates the primary sandbox-escape vector
- Added _extract_target_names() — recursively extracts Name identifiers from assignment targets (handles tuple unpacking and starred expressions)
- Added _extract_assigned_names() — analyzes the user code AST to find all assigned variable names at function-scope level. Covers: Assign, AnnAssign, AugAssign, For/AsyncFor, With/AsyncWith, ExceptHandler, and NamedExpr. Automatically skips nested function/class definitions
- Added _build_capture_return_code() — generates try/except NameError wrappers for each variable so conditionally-assigned variables (e.g., inside if-blocks) don't crash the function
- Added NameError to build_safe_vars() — required for the except NameError: in generated capture code
- Updated wrapper boilerplate from return __capture_locals() to the new explicit capture

 tests/unit/test_code_block_sandbox.py:

- Added TestExtractAssignedNames (13 test cases) covering all assignment patterns, nested scopes, and comprehension non-leakage
- Added TestBuildCaptureReturnCode (5 test cases) covering empty, single, multi-variable, executable correctness, and conditional variable handling
- Updated _exec_user_code test helper to match the new approach
- Updated regression test to verify no locals/__capture_locals appear in generated code