### PR TITLE
[scraper] Fix: render value-only select options in json_to_html

### DIFF
--- a/skyvern/webeye/scraper/scraped_page.py
+++ b/skyvern/webeye/scraper/scraped_page.py
@@ -89,9 +89,9 @@ def json_to_html(element: dict, need_skyvern_attrs: bool = True) -> str:
     )
     # build option HTML
     option_html = "".join(
-        f'<option index="{option.get("optionIndex")}">{option.get("text")}</option>'
-        if option.get("text")
-        else f'<option index="{option.get("optionIndex")}" value="{option.get("value")}">{option.get("text")}</option>'
+        f'<option index="{option.get("optionIndex")}">{option_text}</option>'
+        if (option_text := str(option.get("text") or "").strip())
+        else f'<option index="{option.get("optionIndex")}" value="{option.get("value")}">{option.get("value")}</option>'
         for option in element.get("options", [])
     )
 

--- a/skyvern/webeye/scraper/scraped_page.py
+++ b/skyvern/webeye/scraper/scraped_page.py
@@ -107,9 +107,9 @@ def json_to_html(element: dict, need_skyvern_attrs: bool = True) -> str:
     )
     # build option HTML
     option_html = "".join(
-        f'<option index="{option.get("optionIndex")}">{option.get("text")}</option>'
-        if option.get("text")
-        else f'<option index="{option.get("optionIndex")}" value="{option.get("value")}">{option.get("text")}</option>'
+        f'<option index="{option.get("optionIndex")}">{option_text}</option>'
+        if (option_text := str(option.get("text") or "").strip())
+        else f'<option index="{option.get("optionIndex")}" value="{option.get("value")}">{option.get("value")}</option>'
         for option in element.get("options", [])
     )
 

--- a/tests/unit/test_json_to_html_option_fallback.py
+++ b/tests/unit/test_json_to_html_option_fallback.py
@@ -1,0 +1,52 @@
+"""Tests for json_to_html rendering value-only <select> options.
+
+A native <option> carries {text, value, optionIndex}. When the text is blank or
+whitespace-only, the option must render its value as the body so the LLM planner
+can identify it (mirroring _collect_option_texts in handler.py). Otherwise the
+option shows up unlabeled and the matcher cannot pick it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from skyvern.forge.sdk.core import skyvern_context
+from skyvern.forge.sdk.core.skyvern_context import SkyvernContext
+from skyvern.webeye.scraper.scraped_page import json_to_html
+
+
+@pytest.fixture(autouse=True)
+def _scoped_context():
+    """`json_to_html` calls `skyvern_context.ensure_context()`, so we need one."""
+    with skyvern_context.scoped(SkyvernContext(organization_id="o_test", workflow_run_id="wr_test")):
+        yield
+
+
+def _select(options: list[dict]) -> str:
+    return json_to_html({"isSelectable": True, "tagName": "select", "options": options}, need_skyvern_attrs=False)
+
+
+def test_has_text_renders_text_as_label() -> None:
+    html = _select([{"optionIndex": 0, "text": "United States", "value": "us"}])
+    assert '<option index="0">United States</option>' in html
+
+
+def test_empty_text_falls_back_to_value() -> None:
+    html = _select([{"optionIndex": 1, "text": "", "value": "ca"}])
+    assert '<option index="1" value="ca">ca</option>' in html
+
+
+def test_whitespace_text_falls_back_to_value() -> None:
+    html = _select([{"optionIndex": 2, "text": "   ", "value": "mx"}])
+    assert '<option index="2" value="mx">mx</option>' in html
+
+
+def test_no_option_is_rendered_with_empty_body() -> None:
+    html = _select(
+        [
+            {"optionIndex": 0, "text": "United States", "value": "us"},
+            {"optionIndex": 1, "text": "", "value": "ca"},
+            {"optionIndex": 2, "text": "   ", "value": "mx"},
+        ]
+    )
+    assert "></option>" not in html


### PR DESCRIPTION
## Description

`json_to_html` is the serializer that turns a native `<select>` into the HTML the LLM planner reads. Each option carries `{text, value, optionIndex}`.

When an option's `text` is blank, the option was rendered with an empty body:

```html
<option index="1" value="ca"></option>
```

And when `text` was whitespace-only (`"   "`), it took the has-text branch, so the body was blank **and** the value was dropped entirely:

```html
<option index="2">   </option>
```

Either way the option is effectively unlabeled, so the planner can't tell what it is and the matcher can't pick it. Real selects frequently have value-only options (ISO country codes, placeholder-less menus), so these get hidden from the model.

The sibling helper `_collect_option_texts` in `handler.py` already handles this exact case: it strips the option text and falls back to `value` when the text is blank. This change mirrors that intent in `json_to_html`: strip the option text, and use the value as the body when the text is blank. The has-text rendering is unchanged.

Before / after for `[("United States", "us"), ("", "ca"), ("   ", "mx")]`:

```html
<!-- before -->
<option index="0">United States</option><option index="1" value="ca"></option><option index="2">   </option>
<!-- after -->
<option index="0">United States</option><option index="1" value="ca">ca</option><option index="2" value="mx">mx</option>
```

## How Has This Been Tested?

Added a colocated unit test `tests/unit/test_json_to_html_option_fallback.py` (mirrors the existing scoped-context unit tests):

- has-text -> renders text as the label (unchanged)
- empty text -> `<option index="1" value="ca">ca</option>`
- whitespace text -> `<option index="2" value="mx">mx</option>`
- a mixed select -> no empty `></option>` bodies remain

```
uv sync --extra server
uv run pytest tests/unit/test_json_to_html_option_fallback.py \
  tests/unit/test_no_available_option.py \
  tests/unit/test_emerging_elements_prompt_scope.py \
  tests/unit/test_icon_only_element_serialization.py -q
```

All pass; the new tests fail on the pre-fix code and pass after, confirming the fix. These are pure unit tests (no Postgres or `.env` needed). `pre-commit` (ruff, ruff-format, isort, pyupgrade, mypy) passes on the changed files.

## Artifacts (if appropriate):

N/A (backend serialization fix, no UI change).
