### PR TITLE
[frontend] Fix run/block duration display dropping days past 24h

### DIFF
--- a/skyvern-frontend/src/routes/workflows/utils.test.ts
+++ b/skyvern-frontend/src/routes/workflows/utils.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  formatDuration,
   normalizeJsonParameterFormValue,
   parseJsonWorkflowParameterValue,
+  toDuration,
   validateJsonWorkflowParameterValue,
 } from "./utils";
 
@@ -76,5 +78,46 @@ describe("validateJsonWorkflowParameterValue", () => {
     expect(validateJsonWorkflowParameterValue("{not json")).toBe(
       "Invalid JSON",
     );
+  });
+});
+
+describe("toDuration", () => {
+  it("converts sub-minute durations", () => {
+    expect(toDuration(45)).toEqual({ hour: 0, minute: 0, second: 45 });
+  });
+
+  it("converts minutes and seconds", () => {
+    expect(toDuration(125)).toEqual({ hour: 0, minute: 2, second: 5 });
+  });
+
+  it("converts hours, minutes, and seconds", () => {
+    expect(toDuration(3661)).toEqual({ hour: 1, minute: 1, second: 1 });
+  });
+
+  it("floors fractional seconds", () => {
+    expect(toDuration(90.7)).toEqual({ hour: 0, minute: 1, second: 30 });
+  });
+
+  it("preserves hours beyond 24 instead of wrapping", () => {
+    // 25h exactly — `hours % 24` used to report this as 1h since Duration
+    // has no day field to carry the overflow.
+    expect(toDuration(90000)).toEqual({ hour: 25, minute: 0, second: 0 });
+  });
+
+  it("preserves multi-day durations in the hour field", () => {
+    // 49h 1m 5s
+    expect(toDuration(176465)).toEqual({ hour: 49, minute: 1, second: 5 });
+  });
+});
+
+describe("formatDuration", () => {
+  it("omits empty leading units", () => {
+    expect(formatDuration(toDuration(45))).toBe("45s");
+    expect(formatDuration(toDuration(125))).toBe("2m 5s");
+    expect(formatDuration(toDuration(3661))).toBe("1h 1m 1s");
+  });
+
+  it("renders durations longer than a day without losing hours", () => {
+    expect(formatDuration(toDuration(90000))).toBe("25h 0m 0s");
   });
 });

--- a/skyvern-frontend/src/routes/workflows/utils.ts
+++ b/skyvern-frontend/src/routes/workflows/utils.ts
@@ -169,10 +169,9 @@ export interface Duration {
 
 export const toDuration = (seconds: number): Duration => {
   let minutes = Math.floor(seconds / 60);
-  let hours = Math.floor(minutes / 60);
+  const hours = Math.floor(minutes / 60);
   seconds = seconds % 60;
   minutes = minutes % 60;
-  hours = hours % 24;
 
   return {
     hour: Math.floor(hours),


### PR DESCRIPTION
Fixes #7057

### Problem

`toDuration()` in `skyvern-frontend/src/routes/workflows/utils.ts` reduced the hour component with `hours % 24`, but the `Duration` type it returns has no day field and `formatDuration()` only renders hours/minutes/seconds. So any run or block that lasts 24h+ silently loses a full day in its label — a 25h run shows `1h 0m 0s`.

This is reachable from normal run views: `getRunDurationLabel()` (`recentActivity/runActivity.ts`) and the block duration labels in `WorkflowRunTimelineBlockItem.tsx` both feed real elapsed seconds (`finished_at - started_at`) into `toDuration`.

### Fix

Drop the `hours % 24` so the hour field carries the total hours. Minimal, no interface or display-format change — hours can now simply exceed 24.

```
formatDuration(toDuration(90000)) // before: "1h 0m 0s"  after: "25h 0m 0s"
```

### Tests

Added tests to `utils.test.ts` covering sub-minute, minute/second, hour/minute/second, fractional-second flooring, and the >24h / multi-day regression cases. Confirmed the new duration tests fail on the old `% 24` code and pass with the fix; full file suite is green (`vitest run src/routes/workflows/utils.test.ts` → 20 passed). Prettier and ESLint clean on the changed files.