### PR TITLE
Split block.py 2/8: extract branching subsystem → models/branching.py

### DIFF
--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import abc
 import ast
 import asyncio
 import codecs
@@ -32,8 +31,7 @@ import pandas as pd
 import structlog
 from charset_normalizer import from_bytes
 from email_validator import EmailNotValidError, validate_email
-from jinja2 import StrictUndefined, TemplateSyntaxError
-from jinja2.sandbox import SandboxedEnvironment
+from jinja2 import TemplateSyntaxError
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import ValidationError
 from playwright.async_api import Error as PlaywrightError
@@ -53,11 +51,9 @@ from skyvern.constants import (
 from skyvern.exceptions import (
     AzureConfigurationError,
     CodeBlockRunnerSelectionError,
-    ConditionalBranchEvaluationError,
     ContextParameterValueNotFound,
     DownloadFileMaxSizeExceeded,
     FailedToGetTOTPVerificationCode,
-    MalformedBranchEvaluationError,
     MissingBrowserState,
     MissingBrowserStatePage,
     MissingStarterUrl,
@@ -164,7 +160,6 @@ from skyvern.schemas.workflows import (
 from skyvern.services import otp_service
 from skyvern.services.error_detection_service import detect_user_defined_errors_for_task
 from skyvern.utils.strings import generate_random_string
-from skyvern.utils.templating import get_missing_variables
 from skyvern.utils.token_counter import count_tokens
 from skyvern.utils.url_validators import prepend_scheme_and_validate_url
 from skyvern.webeye.actions.action_types import ActionType
@@ -245,11 +240,6 @@ MAX_LOOP_OVER_VALUE_LOG_CHARS = 2000
 # Trades up to N-1 iterations of data loss for O(N/K) writes instead of O(N).
 PERSIST_LOOP_OUTPUT_INTERVAL = 10
 DEFAULT_MAX_STEPS_PER_ITERATION = 50
-
-# Per-field cap for DecisionBlock debug payload (rendered_expression, llm_response, llm_prompt).
-# Same fields exist as branch_metadata debug surface for script-reviewer / UI display; their
-# unbounded form has produced multi-hundred-MB output_parameter rows under recursive Jinja.
-DECISION_BLOCK_FIELD_MAX_BYTES = 64 * 1024
 
 
 def _maybe_truncate_loop_outputs(
@@ -8314,1315 +8304,6 @@ class PrintPageBlock(Block):
         )
 
 
-class BranchEvaluationContext:
-    """Collection of runtime data that BranchCriteria evaluators can consume."""
-
-    def __init__(
-        self,
-        *,
-        workflow_run_context: WorkflowRunContext | None = None,
-        block_label: str | None = None,
-        template_renderer: Callable[[str], str] | None = None,
-    ) -> None:
-        self.workflow_run_context = workflow_run_context
-        self.block_label = block_label
-        self.template_renderer = template_renderer
-
-    def build_llm_safe_context_snapshot(self) -> dict[str, Any]:
-        """
-        Build a minimal context blob for LLM-facing branch evaluation.
-
-        Only includes essential data the LLM needs to evaluate conditions:
-        - Parameter values (base_date, date_1, etc.)
-        - Extracted information from previous blocks
-        - Loop variables (current_value, current_index, current_item)
-        """
-        if self.workflow_run_context is None:
-            return {}
-
-        ctx = self.workflow_run_context
-        raw_values: dict[str, Any] = ctx.values.copy()
-
-        # Keys to skip - these are not useful for evaluating conditions
-        keys_to_skip = {
-            "blocks_metadata",
-            "params",
-            "outputs",
-            "environment",
-            "env",
-            "llm",
-            "workflow_title",
-            "workflow_id",
-            "workflow_permanent_id",
-            "workflow_run_id",
-        }
-
-        snapshot: dict[str, Any] = {}
-        for key, value in raw_values.items():
-            # Skip noisy keys
-            if key in keys_to_skip:
-                continue
-
-            # For block outputs (dicts with extracted_information), only include extracted_information
-            if isinstance(value, dict) and "extracted_information" in value:
-                extracted = value.get("extracted_information")
-                if extracted is not None:
-                    snapshot[key] = extracted
-            else:
-                # Include parameter values directly
-                snapshot[key] = value
-
-        # Copy loop variables (current_value, current_index, current_item) to top level
-        # Required for pure NatLang expressions like "current_value['date']" to work
-        if self.block_label:
-            block_metadata = ctx.get_block_metadata(self.block_label)
-            if "current_value" in block_metadata:
-                snapshot["current_value"] = block_metadata["current_value"]
-            if "current_index" in block_metadata:
-                snapshot["current_index"] = block_metadata["current_index"]
-            if "current_item" in block_metadata:
-                snapshot["current_item"] = block_metadata["current_item"]
-
-        # Mask any real secret values that may have leaked into values
-        snapshot = ctx.mask_secrets_in_data(snapshot)
-
-        return snapshot
-
-    def build_template_data(self) -> dict[str, Any]:
-        """Build Jinja template data mirroring block parameter rendering context."""
-        if self.workflow_run_context is None:
-            return {
-                "params": {},
-                "outputs": {},
-                "environment": {},
-                "env": {},
-                "llm": {},
-            }
-
-        ctx = self.workflow_run_context
-        template_data = ctx.values.copy()
-        if ctx.include_secrets_in_templates:
-            template_data.update(ctx.secrets)
-
-            credential_params: list[tuple[str, dict[str, Any]]] = []
-            for key, value in template_data.items():
-                if isinstance(value, dict) and "context" in value and "username" in value and "password" in value:
-                    credential_params.append((key, value))
-
-            for key, value in credential_params:
-                username_secret_id = value.get("username", "")
-                password_secret_id = value.get("password", "")
-                real_username = template_data.get(username_secret_id, "")
-                real_password = template_data.get(password_secret_id, "")
-                template_data[f"{key}_real_username"] = real_username
-                template_data[f"{key}_real_password"] = real_password
-
-        if self.block_label:
-            block_reference_data: dict[str, Any] = ctx.get_block_metadata(self.block_label)
-            if self.block_label in template_data:
-                current_value = template_data[self.block_label]
-                if isinstance(current_value, dict):
-                    block_reference_data.update(current_value)
-            template_data[self.block_label] = block_reference_data
-
-            if "current_index" in block_reference_data:
-                template_data["current_index"] = block_reference_data["current_index"]
-            if "current_item" in block_reference_data:
-                template_data["current_item"] = block_reference_data["current_item"]
-            if "current_value" in block_reference_data:
-                template_data["current_value"] = block_reference_data["current_value"]
-
-        template_data.setdefault("workflow_title", ctx.workflow_title)
-        template_data.setdefault("workflow_id", ctx.workflow_id)
-        template_data.setdefault("workflow_permanent_id", ctx.workflow_permanent_id)
-        template_data.setdefault("workflow_run_id", ctx.workflow_run_id)
-        template_data.setdefault("current_date", datetime.now(timezone.utc).strftime(CURRENT_DATE_FORMAT))
-
-        template_data.setdefault("params", template_data.get("params", {}))
-        template_data.setdefault("outputs", template_data.get("outputs", {}))
-        template_data.setdefault("environment", template_data.get("environment", {}))
-        template_data.setdefault("env", template_data.get("environment"))
-        template_data.setdefault("llm", template_data.get("llm", {}))
-
-        return template_data
-
-
-class BranchCriteria(BaseModel, abc.ABC):
-    """Abstract interface describing how a branch condition should be evaluated."""
-
-    criteria_type: str
-    expression: str
-    description: str | None = None
-
-    @abc.abstractmethod
-    async def evaluate(self, context: BranchEvaluationContext) -> bool:
-        """Return True when the branch should execute."""
-        raise NotImplementedError
-
-    def requires_llm(self) -> bool:
-        """Whether the criteria relies on an LLM classification step."""
-        return False
-
-
-def _evaluate_truthy_string(value: str) -> bool:
-    """
-    Evaluate a string as a boolean, handling common truthy/falsy representations.
-
-    Truthy: "true", "True", "TRUE", "1", "yes", "y", "on", non-zero numbers
-    Falsy: "", "false", "False", "FALSE", "0", "no", "n", "off", "null", "None", whitespace-only
-
-    For other strings, use Python's default bool() behavior (non-empty = truthy).
-    """
-    if not value or not value.strip():
-        return False
-
-    normalized = value.strip().lower()
-
-    # Explicit falsy values
-    if normalized in ("false", "0", "no", "n", "off", "null", "none"):
-        return False
-
-    # Explicit truthy values
-    if normalized in ("true", "1", "yes", "y", "on"):
-        return True
-
-    # Try to parse as a number
-    try:
-        num = float(normalized)
-        return num != 0.0
-    except ValueError:
-        pass
-
-    # For any other non-empty string, consider it truthy
-    # This allows expressions like "{{ 'some text' }}" to be truthy
-    return True
-
-
-class JinjaBranchCriteria(BranchCriteria):
-    """Jinja2-templated branch criteria (only supported criteria type for now)."""
-
-    criteria_type: Literal["jinja2_template"] = "jinja2_template"
-
-    async def evaluate(self, context: BranchEvaluationContext) -> bool:
-        # Prefer the renderer provided by the caller (matches block parameter rendering),
-        # otherwise build a minimal sandboxed renderer using the evaluation context.
-        if context.template_renderer:
-            try:
-                rendered = context.template_renderer(self.expression)
-            except MissingJinjaVariables:
-                # Let upstream MissingJinjaVariables bubble as-is.
-                raise
-            except Exception as exc:  # pragma: no cover - caught for robustness
-                raise FailedToFormatJinjaStyleParameter(self.expression, str(exc)) from exc
-        else:
-            template_data = context.build_template_data()
-            sandbox_env = (
-                SandboxedEnvironment(undefined=StrictUndefined)
-                if settings.WORKFLOW_TEMPLATING_STRICTNESS == "strict"
-                else SandboxedEnvironment()
-            )
-
-            try:
-                missing_vars = get_missing_variables(self.expression, template_data)
-                if missing_vars:
-                    raise MissingJinjaVariables(self.expression, missing_vars)
-
-                template = sandbox_env.from_string(self.expression)
-                rendered = template.render(template_data)
-            except MissingJinjaVariables:
-                raise
-            except Exception as exc:
-                # Covers syntax errors and rendering issues
-                raise FailedToFormatJinjaStyleParameter(self.expression, str(exc)) from exc
-
-        return _evaluate_truthy_string(rendered)
-
-
-class PromptBranchCriteria(BranchCriteria):
-    """Natural language branch criteria."""
-
-    criteria_type: Literal["prompt"] = "prompt"
-
-    async def evaluate(self, context: BranchEvaluationContext) -> bool:
-        # Evaluated via ConditionalBlock.execute (batched) or WhileLoopBlock
-        # _evaluate_condition (single-branch batch helper).
-        raise NotImplementedError("PromptBranchCriteria is evaluated via extraction batch helpers, not per-branch.")
-
-    def requires_llm(self) -> bool:
-        return True
-
-
-def _is_pure_jinja_expression(expression: str) -> bool:
-    """
-    Determine if an expression is a pure Jinja template (single block) vs Jinja+NatLang (mixed).
-
-    Pure Jinja: "{{ A == B }}" - single Jinja block, should be evaluated server-side
-    Jinja+NatLang: "{{ A }} is same as {{ B }}" - multiple Jinja blocks mixed with natural language
-
-    Returns True only for pure Jinja expressions that can be evaluated to boolean server-side.
-    """
-    if not expression:
-        return False
-
-    stripped = expression.strip()
-
-    # Must start with {{ and end with }}
-    if not (stripped.startswith("{{") and stripped.endswith("}}")):
-        return False
-
-    # Count the number of {{ occurrences
-    # If there's more than one, it's Jinja+NatLang (e.g., "{{ A }} is same as {{ B }}")
-    jinja_open_count = stripped.count("{{")
-    if jinja_open_count > 1:
-        return False
-
-    # Single {{ and ends with }} - this is pure Jinja
-    return True
-
-
-def _resolve_nested_path(value: Any, path: str) -> Any:
-    """
-    Resolve a dotted/bracket access path on a nested value.
-
-    Examples:
-        _resolve_nested_path({"a": {"b": 1}}, ".a.b") -> 1
-        _resolve_nested_path([{"x": 2}], "[0].x") -> 2
-
-    Args:
-        value: The root value to traverse
-        path: The access path (e.g., ".field1.field2[0].field3")
-
-    Returns:
-        The resolved leaf value
-
-    Raises:
-        LookupError: If the path cannot be resolved
-    """
-    segments = re.findall(r"\.([a-zA-Z_]\w*)|\[(\d+)\]", path)
-    current = value
-    for dot_key, bracket_idx in segments:
-        if dot_key:
-            if isinstance(current, dict):
-                if dot_key not in current:
-                    raise LookupError(f"Key {dot_key!r} not found")
-                current = current[dot_key]
-            else:
-                raise LookupError(f"Cannot access .{dot_key} on {type(current).__name__}")
-        elif bracket_idx:
-            idx = int(bracket_idx)
-            if isinstance(current, (list, tuple)):
-                if idx >= len(current):
-                    raise LookupError(f"Index [{idx}] out of range")
-                current = current[idx]
-            else:
-                raise LookupError(f"Cannot index [{idx}] on {type(current).__name__}")
-    return current
-
-
-_JINJA_DISPLAY_FILTERS: dict[str, Callable[[Any], Any]] = {
-    "lower": lambda v: str(v).lower(),
-    "upper": lambda v: str(v).upper(),
-    "trim": lambda v: str(v).strip(),
-    "title": lambda v: str(v).title(),
-    "capitalize": lambda v: str(v).capitalize(),
-    "int": lambda v: int(v),
-    "float": lambda v: float(v),
-    "string": lambda v: str(v),
-    "length": lambda v: len(v),
-    "abs": lambda v: abs(v),
-}
-
-
-def _render_jinja_expression_for_display(
-    expression: str,
-    context_values: dict[str, Any],
-    block_label: str | None = None,
-) -> str:
-    """
-    Render a pure Jinja expression for UI display by substituting variable names with values.
-
-    This is for display purposes only - it shows users what values were compared
-    without actually evaluating the expression. For example:
-    - Input: "{{ base_date == date_1 }}" with context {"base_date": "01-25-2026", "date_1": "01-25-2026"}
-    - Output: '"01-25-2026" == "01-25-2026"'
-    - Input: "{{ output.extracted_information.field != None }}" with nested dict context
-    - Output: '"some_value" != None'
-    - Input: "{{ output.status|lower == 'active' }}" with context {"output": {"status": "Active"}}
-    - Output: '"active" == \'active\''
-
-    Known Jinja filters (lower, upper, trim, etc.) are applied to the resolved value.
-    Unknown filters are left as-is in the output.
-
-    Returns the original expression if it's not a pure Jinja expression or if rendering fails.
-    """
-    if not _is_pure_jinja_expression(expression):
-        return expression
-
-    try:
-        # Extract inner expression (strip {{ and }})
-        inner_expr = expression.strip()[2:-2].strip()
-        display_expr = inner_expr
-
-        # Substitute variable references (including dotted/bracket access paths and filters)
-        # with their values.
-        # Match var_name optionally followed by .field or [index] segments,
-        # then optionally followed by a |filter_name.
-        # Sort by key length (longest first) to avoid partial matches.
-        for var_name in sorted(context_values.keys(), key=len, reverse=True):
-            pattern = r"\b" + re.escape(var_name) + r"((?:\.[a-zA-Z_]\w*|\[\d+\])*)(\|[a-zA-Z_]\w*)?"
-
-            def _replacer(match: re.Match, _var_name: str = var_name) -> str:
-                access_path = match.group(1)  # the dotted/bracket part after var_name
-                filter_expr = match.group(2)  # e.g., "|lower" or None
-                var_value = context_values[_var_name]
-
-                if access_path:
-                    try:
-                        var_value = _resolve_nested_path(var_value, access_path)
-                    except LookupError:
-                        # Path couldn't be resolved — return original text unchanged
-                        return match.group(0)
-
-                if filter_expr:
-                    filter_name = filter_expr[1:]  # strip the leading |
-                    filter_fn = _JINJA_DISPLAY_FILTERS.get(filter_name)
-                    if filter_fn is not None:
-                        try:
-                            var_value = filter_fn(var_value)
-                        except Exception:
-                            # Filter application failed — show value with filter text
-                            if isinstance(var_value, str):
-                                return f'"{var_value}"{filter_expr}'
-                            return f"{var_value}{filter_expr}"
-                    else:
-                        # Unknown filter — show value with filter text preserved
-                        if isinstance(var_value, str):
-                            return f'"{var_value}"{filter_expr}'
-                        return f"{var_value}{filter_expr}"
-
-                if isinstance(var_value, str):
-                    return f'"{var_value}"'
-                return str(var_value)
-
-            display_expr = re.sub(pattern, _replacer, display_expr)
-
-        return display_expr
-    except Exception as exc:
-        LOG.debug(
-            "Failed to render Jinja expression for display",
-            block_label=block_label,
-            expression=expression,
-            error=str(exc),
-        )
-        return expression
-
-
-def _find_evaluations_array(output_value: dict[str, Any]) -> list[Any]:
-    """
-    Extract the evaluations array from LLM output.
-
-    ExtractionBlock wraps output in 'extracted_information', so we check there first.
-    Falls back to direct access if not found in the nested structure.
-
-    Args:
-        output_value: The raw output from ExtractionBlock
-
-    Returns:
-        List of evaluation objects from the LLM
-
-    Raises:
-        ValueError: If evaluations array is not found or has wrong type
-    """
-    # Try standard ExtractionBlock format: output_value.extracted_information.evaluations
-    extracted_info = output_value.get("extracted_information")
-    if isinstance(extracted_info, dict):
-        raw_evaluations = extracted_info.get("evaluations")
-    else:
-        # Fallback: try direct access at output_value.evaluations
-        raw_evaluations = output_value.get("evaluations")
-
-    if not isinstance(raw_evaluations, list):
-        raise ValueError(f"Expected array of evaluations, got: {type(raw_evaluations)}")
-
-    return raw_evaluations
-
-
-def _parse_single_evaluation(
-    evaluation: Any,
-    idx: int,
-    fallback_rendered_expressions: list[str],
-) -> tuple[bool, str]:
-    """
-    Parse a single evaluation from the LLM response.
-
-    Handles two formats:
-    - Dict format: {result: bool, reasoning: str}
-    - Legacy format: just a boolean value
-
-    The rendered expression always comes from the Jinja pre-rendering step (fallback),
-    not from the LLM response, to avoid the LLM re-interpreting already-resolved values.
-
-    Args:
-        evaluation: Single evaluation object from LLM (dict or bool)
-        idx: Index of this evaluation (for fallback lookup)
-        fallback_rendered_expressions: Pre-rendered expressions from Jinja rendering
-
-    Returns:
-        Tuple of (boolean_result, rendered_expression_string)
-    """
-    rendered_expression = fallback_rendered_expressions[idx] if idx < len(fallback_rendered_expressions) else ""
-
-    if isinstance(evaluation, dict):
-        result = evaluation.get("result")
-        if isinstance(result, bool):
-            bool_result = result
-        else:
-            bool_result = _evaluate_truthy_string(str(result))
-            LOG.warning(
-                "Conditional branch evaluation returned non-boolean result",
-                branch_index=idx,
-                result=result,
-                evaluated_result=bool_result,
-            )
-
-        return (bool_result, rendered_expression)
-    else:
-        # Legacy format: just a boolean
-        if isinstance(evaluation, bool):
-            bool_result = evaluation
-        else:
-            bool_result = _evaluate_truthy_string(str(evaluation))
-
-        return (bool_result, rendered_expression)
-
-
-# Number of times to evaluate the prompt-based conditional branches before giving up.
-# The dominant failure is a transient malformed/under-returned LLM batch; one re-roll
-# recovers most of them while still failing loudly when the model is persistently wrong.
-MAX_PROMPT_BRANCH_EVAL_ATTEMPTS = 2
-
-
-def _build_branch_evaluation_schema(num_branches: int) -> dict[str, Any]:
-    """Strict JSON schema for the batched branch-evaluation LLM call.
-
-    ``additionalProperties: false`` plus a required ``condition_index`` stop the model from
-    injecting hallucinated fields and force one self-identifying result per condition.
-    """
-    return {
-        "type": "object",
-        "additionalProperties": False,
-        "properties": {
-            "evaluations": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "additionalProperties": False,
-                    "properties": {
-                        "condition_index": {
-                            "type": "integer",
-                            "description": (
-                                "The 1-based index of the condition this object evaluates "
-                                "(Condition 1 -> 1, Condition 2 -> 2, ...)."
-                            ),
-                        },
-                        "reasoning": {
-                            "type": "string",
-                            "description": "Explanation of the reasoning behind evaluating the condition.",
-                        },
-                        "result": {
-                            "type": "boolean",
-                            "description": "TRUE if the condition is satisfied, FALSE otherwise.",
-                        },
-                    },
-                    "required": ["condition_index", "reasoning", "result"],
-                },
-                "description": "Exactly one evaluation per condition, covering condition_index 1..N.",
-                "minItems": num_branches,
-                "maxItems": num_branches,
-            }
-        },
-        "required": ["evaluations"],
-    }
-
-
-def _coerce_condition_index(raw: Any) -> int | None:
-    """Read a 1-based ``condition_index`` the LLM may have typed loosely.
-
-    Accepts ints, integral floats (``2.0``), and digit strings (``"2"``); returns ``None`` for
-    bools (an int subclass that must not read as 0/1) and non-integral/garbage values. The schema
-    is a prompt-level hint, not provider-enforced, so a model that under-returns can equally
-    mistype the index; coercing keeps a loosely-typed index on the order-safe alignment path
-    instead of misrouting via positional fallback.
-    """
-    if isinstance(raw, bool):
-        return None
-    if isinstance(raw, int):
-        return raw
-    if isinstance(raw, float):
-        return int(raw) if raw.is_integer() else None
-    if isinstance(raw, str):
-        try:
-            return int(raw.strip())
-        except ValueError:
-            return None
-    return None
-
-
-def _align_branch_evaluations(
-    *,
-    output_value: Any,
-    branches: list[BranchCondition],
-    rendered_expressions: list[str],
-) -> tuple[list[bool], list[str], dict[str, Any]]:
-    """Align the LLM evaluations to ``branches``.
-
-    Returns ``(results, rendered_expressions, normalized_output)``, where ``normalized_output``
-    is the evaluations wrapped in a dict for recording/UI. Prefers the LLM-provided 1-based
-    ``condition_index`` (coerced from ints, integral floats, or digit strings): this is order-safe
-    and immune to hallucinated extra entries that would shift positional alignment. Falls back to
-    positional parsing only when no usable index is present and the count matches exactly. A
-    wrong-length or mis-indexed batch is discarded wholesale (never gap-filled) by raising
-    ``MalformedBranchEvaluationError`` so the caller can retry or fail loudly.
-    """
-    n = len(branches)
-
-    if isinstance(output_value, list):
-        output_value = {"evaluations": output_value}
-    if not isinstance(output_value, dict):
-        raise MalformedBranchEvaluationError(f"unexpected output format: {type(output_value)}")
-    try:
-        raw_evaluations = _find_evaluations_array(output_value)
-    except ValueError as exc:
-        raise MalformedBranchEvaluationError(str(exc)) from exc
-
-    by_index: dict[int, Any] = {}
-    saw_condition_index = False
-    for evaluation in raw_evaluations:
-        if not isinstance(evaluation, dict):
-            continue
-        raw_index = _coerce_condition_index(evaluation.get("condition_index"))
-        if raw_index is None:
-            continue
-        saw_condition_index = True
-        if not (1 <= raw_index <= n):
-            continue
-        if raw_index in by_index:
-            raise MalformedBranchEvaluationError(f"duplicate condition_index {raw_index}")
-        by_index[raw_index] = evaluation
-
-    if saw_condition_index:
-        if set(by_index.keys()) != set(range(1, n + 1)):
-            raise MalformedBranchEvaluationError(f"condition_index set {sorted(by_index.keys())} does not cover 1..{n}")
-        ordered: list[Any] = [by_index[i] for i in range(1, n + 1)]
-    else:
-        # Legacy path (no condition_index): the LLM occasionally appends reasoning=None
-        # placeholder entries. Strip them and accept only when the remainder is exactly N.
-        well_formed = [e for e in raw_evaluations if not (isinstance(e, dict) and e.get("reasoning") is None)]
-        ordered = well_formed if len(well_formed) == n else list(raw_evaluations)
-        if len(ordered) != n:
-            raise MalformedBranchEvaluationError(f"returned {len(ordered)} results for {n} branches")
-
-    results_array: list[bool] = []
-    llm_rendered_expressions: list[str] = []
-    for idx, evaluation in enumerate(ordered):
-        bool_result, rendered_expr = _parse_single_evaluation(
-            evaluation=evaluation,
-            idx=idx,
-            fallback_rendered_expressions=rendered_expressions,
-        )
-        results_array.append(bool_result)
-        llm_rendered_expressions.append(rendered_expr)
-    return results_array, llm_rendered_expressions, output_value
-
-
-# Pattern to find Jinja template blocks like {{ variable_name }}
-_JINJA_BLOCK_RE = re.compile(r"\{\{(.*?)\}\}")
-# Marker inserted into rendered expressions when a Jinja variable resolved to
-# an empty/whitespace-only value.  The LLM uses this to reason about emptiness.
-_EMPTY_VALUE_MARKER = "(empty value)"
-
-
-def _make_empty_params_explicit(
-    original_expression: str,
-    rendered_expression: str,
-) -> tuple[str, bool]:
-    """
-    Detect Jinja template variables that resolved to empty values and replace
-    the empty gaps with explicit ``(empty value)`` markers.
-
-    When ``{{test_parameter}}`` resolves to ``""``, the rendered expression becomes
-    malformed (e.g., ``"if  is not empty"``).  This function detects such cases by
-    comparing the *original* expression (with ``{{ }}`` blocks) against the
-    *rendered* expression and rebuilds it with clear markers so the LLM can
-    evaluate the condition correctly.
-
-    Returns:
-        ``(patched_expression, was_patched)``
-    """
-    if not original_expression or "{{" not in original_expression:
-        return rendered_expression, False
-
-    # Split the original expression into alternating [static, var, static, var, ...] parts.
-    parts = _JINJA_BLOCK_RE.split(original_expression)
-    if len(parts) <= 1:
-        return rendered_expression, False
-
-    # Extract static parts (even indices) and build a regex that captures what
-    # each Jinja block rendered to by using the static text as anchors.
-    static_parts = [parts[i] for i in range(0, len(parts), 2)]
-    num_vars = len(parts) // 2
-
-    # When two Jinja variables are adjacent (e.g. "{{a}}{{b}}") the interior
-    # static separator is an empty string and the non-greedy regex cannot
-    # reliably attribute rendered text to the correct variable.  Bail out.
-    if num_vars > 1 and any(static == "" for static in static_parts[1:-1]):
-        return rendered_expression, False
-
-    # NOTE: if a rendered value happens to contain the same text as a static
-    # anchor the regex may split on the wrong occurrence.  This is extremely
-    # unlikely in user-authored conditional expressions and the worst-case
-    # outcome is an unnecessary "(empty value)" marker, which still beats the
-    # invisible empty-string that caused SKY-8073.
-
-    regex_fragments: list[str] = []
-    for i, static in enumerate(static_parts):
-        regex_fragments.append(re.escape(static))
-        if i < num_vars:
-            regex_fragments.append("(.*?)")
-
-    match = re.match("^" + "".join(regex_fragments) + "$", rendered_expression, re.DOTALL)
-    if not match:
-        return rendered_expression, False
-
-    rendered_values = match.groups()
-    has_empty = any(not v.strip() for v in rendered_values)
-    if not has_empty:
-        return rendered_expression, False
-
-    # Rebuild the expression, replacing empty rendered values with an explicit marker.
-    result_parts: list[str] = []
-    for i, static in enumerate(static_parts):
-        result_parts.append(static)
-        if i < len(rendered_values):
-            if not rendered_values[i].strip():
-                result_parts.append(_EMPTY_VALUE_MARKER)
-            else:
-                result_parts.append(rendered_values[i])
-
-    return "".join(result_parts), True
-
-
-def _cap_debug_field(value: Any, *, limit_bytes: int = DECISION_BLOCK_FIELD_MAX_BYTES) -> Any:
-    """Cap a string at ``limit_bytes`` UTF-8 bytes (suffix included); non-strings pass through (SKY-9779)."""
-    if not isinstance(value, str):
-        return value
-    encoded = value.encode("utf-8")
-    if len(encoded) <= limit_bytes:
-        return value
-    overflow_bytes = len(encoded) - limit_bytes
-    suffix = f"…[truncated {overflow_bytes} bytes]"
-    suffix_bytes = len(suffix.encode("utf-8"))
-    head_budget = max(0, limit_bytes - suffix_bytes)
-    return encoded[:head_budget].decode("utf-8", errors="ignore") + suffix
-
-
-def _trim_branch_evaluations(branch_evaluations: list[dict] | None) -> list[dict] | None:
-    """Drop ``rendered_expression`` on non-matched branches; cap the matched one (SKY-9779)."""
-    if not branch_evaluations:
-        return branch_evaluations
-    trimmed: list[dict] = []
-    for ev in branch_evaluations:
-        if ev.get("is_matched"):
-            ev = {**ev, "rendered_expression": _cap_debug_field(ev.get("rendered_expression"))}
-        else:
-            ev = {k: v for k, v in ev.items() if k != "rendered_expression"}
-        trimmed.append(ev)
-    return trimmed
-
-
-class BranchCondition(BaseModel):
-    """Represents a single conditional branch edge within a ConditionalBlock."""
-
-    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    criteria: BranchCriteriaTypeVar | None = None
-    next_block_label: str | None = None
-    description: str | None = None
-    is_default: bool = False
-
-    @model_validator(mode="after")
-    def validate_condition(self) -> BranchCondition:
-        if isinstance(self.criteria, dict):
-            criteria_type = self.criteria.get("criteria_type")
-            if criteria_type is None:
-                # Infer criteria type from expression format
-                expression = self.criteria.get("expression", "")
-                if _is_pure_jinja_expression(expression):
-                    criteria_type = "jinja2_template"
-                else:
-                    criteria_type = "prompt"
-            if criteria_type == "prompt":
-                self.criteria = PromptBranchCriteria(**self.criteria)
-            else:
-                self.criteria = JinjaBranchCriteria(**self.criteria)
-        if self.criteria is None and not self.is_default:
-            raise ValueError("Branches without criteria must be marked as default.")
-        if self.criteria is not None and self.is_default:
-            raise ValueError("Default branches may not define criteria.")
-        if self.criteria and isinstance(self.criteria, BranchCriteria):
-            expression = self.criteria.expression
-            criteria_dict = self.criteria.model_dump()
-            if _is_pure_jinja_expression(expression):
-                criteria_dict["criteria_type"] = "jinja2_template"
-                self.criteria = JinjaBranchCriteria(**criteria_dict)
-            else:
-                criteria_dict["criteria_type"] = "prompt"
-                self.criteria = PromptBranchCriteria(**criteria_dict)
-        return self
-
-
-async def _evaluate_prompt_branch_conditions_batch(
-    *,
-    log_label: str,
-    branches: list[BranchCondition],
-    evaluation_context: BranchEvaluationContext,
-    workflow_run_id: str,
-    workflow_run_block_id: str,
-    organization_id: str | None,
-    browser_session_id: str | None,
-    workflow_id: str,
-    extraction_description_suffix: str = "",
-) -> tuple[list[bool], list[str], str | None, dict | None]:
-    if organization_id is None:
-        raise ValueError("organization_id is required to evaluate natural language branches")
-
-    if not branches:
-        return ([], [], None, None)
-
-    workflow_run_context = evaluation_context.workflow_run_context
-
-    rendered_expressions: list[str] = []
-    has_any_pure_natlang = False
-
-    for idx, branch in enumerate(branches):
-        expression = branch.criteria.expression if branch.criteria else ""
-        has_jinja = "{{" in expression
-
-        if has_jinja:
-            try:
-                rendered_expression = (
-                    evaluation_context.template_renderer(expression)
-                    if evaluation_context.template_renderer
-                    else expression
-                )
-            except Exception as render_exc:
-                LOG.error(
-                    "Conditional branch expression rendering FAILED",
-                    block_label=log_label,
-                    branch_index=idx,
-                    original_expression=expression,
-                    error=str(render_exc),
-                    exc_info=True,
-                )
-                rendered_expression = expression
-                has_any_pure_natlang = True
-            else:
-                rendered_expression, was_patched = _make_empty_params_explicit(expression, rendered_expression)
-                if was_patched:
-                    LOG.info(
-                        "Conditional branch expression patched for empty parameter(s)",
-                        workflow_run_id=workflow_run_id,
-                        block_label=log_label,
-                        branch_index=idx,
-                        original_expression=expression,
-                        patched_expression=rendered_expression,
-                    )
-        else:
-            rendered_expression = expression
-            has_any_pure_natlang = True
-
-        LOG.info(
-            "Conditional branch expression rendering",
-            block_label=log_label,
-            branch_index=idx,
-            original_expression=expression,
-            rendered_expression=rendered_expression,
-            has_jinja=has_jinja,
-            expression_changed=expression != rendered_expression,
-        )
-
-        rendered_expressions.append(rendered_expression)
-
-    if has_any_pure_natlang:
-        context_snapshot = evaluation_context.build_llm_safe_context_snapshot()
-        context_json = json.dumps(context_snapshot, default=str)
-    else:
-        context_json = None
-
-    extraction_goal = prompt_engine.load_prompt(
-        "conditional-prompt-branch-evaluation",
-        conditions=rendered_expressions,
-        context_json=context_json,
-    )
-
-    data_schema = _build_branch_evaluation_schema(len(branches))
-
-    desc_suffix = extraction_description_suffix or f"{len(branches)} conditions"
-
-    last_malformed: MalformedBranchEvaluationError | None = None
-    for attempt in range(MAX_PROMPT_BRANCH_EVAL_ATTEMPTS):
-        # Vary the goal on retries so the extraction cache key (which includes
-        # data_extraction_goal) changes and we get a genuine re-roll instead of replaying
-        # the malformed cached result that just failed validation.
-        attempt_goal = extraction_goal
-        if attempt > 0:
-            attempt_goal = (
-                f"{extraction_goal}\n\n"
-                f"Re-evaluation attempt {attempt + 1}: return exactly {len(branches)} results, "
-                f"one object per numbered condition, each tagged with its condition_index."
-            )
-
-        prompt_branch_eval_id = generate_random_string()
-        output_param = OutputParameter(
-            output_parameter_id=str(uuid.uuid4()),
-            key=f"prompt_branch_eval_{prompt_branch_eval_id}",
-            workflow_id=workflow_id,
-            created_at=datetime.now(),
-            modified_at=datetime.now(),
-            parameter_type=ParameterType.OUTPUT,
-            description=f"Conditional branch evaluation results ({desc_suffix})",
-        )
-        extraction_block = ExtractionBlock(
-            label=f"prompt_branch_eval_{prompt_branch_eval_id}",
-            data_extraction_goal=attempt_goal,
-            data_schema=data_schema,
-            output_parameter=output_param,
-        )
-
-        LOG.info(
-            "Conditional branch ExtractionBlock created (batched)",
-            block_label=log_label,
-            prompt_branch_eval_id=prompt_branch_eval_id,
-            num_conditions=len(branches),
-            attempt=attempt,
-            extraction_goal_preview=attempt_goal[:500] if attempt_goal else None,
-            has_browser_session=browser_session_id is not None,
-            has_any_pure_natlang=has_any_pure_natlang,
-            has_context=context_json is not None,
-        )
-
-        extraction_result = await extraction_block.execute(
-            workflow_run_id=workflow_run_id,
-            workflow_run_block_id=workflow_run_block_id,
-            organization_id=organization_id,
-            browser_session_id=browser_session_id,
-        )
-
-        if not extraction_result.success:
-            # Extraction-level failures already retry at the step level inside the task;
-            # surface them immediately rather than re-rolling the whole batch.
-            LOG.error(
-                "Conditional branch ExtractionBlock failed",
-                block_label=log_label,
-                failure_reason=extraction_result.failure_reason,
-            )
-            raise ConditionalBranchEvaluationError(
-                f"Branch evaluation failed: "
-                f"{extraction_result.failure_reason or 'Unknown error (no failure reason provided)'}"
-            )
-
-        raw_output_value = extraction_result.output_parameter_value
-        try:
-            results_array, llm_rendered_expressions, normalized_output = _align_branch_evaluations(
-                output_value=raw_output_value,
-                branches=branches,
-                rendered_expressions=rendered_expressions,
-            )
-        except MalformedBranchEvaluationError as malformed:
-            last_malformed = malformed
-            LOG.warning(
-                "Conditional branch evaluation output malformed",
-                block_label=log_label,
-                attempt=attempt,
-                will_retry=attempt + 1 < MAX_PROMPT_BRANCH_EVAL_ATTEMPTS,
-                error=str(malformed),
-                raw_output=raw_output_value,
-            )
-            continue
-
-        # Record the output parameter only for the attempt we actually accept, so a failed
-        # attempt's payload never lands in the workflow context when a later attempt succeeds.
-        if workflow_run_context:
-            try:
-                await extraction_block.record_output_parameter_value(
-                    workflow_run_context=workflow_run_context,
-                    workflow_run_id=workflow_run_id,
-                    value=normalized_output,
-                )
-            except Exception:
-                LOG.warning(
-                    "Failed to record conditional branch evaluation output",
-                    workflow_run_id=workflow_run_id,
-                    block_label=log_label,
-                    exc_info=True,
-                )
-
-        LOG.info(
-            "Conditional branch evaluation results",
-            block_label=log_label,
-            results=results_array,
-            llm_rendered_expressions=llm_rendered_expressions,
-            attempt=attempt,
-            raw_output=normalized_output,
-        )
-        return (results_array, llm_rendered_expressions, extraction_goal, normalized_output)
-
-    LOG.error(
-        "Conditional branch evaluation failed after retries",
-        block_label=log_label,
-        attempts=MAX_PROMPT_BRANCH_EVAL_ATTEMPTS,
-        error=str(last_malformed),
-    )
-    raise ConditionalBranchEvaluationError(f"Conditional branch evaluation failed: {last_malformed}")
-
-
-class ConditionalBlock(Block):
-    """Branching block that selects the next block label based on list-ordered conditions."""
-
-    # There is a mypy bug with Literal. Without the type: ignore, mypy will raise an error:
-    # Parameter 1 of Literal[...] cannot be of type "Any"
-    block_type: Literal[BlockType.CONDITIONAL] = BlockType.CONDITIONAL  # type: ignore
-
-    branch_conditions: list[BranchCondition] = Field(default_factory=list)
-
-    @model_validator(mode="after")
-    def validate_branches(self) -> ConditionalBlock:
-        if not self.branch_conditions:
-            raise ValueError("Conditional blocks require at least one branch.")
-
-        default_branches = [branch for branch in self.branch_conditions if branch.is_default]
-        if len(default_branches) > 1:
-            raise ValueError("Only one default branch is permitted per conditional block.")
-
-        return self
-
-    def get_all_parameters(
-        self,
-        workflow_run_id: str,  # noqa: ARG002 - preserved for interface compatibility
-    ) -> list[PARAMETER_TYPE]:
-        # BranchCriteria subclasses will surface their parameter dependencies once implemented.
-        return []
-
-    async def _evaluate_prompt_branches(
-        self,
-        *,
-        branches: list[BranchCondition],
-        evaluation_context: BranchEvaluationContext,
-        workflow_run_id: str,
-        workflow_run_block_id: str,
-        organization_id: str | None = None,
-        browser_session_id: str | None = None,
-    ) -> tuple[list[bool], list[str], str | None, dict | None]:
-        """
-        Evaluate natural language branch conditions in batch.
-
-        All prompt-based conditions are batched into ONE LLM call for performance.
-        Jinja parts ({{ }}) are pre-rendered before sending to LLM.
-
-        Evaluation strategy:
-        - If any condition is pure natural language, use ExtractionBlock for browser/page context.
-        - If all conditions contain Jinja and are pre-rendered, use direct LLM call (no browser context).
-
-        Returns:
-            A tuple of (results, rendered_expressions, extraction_goal, llm_response):
-            - results: List of boolean results for each branch
-            - rendered_expressions: List of expressions after Jinja pre-rendering
-            - extraction_goal: The prompt sent to the LLM (for UI display)
-            - llm_response: The raw LLM response for debugging
-        """
-        return await _evaluate_prompt_branch_conditions_batch(
-            log_label=self.label,
-            branches=branches,
-            evaluation_context=evaluation_context,
-            workflow_run_id=workflow_run_id,
-            workflow_run_block_id=workflow_run_block_id,
-            organization_id=organization_id,
-            browser_session_id=browser_session_id,
-            workflow_id=self.output_parameter.workflow_id,
-            extraction_description_suffix=f"{len(branches)} conditions",
-        )
-
-    async def execute(  # noqa: D401
-        self,
-        workflow_run_id: str,
-        workflow_run_block_id: str,
-        organization_id: str | None = None,
-        browser_session_id: str | None = None,
-        **kwargs: dict,
-    ) -> BlockResult:
-        """
-        Evaluate conditional branches and determine next block to execute.
-
-        Returns a BlockResult with branch metadata in the output_parameter_value.
-        """
-        workflow_run_context = app.WORKFLOW_CONTEXT_MANAGER.get_workflow_run_context(workflow_run_id)
-        evaluation_context = BranchEvaluationContext(
-            workflow_run_context=workflow_run_context,
-            block_label=self.label,
-            template_renderer=(
-                lambda potential_template: self.format_block_parameter_template_from_workflow_run_context(
-                    potential_template,
-                    workflow_run_context,
-                )
-            )
-            if workflow_run_context
-            else None,
-        )
-
-        matched_branch = None
-        failure_reason: str | None = None
-
-        # Track all branch evaluations for UI display
-        branch_evaluations_list: list[dict] = []
-        prompt_rendered_by_id: dict[str, str] = {}
-
-        natural_language_branches = [
-            branch for branch in self.ordered_branches if isinstance(branch.criteria, PromptBranchCriteria)
-        ]
-        prompt_results_by_id: dict[str, bool] = {}
-        prompt_llm_response: dict | None = None
-        prompt_extraction_goal: str | None = None
-        if natural_language_branches:
-            try:
-                (
-                    prompt_results,
-                    prompt_rendered_expressions,
-                    prompt_extraction_goal,
-                    prompt_llm_response,
-                ) = await self._evaluate_prompt_branches(
-                    branches=natural_language_branches,
-                    evaluation_context=evaluation_context,
-                    workflow_run_id=workflow_run_id,
-                    workflow_run_block_id=workflow_run_block_id,
-                    organization_id=organization_id,
-                    browser_session_id=browser_session_id,
-                )
-                prompt_results_by_id = {
-                    branch.id: result for branch, result in zip(natural_language_branches, prompt_results, strict=False)
-                }
-                prompt_rendered_by_id = {
-                    branch.id: rendered
-                    for branch, rendered in zip(natural_language_branches, prompt_rendered_expressions, strict=False)
-                }
-            except Exception as exc:
-                failure_reason = f"Failed to evaluate natural language branches: {str(exc)}"
-                LOG.error(
-                    "Failed to evaluate natural language branches",
-                    block_label=self.label,
-                    error=str(exc),
-                    exc_info=True,
-                )
-
-        for idx, branch in enumerate(self.ordered_branches):
-            branch_eval: dict = {
-                "branch_id": branch.id,
-                "branch_index": idx,
-                "criteria_type": branch.criteria.criteria_type if branch.criteria else None,
-                "original_expression": branch.criteria.expression if branch.criteria else None,
-                "rendered_expression": None,
-                "result": None,
-                "is_matched": False,
-                "is_default": branch.is_default,
-                "next_block_label": branch.next_block_label,
-                "error": None,
-            }
-
-            # Handle default branch (no criteria to evaluate)
-            if branch.criteria is None:
-                # Default branch - only matched if no other branch matches
-                branch_evaluations_list.append(branch_eval)
-                continue
-
-            if branch.criteria.criteria_type == "prompt":
-                if failure_reason:
-                    branch_eval["error"] = failure_reason
-                    branch_evaluations_list.append(branch_eval)
-                    break
-                prompt_result = prompt_results_by_id.get(branch.id)
-                rendered_expr = prompt_rendered_by_id.get(branch.id)
-                branch_eval["rendered_expression"] = rendered_expr
-                if prompt_result is None:
-                    failure_reason = "Missing result for natural language branch evaluation"
-                    branch_eval["error"] = failure_reason
-                    LOG.error(
-                        "Missing prompt evaluation result",
-                        block_label=self.label,
-                        branch_index=idx,
-                        branch_id=branch.id,
-                    )
-                    branch_evaluations_list.append(branch_eval)
-                    break
-                branch_eval["result"] = prompt_result
-                branch_evaluations_list.append(branch_eval)
-                if prompt_result:
-                    matched_branch = branch
-                    branch_eval["is_matched"] = True
-                    LOG.info(
-                        "Conditional natural language branch matched",
-                        block_label=self.label,
-                        branch_index=idx,
-                        next_block_label=branch.next_block_label,
-                    )
-                    break
-                continue
-
-            # Jinja template branch
-            try:
-                # Render the expression for UI display - substitute variables without evaluating
-                rendered_expression = _render_jinja_expression_for_display(
-                    expression=branch.criteria.expression,
-                    context_values=evaluation_context.workflow_run_context.values
-                    if evaluation_context.workflow_run_context
-                    else {},
-                    block_label=self.label,
-                )
-                branch_eval["rendered_expression"] = rendered_expression
-
-                result = await branch.criteria.evaluate(evaluation_context)
-                branch_eval["result"] = result
-                branch_evaluations_list.append(branch_eval)
-
-                if result:
-                    matched_branch = branch
-                    branch_eval["is_matched"] = True
-                    LOG.info(
-                        "Conditional branch matched",
-                        block_label=self.label,
-                        branch_index=idx,
-                        next_block_label=branch.next_block_label,
-                    )
-                    break
-            except Exception as exc:
-                failure_reason = f"Failed to evaluate branch {idx} for {self.label}: {str(exc)}"
-                branch_eval["error"] = str(exc)
-                branch_eval["result"] = None
-                branch_evaluations_list.append(branch_eval)
-                LOG.error(
-                    "Failed to evaluate conditional branch",
-                    block_label=self.label,
-                    branch_index=idx,
-                    error=str(exc),
-                    exc_info=True,
-                )
-                break
-
-        if matched_branch is None and failure_reason is None:
-            matched_branch = self.get_default_branch()
-            # Update is_matched for default branch in evaluations
-            if matched_branch:
-                for eval_entry in branch_evaluations_list:
-                    if eval_entry["branch_id"] == matched_branch.id:
-                        eval_entry["is_matched"] = True
-                        break
-
-        matched_index = self.ordered_branches.index(matched_branch) if matched_branch in self.ordered_branches else None
-        next_block_label = matched_branch.next_block_label if matched_branch else None
-        executed_branch_id = matched_branch.id if matched_branch else None
-
-        # Extract execution details for frontend display
-        executed_branch_expression: str | None = None
-        executed_branch_result: bool | None = None
-        executed_branch_next_block: str | None = None
-
-        if matched_branch:
-            executed_branch_next_block = matched_branch.next_block_label
-            if matched_branch.is_default:
-                # Default/else branch - no expression to evaluate
-                executed_branch_expression = None
-                executed_branch_result = None
-            elif matched_branch.criteria:
-                # Regular condition branch - it matched
-                executed_branch_expression = matched_branch.criteria.expression
-                executed_branch_result = True
-
-        branch_metadata: BlockMetadata = {
-            "branch_taken": next_block_label,
-            "branch_index": matched_index,
-            "branch_id": executed_branch_id,
-            "branch_description": matched_branch.description if matched_branch else None,
-            "criteria_type": matched_branch.criteria.criteria_type
-            if matched_branch and matched_branch.criteria
-            else None,
-            "criteria_expression": matched_branch.criteria.expression
-            if matched_branch and matched_branch.criteria
-            else None,
-            "next_block_label": next_block_label,
-            # Detailed evaluation info for all branches (rendered_expression trimmed/capped — SKY-9779)
-            "evaluations": _trim_branch_evaluations(branch_evaluations_list) if branch_evaluations_list else None,
-            # Raw LLM response for debugging prompt-based evaluations (masked for secrets, capped)
-            "llm_response": _cap_debug_field(
-                workflow_run_context.mask_secrets_in_data(prompt_llm_response)
-                if workflow_run_context and prompt_llm_response
-                else prompt_llm_response
-            ),
-            # The exact prompt sent to LLM for debugging (masked for secrets, capped)
-            "llm_prompt": _cap_debug_field(
-                workflow_run_context.mask_secrets_in_data(prompt_extraction_goal)
-                if workflow_run_context and prompt_extraction_goal
-                else prompt_extraction_goal
-            ),
-        }
-
-        status = BlockStatus.completed
-        success = True
-
-        if failure_reason:
-            status = BlockStatus.failed
-            success = False
-        elif matched_branch is None:
-            failure_reason = "No conditional branch matched and no default branch configured"
-            status = BlockStatus.failed
-            success = False
-
-        if workflow_run_context:
-            workflow_run_context.update_block_metadata(self.label, branch_metadata)
-            try:
-                await self.record_output_parameter_value(
-                    workflow_run_context=workflow_run_context,
-                    workflow_run_id=workflow_run_id,
-                    value=branch_metadata,
-                )
-            except Exception as exc:
-                LOG.warning(
-                    "Failed to record branch metadata as output parameter",
-                    workflow_run_id=workflow_run_id,
-                    block_label=self.label,
-                    error=str(exc),
-                )
-
-        block_result = await self.build_block_result(
-            success=success,
-            failure_reason=failure_reason,
-            output_parameter_value=branch_metadata,
-            status=status,
-            workflow_run_block_id=workflow_run_block_id,
-            organization_id=organization_id,
-            executed_branch_id=executed_branch_id,
-            executed_branch_expression=executed_branch_expression,
-            executed_branch_result=executed_branch_result,
-            executed_branch_next_block=executed_branch_next_block,
-        )
-        return block_result
-
-    @property
-    def ordered_branches(self) -> list[BranchCondition]:
-        """Convenience accessor that returns branches in author-specified list order."""
-        return list(self.branch_conditions)
-
-    def get_default_branch(self) -> BranchCondition | None:
-        """Return the default/else branch when configured."""
-        return next((branch for branch in self.branch_conditions if branch.is_default), None)
-
-
 class WorkflowTriggerBlock(Block):
     # There is a mypy bug with Literal. Without the type: ignore, mypy will raise an error:
     # Parameter 1 of Literal[...] cannot be of type "Any"
@@ -10070,12 +8751,378 @@ def get_all_blocks(blocks: list[BlockTypeVar]) -> list[BlockTypeVar]:
     return all_blocks
 
 
+# isort: off
+# branching.py is a leaf module (it only imports Block-module names lazily at call time),
+# so this import is cycle-safe in any import order. It lives down here with the other
+# submodule imports to keep the facade re-export section in one place.
+# ``_evaluate_prompt_branch_conditions_batch`` is re-exported because WhileLoopBlock (which
+# stays here) drives while-loop conditions through it. ``ConditionalBlock`` is defined below
+# rather than in branching.py because it subclasses ``Block``; a module-level Block import in
+# branching.py would make it un-importable on its own (see PR #6979 review).
+from skyvern.forge.sdk.workflow.models.branching import (  # noqa: E402
+    DECISION_BLOCK_FIELD_MAX_BYTES,  # noqa: F401 - re-exported for facade compatibility
+    BranchCondition,
+    BranchCriteria,  # noqa: F401 - re-exported for facade compatibility
+    BranchCriteriaSubclasses,  # noqa: F401 - re-exported for facade compatibility
+    BranchCriteriaTypeVar,
+    BranchEvaluationContext,
+    JinjaBranchCriteria,  # noqa: F401 - re-exported for facade compatibility
+    PromptBranchCriteria,
+    _build_branch_evaluation_schema,  # noqa: F401 - re-exported for facade compatibility
+    _cap_debug_field,  # noqa: F401 - re-exported for facade compatibility
+    _coerce_condition_index,  # noqa: F401 - re-exported for facade compatibility
+    _evaluate_prompt_branch_conditions_batch,
+    _make_empty_params_explicit,  # noqa: F401 - re-exported for facade compatibility
+    _render_jinja_expression_for_display,
+    _trim_branch_evaluations,  # noqa: F401 - re-exported for facade compatibility
+)
+
 # Late import: google_sheets_blocks imports Block from this module, so top-level import would cycle.
 from skyvern.forge.sdk.workflow.models.google_sheets_blocks import (  # noqa: E402
     GoogleSheetsReadBlock,
     GoogleSheetsWriteBlock,
 )
 from skyvern.forge.sdk.workflow.models.pdf_fill_block import PdfFillBlock  # noqa: E402
+# isort: on
+
+
+class ConditionalBlock(Block):
+    """Branching block that selects the next block label based on list-ordered conditions."""
+
+    # There is a mypy bug with Literal. Without the type: ignore, mypy will raise an error:
+    # Parameter 1 of Literal[...] cannot be of type "Any"
+    block_type: Literal[BlockType.CONDITIONAL] = BlockType.CONDITIONAL  # type: ignore
+
+    branch_conditions: list[BranchCondition] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_branches(self) -> ConditionalBlock:
+        if not self.branch_conditions:
+            raise ValueError("Conditional blocks require at least one branch.")
+
+        default_branches = [branch for branch in self.branch_conditions if branch.is_default]
+        if len(default_branches) > 1:
+            raise ValueError("Only one default branch is permitted per conditional block.")
+
+        return self
+
+    def get_all_parameters(
+        self,
+        workflow_run_id: str,  # noqa: ARG002 - preserved for interface compatibility
+    ) -> list[PARAMETER_TYPE]:
+        # BranchCriteria subclasses will surface their parameter dependencies once implemented.
+        return []
+
+    async def _evaluate_prompt_branches(
+        self,
+        *,
+        branches: list[BranchCondition],
+        evaluation_context: BranchEvaluationContext,
+        workflow_run_id: str,
+        workflow_run_block_id: str,
+        organization_id: str | None = None,
+        browser_session_id: str | None = None,
+    ) -> tuple[list[bool], list[str], str | None, dict | None]:
+        """
+        Evaluate natural language branch conditions in batch.
+
+        All prompt-based conditions are batched into ONE LLM call for performance.
+        Jinja parts ({{ }}) are pre-rendered before sending to LLM.
+
+        Evaluation strategy:
+        - If any condition is pure natural language, use ExtractionBlock for browser/page context.
+        - If all conditions contain Jinja and are pre-rendered, use direct LLM call (no browser context).
+
+        Returns:
+            A tuple of (results, rendered_expressions, extraction_goal, llm_response):
+            - results: List of boolean results for each branch
+            - rendered_expressions: List of expressions after Jinja pre-rendering
+            - extraction_goal: The prompt sent to the LLM (for UI display)
+            - llm_response: The raw LLM response for debugging
+        """
+        return await _evaluate_prompt_branch_conditions_batch(
+            log_label=self.label,
+            branches=branches,
+            evaluation_context=evaluation_context,
+            workflow_run_id=workflow_run_id,
+            workflow_run_block_id=workflow_run_block_id,
+            organization_id=organization_id,
+            browser_session_id=browser_session_id,
+            workflow_id=self.output_parameter.workflow_id,
+            extraction_description_suffix=f"{len(branches)} conditions",
+        )
+
+    async def execute(  # noqa: D401
+        self,
+        workflow_run_id: str,
+        workflow_run_block_id: str,
+        organization_id: str | None = None,
+        browser_session_id: str | None = None,
+        **kwargs: dict,
+    ) -> BlockResult:
+        """
+        Evaluate conditional branches and determine next block to execute.
+
+        Returns a BlockResult with branch metadata in the output_parameter_value.
+        """
+        workflow_run_context = app.WORKFLOW_CONTEXT_MANAGER.get_workflow_run_context(workflow_run_id)
+        evaluation_context = BranchEvaluationContext(
+            workflow_run_context=workflow_run_context,
+            block_label=self.label,
+            template_renderer=(
+                lambda potential_template: self.format_block_parameter_template_from_workflow_run_context(
+                    potential_template,
+                    workflow_run_context,
+                )
+            )
+            if workflow_run_context
+            else None,
+        )
+
+        matched_branch = None
+        failure_reason: str | None = None
+
+        # Track all branch evaluations for UI display
+        branch_evaluations_list: list[dict] = []
+        prompt_rendered_by_id: dict[str, str] = {}
+
+        natural_language_branches = [
+            branch for branch in self.ordered_branches if isinstance(branch.criteria, PromptBranchCriteria)
+        ]
+        prompt_results_by_id: dict[str, bool] = {}
+        prompt_llm_response: dict | None = None
+        prompt_extraction_goal: str | None = None
+        if natural_language_branches:
+            try:
+                (
+                    prompt_results,
+                    prompt_rendered_expressions,
+                    prompt_extraction_goal,
+                    prompt_llm_response,
+                ) = await self._evaluate_prompt_branches(
+                    branches=natural_language_branches,
+                    evaluation_context=evaluation_context,
+                    workflow_run_id=workflow_run_id,
+                    workflow_run_block_id=workflow_run_block_id,
+                    organization_id=organization_id,
+                    browser_session_id=browser_session_id,
+                )
+                prompt_results_by_id = {
+                    branch.id: result for branch, result in zip(natural_language_branches, prompt_results, strict=False)
+                }
+                prompt_rendered_by_id = {
+                    branch.id: rendered
+                    for branch, rendered in zip(natural_language_branches, prompt_rendered_expressions, strict=False)
+                }
+            except Exception as exc:
+                failure_reason = f"Failed to evaluate natural language branches: {str(exc)}"
+                LOG.error(
+                    "Failed to evaluate natural language branches",
+                    block_label=self.label,
+                    error=str(exc),
+                    exc_info=True,
+                )
+
+        for idx, branch in enumerate(self.ordered_branches):
+            branch_eval: dict = {
+                "branch_id": branch.id,
+                "branch_index": idx,
+                "criteria_type": branch.criteria.criteria_type if branch.criteria else None,
+                "original_expression": branch.criteria.expression if branch.criteria else None,
+                "rendered_expression": None,
+                "result": None,
+                "is_matched": False,
+                "is_default": branch.is_default,
+                "next_block_label": branch.next_block_label,
+                "error": None,
+            }
+
+            # Handle default branch (no criteria to evaluate)
+            if branch.criteria is None:
+                # Default branch - only matched if no other branch matches
+                branch_evaluations_list.append(branch_eval)
+                continue
+
+            if branch.criteria.criteria_type == "prompt":
+                if failure_reason:
+                    branch_eval["error"] = failure_reason
+                    branch_evaluations_list.append(branch_eval)
+                    break
+                prompt_result = prompt_results_by_id.get(branch.id)
+                rendered_expr = prompt_rendered_by_id.get(branch.id)
+                branch_eval["rendered_expression"] = rendered_expr
+                if prompt_result is None:
+                    failure_reason = "Missing result for natural language branch evaluation"
+                    branch_eval["error"] = failure_reason
+                    LOG.error(
+                        "Missing prompt evaluation result",
+                        block_label=self.label,
+                        branch_index=idx,
+                        branch_id=branch.id,
+                    )
+                    branch_evaluations_list.append(branch_eval)
+                    break
+                branch_eval["result"] = prompt_result
+                branch_evaluations_list.append(branch_eval)
+                if prompt_result:
+                    matched_branch = branch
+                    branch_eval["is_matched"] = True
+                    LOG.info(
+                        "Conditional natural language branch matched",
+                        block_label=self.label,
+                        branch_index=idx,
+                        next_block_label=branch.next_block_label,
+                    )
+                    break
+                continue
+
+            # Jinja template branch
+            try:
+                # Render the expression for UI display - substitute variables without evaluating
+                rendered_expression = _render_jinja_expression_for_display(
+                    expression=branch.criteria.expression,
+                    context_values=evaluation_context.workflow_run_context.values
+                    if evaluation_context.workflow_run_context
+                    else {},
+                    block_label=self.label,
+                )
+                branch_eval["rendered_expression"] = rendered_expression
+
+                result = await branch.criteria.evaluate(evaluation_context)
+                branch_eval["result"] = result
+                branch_evaluations_list.append(branch_eval)
+
+                if result:
+                    matched_branch = branch
+                    branch_eval["is_matched"] = True
+                    LOG.info(
+                        "Conditional branch matched",
+                        block_label=self.label,
+                        branch_index=idx,
+                        next_block_label=branch.next_block_label,
+                    )
+                    break
+            except Exception as exc:
+                failure_reason = f"Failed to evaluate branch {idx} for {self.label}: {str(exc)}"
+                branch_eval["error"] = str(exc)
+                branch_eval["result"] = None
+                branch_evaluations_list.append(branch_eval)
+                LOG.error(
+                    "Failed to evaluate conditional branch",
+                    block_label=self.label,
+                    branch_index=idx,
+                    error=str(exc),
+                    exc_info=True,
+                )
+                break
+
+        if matched_branch is None and failure_reason is None:
+            matched_branch = self.get_default_branch()
+            # Update is_matched for default branch in evaluations
+            if matched_branch:
+                for eval_entry in branch_evaluations_list:
+                    if eval_entry["branch_id"] == matched_branch.id:
+                        eval_entry["is_matched"] = True
+                        break
+
+        matched_index = self.ordered_branches.index(matched_branch) if matched_branch in self.ordered_branches else None
+        next_block_label = matched_branch.next_block_label if matched_branch else None
+        executed_branch_id = matched_branch.id if matched_branch else None
+
+        # Extract execution details for frontend display
+        executed_branch_expression: str | None = None
+        executed_branch_result: bool | None = None
+        executed_branch_next_block: str | None = None
+
+        if matched_branch:
+            executed_branch_next_block = matched_branch.next_block_label
+            if matched_branch.is_default:
+                # Default/else branch - no expression to evaluate
+                executed_branch_expression = None
+                executed_branch_result = None
+            elif matched_branch.criteria:
+                # Regular condition branch - it matched
+                executed_branch_expression = matched_branch.criteria.expression
+                executed_branch_result = True
+
+        branch_metadata: BlockMetadata = {
+            "branch_taken": next_block_label,
+            "branch_index": matched_index,
+            "branch_id": executed_branch_id,
+            "branch_description": matched_branch.description if matched_branch else None,
+            "criteria_type": matched_branch.criteria.criteria_type
+            if matched_branch and matched_branch.criteria
+            else None,
+            "criteria_expression": matched_branch.criteria.expression
+            if matched_branch and matched_branch.criteria
+            else None,
+            "next_block_label": next_block_label,
+            # Detailed evaluation info for all branches (rendered_expression trimmed/capped — SKY-9779)
+            "evaluations": _trim_branch_evaluations(branch_evaluations_list) if branch_evaluations_list else None,
+            # Raw LLM response for debugging prompt-based evaluations (masked for secrets, capped)
+            "llm_response": _cap_debug_field(
+                workflow_run_context.mask_secrets_in_data(prompt_llm_response)
+                if workflow_run_context and prompt_llm_response
+                else prompt_llm_response
+            ),
+            # The exact prompt sent to LLM for debugging (masked for secrets, capped)
+            "llm_prompt": _cap_debug_field(
+                workflow_run_context.mask_secrets_in_data(prompt_extraction_goal)
+                if workflow_run_context and prompt_extraction_goal
+                else prompt_extraction_goal
+            ),
+        }
+
+        status = BlockStatus.completed
+        success = True
+
+        if failure_reason:
+            status = BlockStatus.failed
+            success = False
+        elif matched_branch is None:
+            failure_reason = "No conditional branch matched and no default branch configured"
+            status = BlockStatus.failed
+            success = False
+
+        if workflow_run_context:
+            workflow_run_context.update_block_metadata(self.label, branch_metadata)
+            try:
+                await self.record_output_parameter_value(
+                    workflow_run_context=workflow_run_context,
+                    workflow_run_id=workflow_run_id,
+                    value=branch_metadata,
+                )
+            except Exception as exc:
+                LOG.warning(
+                    "Failed to record branch metadata as output parameter",
+                    workflow_run_id=workflow_run_id,
+                    block_label=self.label,
+                    error=str(exc),
+                )
+
+        block_result = await self.build_block_result(
+            success=success,
+            failure_reason=failure_reason,
+            output_parameter_value=branch_metadata,
+            status=status,
+            workflow_run_block_id=workflow_run_block_id,
+            organization_id=organization_id,
+            executed_branch_id=executed_branch_id,
+            executed_branch_expression=executed_branch_expression,
+            executed_branch_result=executed_branch_result,
+            executed_branch_next_block=executed_branch_next_block,
+        )
+        return block_result
+
+    @property
+    def ordered_branches(self) -> list[BranchCondition]:
+        """Convenience accessor that returns branches in author-specified list order."""
+        return list(self.branch_conditions)
+
+    def get_default_branch(self) -> BranchCondition | None:
+        """Return the default/else branch when configured."""
+        return next((branch for branch in self.branch_conditions if branch.is_default), None)
+
 
 BlockSubclasses = Union[
     ConditionalBlock,
@@ -10108,10 +9155,6 @@ BlockSubclasses = Union[
     PdfFillBlock,
 ]
 BlockTypeVar = Annotated[BlockSubclasses, Field(discriminator="block_type")]
-
-
-BranchCriteriaSubclasses = Union[JinjaBranchCriteria, PromptBranchCriteria]
-BranchCriteriaTypeVar = Annotated[BranchCriteriaSubclasses, Field(discriminator="criteria_type")]
 
 
 def resolve_conditional_merge_edges(

--- a/skyvern/forge/sdk/workflow/models/branching.py
+++ b/skyvern/forge/sdk/workflow/models/branching.py
@@ -1,0 +1,1014 @@
+from __future__ import annotations
+
+import abc
+import json
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Annotated, Any, Callable, Literal, Union
+
+import structlog
+from jinja2 import StrictUndefined
+from jinja2.sandbox import SandboxedEnvironment
+from pydantic import BaseModel, Field, model_validator
+
+from skyvern.config import settings
+from skyvern.exceptions import ConditionalBranchEvaluationError, MalformedBranchEvaluationError
+from skyvern.forge.prompts import prompt_engine
+from skyvern.forge.sdk.workflow.context_manager import WorkflowRunContext
+from skyvern.forge.sdk.workflow.exceptions import FailedToFormatJinjaStyleParameter, MissingJinjaVariables
+from skyvern.forge.sdk.workflow.models.parameter import OutputParameter, ParameterType
+from skyvern.utils.strings import generate_random_string
+from skyvern.utils.templating import get_missing_variables
+
+LOG = structlog.get_logger()
+
+
+class BranchEvaluationContext:
+    """Collection of runtime data that BranchCriteria evaluators can consume."""
+
+    def __init__(
+        self,
+        *,
+        workflow_run_context: WorkflowRunContext | None = None,
+        block_label: str | None = None,
+        template_renderer: Callable[[str], str] | None = None,
+    ) -> None:
+        self.workflow_run_context = workflow_run_context
+        self.block_label = block_label
+        self.template_renderer = template_renderer
+
+    def build_llm_safe_context_snapshot(self) -> dict[str, Any]:
+        """
+        Build a minimal context blob for LLM-facing branch evaluation.
+
+        Only includes essential data the LLM needs to evaluate conditions:
+        - Parameter values (base_date, date_1, etc.)
+        - Extracted information from previous blocks
+        - Loop variables (current_value, current_index, current_item)
+        """
+        if self.workflow_run_context is None:
+            return {}
+
+        ctx = self.workflow_run_context
+        raw_values: dict[str, Any] = ctx.values.copy()
+
+        # Keys to skip - these are not useful for evaluating conditions
+        keys_to_skip = {
+            "blocks_metadata",
+            "params",
+            "outputs",
+            "environment",
+            "env",
+            "llm",
+            "workflow_title",
+            "workflow_id",
+            "workflow_permanent_id",
+            "workflow_run_id",
+        }
+
+        snapshot: dict[str, Any] = {}
+        for key, value in raw_values.items():
+            # Skip noisy keys
+            if key in keys_to_skip:
+                continue
+
+            # For block outputs (dicts with extracted_information), only include extracted_information
+            if isinstance(value, dict) and "extracted_information" in value:
+                extracted = value.get("extracted_information")
+                if extracted is not None:
+                    snapshot[key] = extracted
+            else:
+                # Include parameter values directly
+                snapshot[key] = value
+
+        # Copy loop variables (current_value, current_index, current_item) to top level
+        # Required for pure NatLang expressions like "current_value['date']" to work
+        if self.block_label:
+            block_metadata = ctx.get_block_metadata(self.block_label)
+            if "current_value" in block_metadata:
+                snapshot["current_value"] = block_metadata["current_value"]
+            if "current_index" in block_metadata:
+                snapshot["current_index"] = block_metadata["current_index"]
+            if "current_item" in block_metadata:
+                snapshot["current_item"] = block_metadata["current_item"]
+
+        # Mask any real secret values that may have leaked into values
+        snapshot = ctx.mask_secrets_in_data(snapshot)
+
+        return snapshot
+
+    def build_template_data(self) -> dict[str, Any]:
+        """Build Jinja template data mirroring block parameter rendering context."""
+        if self.workflow_run_context is None:
+            return {
+                "params": {},
+                "outputs": {},
+                "environment": {},
+                "env": {},
+                "llm": {},
+            }
+
+        ctx = self.workflow_run_context
+        template_data = ctx.values.copy()
+        if ctx.include_secrets_in_templates:
+            template_data.update(ctx.secrets)
+
+            credential_params: list[tuple[str, dict[str, Any]]] = []
+            for key, value in template_data.items():
+                if isinstance(value, dict) and "context" in value and "username" in value and "password" in value:
+                    credential_params.append((key, value))
+
+            for key, value in credential_params:
+                username_secret_id = value.get("username", "")
+                password_secret_id = value.get("password", "")
+                real_username = template_data.get(username_secret_id, "")
+                real_password = template_data.get(password_secret_id, "")
+                template_data[f"{key}_real_username"] = real_username
+                template_data[f"{key}_real_password"] = real_password
+
+        if self.block_label:
+            block_reference_data: dict[str, Any] = ctx.get_block_metadata(self.block_label)
+            if self.block_label in template_data:
+                current_value = template_data[self.block_label]
+                if isinstance(current_value, dict):
+                    block_reference_data.update(current_value)
+            template_data[self.block_label] = block_reference_data
+
+            if "current_index" in block_reference_data:
+                template_data["current_index"] = block_reference_data["current_index"]
+            if "current_item" in block_reference_data:
+                template_data["current_item"] = block_reference_data["current_item"]
+            if "current_value" in block_reference_data:
+                template_data["current_value"] = block_reference_data["current_value"]
+
+        template_data.setdefault("workflow_title", ctx.workflow_title)
+        template_data.setdefault("workflow_id", ctx.workflow_id)
+        template_data.setdefault("workflow_permanent_id", ctx.workflow_permanent_id)
+        template_data.setdefault("workflow_run_id", ctx.workflow_run_id)
+
+        # Late import: block.py is the facade over this leaf module, so pull its
+        # constants only at call time to keep this module importable on its own.
+        from skyvern.forge.sdk.workflow.models.block import CURRENT_DATE_FORMAT
+
+        template_data.setdefault("current_date", datetime.now(timezone.utc).strftime(CURRENT_DATE_FORMAT))
+
+        template_data.setdefault("params", template_data.get("params", {}))
+        template_data.setdefault("outputs", template_data.get("outputs", {}))
+        template_data.setdefault("environment", template_data.get("environment", {}))
+        template_data.setdefault("env", template_data.get("environment"))
+        template_data.setdefault("llm", template_data.get("llm", {}))
+
+        return template_data
+
+
+class BranchCriteria(BaseModel, abc.ABC):
+    """Abstract interface describing how a branch condition should be evaluated."""
+
+    criteria_type: str
+    expression: str
+    description: str | None = None
+
+    @abc.abstractmethod
+    async def evaluate(self, context: BranchEvaluationContext) -> bool:
+        """Return True when the branch should execute."""
+        raise NotImplementedError
+
+    def requires_llm(self) -> bool:
+        """Whether the criteria relies on an LLM classification step."""
+        return False
+
+
+def _evaluate_truthy_string(value: str) -> bool:
+    """
+    Evaluate a string as a boolean, handling common truthy/falsy representations.
+
+    Truthy: "true", "True", "TRUE", "1", "yes", "y", "on", non-zero numbers
+    Falsy: "", "false", "False", "FALSE", "0", "no", "n", "off", "null", "None", whitespace-only
+
+    For other strings, use Python's default bool() behavior (non-empty = truthy).
+    """
+    if not value or not value.strip():
+        return False
+
+    normalized = value.strip().lower()
+
+    # Explicit falsy values
+    if normalized in ("false", "0", "no", "n", "off", "null", "none"):
+        return False
+
+    # Explicit truthy values
+    if normalized in ("true", "1", "yes", "y", "on"):
+        return True
+
+    # Try to parse as a number
+    try:
+        num = float(normalized)
+        return num != 0.0
+    except ValueError:
+        pass
+
+    # For any other non-empty string, consider it truthy
+    # This allows expressions like "{{ 'some text' }}" to be truthy
+    return True
+
+
+class JinjaBranchCriteria(BranchCriteria):
+    """Jinja2-templated branch criteria (only supported criteria type for now)."""
+
+    criteria_type: Literal["jinja2_template"] = "jinja2_template"
+
+    async def evaluate(self, context: BranchEvaluationContext) -> bool:
+        # Prefer the renderer provided by the caller (matches block parameter rendering),
+        # otherwise build a minimal sandboxed renderer using the evaluation context.
+        if context.template_renderer:
+            try:
+                rendered = context.template_renderer(self.expression)
+            except MissingJinjaVariables:
+                # Let upstream MissingJinjaVariables bubble as-is.
+                raise
+            except Exception as exc:  # pragma: no cover - caught for robustness
+                raise FailedToFormatJinjaStyleParameter(self.expression, str(exc)) from exc
+        else:
+            template_data = context.build_template_data()
+            sandbox_env = (
+                SandboxedEnvironment(undefined=StrictUndefined)
+                if settings.WORKFLOW_TEMPLATING_STRICTNESS == "strict"
+                else SandboxedEnvironment()
+            )
+
+            try:
+                missing_vars = get_missing_variables(self.expression, template_data)
+                if missing_vars:
+                    raise MissingJinjaVariables(self.expression, missing_vars)
+
+                template = sandbox_env.from_string(self.expression)
+                rendered = template.render(template_data)
+            except MissingJinjaVariables:
+                raise
+            except Exception as exc:
+                # Covers syntax errors and rendering issues
+                raise FailedToFormatJinjaStyleParameter(self.expression, str(exc)) from exc
+
+        return _evaluate_truthy_string(rendered)
+
+
+class PromptBranchCriteria(BranchCriteria):
+    """Natural language branch criteria."""
+
+    criteria_type: Literal["prompt"] = "prompt"
+
+    async def evaluate(self, context: BranchEvaluationContext) -> bool:
+        # Evaluated via ConditionalBlock.execute (batched) or WhileLoopBlock
+        # _evaluate_condition (single-branch batch helper).
+        raise NotImplementedError("PromptBranchCriteria is evaluated via extraction batch helpers, not per-branch.")
+
+    def requires_llm(self) -> bool:
+        return True
+
+
+def _is_pure_jinja_expression(expression: str) -> bool:
+    """
+    Determine if an expression is a pure Jinja template (single block) vs Jinja+NatLang (mixed).
+
+    Pure Jinja: "{{ A == B }}" - single Jinja block, should be evaluated server-side
+    Jinja+NatLang: "{{ A }} is same as {{ B }}" - multiple Jinja blocks mixed with natural language
+
+    Returns True only for pure Jinja expressions that can be evaluated to boolean server-side.
+    """
+    if not expression:
+        return False
+
+    stripped = expression.strip()
+
+    # Must start with {{ and end with }}
+    if not (stripped.startswith("{{") and stripped.endswith("}}")):
+        return False
+
+    # Count the number of {{ occurrences
+    # If there's more than one, it's Jinja+NatLang (e.g., "{{ A }} is same as {{ B }}")
+    jinja_open_count = stripped.count("{{")
+    if jinja_open_count > 1:
+        return False
+
+    # Single {{ and ends with }} - this is pure Jinja
+    return True
+
+
+def _resolve_nested_path(value: Any, path: str) -> Any:
+    """
+    Resolve a dotted/bracket access path on a nested value.
+
+    Examples:
+        _resolve_nested_path({"a": {"b": 1}}, ".a.b") -> 1
+        _resolve_nested_path([{"x": 2}], "[0].x") -> 2
+
+    Args:
+        value: The root value to traverse
+        path: The access path (e.g., ".field1.field2[0].field3")
+
+    Returns:
+        The resolved leaf value
+
+    Raises:
+        LookupError: If the path cannot be resolved
+    """
+    segments = re.findall(r"\.([a-zA-Z_]\w*)|\[(\d+)\]", path)
+    current = value
+    for dot_key, bracket_idx in segments:
+        if dot_key:
+            if isinstance(current, dict):
+                if dot_key not in current:
+                    raise LookupError(f"Key {dot_key!r} not found")
+                current = current[dot_key]
+            else:
+                raise LookupError(f"Cannot access .{dot_key} on {type(current).__name__}")
+        elif bracket_idx:
+            idx = int(bracket_idx)
+            if isinstance(current, (list, tuple)):
+                if idx >= len(current):
+                    raise LookupError(f"Index [{idx}] out of range")
+                current = current[idx]
+            else:
+                raise LookupError(f"Cannot index [{idx}] on {type(current).__name__}")
+    return current
+
+
+_JINJA_DISPLAY_FILTERS: dict[str, Callable[[Any], Any]] = {
+    "lower": lambda v: str(v).lower(),
+    "upper": lambda v: str(v).upper(),
+    "trim": lambda v: str(v).strip(),
+    "title": lambda v: str(v).title(),
+    "capitalize": lambda v: str(v).capitalize(),
+    "int": lambda v: int(v),
+    "float": lambda v: float(v),
+    "string": lambda v: str(v),
+    "length": lambda v: len(v),
+    "abs": lambda v: abs(v),
+}
+
+
+def _render_jinja_expression_for_display(
+    expression: str,
+    context_values: dict[str, Any],
+    block_label: str | None = None,
+) -> str:
+    """
+    Render a pure Jinja expression for UI display by substituting variable names with values.
+
+    This is for display purposes only - it shows users what values were compared
+    without actually evaluating the expression. For example:
+    - Input: "{{ base_date == date_1 }}" with context {"base_date": "01-25-2026", "date_1": "01-25-2026"}
+    - Output: '"01-25-2026" == "01-25-2026"'
+    - Input: "{{ output.extracted_information.field != None }}" with nested dict context
+    - Output: '"some_value" != None'
+    - Input: "{{ output.status|lower == 'active' }}" with context {"output": {"status": "Active"}}
+    - Output: '"active" == \'active\''
+
+    Known Jinja filters (lower, upper, trim, etc.) are applied to the resolved value.
+    Unknown filters are left as-is in the output.
+
+    Returns the original expression if it's not a pure Jinja expression or if rendering fails.
+    """
+    if not _is_pure_jinja_expression(expression):
+        return expression
+
+    try:
+        # Extract inner expression (strip {{ and }})
+        inner_expr = expression.strip()[2:-2].strip()
+        display_expr = inner_expr
+
+        # Substitute variable references (including dotted/bracket access paths and filters)
+        # with their values.
+        # Match var_name optionally followed by .field or [index] segments,
+        # then optionally followed by a |filter_name.
+        # Sort by key length (longest first) to avoid partial matches.
+        for var_name in sorted(context_values.keys(), key=len, reverse=True):
+            pattern = r"\b" + re.escape(var_name) + r"((?:\.[a-zA-Z_]\w*|\[\d+\])*)(\|[a-zA-Z_]\w*)?"
+
+            def _replacer(match: re.Match, _var_name: str = var_name) -> str:
+                access_path = match.group(1)  # the dotted/bracket part after var_name
+                filter_expr = match.group(2)  # e.g., "|lower" or None
+                var_value = context_values[_var_name]
+
+                if access_path:
+                    try:
+                        var_value = _resolve_nested_path(var_value, access_path)
+                    except LookupError:
+                        # Path couldn't be resolved — return original text unchanged
+                        return match.group(0)
+
+                if filter_expr:
+                    filter_name = filter_expr[1:]  # strip the leading |
+                    filter_fn = _JINJA_DISPLAY_FILTERS.get(filter_name)
+                    if filter_fn is not None:
+                        try:
+                            var_value = filter_fn(var_value)
+                        except Exception:
+                            # Filter application failed — show value with filter text
+                            if isinstance(var_value, str):
+                                return f'"{var_value}"{filter_expr}'
+                            return f"{var_value}{filter_expr}"
+                    else:
+                        # Unknown filter — show value with filter text preserved
+                        if isinstance(var_value, str):
+                            return f'"{var_value}"{filter_expr}'
+                        return f"{var_value}{filter_expr}"
+
+                if isinstance(var_value, str):
+                    return f'"{var_value}"'
+                return str(var_value)
+
+            display_expr = re.sub(pattern, _replacer, display_expr)
+
+        return display_expr
+    except Exception as exc:
+        LOG.debug(
+            "Failed to render Jinja expression for display",
+            block_label=block_label,
+            expression=expression,
+            error=str(exc),
+        )
+        return expression
+
+
+def _find_evaluations_array(output_value: dict[str, Any]) -> list[Any]:
+    """
+    Extract the evaluations array from LLM output.
+
+    ExtractionBlock wraps output in 'extracted_information', so we check there first.
+    Falls back to direct access if not found in the nested structure.
+
+    Args:
+        output_value: The raw output from ExtractionBlock
+
+    Returns:
+        List of evaluation objects from the LLM
+
+    Raises:
+        ValueError: If evaluations array is not found or has wrong type
+    """
+    # Try standard ExtractionBlock format: output_value.extracted_information.evaluations
+    extracted_info = output_value.get("extracted_information")
+    if isinstance(extracted_info, dict):
+        raw_evaluations = extracted_info.get("evaluations")
+    else:
+        # Fallback: try direct access at output_value.evaluations
+        raw_evaluations = output_value.get("evaluations")
+
+    if not isinstance(raw_evaluations, list):
+        raise ValueError(f"Expected array of evaluations, got: {type(raw_evaluations)}")
+
+    return raw_evaluations
+
+
+def _parse_single_evaluation(
+    evaluation: Any,
+    idx: int,
+    fallback_rendered_expressions: list[str],
+) -> tuple[bool, str]:
+    """
+    Parse a single evaluation from the LLM response.
+
+    Handles two formats:
+    - Dict format: {result: bool, reasoning: str}
+    - Legacy format: just a boolean value
+
+    The rendered expression always comes from the Jinja pre-rendering step (fallback),
+    not from the LLM response, to avoid the LLM re-interpreting already-resolved values.
+
+    Args:
+        evaluation: Single evaluation object from LLM (dict or bool)
+        idx: Index of this evaluation (for fallback lookup)
+        fallback_rendered_expressions: Pre-rendered expressions from Jinja rendering
+
+    Returns:
+        Tuple of (boolean_result, rendered_expression_string)
+    """
+    rendered_expression = fallback_rendered_expressions[idx] if idx < len(fallback_rendered_expressions) else ""
+
+    if isinstance(evaluation, dict):
+        result = evaluation.get("result")
+        if isinstance(result, bool):
+            bool_result = result
+        else:
+            bool_result = _evaluate_truthy_string(str(result))
+            LOG.warning(
+                "Conditional branch evaluation returned non-boolean result",
+                branch_index=idx,
+                result=result,
+                evaluated_result=bool_result,
+            )
+
+        return (bool_result, rendered_expression)
+    else:
+        # Legacy format: just a boolean
+        if isinstance(evaluation, bool):
+            bool_result = evaluation
+        else:
+            bool_result = _evaluate_truthy_string(str(evaluation))
+
+        return (bool_result, rendered_expression)
+
+
+# Number of times to evaluate the prompt-based conditional branches before giving up.
+# The dominant failure is a transient malformed/under-returned LLM batch; one re-roll
+# recovers most of them while still failing loudly when the model is persistently wrong.
+MAX_PROMPT_BRANCH_EVAL_ATTEMPTS = 2
+
+
+def _build_branch_evaluation_schema(num_branches: int) -> dict[str, Any]:
+    """Strict JSON schema for the batched branch-evaluation LLM call.
+
+    ``additionalProperties: false`` plus a required ``condition_index`` stop the model from
+    injecting hallucinated fields and force one self-identifying result per condition.
+    """
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "evaluations": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "condition_index": {
+                            "type": "integer",
+                            "description": (
+                                "The 1-based index of the condition this object evaluates "
+                                "(Condition 1 -> 1, Condition 2 -> 2, ...)."
+                            ),
+                        },
+                        "reasoning": {
+                            "type": "string",
+                            "description": "Explanation of the reasoning behind evaluating the condition.",
+                        },
+                        "result": {
+                            "type": "boolean",
+                            "description": "TRUE if the condition is satisfied, FALSE otherwise.",
+                        },
+                    },
+                    "required": ["condition_index", "reasoning", "result"],
+                },
+                "description": "Exactly one evaluation per condition, covering condition_index 1..N.",
+                "minItems": num_branches,
+                "maxItems": num_branches,
+            }
+        },
+        "required": ["evaluations"],
+    }
+
+
+def _coerce_condition_index(raw: Any) -> int | None:
+    """Read a 1-based ``condition_index`` the LLM may have typed loosely.
+
+    Accepts ints, integral floats (``2.0``), and digit strings (``"2"``); returns ``None`` for
+    bools (an int subclass that must not read as 0/1) and non-integral/garbage values. The schema
+    is a prompt-level hint, not provider-enforced, so a model that under-returns can equally
+    mistype the index; coercing keeps a loosely-typed index on the order-safe alignment path
+    instead of misrouting via positional fallback.
+    """
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        return raw
+    if isinstance(raw, float):
+        return int(raw) if raw.is_integer() else None
+    if isinstance(raw, str):
+        try:
+            return int(raw.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _align_branch_evaluations(
+    *,
+    output_value: Any,
+    branches: list[BranchCondition],
+    rendered_expressions: list[str],
+) -> tuple[list[bool], list[str], dict[str, Any]]:
+    """Align the LLM evaluations to ``branches``.
+
+    Returns ``(results, rendered_expressions, normalized_output)``, where ``normalized_output``
+    is the evaluations wrapped in a dict for recording/UI. Prefers the LLM-provided 1-based
+    ``condition_index`` (coerced from ints, integral floats, or digit strings): this is order-safe
+    and immune to hallucinated extra entries that would shift positional alignment. Falls back to
+    positional parsing only when no usable index is present and the count matches exactly. A
+    wrong-length or mis-indexed batch is discarded wholesale (never gap-filled) by raising
+    ``MalformedBranchEvaluationError`` so the caller can retry or fail loudly.
+    """
+    n = len(branches)
+
+    if isinstance(output_value, list):
+        output_value = {"evaluations": output_value}
+    if not isinstance(output_value, dict):
+        raise MalformedBranchEvaluationError(f"unexpected output format: {type(output_value)}")
+    try:
+        raw_evaluations = _find_evaluations_array(output_value)
+    except ValueError as exc:
+        raise MalformedBranchEvaluationError(str(exc)) from exc
+
+    by_index: dict[int, Any] = {}
+    saw_condition_index = False
+    for evaluation in raw_evaluations:
+        if not isinstance(evaluation, dict):
+            continue
+        raw_index = _coerce_condition_index(evaluation.get("condition_index"))
+        if raw_index is None:
+            continue
+        saw_condition_index = True
+        if not (1 <= raw_index <= n):
+            continue
+        if raw_index in by_index:
+            raise MalformedBranchEvaluationError(f"duplicate condition_index {raw_index}")
+        by_index[raw_index] = evaluation
+
+    if saw_condition_index:
+        if set(by_index.keys()) != set(range(1, n + 1)):
+            raise MalformedBranchEvaluationError(f"condition_index set {sorted(by_index.keys())} does not cover 1..{n}")
+        ordered: list[Any] = [by_index[i] for i in range(1, n + 1)]
+    else:
+        # Legacy path (no condition_index): the LLM occasionally appends reasoning=None
+        # placeholder entries. Strip them and accept only when the remainder is exactly N.
+        well_formed = [e for e in raw_evaluations if not (isinstance(e, dict) and e.get("reasoning") is None)]
+        ordered = well_formed if len(well_formed) == n else list(raw_evaluations)
+        if len(ordered) != n:
+            raise MalformedBranchEvaluationError(f"returned {len(ordered)} results for {n} branches")
+
+    results_array: list[bool] = []
+    llm_rendered_expressions: list[str] = []
+    for idx, evaluation in enumerate(ordered):
+        bool_result, rendered_expr = _parse_single_evaluation(
+            evaluation=evaluation,
+            idx=idx,
+            fallback_rendered_expressions=rendered_expressions,
+        )
+        results_array.append(bool_result)
+        llm_rendered_expressions.append(rendered_expr)
+    return results_array, llm_rendered_expressions, output_value
+
+
+# Pattern to find Jinja template blocks like {{ variable_name }}
+_JINJA_BLOCK_RE = re.compile(r"\{\{(.*?)\}\}")
+# Marker inserted into rendered expressions when a Jinja variable resolved to
+# an empty/whitespace-only value.  The LLM uses this to reason about emptiness.
+_EMPTY_VALUE_MARKER = "(empty value)"
+
+
+def _make_empty_params_explicit(
+    original_expression: str,
+    rendered_expression: str,
+) -> tuple[str, bool]:
+    """
+    Detect Jinja template variables that resolved to empty values and replace
+    the empty gaps with explicit ``(empty value)`` markers.
+
+    When ``{{test_parameter}}`` resolves to ``""``, the rendered expression becomes
+    malformed (e.g., ``"if  is not empty"``).  This function detects such cases by
+    comparing the *original* expression (with ``{{ }}`` blocks) against the
+    *rendered* expression and rebuilds it with clear markers so the LLM can
+    evaluate the condition correctly.
+
+    Returns:
+        ``(patched_expression, was_patched)``
+    """
+    if not original_expression or "{{" not in original_expression:
+        return rendered_expression, False
+
+    # Split the original expression into alternating [static, var, static, var, ...] parts.
+    parts = _JINJA_BLOCK_RE.split(original_expression)
+    if len(parts) <= 1:
+        return rendered_expression, False
+
+    # Extract static parts (even indices) and build a regex that captures what
+    # each Jinja block rendered to by using the static text as anchors.
+    static_parts = [parts[i] for i in range(0, len(parts), 2)]
+    num_vars = len(parts) // 2
+
+    # When two Jinja variables are adjacent (e.g. "{{a}}{{b}}") the interior
+    # static separator is an empty string and the non-greedy regex cannot
+    # reliably attribute rendered text to the correct variable.  Bail out.
+    if num_vars > 1 and any(static == "" for static in static_parts[1:-1]):
+        return rendered_expression, False
+
+    # NOTE: if a rendered value happens to contain the same text as a static
+    # anchor the regex may split on the wrong occurrence.  This is extremely
+    # unlikely in user-authored conditional expressions and the worst-case
+    # outcome is an unnecessary "(empty value)" marker, which still beats the
+    # invisible empty-string that caused SKY-8073.
+
+    regex_fragments: list[str] = []
+    for i, static in enumerate(static_parts):
+        regex_fragments.append(re.escape(static))
+        if i < num_vars:
+            regex_fragments.append("(.*?)")
+
+    match = re.match("^" + "".join(regex_fragments) + "$", rendered_expression, re.DOTALL)
+    if not match:
+        return rendered_expression, False
+
+    rendered_values = match.groups()
+    has_empty = any(not v.strip() for v in rendered_values)
+    if not has_empty:
+        return rendered_expression, False
+
+    # Rebuild the expression, replacing empty rendered values with an explicit marker.
+    result_parts: list[str] = []
+    for i, static in enumerate(static_parts):
+        result_parts.append(static)
+        if i < len(rendered_values):
+            if not rendered_values[i].strip():
+                result_parts.append(_EMPTY_VALUE_MARKER)
+            else:
+                result_parts.append(rendered_values[i])
+
+    return "".join(result_parts), True
+
+
+# Per-field cap for DecisionBlock debug payload (rendered_expression, llm_response, llm_prompt).
+# Same fields exist as branch_metadata debug surface for script-reviewer / UI display; their
+# unbounded form has produced multi-hundred-MB output_parameter rows under recursive Jinja.
+DECISION_BLOCK_FIELD_MAX_BYTES = 64 * 1024
+
+
+def _cap_debug_field(value: Any, *, limit_bytes: int = DECISION_BLOCK_FIELD_MAX_BYTES) -> Any:
+    """Cap a string at ``limit_bytes`` UTF-8 bytes (suffix included); non-strings pass through (SKY-9779)."""
+    if not isinstance(value, str):
+        return value
+    encoded = value.encode("utf-8")
+    if len(encoded) <= limit_bytes:
+        return value
+    overflow_bytes = len(encoded) - limit_bytes
+    suffix = f"…[truncated {overflow_bytes} bytes]"
+    suffix_bytes = len(suffix.encode("utf-8"))
+    head_budget = max(0, limit_bytes - suffix_bytes)
+    return encoded[:head_budget].decode("utf-8", errors="ignore") + suffix
+
+
+def _trim_branch_evaluations(branch_evaluations: list[dict] | None) -> list[dict] | None:
+    """Drop ``rendered_expression`` on non-matched branches; cap the matched one (SKY-9779)."""
+    if not branch_evaluations:
+        return branch_evaluations
+    trimmed: list[dict] = []
+    for ev in branch_evaluations:
+        if ev.get("is_matched"):
+            ev = {**ev, "rendered_expression": _cap_debug_field(ev.get("rendered_expression"))}
+        else:
+            ev = {k: v for k, v in ev.items() if k != "rendered_expression"}
+        trimmed.append(ev)
+    return trimmed
+
+
+class BranchCondition(BaseModel):
+    """Represents a single conditional branch edge within a ConditionalBlock."""
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    criteria: BranchCriteriaTypeVar | None = None
+    next_block_label: str | None = None
+    description: str | None = None
+    is_default: bool = False
+
+    @model_validator(mode="after")
+    def validate_condition(self) -> BranchCondition:
+        if isinstance(self.criteria, dict):
+            criteria_type = self.criteria.get("criteria_type")
+            if criteria_type is None:
+                # Infer criteria type from expression format
+                expression = self.criteria.get("expression", "")
+                if _is_pure_jinja_expression(expression):
+                    criteria_type = "jinja2_template"
+                else:
+                    criteria_type = "prompt"
+            if criteria_type == "prompt":
+                self.criteria = PromptBranchCriteria(**self.criteria)
+            else:
+                self.criteria = JinjaBranchCriteria(**self.criteria)
+        if self.criteria is None and not self.is_default:
+            raise ValueError("Branches without criteria must be marked as default.")
+        if self.criteria is not None and self.is_default:
+            raise ValueError("Default branches may not define criteria.")
+        if self.criteria and isinstance(self.criteria, BranchCriteria):
+            expression = self.criteria.expression
+            criteria_dict = self.criteria.model_dump()
+            if _is_pure_jinja_expression(expression):
+                criteria_dict["criteria_type"] = "jinja2_template"
+                self.criteria = JinjaBranchCriteria(**criteria_dict)
+            else:
+                criteria_dict["criteria_type"] = "prompt"
+                self.criteria = PromptBranchCriteria(**criteria_dict)
+        return self
+
+
+async def _evaluate_prompt_branch_conditions_batch(
+    *,
+    log_label: str,
+    branches: list[BranchCondition],
+    evaluation_context: BranchEvaluationContext,
+    workflow_run_id: str,
+    workflow_run_block_id: str,
+    organization_id: str | None,
+    browser_session_id: str | None,
+    workflow_id: str,
+    extraction_description_suffix: str = "",
+) -> tuple[list[bool], list[str], str | None, dict | None]:
+    # Late import: block.py is the facade over this leaf module, so pull ExtractionBlock
+    # only at call time to keep this module importable on its own.
+    from skyvern.forge.sdk.workflow.models.block import ExtractionBlock
+
+    if organization_id is None:
+        raise ValueError("organization_id is required to evaluate natural language branches")
+
+    if not branches:
+        return ([], [], None, None)
+
+    workflow_run_context = evaluation_context.workflow_run_context
+
+    rendered_expressions: list[str] = []
+    has_any_pure_natlang = False
+
+    for idx, branch in enumerate(branches):
+        expression = branch.criteria.expression if branch.criteria else ""
+        has_jinja = "{{" in expression
+
+        if has_jinja:
+            try:
+                rendered_expression = (
+                    evaluation_context.template_renderer(expression)
+                    if evaluation_context.template_renderer
+                    else expression
+                )
+            except Exception as render_exc:
+                LOG.error(
+                    "Conditional branch expression rendering FAILED",
+                    block_label=log_label,
+                    branch_index=idx,
+                    original_expression=expression,
+                    error=str(render_exc),
+                    exc_info=True,
+                )
+                rendered_expression = expression
+                has_any_pure_natlang = True
+            else:
+                rendered_expression, was_patched = _make_empty_params_explicit(expression, rendered_expression)
+                if was_patched:
+                    LOG.info(
+                        "Conditional branch expression patched for empty parameter(s)",
+                        workflow_run_id=workflow_run_id,
+                        block_label=log_label,
+                        branch_index=idx,
+                        original_expression=expression,
+                        patched_expression=rendered_expression,
+                    )
+        else:
+            rendered_expression = expression
+            has_any_pure_natlang = True
+
+        LOG.info(
+            "Conditional branch expression rendering",
+            block_label=log_label,
+            branch_index=idx,
+            original_expression=expression,
+            rendered_expression=rendered_expression,
+            has_jinja=has_jinja,
+            expression_changed=expression != rendered_expression,
+        )
+
+        rendered_expressions.append(rendered_expression)
+
+    if has_any_pure_natlang:
+        context_snapshot = evaluation_context.build_llm_safe_context_snapshot()
+        context_json = json.dumps(context_snapshot, default=str)
+    else:
+        context_json = None
+
+    extraction_goal = prompt_engine.load_prompt(
+        "conditional-prompt-branch-evaluation",
+        conditions=rendered_expressions,
+        context_json=context_json,
+    )
+
+    data_schema = _build_branch_evaluation_schema(len(branches))
+
+    desc_suffix = extraction_description_suffix or f"{len(branches)} conditions"
+
+    last_malformed: MalformedBranchEvaluationError | None = None
+    for attempt in range(MAX_PROMPT_BRANCH_EVAL_ATTEMPTS):
+        # Vary the goal on retries so the extraction cache key (which includes
+        # data_extraction_goal) changes and we get a genuine re-roll instead of replaying
+        # the malformed cached result that just failed validation.
+        attempt_goal = extraction_goal
+        if attempt > 0:
+            attempt_goal = (
+                f"{extraction_goal}\n\n"
+                f"Re-evaluation attempt {attempt + 1}: return exactly {len(branches)} results, "
+                f"one object per numbered condition, each tagged with its condition_index."
+            )
+
+        prompt_branch_eval_id = generate_random_string()
+        output_param = OutputParameter(
+            output_parameter_id=str(uuid.uuid4()),
+            key=f"prompt_branch_eval_{prompt_branch_eval_id}",
+            workflow_id=workflow_id,
+            created_at=datetime.now(),
+            modified_at=datetime.now(),
+            parameter_type=ParameterType.OUTPUT,
+            description=f"Conditional branch evaluation results ({desc_suffix})",
+        )
+        extraction_block = ExtractionBlock(
+            label=f"prompt_branch_eval_{prompt_branch_eval_id}",
+            data_extraction_goal=attempt_goal,
+            data_schema=data_schema,
+            output_parameter=output_param,
+        )
+
+        LOG.info(
+            "Conditional branch ExtractionBlock created (batched)",
+            block_label=log_label,
+            prompt_branch_eval_id=prompt_branch_eval_id,
+            num_conditions=len(branches),
+            attempt=attempt,
+            extraction_goal_preview=attempt_goal[:500] if attempt_goal else None,
+            has_browser_session=browser_session_id is not None,
+            has_any_pure_natlang=has_any_pure_natlang,
+            has_context=context_json is not None,
+        )
+
+        extraction_result = await extraction_block.execute(
+            workflow_run_id=workflow_run_id,
+            workflow_run_block_id=workflow_run_block_id,
+            organization_id=organization_id,
+            browser_session_id=browser_session_id,
+        )
+
+        if not extraction_result.success:
+            # Extraction-level failures already retry at the step level inside the task;
+            # surface them immediately rather than re-rolling the whole batch.
+            LOG.error(
+                "Conditional branch ExtractionBlock failed",
+                block_label=log_label,
+                failure_reason=extraction_result.failure_reason,
+            )
+            raise ConditionalBranchEvaluationError(
+                f"Branch evaluation failed: "
+                f"{extraction_result.failure_reason or 'Unknown error (no failure reason provided)'}"
+            )
+
+        raw_output_value = extraction_result.output_parameter_value
+        try:
+            results_array, llm_rendered_expressions, normalized_output = _align_branch_evaluations(
+                output_value=raw_output_value,
+                branches=branches,
+                rendered_expressions=rendered_expressions,
+            )
+        except MalformedBranchEvaluationError as malformed:
+            last_malformed = malformed
+            LOG.warning(
+                "Conditional branch evaluation output malformed",
+                block_label=log_label,
+                attempt=attempt,
+                will_retry=attempt + 1 < MAX_PROMPT_BRANCH_EVAL_ATTEMPTS,
+                error=str(malformed),
+                raw_output=raw_output_value,
+            )
+            continue
+
+        # Record the output parameter only for the attempt we actually accept, so a failed
+        # attempt's payload never lands in the workflow context when a later attempt succeeds.
+        if workflow_run_context:
+            try:
+                await extraction_block.record_output_parameter_value(
+                    workflow_run_context=workflow_run_context,
+                    workflow_run_id=workflow_run_id,
+                    value=normalized_output,
+                )
+            except Exception:
+                LOG.warning(
+                    "Failed to record conditional branch evaluation output",
+                    workflow_run_id=workflow_run_id,
+                    block_label=log_label,
+                    exc_info=True,
+                )
+
+        LOG.info(
+            "Conditional branch evaluation results",
+            block_label=log_label,
+            results=results_array,
+            llm_rendered_expressions=llm_rendered_expressions,
+            attempt=attempt,
+            raw_output=normalized_output,
+        )
+        return (results_array, llm_rendered_expressions, extraction_goal, normalized_output)
+
+    LOG.error(
+        "Conditional branch evaluation failed after retries",
+        block_label=log_label,
+        attempts=MAX_PROMPT_BRANCH_EVAL_ATTEMPTS,
+        error=str(last_malformed),
+    )
+    raise ConditionalBranchEvaluationError(f"Conditional branch evaluation failed: {last_malformed}")
+
+
+BranchCriteriaSubclasses = Union[JinjaBranchCriteria, PromptBranchCriteria]
+BranchCriteriaTypeVar = Annotated[BranchCriteriaSubclasses, Field(discriminator="criteria_type")]

--- a/tests/unit/workflow/test_conditional_branch_evaluation.py
+++ b/tests/unit/workflow/test_conditional_branch_evaluation.py
@@ -72,7 +72,9 @@ async def test_jinja_rendered_prompt_condition_keeps_browser_session() -> None:
     evaluation_context.build_llm_safe_context_snapshot = MagicMock(return_value={"Single_or_Joint__c": "Joint"})  # type: ignore[method-assign]
 
     with (
-        patch("skyvern.forge.sdk.workflow.models.block.prompt_engine.load_prompt", return_value="goal") as mock_prompt,
+        patch(
+            "skyvern.forge.sdk.workflow.models.branching.prompt_engine.load_prompt", return_value="goal"
+        ) as mock_prompt,
         patch("skyvern.forge.sdk.workflow.models.block.ExtractionBlock") as mock_extraction_cls,
     ):
         mock_extraction = MagicMock()
@@ -115,7 +117,9 @@ async def test_pure_natlang_prompt_condition_uses_browser_session_and_context() 
     evaluation_context.build_llm_safe_context_snapshot = MagicMock(return_value={"plan": "premium"})  # type: ignore[method-assign]
 
     with (
-        patch("skyvern.forge.sdk.workflow.models.block.prompt_engine.load_prompt", return_value="goal") as mock_prompt,
+        patch(
+            "skyvern.forge.sdk.workflow.models.branching.prompt_engine.load_prompt", return_value="goal"
+        ) as mock_prompt,
         patch("skyvern.forge.sdk.workflow.models.block.ExtractionBlock") as mock_extraction_cls,
     ):
         mock_extraction = MagicMock()
@@ -378,7 +382,9 @@ async def test_empty_param_produces_explicit_marker_in_prompt_evaluation() -> No
     evaluation_context.build_llm_safe_context_snapshot = MagicMock(return_value={"test_parameter": ""})  # type: ignore[method-assign]
 
     with (
-        patch("skyvern.forge.sdk.workflow.models.block.prompt_engine.load_prompt", return_value="goal") as mock_prompt,
+        patch(
+            "skyvern.forge.sdk.workflow.models.branching.prompt_engine.load_prompt", return_value="goal"
+        ) as mock_prompt,
         patch("skyvern.forge.sdk.workflow.models.block.ExtractionBlock") as mock_extraction_cls,
     ):
         mock_extraction = MagicMock()
@@ -433,7 +439,7 @@ async def test_extraction_failure_with_none_reason_produces_informative_error() 
     evaluation_context.build_llm_safe_context_snapshot = MagicMock(return_value={})  # type: ignore[method-assign]
 
     with (
-        patch("skyvern.forge.sdk.workflow.models.block.prompt_engine.load_prompt", return_value="goal"),
+        patch("skyvern.forge.sdk.workflow.models.branching.prompt_engine.load_prompt", return_value="goal"),
         patch("skyvern.forge.sdk.workflow.models.block.ExtractionBlock") as mock_extraction_cls,
     ):
         mock_extraction = MagicMock()
@@ -466,7 +472,7 @@ async def test_extraction_failure_with_reason_preserves_original_message() -> No
     evaluation_context.build_llm_safe_context_snapshot = MagicMock(return_value={})  # type: ignore[method-assign]
 
     with (
-        patch("skyvern.forge.sdk.workflow.models.block.prompt_engine.load_prompt", return_value="goal"),
+        patch("skyvern.forge.sdk.workflow.models.branching.prompt_engine.load_prompt", return_value="goal"),
         patch("skyvern.forge.sdk.workflow.models.block.ExtractionBlock") as mock_extraction_cls,
     ):
         mock_extraction = MagicMock()
@@ -515,7 +521,7 @@ async def test_extra_placeholder_evals_recovered_when_well_formed_subset_matches
     ]
 
     with (
-        patch("skyvern.forge.sdk.workflow.models.block.prompt_engine.load_prompt", return_value="goal"),
+        patch("skyvern.forge.sdk.workflow.models.branching.prompt_engine.load_prompt", return_value="goal"),
         patch("skyvern.forge.sdk.workflow.models.block.ExtractionBlock") as mock_extraction_cls,
     ):
         mock_extraction = MagicMock()
