### PR TITLE
[utils] Pass under-budget dicts through prompt truncation unchanged

### DIFF
--- a/skyvern/utils/prompt_truncation.py
+++ b/skyvern/utils/prompt_truncation.py
@@ -84,6 +84,14 @@ def truncate_previous_extracted_information(
     rendered_before = value if isinstance(value, str) else json.dumps(value, default=str)
     before_tokens = count_tokens(rendered_before)
 
+    # A value already within budget passes through unchanged. The str and list
+    # branches short-circuit on their own, but the dict branch would otherwise
+    # still impose a per-key cap and could coerce an under-budget value (e.g. a
+    # list or nested dict) into a tail-cropped, invalid-JSON string. This also
+    # keeps an empty list/dict from being rendered to its string form.
+    if before_tokens <= max_tokens:
+        return value
+
     if isinstance(value, str):
         result: Any = _crop_string(value, max_tokens)
     elif isinstance(value, list):

--- a/tests/unit/test_prompt_truncation.py
+++ b/tests/unit/test_prompt_truncation.py
@@ -78,6 +78,43 @@ def test_truncate_dict_preserves_value_types_when_under_per_key_budget() -> None
     assert isinstance(result["small_str"], str)
 
 
+def test_truncate_dict_under_total_budget_preserves_uneven_value() -> None:
+    import json
+
+    from skyvern.utils.prompt_truncation import truncate_previous_extracted_information
+    from skyvern.utils.token_counter import count_tokens
+
+    # A dict that fits the total budget but has one value larger than
+    # max_tokens / num_keys. It must pass through unchanged, exactly like the
+    # str and list branches — not get its list value cropped and coerced into a
+    # truncated, invalid-JSON string.
+    value = {
+        "results": [{"id": i, "name": f"row{i}"} for i in range(40)],
+        "summary": "ok",
+    }
+    total_tokens = count_tokens(json.dumps(value, default=str))
+    result = truncate_previous_extracted_information(value, max_tokens=total_tokens + 50)
+    assert result == value
+    assert isinstance(result["results"], list)
+    assert len(result["results"]) == 40
+
+
+def test_truncate_empty_list_stays_a_list() -> None:
+    from skyvern.utils.prompt_truncation import truncate_previous_extracted_information
+
+    result = truncate_previous_extracted_information([], max_tokens=100)
+    assert result == []
+    assert isinstance(result, list)
+
+
+def test_truncate_empty_dict_stays_a_dict() -> None:
+    from skyvern.utils.prompt_truncation import truncate_previous_extracted_information
+
+    result = truncate_previous_extracted_information({}, max_tokens=100)
+    assert result == {}
+    assert isinstance(result, dict)
+
+
 def test_truncate_respects_default_budget() -> None:
     from skyvern.utils.prompt_truncation import PREVIOUS_EXTRACTED_INFO_MAX_TOKENS
 


### PR DESCRIPTION
Fixes #7061

### Problem

`truncate_previous_extracted_information` (`skyvern/utils/prompt_truncation.py`) returns the value unchanged for `str` and `list` inputs that already fit `max_tokens`, but the `dict` branch had no such guard. `_crop_dict` always imposes a per-key cap of `max_tokens // len(value)`, so a dict that fits the total budget but holds one larger value had that value cropped, and for a `list` or nested `dict` value coerced into a tail-truncated, invalid-JSON string (front data lost, type changed). An empty list was rendered to the string `"[]"`.

Since `previous_extracted_information` is real model context, often `{"results": [...], "summary": "..."}`, this corrupts the extraction context even when it is within budget.

### Fix

Add a single under-budget short-circuit after measuring `before_tokens`, so every input type behaves consistently:

```python
if before_tokens <= max_tokens:
    return value
```

### Tests

Added regression tests for the under-budget uneven dict (value stays a 40 item list, dict unchanged) and the empty list/dict cases. Confirmed the dict and empty-list tests fail on the old code and pass with the fix. Full `tests/unit/test_prompt_truncation.py` is green, including the existing over-budget dict tests; ruff check and ruff format are clean.