### PR TITLE
SKY-11840: Fix enable_download extra header parsing

### DIFF
--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -97,7 +97,7 @@ def parse_extra_headers(extra_http_headers: dict[str, str] | None) -> ParsedBrow
             if key_lower == FRESH_CONTEXT_HEADER.lower():
                 use_fresh_context = value.lower() == "true"
             elif key_lower == "enable_download":
-                enable_download = bool(value)
+                enable_download = value.lower() in {"true", "1", "yes"}
             else:
                 headers[key] = value
 

--- a/tests/unit/test_browser_extra_headers.py
+++ b/tests/unit/test_browser_extra_headers.py
@@ -1,0 +1,17 @@
+import pytest
+
+from skyvern.webeye.browser_factory import parse_extra_headers
+
+
+@pytest.mark.parametrize("value", ["true", "1", "yes", "TRUE", "YES"])
+def test_parse_extra_headers_enable_download_accepts_true_values(value: str) -> None:
+    parsed_headers = parse_extra_headers({"enable_download": value})
+
+    assert parsed_headers.enable_download is True
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", ""])
+def test_parse_extra_headers_enable_download_rejects_false_values(value: str) -> None:
+    parsed_headers = parse_extra_headers({"enable_download": value})
+
+    assert parsed_headers.enable_download is False


### PR DESCRIPTION
## Bug
`enable_download` in `parse_extra_headers` treated any non-empty header value as enabled, so values like `"false"`, `"0"`, and `"no"` still turned on download interception.

## Root cause
The parser used `bool(value)` on the raw header string. In Python, every non-empty string is truthy regardless of its text.

## Fix
Parse the header as an explicit boolean token and only enable downloads for `true`, `1`, or `yes` case-insensitively.

## Test
Added focused unit coverage for true-like and false-like `enable_download` values.

Linear: https://linear.app/skyvern/issue/SKY-11840/enable-download-extra-header-treats-any-non-empty-value-as-true

Verification:
- `uv sync --python 3.11 --extra server --group dev`
- `uv run ruff check skyvern && uv run ruff format --check skyvern`
- `uv run pre-commit run mypy --all-files`
- `uv run pre-commit run --files skyvern/webeye/browser_factory.py tests/unit/test_browser_extra_headers.py`
- `uv run pytest tests/unit/test_browser_extra_headers.py`