@@ -554,7 +560,7 @@ async def test_extra_evals_not_recovered_when_well_formed_count_does_not_match()
     ]
 
     with (
-        patch("skyvern.forge.sdk.workflow.models.block.prompt_engine.load_prompt", return_value="goal"),
+        patch("skyvern.forge.sdk.workflow.models.branching.prompt_engine.load_prompt", return_value="goal"),
         patch("skyvern.forge.sdk.workflow.models.block.ExtractionBlock") as mock_extraction_cls,
     ):
         mock_extraction = MagicMock()
@@ -597,7 +603,7 @@ async def test_extra_placeholder_evals_multi_branch_preserves_order() -> None:
     ]
 
     with (
-        patch("skyvern.forge.sdk.workflow.models.block.prompt_engine.load_prompt", return_value="goal"),
+        patch("skyvern.forge.sdk.workflow.models.branching.prompt_engine.load_prompt", return_value="goal"),
         patch("skyvern.forge.sdk.workflow.models.block.ExtractionBlock") as mock_extraction_cls,
     ):
         mock_extraction = MagicMock()
@@ -669,7 +675,7 @@ async def test_condition_index_alignment_is_order_independent() -> None:
         {"condition_index": 1, "reasoning": "A", "result": False},
     ]
     with (
-        patch("skyvern.forge.sdk.workflow.models.block.prompt_engine.load_prompt", return_value="goal"),
+        patch("skyvern.forge.sdk.workflow.models.branching.prompt_engine.load_prompt", return_value="goal"),
         patch("skyvern.forge.sdk.workflow.models.block.ExtractionBlock") as mock_extraction_cls,
     ):
         mock_extraction = MagicMock()
