### PR TITLE
fix: In the Docker UI image, localServer.js awaited open(url) unguarded

### DIFF
--- a/skyvern-frontend/localServer.js
+++ b/skyvern-frontend/localServer.js
@@ -5,6 +5,22 @@ import open from "open";
 const port = 8080;
 const url = `http://localhost:${port}`;
 
+// Opening a browser fails in headless environments (e.g. the Docker image,
+// which has no xdg-open/gio/etc.). Left unhandled, that rejection crashes
+// the whole process right after the HTTP server starts listening, so the
+// container restart-loops and requests intermittently fail with a blank
+// page. Auto-opening a browser is a convenience, not a requirement, so a
+// failure here should just be logged.
+export async function openBrowserSafely(targetUrl) {
+  try {
+    await open(targetUrl);
+  } catch (error) {
+    console.log(
+      `[${new Date().toISOString()}] Skipping browser auto-open: ${error.message}`,
+    );
+  }
+}
+
 const server = createServer((request, response) => {
   const start = Date.now();
 
@@ -39,5 +55,5 @@ server.listen(8080, async () => {
   console.log(
     `[${new Date().toISOString()}] Frontend server running at ${url}`,
   );
-  await open(url);
+  await openBrowserSafely(url);
 });

--- a/skyvern-frontend/localServer.test.js
+++ b/skyvern-frontend/localServer.test.js
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("http", () => {
+  const createServer = vi.fn(() => ({ listen: vi.fn() }));
+  return { createServer, default: { createServer } };
+});
+vi.mock("serve-handler", () => ({ default: vi.fn() }));
+
+describe("openBrowserSafely", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock("open");
+  });
+
+  it("does not throw when opening a browser fails (e.g. headless Docker container)", async () => {
+    vi.doMock("open", () => ({
+      default: vi.fn().mockRejectedValue(new Error("spawn xdg-open ENOENT")),
+    }));
+
+    const { openBrowserSafely } = await import("./localServer.js");
+
+    await expect(
+      openBrowserSafely("http://localhost:8080"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("still opens the browser when it succeeds", async () => {
+    const open = vi.fn().mockResolvedValue(undefined);
+    vi.doMock("open", () => ({ default: open }));
+
+    const { openBrowserSafely } = await import("./localServer.js");
+
+    await openBrowserSafely("http://localhost:8080");
+
+    expect(open).toHaveBeenCalledWith("http://localhost:8080");
+  });
+});


### PR DESCRIPTION
Fixes #6004

## Summary
In the Docker UI image, localServer.js awaited open(url) unguarded inside the listen callback; in the headless container there's no xdg-open/gio/etc., so the rejection was unhandled and crashed the whole Node process (confirmed with a minimal repro) right after the server started, causing docker-compose to restart-loop and serve a blank page. Wrapped the call in a new openBrowserSafely() helper that catches and logs the failure instead of crashing, and added localServer.test.js covering both the failure and success paths.

## Changes
- `skyvern-frontend/localServer.js`
- `skyvern-frontend/localServer.test.js`

## How this was tested
Ran `make sure that you are using the latest version.` locally.
