### PR TITLE
SKY-11839: Fix workflow block label collision on rename

### DIFF
--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.test.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { getUniqueLabelForExistingNode } from "./workflowEditorUtils";
+
+describe("getUniqueLabelForExistingNode", () => {
+  it("appends a suffix when a renamed node collides with one existing label", () => {
+    expect(getUniqueLabelForExistingNode("block_1", ["block_1"])).toBe(
+      "block_1_2",
+    );
+  });
+
+  it("keeps incrementing suffixes until the renamed node label is unique", () => {
+    expect(getUniqueLabelForExistingNode("foo", ["foo", "foo_2"])).toBe(
+      "foo_3",
+    );
+  });
+});

--- a/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
+++ b/skyvern-frontend/src/routes/workflows/editor/workflowEditorUtils.ts
@@ -3889,7 +3889,7 @@ function getUniqueLabelForExistingNode(
   if (!existingLabels.includes(label)) {
     return label;
   }
-  for (let i = 2; i < existingLabels.length + 1; i++) {
+  for (let i = 2; i < existingLabels.length + 2; i++) {
     const candidate = `${label}_${i}`;
     if (!existingLabels.includes(candidate)) {
       return candidate;


### PR DESCRIPTION
Bug
- Renaming a workflow block to a label already used by another block could leave duplicate labels in the editor.
- Linear: https://linear.app/skyvern/issue/SKY-11839/renaming-a-workflow-block-to-collide-with-one-other-block-produces-a

Root cause
- getUniqueLabelForExistingNode stopped its suffix search at existingLabels.length + 1.
- With one existing collision it never tried _2, and with saturated suffixes it could fall through to the colliding label.

Fix
- Extend the suffix loop bound to include the first guaranteed free candidate.
- Add regression coverage for a single collision and for foo/foo_2 -> foo_3.

Tests
- npm ci
- npx vitest run src/routes/workflows/editor/workflowEditorUtils.test.ts
- npx eslint src/routes/workflows/editor/workflowEditorUtils.ts src/routes/workflows/editor/workflowEditorUtils.test.ts
- npx tsc --noEmit
- npx prettier --check src/routes/workflows/editor/workflowEditorUtils.ts src/routes/workflows/editor/workflowEditorUtils.test.ts
- uv sync --extra server --group dev
- uv run ruff check skyvern
- uv run ruff format --check skyvern
- uv run pre-commit run mypy --all-files
- uv run pytest tests/unit/workflow/test_workflow_graph_validation.py
- uv run pre-commit run --all-files