### PR TITLE
fix: determine recording Content-Type from file extension

### DIFF
--- a/skyvern-frontend/artifactServer.js
+++ b/skyvern-frontend/artifactServer.js
@@ -41,7 +41,7 @@ app.get("/artifact/recording", (req, res) => {
     "Content-Range": `bytes ${start}-${end}/${videoSize}`,
     "Accept-Ranges": "bytes",
     "Content-Length": contentLength,
-    "Content-Type": "video/mp4",
+    "Content-Type": path.toLowerCase().endsWith(".webm") ? "video/webm" : "video/mp4",
   };
   res.writeHead(206, headers);
   const stream = fs.createReadStream(path, {
@@ -91,3 +91,4 @@ app.listen(9090, () => {
     `[${new Date().toISOString()}] Artifact server running at http://localhost:9090`,
   );
 });
+


### PR DESCRIPTION
Recording files use the `.webm` extension but the artifact server hardcoded `video/mp4` as the Content-Type for all recordings. This caused browsers to misinterpret the video format.

Instead of assuming a single format, derive the Content-Type from the file extension — matching the approach used in `agent_protocol.py` (`_VIDEO_CONTENT_TYPES_BY_EXTENSION`).

Fixes #6146