### PR TITLE
fix(copilot): union dict keys when summarizing a list for the LLM

### DIFF
--- a/skyvern/forge/sdk/copilot/output_utils.py
+++ b/skyvern/forge/sdk/copilot/output_utils.py
@@ -222,7 +222,7 @@ def _summarize_extracted_data(extracted: Any) -> str:
         if not extracted:
             return "Extracted empty list."
         if isinstance(extracted[0], dict):
-            keys = sorted(extracted[0].keys())
+            keys = sorted({k for item in extracted if isinstance(item, dict) for k in item})
             return f"Extracted {len(extracted)} items. Keys: {', '.join(keys)}"
         return f"Extracted list with {len(extracted)} items."
     if isinstance(extracted, dict):
@@ -456,7 +456,7 @@ def _describe_value_shape(value: Any) -> str:
         if not value:
             return "empty list"
         if isinstance(value[0], dict):
-            keys = sorted(value[0].keys())
+            keys = sorted({k for item in value if isinstance(item, dict) for k in item})
             return f"list of {len(value)} items, keys: {', '.join(keys)}"
         return f"list of {len(value)} items"
     if isinstance(value, dict):

--- a/skyvern/forge/sdk/copilot/output_utils.py
+++ b/skyvern/forge/sdk/copilot/output_utils.py
@@ -221,7 +221,7 @@ def _summarize_extracted_data(extracted: Any) -> str:
         if not extracted:
             return "Extracted empty list."
         if isinstance(extracted[0], dict):
-            keys = sorted(extracted[0].keys())
+            keys = sorted({k for item in extracted if isinstance(item, dict) for k in item})
             return f"Extracted {len(extracted)} items. Keys: {', '.join(keys)}"
         return f"Extracted list with {len(extracted)} items."
     if isinstance(extracted, dict):
@@ -517,7 +517,7 @@ def _describe_value_shape(value: Any) -> str:
         if not value:
             return "empty list"
         if isinstance(value[0], dict):
-            keys = sorted(value[0].keys())
+            keys = sorted({k for item in value if isinstance(item, dict) for k in item})
             return f"list of {len(value)} items, keys: {', '.join(keys)}"
         return f"list of {len(value)} items"
     if isinstance(value, dict):

--- a/tests/unit/test_copilot_output_utils.py
+++ b/tests/unit/test_copilot_output_utils.py
@@ -231,6 +231,18 @@ class TestSanitization:
         assert data["action_trace_summary"] == ["click #submit failed"]
         assert data["current_url"] == "https://example.test"
 
+    def test_run_blocks_extracted_data_summary_unions_keys_across_items(self) -> None:
+        # extracted_data is summarized to a shape string; a list whose later
+        # items carry extra keys must report them all, not just item[0]'s.
+        result = {
+            "ok": True,
+            "data": {
+                "blocks": [{"label": "extract", "extracted_data": [{"a": 1}, {"a": 1, "b": 2, "c": 3}]}],
+            },
+        }
+        sanitized = sanitize_tool_result_for_llm("run_blocks_and_collect_debug", result)
+        assert sanitized["data"]["blocks"][0]["extracted_data"] == "Extracted 2 items. Keys: a, b, c"
+
 
 class TestSummarizeToolResult:
     @staticmethod
@@ -392,6 +404,22 @@ class TestSummarizeToolResult:
             {"ok": True, "data": {"result": None}},
         )
         assert summary == "Evaluated JavaScript"
+
+    def test_evaluate_heterogeneous_list_reports_keys_from_all_items(self) -> None:
+        # Later rows often carry fields the first row lacks; the shape must
+        # union every key so the bullet does not understate the result.
+        summary = self._summarize(
+            "evaluate",
+            {
+                "ok": True,
+                "data": {"result": [{"name": "a"}, {"name": "b", "href": "x", "price": 1}]},
+            },
+        )
+        assert "list" in summary
+        assert "2" in summary
+        assert "name" in summary
+        assert "href" in summary
+        assert "price" in summary
 
     def test_failure_strips_http_headers_blob(self) -> None:
         # Failure summaries must never embed an HTTP-response-headers dict.

--- a/tests/unit/test_copilot_output_utils.py
+++ b/tests/unit/test_copilot_output_utils.py
@@ -259,6 +259,18 @@ class TestSanitization:
         assert data["action_trace_summary"] == ["click #submit failed"]
         assert data["current_url"] == "https://example.test"
 
+    def test_run_blocks_extracted_data_summary_unions_keys_across_items(self) -> None:
+        # extracted_data is summarized to a shape string; a list whose later
+        # items carry extra keys must report them all, not just item[0]'s.
+        result = {
+            "ok": True,
+            "data": {
+                "blocks": [{"label": "extract", "extracted_data": [{"a": 1}, {"a": 1, "b": 2, "c": 3}]}],
+            },
+        }
+        sanitized = sanitize_tool_result_for_llm("run_blocks_and_collect_debug", result)
+        assert sanitized["data"]["blocks"][0]["extracted_data"] == "Extracted 2 items. Keys: a, b, c"
+
 
 class TestSummarizeToolResult:
     @staticmethod
@@ -471,6 +483,22 @@ class TestSummarizeToolResult:
             {"ok": True, "data": {"result": None}},
         )
         assert summary == "Evaluated JavaScript"
+
+    def test_evaluate_heterogeneous_list_reports_keys_from_all_items(self) -> None:
+        # Later rows often carry fields the first row lacks; the shape must
+        # union every key so the bullet does not understate the result.
+        summary = self._summarize(
+            "evaluate",
+            {
+                "ok": True,
+                "data": {"result": [{"name": "a"}, {"name": "b", "href": "x", "price": 1}]},
+            },
+        )
+        assert "list" in summary
+        assert "2" in summary
+        assert "name" in summary
+        assert "href" in summary
+        assert "price" in summary
 
     def test_failure_strips_http_headers_blob(self) -> None:
         # Failure summaries must never embed an HTTP-response-headers dict.


### PR DESCRIPTION
## Description

Two copilot helpers in `skyvern/forge/sdk/copilot/output_utils.py` summarize a list of dicts to a key list, but only read the first item's keys. When list items are heterogeneous, every key that the first row lacks is silently dropped:

- `_summarize_extracted_data` shapes `extracted_data` for the workflow-copilot LLM context.
- `_describe_value_shape` shapes a JS evaluation result for a chat activity bullet.

So `[{"a": 1}, {"a": 1, "b": 2, "c": 3}]` summarized as `Keys: a`, and the LLM (and the user) saw an incomplete shape. Heterogeneous extracted rows are common, so this understates the result.

This unions keys across all dict items instead of just `[0]`:

```python
keys = sorted({k for item in extracted if isinstance(item, dict) for k in item})
```

The message strings are unchanged. The existing `isinstance(x[0], dict)` guard and the non-dict-list path are untouched; non-dict items in a mixed list are skipped safely.

## How Has This Been Tested?

- `uv run pytest tests/unit/test_copilot_output_utils.py -q` -> 94 passed.
- Full `tests/unit/` -> 10460 passed, 62 skipped (2 unrelated `test_setup_quickstart.py` failures also fail on `main` without this change).
- `pre-commit run --files skyvern/forge/sdk/copilot/output_utils.py tests/unit/test_copilot_output_utils.py` -> ruff, ruff-format, isort, pyupgrade, mypy all pass.
- Two added tests exercise the public entrypoints (`sanitize_tool_result_for_llm`, `summarize_tool_result`) with a heterogeneous list. Reverting the source makes them fail, so they are not vacuous.

## Artifacts (if appropriate):

n/a (logic-only change; no UI).
