### PR TITLE
[webeye] Position cursor at edge coordinate 0 in drag and left_mouse

### DIFF
--- a/skyvern/webeye/actions/handler_utils.py
+++ b/skyvern/webeye/actions/handler_utils.py
@@ -114,7 +114,7 @@ async def keypress(page: Page, keys: list[str], hold: bool = False, duration: fl
 async def drag(
     page: Page, start_x: int | None = None, start_y: int | None = None, path: list[tuple[int, int]] | None = None
 ) -> None:
-    if start_x and start_y:
+    if start_x is not None and start_y is not None:
         await EventStrategyFactory.move_cursor(page, start_x, start_y)
     await page.mouse.down()
     path = path or []
@@ -131,7 +131,7 @@ async def drag(
 
 
 async def left_mouse(page: Page, x: int | None, y: int | None, direction: Literal["down", "up"]) -> None:
-    if x and y:
+    if x is not None and y is not None:
         await EventStrategyFactory.move_cursor(page, x, y)
     if direction == "down":
         await page.mouse.down()

--- a/tests/unit/webeye/test_handler_utils_mouse.py
+++ b/tests/unit/webeye/test_handler_utils_mouse.py
@@ -1,0 +1,70 @@
+"""Regression tests for cursor positioning in drag/left_mouse.
+
+Both functions gated the move-to-start on a truthiness check, so a coordinate
+of 0 (a screen edge) was treated as "no coordinate" and the cursor was never
+moved before the mouse press. The drag/click then fired at the previous cursor
+position instead of the requested edge coordinate.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from skyvern.webeye.actions import handler_utils
+
+
+def _fake_page() -> MagicMock:
+    page = MagicMock()
+    page.mouse.down = AsyncMock()
+    page.mouse.up = AsyncMock()
+    return page
+
+
+@pytest.mark.asyncio
+async def test_drag_moves_cursor_to_zero_start() -> None:
+    page = _fake_page()
+    with (
+        patch.object(handler_utils.EventStrategyFactory, "move_cursor", new=AsyncMock()) as move_cursor,
+        patch.object(handler_utils.EventStrategyFactory, "sync_cursor_position", new=MagicMock()),
+    ):
+        await handler_utils.drag(page, start_x=0, start_y=0)
+    move_cursor.assert_awaited_once_with(page, 0, 0)
+
+
+@pytest.mark.asyncio
+async def test_drag_moves_cursor_to_zero_x_nonzero_y() -> None:
+    page = _fake_page()
+    with (
+        patch.object(handler_utils.EventStrategyFactory, "move_cursor", new=AsyncMock()) as move_cursor,
+        patch.object(handler_utils.EventStrategyFactory, "sync_cursor_position", new=MagicMock()),
+    ):
+        await handler_utils.drag(page, start_x=0, start_y=5)
+    move_cursor.assert_awaited_once_with(page, 0, 5)
+
+
+@pytest.mark.asyncio
+async def test_drag_skips_move_when_start_missing() -> None:
+    page = _fake_page()
+    with patch.object(handler_utils.EventStrategyFactory, "move_cursor", new=AsyncMock()) as move_cursor:
+        await handler_utils.drag(page, start_x=None, start_y=None, path=[(3, 4)])
+    # move_cursor still runs for the path point, but never for a None start.
+    for call in move_cursor.await_args_list:
+        assert call.args[1:] != (None, None)
+
+
+@pytest.mark.asyncio
+async def test_left_mouse_moves_cursor_to_zero() -> None:
+    page = _fake_page()
+    with patch.object(handler_utils.EventStrategyFactory, "move_cursor", new=AsyncMock()) as move_cursor:
+        await handler_utils.left_mouse(page, x=0, y=0, direction="down")
+    move_cursor.assert_awaited_once_with(page, 0, 0)
+    page.mouse.down.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_left_mouse_skips_move_when_coordinates_missing() -> None:
+    page = _fake_page()
+    with patch.object(handler_utils.EventStrategyFactory, "move_cursor", new=AsyncMock()) as move_cursor:
+        await handler_utils.left_mouse(page, x=None, y=None, direction="up")
+    move_cursor.assert_not_awaited()
+    page.mouse.up.assert_awaited_once()


### PR DESCRIPTION
Fixes #7079

### Problem

`drag` and `left_mouse` (`skyvern/webeye/actions/handler_utils.py`) gated the move-to-start on `if start_x and start_y` / `if x and y`. Coordinate `0` is falsy, so a drag or click at a screen edge (x or y == 0) skipped the cursor move and the press fired at the previous cursor position. `drag` already uses `is not None` for the same coordinates when setting `last_x`/`last_y` and calling `sync_cursor_position`, confirming the intended check.

### Fix

Use `is not None` so `0` is treated as a real coordinate; only a missing (`None`) coordinate skips the move.

### Tests

Added `tests/unit/webeye/test_handler_utils_mouse.py` (mocked page and EventStrategyFactory) asserting `move_cursor` is invoked for zero coordinates in both functions and skipped only when a coordinate is `None`. Confirmed the zero-coordinate cases fail on the old truthiness check and pass with the fix. ruff check and ruff format are clean.