@@ -701,7 +707,7 @@ async def test_hallucinated_unindexed_entry_does_not_misroute() -> None:
         {"condition_index": 2, "reasoning": "B", "result": True},
     ]
     with (
-        patch("skyvern.forge.sdk.workflow.models.block.prompt_engine.load_prompt", return_value="goal"),
+        patch("skyvern.forge.sdk.workflow.models.branching.prompt_engine.load_prompt", return_value="goal"),
         patch("skyvern.forge.sdk.workflow.models.block.ExtractionBlock") as mock_extraction_cls,
     ):
         mock_extraction = MagicMock()
@@ -736,7 +742,7 @@ async def test_under_return_retries_then_succeeds() -> None:
         ],
     )
     with (
-        patch("skyvern.forge.sdk.workflow.models.block.prompt_engine.load_prompt", return_value="goal"),
+        patch("skyvern.forge.sdk.workflow.models.branching.prompt_engine.load_prompt", return_value="goal"),
         patch("skyvern.forge.sdk.workflow.models.block.ExtractionBlock") as mock_extraction_cls,
     ):
         mock_extraction = MagicMock()
@@ -764,7 +770,7 @@ async def test_under_return_fails_loudly_after_retries_exhausted() -> None:
 
     bad = _extraction_result(block.output_parameter, [{"condition_index": 1, "reasoning": "A", "result": False}])
     with (
-        patch("skyvern.forge.sdk.workflow.models.block.prompt_engine.load_prompt", return_value="goal"),
+        patch("skyvern.forge.sdk.workflow.models.branching.prompt_engine.load_prompt", return_value="goal"),
         patch("skyvern.forge.sdk.workflow.models.block.ExtractionBlock") as mock_extraction_cls,
     ):
         mock_extraction = MagicMock()
