### PR TITLE
SKY-11836: Avoid reseeding global random in generate_random_string

### DIFF
--- a/skyvern/utils/strings.py
+++ b/skyvern/utils/strings.py
@@ -1,4 +1,3 @@
-import os
 import random
 import re
 import string
@@ -6,12 +5,11 @@ import unicodedata
 import uuid
 
 RANDOM_STRING_POOL = string.ascii_letters + string.digits
+_SYSTEM_RANDOM = random.SystemRandom()
 
 
 def generate_random_string(length: int = 5) -> str:
-    # Use the os.urandom(16) as the seed
-    random.seed(os.urandom(16))
-    return "".join(random.choices(RANDOM_STRING_POOL, k=length))
+    return "".join(_SYSTEM_RANDOM.choices(RANDOM_STRING_POOL, k=length))
 
 
 def is_uuid(string: str) -> bool:

--- a/tests/unit_tests/test_strings.py
+++ b/tests/unit_tests/test_strings.py
@@ -1,5 +1,6 @@
 """Tests for string utility functions."""
 
+import random
 import string
 
 from skyvern.utils.strings import RANDOM_STRING_POOL, generate_random_string
@@ -58,6 +59,15 @@ class TestGenerateRandomString:
         results = [generate_random_string(20) for _ in range(10)]
         # All results should be unique (statistically extremely likely with length 20)
         assert len(set(results)) == 10
+
+    def test_does_not_mutate_global_random_state(self):
+        """Should not perturb callers using the module-level random PRNG."""
+        random.seed(12345)
+        state_before = random.getstate()
+
+        generate_random_string()
+
+        assert random.getstate() == state_before
 
     def test_distribution(self):
         """Characters should be reasonably distributed."""


### PR DESCRIPTION
## Bug

`generate_random_string()` reseeded Python's module-level `random` PRNG on every call, so unrelated code using `random.*` could have its deterministic or concurrent random stream perturbed.

Linear: https://linear.app/skyvern/issue/SKY-11836/generate-random-string-reseeds-the-global-random-prng-on-every-call

## Root cause

The helper called `random.seed(os.urandom(16))` before drawing with `random.choices(...)`, mutating process-global PRNG state as a side effect.

## Fix

Use a module-local `random.SystemRandom()` instance for the string draw and remove the per-call global reseed. Existing length and character-pool behavior is unchanged.

## Test

Added a regression test that seeds the global PRNG, calls `generate_random_string()`, and asserts `random.getstate()` is unchanged.

Validation:
- `uv sync --python 3.11 --extra server --group dev`
- `uv run pytest tests/unit_tests/test_strings.py -q`
- `uv run ruff check skyvern`
- `uv run ruff format --check skyvern`
- `uv run pre-commit run mypy --all-files`
- `uv run pre-commit run --files skyvern/utils/strings.py tests/unit_tests/test_strings.py`