### PR TITLE
[frontend] Fix duplicate block label on single-collision rename

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.getUniqueLabelForExistingNode.test.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.getUniqueLabelForExistingNode.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { getUniqueLabelForExistingNode } from "./workflowEditorUtils";
+
+describe("getUniqueLabelForExistingNode", () => {
+  it("returns the label unchanged when it does not collide", () => {
+    expect(getUniqueLabelForExistingNode("block_1", ["other"])).toBe("block_1");
+    expect(getUniqueLabelForExistingNode("block_1", [])).toBe("block_1");
+  });
+
+  it("suffixes on a single collision instead of returning the duplicate", () => {
+    // Regression: the loop bound was existingLabels.length + 1, so with one
+    // existing label the loop never ran and the colliding label was returned.
+    expect(getUniqueLabelForExistingNode("block_1", ["block_1"])).toBe(
+      "block_1_2",
+    );
+  });
+
+  it("finds the next free suffix when earlier suffixes are taken", () => {
+    expect(getUniqueLabelForExistingNode("foo", ["foo", "foo_2"])).toBe(
+      "foo_3",
+    );
+    expect(getUniqueLabelForExistingNode("x", ["x", "x_2", "x_3"])).toBe("x_4");
+  });
+
+  it("always returns a label not already present", () => {
+    for (let n = 1; n <= 25; n++) {
+      const existing = [
+        "dup",
+        ...Array.from({ length: n }, (_, i) => `dup_${i + 2}`),
+      ];
+      const result = getUniqueLabelForExistingNode("dup", existing);
+      expect(existing).not.toContain(result);
+    }
+  });
+});

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -3876,7 +3876,7 @@ function getUniqueLabelForExistingNode(
   if (!existingLabels.includes(label)) {
     return label;
   }
-  for (let i = 2; i < existingLabels.length + 1; i++) {
+  for (let i = 2; i < existingLabels.length + 2; i++) {
     const candidate = `${label}_${i}`;
     if (!existingLabels.includes(candidate)) {
       return candidate;


### PR DESCRIPTION
Fixes #7074

### Problem

`getUniqueLabelForExistingNode` (`skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts`) looped `for (i = 2; i < existingLabels.length + 1; i++)`. With one existing label the loop never ran, and with N labels it tried only N-1 candidates (`label_2 .. label_N`), so it fell through and returned the colliding label unchanged.

Its caller `useLabelChangeHandler.ts` builds `existingLabels` from every other block node and renames the edited block to the returned value, so renaming a block to match exactly one other block produced two blocks with the same label. Labels must be unique because output parameters are keyed by them (`<label>_output`).

### Fix

Widen the bound to `existingLabels.length + 2`, matching the sibling `generateNodeLabel`, so a free suffix is always found.

```
getUniqueLabelForExistingNode("block_1", ["block_1"]) // before "block_1", after "block_1_2"
getUniqueLabelForExistingNode("foo", ["foo", "foo_2"]) // before "foo",     after "foo_3"
```

### Tests

Added `workflowEditorUtils.getUniqueLabelForExistingNode.test.ts` covering no collision, single collision, next-free-suffix, and a property check that the result is never already present for collision sets of size 1 through 25. Confirmed the collision tests fail on the old bound and pass with the fix. `vitest run` on the file is green, prettier and eslint clean.