@@ -799,7 +805,7 @@ async def test_retry_varies_extraction_goal_for_true_reroll() -> None:
         ],
     )
     with (
-        patch("skyvern.forge.sdk.workflow.models.block.prompt_engine.load_prompt", return_value="goal"),
+        patch("skyvern.forge.sdk.workflow.models.branching.prompt_engine.load_prompt", return_value="goal"),
         patch("skyvern.forge.sdk.workflow.models.block.ExtractionBlock") as mock_extraction_cls,
     ):
         mock_extraction = MagicMock()
@@ -835,7 +841,7 @@ async def test_branch_eval_schema_is_strict_and_indexed() -> None:
         ],
     )
     with (
-        patch("skyvern.forge.sdk.workflow.models.block.prompt_engine.load_prompt", return_value="goal"),
+        patch("skyvern.forge.sdk.workflow.models.branching.prompt_engine.load_prompt", return_value="goal"),
         patch("skyvern.forge.sdk.workflow.models.block.ExtractionBlock") as mock_extraction_cls,
     ):
         mock_extraction = MagicMock()
@@ -890,7 +896,7 @@ async def test_string_condition_index_out_of_order_aligns_by_index() -> None:
         {"condition_index": "1", "reasoning": "A", "result": False},
     ]
     with (
-        patch("skyvern.forge.sdk.workflow.models.block.prompt_engine.load_prompt", return_value="goal"),
+        patch("skyvern.forge.sdk.workflow.models.branching.prompt_engine.load_prompt", return_value="goal"),
         patch("skyvern.forge.sdk.workflow.models.block.ExtractionBlock") as mock_extraction_cls,
     ):
         mock_extraction = MagicMock()
