### PR TITLE
fix: Added an early short-circuit in truncate_previous_extracted_informa

### DIFF
--- a/skyvern/utils/prompt_truncation.py
+++ b/skyvern/utils/prompt_truncation.py
@@ -84,6 +84,9 @@ def truncate_previous_extracted_information(
     rendered_before = value if isinstance(value, str) else json.dumps(value, default=str)
     before_tokens = count_tokens(rendered_before)
 
+    if before_tokens <= max_tokens:
+        return value
+
     if isinstance(value, str):
         result: Any = _crop_string(value, max_tokens)
     elif isinstance(value, list):

--- a/tests/unit/test_prompt_truncation.py
+++ b/tests/unit/test_prompt_truncation.py
@@ -78,6 +78,35 @@ def test_truncate_dict_preserves_value_types_when_under_per_key_budget() -> None
     assert isinstance(result["small_str"], str)
 
 
+def test_truncate_dict_under_budget_passes_through_unchanged() -> None:
+    """Regression test for issue #7061: a dict whose total size fits max_tokens
+    must pass through unchanged, even if one key's value would blow the
+    per-key share that _crop_dict imposes."""
+    import json
+
+    from skyvern.utils.prompt_truncation import truncate_previous_extracted_information
+    from skyvern.utils.token_counter import count_tokens
+
+    value = {"results": [{"id": i, "name": f"row{i}"} for i in range(40)], "summary": "ok"}
+    budget = count_tokens(json.dumps(value)) + 50
+    result = truncate_previous_extracted_information(value, max_tokens=budget)
+
+    assert result == value
+    assert isinstance(result["results"], list)
+    assert len(result["results"]) == 40
+
+
+def test_truncate_top_level_empty_list_passes_through() -> None:
+    """An empty list under budget must stay a list, not get coerced to the
+    string "[]" by the list branch's `cropped if cropped else ...` fallback."""
+    from skyvern.utils.prompt_truncation import truncate_previous_extracted_information
+
+    result = truncate_previous_extracted_information([], max_tokens=1000)
+
+    assert result == []
+    assert isinstance(result, list)
+
+
 def test_truncate_respects_default_budget() -> None:
     from skyvern.utils.prompt_truncation import PREVIOUS_EXTRACTED_INFO_MAX_TOKENS
 


### PR DESCRIPTION
Fixes #7061

## Summary
Added an early short-circuit in truncate_previous_extracted_information right after measuring before_tokens: if the value is already within max_tokens, return it unchanged before any type-specific branch runs. This fixes both the dict per-key-cap corruption (large list/dict values getting coerced into truncated JSON strings even though the whole dict fit the budget) and the empty-list-to-"[]"-string coercion in the list branch, matching the str branch's existing pass-through behavior. Added two regression tests reproducing the issue's dict/list scenarios, both verified to fail against the pre-fix code and pass after the fix.

## Changes
- `skyvern/utils/prompt_truncation.py`
- `tests/unit/test_prompt_truncation.py`

## How this was tested
Ran `make sure that you are using the latest version.` locally.
