### PR TITLE
fix(fuzzy_matcher): guard option stem length in Pass 3 of match_option

### DIFF
--- a/skyvern/core/script_generations/fuzzy_matcher.py
+++ b/skyvern/core/script_generations/fuzzy_matcher.py
@@ -74,6 +74,8 @@ def match_option(candidate: str, options: list[str], *, min_substring_len: int =
     if len(candidate_stem) >= min_substring_len:
         for i, opt in enumerate(options):
             opt_stem = _normalize(opt).rstrip("s")
+            if len(opt_stem) < min_substring_len:
+                continue
             if candidate_stem in opt_stem or opt_stem in candidate_stem:
                 return i
 

--- a/skyvern/core/script_generations/fuzzy_matcher.py
+++ b/skyvern/core/script_generations/fuzzy_matcher.py
@@ -73,6 +73,8 @@ def match_option(candidate: str, options: list[str], *, min_substring_len: int =
     if len(candidate_stem) >= min_substring_len:
         for i, opt in enumerate(options):
             opt_stem = _normalize(opt).rstrip("s")
+            if len(opt_stem) < min_substring_len:
+                continue
             if candidate_stem in opt_stem or opt_stem in candidate_stem:
                 return i
 

--- a/tests/unit/test_fuzzy_matcher.py
+++ b/tests/unit/test_fuzzy_matcher.py
@@ -1,0 +1,96 @@
+import pytest
+
+from skyvern.core.script_generations.fuzzy_matcher import match_option
+
+
+@pytest.mark.parametrize(
+    "candidate, options, expected",
+    [
+        ("Canada", ["Canada", "United States"], 0),
+        ("united states", ["Canada", "United States"], 1),
+        ("Bachelor's Degree", ["bachelors degree", "masters"], 0),
+    ],
+)
+def test_match_option_exact(candidate: str, options: list[str], expected: int) -> None:
+    """Pass 1: case-insensitive, apostrophe-normalized exact match."""
+    assert match_option(candidate, options) == expected
+
+
+@pytest.mark.parametrize(
+    "candidate, options, expected",
+    [
+        ("United States", ["Canada", "United States of America"], 1),
+        ("Computer Science and Engineering", ["Computer Science", "Biology"], 0),
+    ],
+)
+def test_match_option_substring(candidate: str, options: list[str], expected: int) -> None:
+    """Pass 2: substring containment in either direction."""
+    assert match_option(candidate, options) == expected
+
+
+@pytest.mark.parametrize(
+    "candidate, options, expected",
+    [
+        ("bachelors", ["bachelor's degree", "masters"], 0),
+        ("masters", ["bachelor", "master of science"], 1),
+        ("masters", ["Masters Degree"], 0),
+    ],
+)
+def test_match_option_stem(candidate: str, options: list[str], expected: int) -> None:
+    """Pass 3: trailing-'s' stem match (e.g. "masters" <-> "master's")."""
+    assert match_option(candidate, options) == expected
+
+
+def test_match_option_word_overlap() -> None:
+    """Pass 4: word-overlap scoring above the 50% threshold."""
+    assert match_option("Master of Science", ["Bachelor of Arts", "Master of Arts"]) == 1
+
+
+@pytest.mark.parametrize(
+    "candidate, options",
+    [
+        # Short option codes collapse to a 1-char stem after rstrip("s") and used
+        # to substring-match almost any candidate in Pass 3. They must NOT match.
+        ("Australia", ["US", "AU"]),
+        ("Tunisia", ["IS", "TN"]),
+        ("Massachusetts", ["US", "MA"]),
+        # An option normalizing to all "s" yields an empty stem, which used to
+        # match every candidate ("" in anything is True).
+        ("bachelor", ["ss", "Other"]),
+    ],
+)
+def test_match_option_short_option_no_false_stem_match(candidate: str, options: list[str]) -> None:
+    """Pass 3 must guard the option stem length, not just the candidate stem.
+
+    Regression: without the guard, ``match_option("Australia", ["US", "AU"])``
+    returned 0 (US) because "us".rstrip("s") -> "u" and "u" in "australia".
+    Returning None lets the caller fall back to AI matching, which is correct.
+    """
+    assert match_option(candidate, options) is None
+
+
+@pytest.mark.parametrize(
+    "candidate, options, expected",
+    [
+        # A short option must still win on an exact match (Pass 1) even though
+        # the stem-length guard skips it in Pass 3.
+        ("AU", ["US", "AU"], 1),
+        ("US", ["US", "Canada"], 0),
+    ],
+)
+def test_match_option_short_option_exact_still_matches(candidate: str, options: list[str], expected: int) -> None:
+    """The stem guard must not regress exact matches on short option codes."""
+    assert match_option(candidate, options) == expected
+
+
+@pytest.mark.parametrize(
+    "candidate, options",
+    [
+        ("", ["Canada"]),
+        ("Canada", []),
+        ("???", ["Canada"]),
+    ],
+)
+def test_match_option_no_match(candidate: str, options: list[str]) -> None:
+    """Empty inputs and unmatchable candidates return None."""
+    assert match_option(candidate, options) is None


### PR DESCRIPTION
## Description

`match_option()` in `skyvern/core/script_generations/fuzzy_matcher.py` is the dropdown/option matcher used by the form-fill pipeline. Pass 3 (the stem pass) strips a trailing `s` from the candidate and each option and substring-compares them, but it only guards the *candidate* stem length, not the *option* stem length. Pass 2 already guards both sides.

As a result a 2-letter option like `US`/`AU`/`IS` collapses to a 1-char stem after `rstrip("s")` and substring-matches almost any candidate:

| call | before | after |
|---|---|---|
| `match_option("Australia", ["US", "AU"])` | `0` (US) | `None` |
| `match_option("Tunisia", ["IS", "TN"])` | `0` (IS) | `None` |
| `match_option("Massachusetts", ["US", "MA"])` | `0` (US) | `None` |
| `match_option("bachelor", ["ss", "Other"])` | `0` (empty stem) | `None` |

In the live form-fill path (`skyvern_page.py`, radio/checkbox group fill), a non-`None` index drives `await self.click(options[match_idx]["selector"])`, so a wrong index clicks the wrong option. Country/state dropdowns that mix 2-letter codes with full names are common, so this fires on realistic input. When `match_option` returns `None` the caller falls back to AI matching, so the fix is strictly safer than the status quo.

The fix adds the same `min_substring_len` guard Pass 2 uses to the option stem (2 lines). True abbreviations (e.g. `Georgia` vs option `GA`) are intentionally sent to the AI fallback rather than guessed, which is the conservative, correct behavior rather than a missing feature.

## How Has This Been Tested?

Added `tests/unit/test_fuzzy_matcher.py` (18 cases): the 4 regressions above, the short-option-still-exact-matches invariant (`("AU", ["US", "AU"]) -> 1`), and the existing exact / substring / stem / word-overlap behavior so the guard can't over-suppress. The 4 regression assertions fail against the pre-fix code and pass after.

```
uv sync --extra server
uv run pytest tests/unit/test_fuzzy_matcher.py -q      # 18 passed
uv run ruff check  skyvern/core/script_generations/fuzzy_matcher.py tests/unit/test_fuzzy_matcher.py
uv run ruff format --check skyvern/core/script_generations/fuzzy_matcher.py tests/unit/test_fuzzy_matcher.py
pre-commit run --files skyvern/core/script_generations/fuzzy_matcher.py tests/unit/test_fuzzy_matcher.py   # ruff, isort, pyupgrade, mypy, autoflake all pass
```

`tests/unit/test_script_skyvern_page.py` still passes (66 passed); it mocks the mapping fill, so it is unaffected by this change.

## Artifacts (if appropriate):

N/A, this is a logic fix covered by the unit tests above.