@@ -920,7 +926,7 @@ async def test_float_condition_index_out_of_order_aligns_by_index() -> None:
         {"condition_index": 1.0, "reasoning": "A", "result": False},
     ]
     with (
-        patch("skyvern.forge.sdk.workflow.models.block.prompt_engine.load_prompt", return_value="goal"),
+        patch("skyvern.forge.sdk.workflow.models.branching.prompt_engine.load_prompt", return_value="goal"),
         patch("skyvern.forge.sdk.workflow.models.block.ExtractionBlock") as mock_extraction_cls,
     ):
         mock_extraction = MagicMock()


### PR DESCRIPTION
**Part 2/8.** Based on 1/8 (#7174). Extracts the branching subsystem (branch criteria + evaluation engine) into `models/branching.py` as a leaf module (lazy call-time imports). `ConditionalBlock` stays in `block.py` and subclasses `Block` (re-exported from `block_base`).

### The full stack (merge in order, 1 → 8)
1. **1/8** #7174 — foundation: `models/block_base.py` (Block base class + shared helpers), base `main`
2. **2/8** #6979 — branching subsystem → `models/branching.py`
3. **3/8** #7170 — CodeBlock → `models/code_block.py`
4. **4/8** #7171 — parser blocks → `models/parser_blocks.py`
5. **5/8** #6977 — storage blocks → `models/storage_blocks.py`
6. **6/8** #6980 — single blocks (TextPrompt, SendEmail, Wait, TaskV2, HttpRequest, PrintPage, WorkflowTrigger) → `models/misc_blocks.py`
7. **7/8** #6978 — task-block family (BaseTaskBlock + subclasses) → `models/task_blocks.py`
8. **8/8** #7179 — control-flow blocks (ForLoop, WhileLoop, Conditional) → `models/control_flow_blocks.py`

After 8/8, `block.py` is a ~495-line facade: it re-exports everything for zero call-site changes, defines the `BlockSubclasses` discriminated union + dispatch (`get_all_blocks`, `resolve_conditional_merge_edges`), and holds shared helpers only.

Each part's submodule imports `Block` from `block_base` (breaking the historical import cycle); every extracted class stays importable from `models.block` via re-export. Each layer is independently green against the full block-related unit suite.

_(Note: branch slugs still read `..-N7..` from the original 7-part plan; the logical part is the M/8 above.)_
