### PR TITLE
SKY-11841: Preserve zero mouse coordinates for mouse actions

### DIFF
--- a/skyvern/webeye/actions/handler_utils.py
+++ b/skyvern/webeye/actions/handler_utils.py
@@ -120,7 +120,7 @@ async def keypress(page: Page, keys: list[str], hold: bool = False, duration: fl
 async def drag(
     page: Page, start_x: int | None = None, start_y: int | None = None, path: list[tuple[int, int]] | None = None
 ) -> None:
-    if start_x and start_y:
+    if start_x is not None and start_y is not None:
         await EventStrategyFactory.move_cursor(page, start_x, start_y)
     await page.mouse.down()
     path = path or []
@@ -137,7 +137,7 @@ async def drag(
 
 
 async def left_mouse(page: Page, x: int | None, y: int | None, direction: Literal["down", "up"]) -> None:
-    if x and y:
+    if x is not None and y is not None:
         await EventStrategyFactory.move_cursor(page, x, y)
     if direction == "down":
         await page.mouse.down()

--- a/tests/unit/test_handler_utils_mouse.py
+++ b/tests/unit/test_handler_utils_mouse.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from skyvern.webeye.actions import handler_utils
+
+
+def _mock_page() -> SimpleNamespace:
+    return SimpleNamespace(mouse=SimpleNamespace(down=AsyncMock(), up=AsyncMock()))
+
+
+@pytest.mark.asyncio
+async def test_drag_moves_cursor_to_start_when_coordinate_is_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    page = _mock_page()
+    move_cursor = AsyncMock()
+    sync_cursor_position = MagicMock()
+    monkeypatch.setattr(handler_utils.EventStrategyFactory, "move_cursor", move_cursor)
+    monkeypatch.setattr(handler_utils.EventStrategyFactory, "sync_cursor_position", sync_cursor_position)
+
+    await handler_utils.drag(page, start_x=0, start_y=5)
+
+    move_cursor.assert_awaited_once_with(page, 0, 5)
+    page.mouse.down.assert_awaited_once()
+    page.mouse.up.assert_awaited_once()
+    sync_cursor_position.assert_called_once_with(page, 0, 5)
+
+
+@pytest.mark.asyncio
+async def test_left_mouse_moves_cursor_when_coordinate_is_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    page = _mock_page()
+    move_cursor = AsyncMock()
+    monkeypatch.setattr(handler_utils.EventStrategyFactory, "move_cursor", move_cursor)
+
+    await handler_utils.left_mouse(page, 0, 0, "down")
+
+    move_cursor.assert_awaited_once_with(page, 0, 0)
+    page.mouse.down.assert_awaited_once()
+    page.mouse.up.assert_not_awaited()


### PR DESCRIPTION
## Description

Linear: https://linear.app/skyvern/issue/SKY-11841/drag-and-left-mouse-skip-cursor-positioning-when-a-coordinate-is-0

Bug: `drag` and `left_mouse` skipped cursor positioning when either coordinate was `0`, so actions targeting the top or left screen edge could start from the previous cursor location.

Root cause: both helpers gated `EventStrategyFactory.move_cursor(...)` behind truthiness checks (`if start_x and start_y`, `if x and y`), which treated valid zero coordinates as missing values.

Fix: use explicit `is not None` checks so only absent coordinates skip cursor movement.

## How Has This Been Tested?

- `uv sync --python 3.12 --extra server --group dev`
- `uv run ruff check skyvern`
- `uv run ruff format --check skyvern`
- `uv run ruff check tests/unit/test_handler_utils_mouse.py`
- `uv run ruff format --check tests/unit/test_handler_utils_mouse.py`
- `uv run pre-commit run mypy --all-files`
- `uv run pytest tests/unit/test_handler_utils_mouse.py`

The new regression tests were first run before the fix and failed because `move_cursor` was not awaited for zero coordinates.

## Artifacts (if appropriate):

N/A
