### PR TITLE
[frontend] Substitute all parameter references when building cache key value

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/utils.test.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/utils.test.ts
@@ -5,6 +5,7 @@ import {
   WorkflowParameterValueType,
 } from "../types/workflowTypes";
 import {
+  constructCacheKeyValueFromParameters,
   getInitialParameters,
   skyvernCredentialToParameterYAML,
 } from "./utils";
@@ -154,5 +155,54 @@ describe("skyvernCredentialToParameterYAML", () => {
       key: "credentials",
       description: null,
     });
+  });
+});
+
+describe("constructCacheKeyValueFromParameters", () => {
+  test("substitutes a single parameter reference", () => {
+    expect(
+      constructCacheKeyValueFromParameters({
+        codeKey: "{{a}}",
+        parameters: { a: "x" },
+      }),
+    ).toBe("x");
+  });
+
+  test("substitutes distinct parameters", () => {
+    expect(
+      constructCacheKeyValueFromParameters({
+        codeKey: "{{a}}-{{b}}",
+        parameters: { a: "1", b: "2" },
+      }),
+    ).toBe("1-2");
+  });
+
+  test("replaces every occurrence of a repeated parameter", () => {
+    // Regression: String.replace only swapped the first "{{a}}", leaving the
+    // second, so the trailing "{" guard discarded the whole key.
+    expect(
+      constructCacheKeyValueFromParameters({
+        codeKey: "{{a}}/{{a}}",
+        parameters: { a: "x" },
+      }),
+    ).toBe("x/x");
+  });
+
+  test("returns empty string when a placeholder is left unresolved", () => {
+    expect(
+      constructCacheKeyValueFromParameters({
+        codeKey: "{{a}}-{{missing}}",
+        parameters: { a: "x" },
+      }),
+    ).toBe("");
+  });
+
+  test("skips null, undefined, and empty-string parameter values", () => {
+    expect(
+      constructCacheKeyValueFromParameters({
+        codeKey: "static-key",
+        parameters: { a: null, b: undefined, c: "" },
+      }),
+    ).toBe("static-key");
   });
 });

--- a/skyvern-frontend/src/routes/workflows/editor/utils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/utils.ts
@@ -191,7 +191,7 @@ const constructCacheKeyValueFromParameters = (opts: {
       continue;
     }
 
-    codeKey = codeKey.replace(`{{${name}}}`, value.toString());
+    codeKey = codeKey.replaceAll(`{{${name}}}`, value.toString());
   }
 
   if (codeKey.includes("{") || codeKey.includes("}")) {


### PR DESCRIPTION
Fixes #7060

### Problem

`constructCacheKeyValueFromParameters` (`skyvern-frontend/src/routes/workflows/editor/utils.ts`) substituted parameters with `String.replace`, which replaces only the first match. A cache key template that references the same parameter more than once (for example `{{a}}/{{a}}`) kept the second placeholder, so the trailing `{`/`}` guard returned an empty string and the cache lookup for that run was silently disabled.

### Fix

Use `replaceAll` so every occurrence is substituted.

```
constructCacheKeyValueFromParameters({ codeKey: "{{a}}/{{a}}", parameters: { a: "x" } })
// before: ""
// after:  "x/x"
```

Templates with distinct parameters, each referenced once, are unaffected.

### Tests

Extended `editor/utils.test.ts` with cases for a single reference, distinct parameters, the repeated reference regression, an unresolved placeholder returning `""`, and skipped null/undefined/empty values. Confirmed the repeated-reference test fails on the old code and passes with the fix. `vitest run` on the file is green, prettier and eslint clean.