### PR TITLE
[frontend] Encode file path in workflow run recording URL

### DIFF
--- a/skyvern-frontend/src/routes/workflows/workflowRun/recordingUrls.test.ts
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/recordingUrls.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { getRecordingUrls } from "./recordingUrls";
+
+describe("getRecordingUrls", () => {
+  it("returns an empty array for missing input", () => {
+    expect(getRecordingUrls(null)).toEqual([]);
+    expect(getRecordingUrls(undefined)).toEqual([]);
+    expect(getRecordingUrls({})).toEqual([]);
+  });
+
+  it("passes non-file URLs through unchanged", () => {
+    const url = "https://example.com/recording.mp4";
+    expect(getRecordingUrls({ recording_urls: [url] })).toEqual([url]);
+  });
+
+  it("percent-encodes the file path in the query so special characters survive", () => {
+    const urls = getRecordingUrls({
+      recording_urls: ["file:///tmp/my recording&x.mp4"],
+    });
+    expect(urls).toHaveLength(1);
+    // The whole path must be one encoded query value, not split on the raw "&".
+    expect(urls[0]).toContain(
+      "path=" + encodeURIComponent("/tmp/my recording&x.mp4"),
+    );
+    // A parser must recover the original path intact.
+    const parsed = new URL(urls[0]!);
+    expect(parsed.searchParams.get("path")).toBe("/tmp/my recording&x.mp4");
+  });
+
+  it("encodes a plain path the same way its task-detail sibling does", () => {
+    const urls = getRecordingUrls({
+      recording_url: "file:///tmp/recording.mp4",
+    });
+    expect(urls[0]).toContain(
+      "path=" + encodeURIComponent("/tmp/recording.mp4"),
+    );
+  });
+
+  it("prefers recording_urls over recording_url", () => {
+    const urls = getRecordingUrls({
+      recording_urls: ["https://example.com/a.mp4"],
+      recording_url: "https://example.com/b.mp4",
+    });
+    expect(urls).toEqual(["https://example.com/a.mp4"]);
+  });
+});

--- a/skyvern-frontend/src/routes/workflows/workflowRun/recordingUrls.ts
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/recordingUrls.ts
@@ -2,7 +2,7 @@ import { artifactApiBaseUrl } from "@/util/env";
 
 function resolveRecordingUrl(url: string): string {
   if (url.startsWith("file://")) {
-    return `${artifactApiBaseUrl}/artifact/recording?path=${url.slice(7)}`;
+    return `${artifactApiBaseUrl}/artifact/recording?path=${encodeURIComponent(url.slice(7))}`;
   }
   return url;
 }


### PR DESCRIPTION
Fixes #7059

### Problem

`resolveRecordingUrl` (`skyvern-frontend/src/routes/workflows/workflowRun/recordingUrls.ts`) built `/artifact/recording?path=${url.slice(7)}` without encoding the path. A `file://` recording path with a space, `&`, `#`, `?`, or `%` produced a malformed URL. With `&` the query splits and the backend receives a truncated `path`, so the run view recording fails to load.

### Fix

Wrap the path in `encodeURIComponent`, matching the sibling builders in `tasks/detail/artifactUtils.ts` (`getRecordingURL`, `getImageURL`, `getScreenshotURL`) that already encode the same query for the same endpoint.

```
getRecordingUrls({ recording_urls: ["file:///tmp/my recording&x.mp4"] })
// before: path=/tmp/my recording&x.mp4   (parsed path truncated at "&")
// after:  path=%2Ftmp%2Fmy%20recording%26x.mp4   (round-trips intact)
```

### Tests

Added `recordingUrls.test.ts` covering the encoded path, the round-trip through `new URL(...)`, non-`file://` passthrough, the `recording_urls` over `recording_url` preference, and empty input. Confirmed the two encoding assertions fail on the old code and pass with the fix. `vitest run` on the file is green, prettier and eslint clean.