### PR TITLE
SKY-11830 Fix previous extracted info truncation

### DIFF
--- a/skyvern/utils/prompt_truncation.py
+++ b/skyvern/utils/prompt_truncation.py
@@ -83,6 +83,8 @@ def truncate_previous_extracted_information(
 
     rendered_before = value if isinstance(value, str) else json.dumps(value, default=str)
     before_tokens = count_tokens(rendered_before)
+    if before_tokens <= max_tokens:
+        return value
 
     if isinstance(value, str):
         result: Any = _crop_string(value, max_tokens)

--- a/tests/unit/test_prompt_truncation.py
+++ b/tests/unit/test_prompt_truncation.py
@@ -61,6 +61,24 @@ def test_truncate_dict_preserves_top_level_keys_and_caps_values() -> None:
     assert count_tokens(json.dumps(result)) <= 400  # small slack for JSON wrapping
 
 
+def test_truncate_dict_under_budget_preserves_nested_list_value() -> None:
+    import json
+
+    from skyvern.utils.prompt_truncation import truncate_previous_extracted_information
+    from skyvern.utils.token_counter import count_tokens
+
+    value = {
+        "results": [{"id": i, "name": f"row{i}"} for i in range(40)],
+        "summary": "ok",
+    }
+    budget = count_tokens(json.dumps(value)) + 50
+
+    result = truncate_previous_extracted_information(value, max_tokens=budget)
+
+    assert result == value
+    assert isinstance(result["results"], list)
+
+
 def test_truncate_dict_preserves_value_types_when_under_per_key_budget() -> None:
     from skyvern.utils.prompt_truncation import truncate_previous_extracted_information
 


### PR DESCRIPTION
Linear: https://linear.app/skyvern/issue/SKY-11830

## Bug
`truncate_previous_extracted_information` could corrupt under-budget dict values in `previous_extracted_information`, turning nested lists or dicts into tail-sliced strings.

## Root cause
The dict branch always called `_crop_dict`, which applies a per-key token budget even when the rendered whole value already fits `max_tokens`.

## Fix
Return the original value unchanged as soon as its rendered token count is within budget, before dispatching to string/list/dict crop behavior.

## Test
Added a regression for an under-budget dict containing a nested `results` list. The test fails on the old behavior because `results` becomes a truncated string, and passes with the shared short-circuit.

Verification:
- `uv sync --extra server --group dev`
- `uv run pytest tests/unit/test_prompt_truncation.py::test_truncate_dict_under_budget_preserves_nested_list_value` (red before fix, green after)
- `uv run pytest tests/unit/test_prompt_truncation.py`
- `uv run ruff check skyvern tests/unit/test_prompt_truncation.py`
- `uv run ruff format --check skyvern tests/unit/test_prompt_truncation.py`
- `uv run pre-commit run mypy --all-files`
- commit pre-commit hooks