### PR TITLE
SKY-11765 Support startup URL for browser sessions

### DIFF
--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -10126,6 +10126,19 @@
       },
       "CreateBrowserSessionRequest": {
         "properties": {
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url",
+            "description": "Optional startup URL to open when the browser session starts.",
+            "default": null
+          },
           "timeout": {
             "anyOf": [
               {

--- a/fern/openapi/skyvern_openapi.json
+++ b/fern/openapi/skyvern_openapi.json
@@ -9265,6 +9265,19 @@
       },
       "CreateBrowserSessionRequest": {
         "properties": {
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url",
+            "description": "Optional startup URL to open when the browser session starts.",
+            "default": null
+          },
           "timeout": {
             "anyOf": [
               {

--- a/skyvern-ts/client/src/api/client/requests/CreateBrowserSessionRequest.ts
+++ b/skyvern-ts/client/src/api/client/requests/CreateBrowserSessionRequest.ts
@@ -7,6 +7,8 @@ import type * as Skyvern from "../../index.js";
  *     {}
  */
 export interface CreateBrowserSessionRequest {
+    /** Optional startup URL to open when the browser session starts. */
+    url?: string;
     /** Timeout in minutes for the session. Timeout is applied after the session is started. Must be between 5 and 1440. Defaults to 60. */
     timeout?: number;
     /**

--- a/skyvern/client/client.py
+++ b/skyvern/client/client.py
@@ -1825,6 +1825,7 @@ class Skyvern:
     def create_browser_session(
         self,
         *,
+        url: typing.Optional[str] = OMIT,
         timeout: typing.Optional[int] = OMIT,
         proxy_location: typing.Optional[CreateBrowserSessionRequestProxyLocation] = OMIT,
         proxy_session_id: typing.Optional[str] = OMIT,
@@ -1838,6 +1839,9 @@ class Skyvern:
 
         Parameters
         ----------
+        url : typing.Optional[str]
+            Optional startup URL to open when the browser session starts.
+
         timeout : typing.Optional[int]
             Timeout in minutes for the session. Timeout is applied after the session is started. Must be between 5 and 1440. Defaults to 60.
 
@@ -1908,6 +1912,7 @@ class Skyvern:
         client.create_browser_session()
         """
         _response = self._raw_client.create_browser_session(
+            url=url,
             timeout=timeout,
             proxy_location=proxy_location,
             proxy_session_id=proxy_session_id,
@@ -4852,6 +4857,7 @@ class AsyncSkyvern:
     async def create_browser_session(
         self,
         *,
+        url: typing.Optional[str] = OMIT,
         timeout: typing.Optional[int] = OMIT,
         proxy_location: typing.Optional[CreateBrowserSessionRequestProxyLocation] = OMIT,
         proxy_session_id: typing.Optional[str] = OMIT,
@@ -4865,6 +4871,9 @@ class AsyncSkyvern:
 
         Parameters
         ----------
+        url : typing.Optional[str]
+            Optional startup URL to open when the browser session starts.
+
         timeout : typing.Optional[int]
             Timeout in minutes for the session. Timeout is applied after the session is started. Must be between 5 and 1440. Defaults to 60.
 
@@ -4943,6 +4952,7 @@ class AsyncSkyvern:
         asyncio.run(main())
         """
         _response = await self._raw_client.create_browser_session(
+            url=url,
             timeout=timeout,
             proxy_location=proxy_location,
             proxy_session_id=proxy_session_id,

--- a/skyvern/client/raw_client.py
+++ b/skyvern/client/raw_client.py
@@ -2562,6 +2562,7 @@ class RawSkyvern:
     def create_browser_session(
         self,
         *,
+        url: typing.Optional[str] = OMIT,
         timeout: typing.Optional[int] = OMIT,
         proxy_location: typing.Optional[CreateBrowserSessionRequestProxyLocation] = OMIT,
         proxy_session_id: typing.Optional[str] = OMIT,
@@ -2575,6 +2576,9 @@ class RawSkyvern:
 
         Parameters
         ----------
+        url : typing.Optional[str]
+            Optional startup URL to open when the browser session starts.
+
         timeout : typing.Optional[int]
             Timeout in minutes for the session. Timeout is applied after the session is started. Must be between 5 and 1440. Defaults to 60.
 
@@ -2639,6 +2643,7 @@ class RawSkyvern:
             "v1/browser_sessions",
             method="POST",
             json={
+                "url": url,
                 "timeout": timeout,
                 "proxy_location": convert_and_respect_annotation_metadata(
                     object_=proxy_location, annotation=CreateBrowserSessionRequestProxyLocation, direction="write"
@@ -6414,6 +6419,7 @@ class AsyncRawSkyvern:
     async def create_browser_session(
         self,
         *,
+        url: typing.Optional[str] = OMIT,
         timeout: typing.Optional[int] = OMIT,
         proxy_location: typing.Optional[CreateBrowserSessionRequestProxyLocation] = OMIT,
         proxy_session_id: typing.Optional[str] = OMIT,
@@ -6427,6 +6433,9 @@ class AsyncRawSkyvern:
 
         Parameters
         ----------
+        url : typing.Optional[str]
+            Optional startup URL to open when the browser session starts.
+
         timeout : typing.Optional[int]
             Timeout in minutes for the session. Timeout is applied after the session is started. Must be between 5 and 1440. Defaults to 60.
 
@@ -6491,6 +6500,7 @@ class AsyncRawSkyvern:
             "v1/browser_sessions",
             method="POST",
             json={
+                "url": url,
                 "timeout": timeout,
                 "proxy_location": convert_and_respect_annotation_metadata(
                     object_=proxy_location, annotation=CreateBrowserSessionRequestProxyLocation, direction="write"

--- a/skyvern/forge/sdk/routes/browser_sessions.py
+++ b/skyvern/forge/sdk/routes/browser_sessions.py
@@ -132,6 +132,7 @@ async def create_browser_session(
         browser_type=browser_session_request.browser_type,
         browser_profile_id=browser_session_request.browser_profile_id,
         generate_browser_profile=browser_session_request.generate_browser_profile,
+        url=browser_session_request.url,
     )
     return await BrowserSessionResponse.from_browser_session(browser_session)
 

--- a/skyvern/schemas/browser_sessions.py
+++ b/skyvern/schemas/browser_sessions.py
@@ -14,6 +14,10 @@ DEFAULT_TIMEOUT = 60
 
 
 class CreateBrowserSessionRequest(BaseModel):
+    url: str | None = Field(
+        default=None,
+        description="Optional startup URL to open when the browser session starts.",
+    )
     timeout: int | None = Field(
         default=DEFAULT_TIMEOUT,
         description=f"Timeout in minutes for the session. Timeout is applied after the session is started. Must be between {MIN_TIMEOUT} and {MAX_TIMEOUT}. Defaults to {DEFAULT_TIMEOUT}.",

--- a/tests/unit/forge/sdk/routes/test_browser_sessions.py
+++ b/tests/unit/forge/sdk/routes/test_browser_sessions.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from skyvern.forge.sdk.routes import browser_sessions as browser_sessions_mod
+from skyvern.forge.sdk.schemas.persistent_browser_sessions import PersistentBrowserSession
+from skyvern.schemas.browser_sessions import CreateBrowserSessionRequest
+
+
+def _session(**kwargs: object) -> PersistentBrowserSession:
+    base: dict[str, object] = {
+        "persistent_browser_session_id": "pbs_1",
+        "organization_id": "org_123",
+        "created_at": datetime(2026, 1, 1),
+        "modified_at": datetime(2026, 1, 1),
+    }
+    base.update(kwargs)
+    return PersistentBrowserSession(**base)
+
+
+@pytest.mark.asyncio
+async def test_create_browser_session_passes_startup_url_to_session_manager() -> None:
+    app_mock = MagicMock()
+    app_mock.PERSISTENT_SESSIONS_MANAGER.create_session = AsyncMock(return_value=_session())
+
+    with patch.object(browser_sessions_mod, "app", app_mock):
+        await browser_sessions_mod.create_browser_session(
+            CreateBrowserSessionRequest(
+                url="https://web.telegram.org",
+                timeout=120,
+                generate_browser_profile=True,
+            ),
+            current_org=SimpleNamespace(organization_id="org_123"),
+        )
+
+    app_mock.PERSISTENT_SESSIONS_MANAGER.create_session.assert_awaited_once_with(
+        organization_id="org_123",
+        timeout_minutes=120,
+        proxy_location=None,
+        proxy_session_id=None,
+        extensions=None,
+        browser_type=None,
+        browser_profile_id=None,
+        generate_browser_profile=True,
+        url="https://web.telegram.org",
+    )

--- a/tests/unit/test_client_proxy_pin_types.py
+++ b/tests/unit/test_client_proxy_pin_types.py
@@ -102,3 +102,21 @@ def test_raw_client_update_credential_sends_rotate_proxy_session_id() -> None:
     )
 
     assert request.call_args.kwargs["json"]["rotate_proxy_session_id"] is True
+
+
+def test_raw_client_create_browser_session_sends_startup_url() -> None:
+    request = Mock(
+        return_value=_response(
+            {
+                "browser_session_id": "pbs_123",
+                "organization_id": "org_123",
+                "status": "created",
+                "created_at": "2026-01-01T00:00:00Z",
+                "modified_at": "2026-01-02T00:00:00Z",
+            }
+        )
+    )
+
+    _raw_client(request).create_browser_session(url="https://web.telegram.org")
+
+    assert request.call_args.kwargs["json"]["url"] == "https://web.telegram.org"


### PR DESCRIPTION
Bug
- POST /v1/browser_sessions accepted unknown url fields by ignoring them, so callers could pass a startup URL but the browser still opened at about:blank.

Root cause
- CreateBrowserSessionRequest did not define url, and the create-browser-session route never forwarded a startup URL into the persistent session manager.

Fix
- Add optional url to CreateBrowserSessionRequest and pass it through browser-session creation.
- Keep omitted-url behavior unchanged.
- Update checked-in OpenAPI/schema and Python/TypeScript client request surfaces for the new optional field.

Test
- uv sync --extra server --group dev
- uv run ruff check skyvern tests/unit/forge/sdk/routes/test_browser_sessions.py tests/unit/test_client_proxy_pin_types.py
- uv run ruff format --check skyvern tests/unit/forge/sdk/routes/test_browser_sessions.py tests/unit/test_client_proxy_pin_types.py
- uv run pre-commit run mypy --all-files
- uv run pytest tests/unit/forge/sdk/routes/test_browser_sessions.py tests/unit/test_client_proxy_pin_types.py -q
- jq empty docs/api-reference/openapi.json
- jq empty fern/openapi/skyvern_openapi.json

Not run
- skyvern-ts/client format:check; pnpm and node_modules are not available in this worktree.

Linear: https://linear.app/skyvern/issue/SKY-11765/support-startup-url-when-creating-browser-sessions