### PR TITLE
SKY-11828: Encode workflow recording file paths

### DIFF
--- a/skyvern-frontend/src/routes/workflows/workflowRun/recordingUrls.test.ts
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/recordingUrls.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { artifactApiBaseUrl } from "@/util/env";
+import { getRecordingUrls } from "./recordingUrls";
+
+describe("getRecordingUrls", () => {
+  it("encodes file recording paths so the path query parameter round-trips", () => {
+    const recordingPath = "/tmp/my recording&x#hash?percent=100%.mp4";
+
+    const [recordingUrl] = getRecordingUrls({
+      recording_urls: [`file://${recordingPath}`],
+    });
+
+    if (recordingUrl === undefined) {
+      throw new Error("Expected a recording URL");
+    }
+
+    expect(recordingUrl).toBe(
+      `${artifactApiBaseUrl}/artifact/recording?path=${encodeURIComponent(recordingPath)}`,
+    );
+    expect(new URL(recordingUrl).searchParams.get("path")).toBe(recordingPath);
+  });
+});

--- a/skyvern-frontend/src/routes/workflows/workflowRun/recordingUrls.ts
+++ b/skyvern-frontend/src/routes/workflows/workflowRun/recordingUrls.ts
@@ -2,7 +2,7 @@ import { artifactApiBaseUrl } from "@/util/env";
 
 function resolveRecordingUrl(url: string): string {
   if (url.startsWith("file://")) {
-    return `${artifactApiBaseUrl}/artifact/recording?path=${url.slice(7)}`;
+    return `${artifactApiBaseUrl}/artifact/recording?path=${encodeURIComponent(url.slice(7))}`;
   }
   return url;
 }


### PR DESCRIPTION
Linear: https://linear.app/skyvern/issue/SKY-11828/workflow-run-recording-url-does-not-encode-file-paths-breaking

## Bug
Workflow-run recording playback breaks when a `file://` recording path contains spaces or URL special characters like `&`, `#`, `?`, or `%`.

## Root cause
`resolveRecordingUrl` stripped `file://` and concatenated the raw filesystem path into `/artifact/recording?path=...`, so query parsing could truncate or reinterpret the path.

## Fix
Encode the stripped file path with `encodeURIComponent` before building the artifact recording URL, matching the sibling artifact URL helpers.

## Test
- `npm test -- recordingUrls.test.ts` (verified red before the fix, green after)
- `npx prettier --check src/routes/workflows/workflowRun/recordingUrls.ts src/routes/workflows/workflowRun/recordingUrls.test.ts`
- `npx eslint src/routes/workflows/workflowRun/recordingUrls.ts src/routes/workflows/workflowRun/recordingUrls.test.ts`
- `npx tsc --noEmit`
- `uv sync --extra server --group dev`
- `uv run ruff check skyvern`
- `uv run ruff format --check skyvern`
- `uv run pre-commit run mypy --all-files`
- `uv run pytest tests/unit/test_fetch_recording_urls.py tests/unit/test_recording_window_filter.py`