### PR TITLE
SKY-11829: Preserve repeated cache key template parameters

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/utils.test.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/utils.test.ts
@@ -4,7 +4,10 @@ import {
   type WorkflowApiResponse,
   WorkflowParameterValueType,
 } from "../types/workflowTypes";
-import { getInitialParameters } from "./utils";
+import {
+  constructCacheKeyValueFromParameters,
+  getInitialParameters,
+} from "./utils";
 
 const baseWorkflow = {
   workflow_id: "w_test",
@@ -95,5 +98,16 @@ describe("getInitialParameters", () => {
         dataType: WorkflowParameterValueType.CredentialId,
       }),
     ]);
+  });
+});
+
+describe("constructCacheKeyValueFromParameters", () => {
+  test("replaces every occurrence of a repeated parameter placeholder", () => {
+    expect(
+      constructCacheKeyValueFromParameters({
+        codeKey: "{{a}}/{{a}}",
+        parameters: { a: "x" },
+      }),
+    ).toBe("x/x");
   });
 });

--- a/skyvern-frontend/src/routes/workflows/editor/utils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/utils.ts
@@ -159,7 +159,7 @@ const constructCacheKeyValueFromParameters = (opts: {
       continue;
     }
 
-    codeKey = codeKey.replace(`{{${name}}}`, value.toString());
+    codeKey = codeKey.split(`{{${name}}}`).join(value.toString());
   }
 
   if (codeKey.includes("{") || codeKey.includes("}")) {


### PR DESCRIPTION
## Description

Bug: [SKY-11829](https://linear.app/skyvern/issue/SKY-11829/cache-key-value-is-dropped-when-a-cache-key-template-references-the) reports that cache-key values are dropped when a cache-key template references the same parameter more than once.

Root cause: `constructCacheKeyValueFromParameters` used string `replace`, which only substituted the first `{{name}}` occurrence. A later repeated placeholder remained unresolved, then the unresolved-brace guard returned an empty cache-key value.

Fix: replace all exact occurrences of each parameter placeholder while preserving the existing unresolved-placeholder guard and empty/null parameter behavior.

## How Has This Been Tested?

- `npm ci`
- Reproduced the bug before the fix with `npx vitest run src/routes/workflows/editor/utils.test.ts` failing: expected `x/x`, received empty string.
- `npx vitest run src/routes/workflows/editor/utils.test.ts`
- `npx eslint src/routes/workflows/editor/utils.ts src/routes/workflows/editor/utils.test.ts --ext ts,tsx --report-unused-disable-directives --max-warnings 0`
- `npx prettier --check src/routes/workflows/editor/utils.ts src/routes/workflows/editor/utils.test.ts`
- `npx tsc --noEmit`
- `uv sync --python 3.11 --extra server --group dev`
- `uv run ruff check skyvern`
- `uv run ruff format --check skyvern`
- `uv run pre-commit run mypy --all-files`
- `git diff --check`

## Artifacts (if appropriate):

N/A - unit-tested utility fix; no visual UI change.