### PR TITLE
SKY-11583 Block workflow HTTP/download SSRF targets

### DIFF
--- a/skyvern/forge/sdk/api/files.py
+++ b/skyvern/forge/sdk/api/files.py
@@ -32,11 +32,8 @@ from skyvern.forge.sdk.core.aiohttp_helper import (
     validate_and_pin_fetch_url,
     validate_and_pin_redirect_url,
 )
-from skyvern.utils.url_validators import (
-    MAX_SAFE_REDIRECTS,
-    SAFE_REDIRECT_STATUS_CODES,
-    encode_url,
-)
+from skyvern.forge.sdk.core.ssrf import create_public_network_trace_config
+from skyvern.utils.url_validators import MAX_SAFE_REDIRECTS, SAFE_REDIRECT_STATUS_CODES, encode_url
 
 if TYPE_CHECKING:
     from skyvern.forge.sdk.core.skyvern_context import SkyvernContext
@@ -239,10 +236,14 @@ async def download_file(
                 LOG.info("Downloading file from local file system", url=url)
                 return local_path
 
-        resolver = SSRFGuardedResolver()
+        resolver = SSRFGuardedResolver(require_public_network=True)
         current_url = await validate_and_pin_fetch_url(url, resolver)
         request_headers = dict(headers or {})
-        async with aiohttp.ClientSession(connector=ssrf_guarded_tcp_connector(resolver)) as session:
+        async with aiohttp.ClientSession(
+            connector=ssrf_guarded_tcp_connector(resolver),
+            # Validate the exact URL aiohttp dispatches; numeric hosts can bypass resolver callbacks.
+            trace_configs=[create_public_network_trace_config()],
+        ) as session:
             LOG.info("Starting to download file", url=url)
             for _ in range(MAX_SAFE_REDIRECTS + 1):
                 encoded_url = encode_url(current_url)

--- a/skyvern/forge/sdk/core/aiohttp_helper.py
+++ b/skyvern/forge/sdk/core/aiohttp_helper.py
@@ -11,7 +11,12 @@ import structlog
 from aiohttp.abc import AbstractResolver, ResolveResult
 from aiohttp.resolver import DefaultResolver
 
-from skyvern.exceptions import HttpException, InvalidUrl
+from skyvern.exceptions import BlockedHost, HttpException, InvalidUrl
+from skyvern.forge.sdk.core.ssrf import (
+    create_public_network_trace_config,
+    validate_public_http_url,
+    validate_public_ip_address,
+)
 from skyvern.utils.url_validators import (
     MAX_SAFE_REDIRECTS,
     SAFE_REDIRECT_STATUS_CODES,
@@ -46,10 +51,11 @@ def strip_cross_origin_redirect_credentials(
 
 
 class SSRFGuardedResolver(AbstractResolver):
-    def __init__(self) -> None:
+    def __init__(self, *, require_public_network: bool = False) -> None:
         self._pinned_host_ips: dict[str, tuple[str, ...]] = {}
         self._trusted_proxy_hosts: set[str] = set()
         self._default_resolver = DefaultResolver()
+        self._require_public_network = require_public_network
 
     @staticmethod
     def _host_key(host: str) -> str:
@@ -58,16 +64,23 @@ class SSRFGuardedResolver(AbstractResolver):
     def pin_host_ips(self, host: str, ips: tuple[str, ...]) -> None:
         if not ips:
             raise OSError(f"No safe addresses resolved for host: {host}")
+        if self._require_public_network:
+            for ip in ips:
+                validate_public_ip_address(ip, host)
         self._pinned_host_ips[self._host_key(host)] = ips
 
     def pin_url_ips(self, url: str, ips: tuple[str, ...]) -> None:
         host = urlparse(url).hostname
         if not host:
             raise InvalidUrl(url=url)
+        if self._require_public_network:
+            validate_public_http_url(url)
         self.pin_host_ips(host, ips)
 
     def trust_proxy_url(self, proxy: str) -> None:
         host = urlparse(proxy).hostname
+        if self._require_public_network:
+            raise BlockedHost(host=f"proxy {host or proxy} (proxies are unsupported with public-network validation)")
         if host:
             self._trusted_proxy_hosts.add(self._host_key(host))
 
@@ -82,6 +95,8 @@ class SSRFGuardedResolver(AbstractResolver):
         ips = self._pinned_host_ips.get(host_key)
         resolved_ips = await asyncio.to_thread(resolve_fetch_host_ips, host) if ips is None else ips
         for ip in resolved_ips:
+            if self._require_public_network:
+                validate_public_ip_address(ip, host)
             ip_family = (
                 socket.AF_INET6 if isinstance(ipaddress.ip_address(ip), ipaddress.IPv6Address) else socket.AF_INET
             )
@@ -133,6 +148,7 @@ async def aiohttp_request(
     timeout: int = DEFAULT_REQUEST_TIMEOUT,
     follow_redirects: bool = True,
     proxy: str | None = None,
+    validate_public_network: bool = False,
 ) -> tuple[int, dict[str, str], Any]:
     """
     Generic HTTP request function that supports all HTTP methods.
@@ -148,12 +164,13 @@ async def aiohttp_request(
         timeout: Request timeout in seconds
         follow_redirects: Whether to follow redirects
         proxy: Proxy URL
+        validate_public_network: Whether to reject non-public request and redirect targets. Proxies are unsupported.
 
     Returns:
         Tuple of (status_code, response_headers, response_body)
         where response_body can be dict (for JSON) or str (for text)
     """
-    resolver = SSRFGuardedResolver()
+    resolver = SSRFGuardedResolver(require_public_network=validate_public_network)
     if proxy:
         resolver.trust_proxy_url(proxy)
     current_url = await validate_and_pin_fetch_url(url, resolver)
@@ -162,9 +179,15 @@ async def aiohttp_request(
     request_cookies = cookies
     strip_body_headers = False
 
-    async with aiohttp.ClientSession(
-        timeout=aiohttp.ClientTimeout(total=timeout), connector=ssrf_guarded_tcp_connector(resolver)
-    ) as session:
+    session_kwargs: dict[str, Any] = {
+        "timeout": aiohttp.ClientTimeout(total=timeout),
+        "connector": ssrf_guarded_tcp_connector(resolver),
+    }
+    if validate_public_network:
+        # Validate the exact URL aiohttp dispatches; numeric hosts can bypass resolver callbacks.
+        session_kwargs["trace_configs"] = [create_public_network_trace_config()]
+
+    async with aiohttp.ClientSession(**session_kwargs) as session:
 
         async def build_request_kwargs() -> dict[str, Any]:
             headers_dict = dict(request_headers)

--- a/skyvern/forge/sdk/core/ssrf.py
+++ b/skyvern/forge/sdk/core/ssrf.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urljoin, urlparse
+
+import aiohttp
+
+from skyvern.exceptions import BlockedHost, InvalidUrl
+
+_HTTP_SCHEMES = {"http", "https"}
+_MAX_URL_LENGTH = 2083
+
+
+def _normalize_host(host: str) -> str:
+    # urlparse().hostname strips brackets for normal URLs, but resolver hooks and
+    # tests may pass RFC 3986 IPv6 literals through in bracketed form.
+    if host.startswith("[") and host.endswith("]"):
+        return host[1:-1]
+    return host
+
+
+def _public_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> ipaddress.IPv4Address | ipaddress.IPv6Address:
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        return ip.ipv4_mapped
+    return ip
+
+
+def validate_public_ip_address(ip_address: str, host: str) -> None:
+    """Reject an IP address unless it is globally routable.
+
+    Args:
+        ip_address: Candidate IPv4 or IPv6 address.
+        host: Original hostname used in the rejection error.
+    """
+    try:
+        ip = _public_ip(ipaddress.ip_address(_normalize_host(ip_address)))
+    except ValueError:
+        return
+
+    if not ip.is_global:
+        raise BlockedHost(host=f"{host} resolved to {ip}")
+
+
+def _raise_if_numeric_host_is_blocked(host: str) -> None:
+    normalized_host = _normalize_host(host)
+    try:
+        resolved_addresses = socket.getaddrinfo(
+            normalized_host,
+            None,
+            0,
+            0,
+            0,
+            socket.AI_NUMERICHOST,
+        )
+    except socket.gaierror:
+        return
+
+    checked: set[str] = set()
+    for resolved_address in resolved_addresses:
+        sockaddr = resolved_address[4]
+        if not sockaddr:
+            continue
+        ip_address = str(sockaddr[0])
+        if ip_address in checked:
+            continue
+        checked.add(ip_address)
+        validate_public_ip_address(ip_address, host)
+
+
+def validate_public_http_url(url: str) -> None:
+    if len(url) > _MAX_URL_LENGTH:
+        raise InvalidUrl(url=url)
+
+    parsed = urlparse(url)
+    if parsed.scheme.lower() not in _HTTP_SCHEMES or not parsed.hostname:
+        raise InvalidUrl(url=url)
+
+    _raise_if_numeric_host_is_blocked(parsed.hostname)
+
+
+def create_public_network_trace_config() -> aiohttp.TraceConfig:
+    trace_config = aiohttp.TraceConfig()
+
+    async def on_request_start(
+        _session: aiohttp.ClientSession,
+        _trace_config_ctx: object,
+        params: aiohttp.TraceRequestStartParams,
+    ) -> None:
+        validate_public_http_url(str(params.url))
+
+    async def on_request_redirect(
+        _session: aiohttp.ClientSession,
+        _trace_config_ctx: object,
+        params: aiohttp.TraceRequestRedirectParams,
+    ) -> None:
+        location = params.response.headers.get("Location")
+        if not location:
+            return
+        validate_public_http_url(urljoin(str(params.url), location))
+
+    trace_config.on_request_start.append(on_request_start)
+    trace_config.on_request_redirect.append(on_request_redirect)
+    return trace_config

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -102,6 +102,7 @@ from skyvern.forge.sdk.copilot.block_goal_wrapping import compose_mini_goal
 from skyvern.forge.sdk.core import skyvern_context
 from skyvern.forge.sdk.core.aiohttp_helper import aiohttp_request
 from skyvern.forge.sdk.core.skyvern_context import SkyvernContext
+from skyvern.forge.sdk.core.ssrf import validate_public_http_url
 from skyvern.forge.sdk.db.enums import TaskType
 from skyvern.forge.sdk.db.exceptions import NotFoundError
 from skyvern.forge.sdk.experimentation.llm_prompt_config import get_llm_handler_for_prompt_type
@@ -9092,6 +9093,19 @@ class HttpRequestBlock(Block):
                 organization_id=organization_id,
             )
 
+        try:
+            validate_public_http_url(self.url)
+        except SkyvernException as e:
+            masked_error = str(workflow_run_context.mask_secrets_in_data(str(e)))
+            return await self.build_block_result(
+                success=False,
+                failure_reason=masked_error,
+                output_parameter_value=None,
+                status=BlockStatus.failed,
+                workflow_run_block_id=workflow_run_block_id,
+                organization_id=organization_id,
+            )
+
         # Add default content-type as application/json if not provided (unless files are being uploaded)
         if not self.headers:
             self.headers = {}
@@ -9255,6 +9269,7 @@ class HttpRequestBlock(Block):
                 files=self.files,
                 timeout=self.timeout,
                 follow_redirects=self.follow_redirects,
+                validate_public_network=True,
             )
 
             success = 200 <= status_code < 300

--- a/tests/unit/test_aiohttp_helper.py
+++ b/tests/unit/test_aiohttp_helper.py
@@ -14,7 +14,12 @@ from skyvern.utils.url_validators import MAX_SAFE_REDIRECTS, validate_fetch_url
 
 @pytest.fixture(autouse=True)
 def public_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_getaddrinfo = socket.getaddrinfo
+
     def resolves_public(host: str, port: int | None, *args: object, **kwargs: object) -> list[object]:
+        flags = kwargs.get("flags", args[3] if len(args) > 3 else 0)
+        if isinstance(flags, int) and flags & socket.AI_NUMERICHOST:
+            return original_getaddrinfo(host, port, *args, **kwargs)
         return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("93.184.216.34", port or 0))]
 
     monkeypatch.setattr("skyvern.utils.url_validators.socket.getaddrinfo", resolves_public)
@@ -90,6 +95,101 @@ async def test_aiohttp_request_trusts_internal_proxy_without_trusting_target() -
     assert proxy_results
     with pytest.raises(BlockedHost):
         await SSRFGuardedResolver().resolve("127.0.0.1", 8080)
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_request_public_network_validation_blocks_loopback_before_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_if_http_session_opens(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("loopback URL should be rejected before opening an HTTP session")
+
+    monkeypatch.setattr("skyvern.forge.sdk.core.aiohttp_helper.aiohttp.ClientSession", fail_if_http_session_opens)
+
+    with pytest.raises(BlockedHost, match="127.0.0.1"):
+        await aiohttp_request(
+            method="GET",
+            url="http://127.0.0.1:45427/private",
+            validate_public_network=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_request_public_network_validation_rejects_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_if_http_session_opens(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("strict public-network requests with a proxy should fail closed")
+
+    monkeypatch.setattr("skyvern.forge.sdk.core.aiohttp_helper.aiohttp.ClientSession", fail_if_http_session_opens)
+
+    with pytest.raises(BlockedHost, match="proxies are unsupported with public-network validation"):
+        await aiohttp_request(
+            method="GET",
+            url="https://8.8.8.8/dns-query",
+            proxy="http://127.0.0.1:8080",
+            validate_public_network=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_request_public_network_validation_allows_public_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_session_kwargs: dict[str, Any] = {}
+    captured_request_kwargs: dict[str, Any] = {}
+
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.headers = {"Content-Type": "application/json"}
+    mock_response.json = AsyncMock(return_value={"success": True})
+    mock_response.text = AsyncMock(return_value='{"success": true}')
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    def capture_request(*_args: Any, **kwargs: Any) -> AsyncMock:
+        captured_request_kwargs.update(kwargs)
+        return mock_response
+
+    mock_session = MagicMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session.request = MagicMock(side_effect=capture_request)
+
+    def capture_session(**kwargs: Any) -> MagicMock:
+        captured_session_kwargs.update(kwargs)
+        return mock_session
+
+    captured_resolver: SSRFGuardedResolver | None = None
+    connector = object()
+    trace_config = object()
+
+    def capture_connector(resolver: SSRFGuardedResolver | None = None) -> object:
+        nonlocal captured_resolver
+        captured_resolver = resolver
+        return connector
+
+    monkeypatch.setattr("skyvern.forge.sdk.core.aiohttp_helper.ssrf_guarded_tcp_connector", capture_connector)
+    monkeypatch.setattr(
+        "skyvern.forge.sdk.core.aiohttp_helper.create_public_network_trace_config",
+        lambda: trace_config,
+    )
+    monkeypatch.setattr("skyvern.forge.sdk.core.aiohttp_helper.aiohttp.ClientSession", capture_session)
+
+    status, _headers, body = await aiohttp_request(
+        method="GET",
+        url="https://8.8.8.8/dns-query",
+        validate_public_network=True,
+    )
+
+    assert status == 200
+    assert body == {"success": True}
+    assert captured_session_kwargs["connector"] is connector
+    assert captured_session_kwargs["trace_configs"] == [trace_config]
+    assert captured_request_kwargs["url"] == "https://8.8.8.8/dns-query"
+    assert captured_resolver is not None
+    with pytest.raises(BlockedHost):
+        captured_resolver.pin_host_ips("shared.example.test", ("100.64.0.1",))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_files_resolve_local_or_download.py
+++ b/tests/unit/test_files_resolve_local_or_download.py
@@ -9,7 +9,7 @@ import pytest
 from multidict import CIMultiDict, CIMultiDictProxy
 
 from skyvern.config import settings
-from skyvern.exceptions import DownloadFileMaxSizeExceeded
+from skyvern.exceptions import BlockedHost, DownloadFileMaxSizeExceeded
 from skyvern.forge.sdk.api import files
 
 
@@ -251,3 +251,14 @@ async def test_download_file_raises_http_error_without_aiohttp_auto_raise(
     assert captured_session_kwargs.get("raise_for_status") is not True
     assert not response.body_read
     assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_download_file_blocks_loopback_url_before_http_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_if_http_session_opens(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("loopback URL should be rejected before opening an HTTP session")
+
+    monkeypatch.setattr(files.aiohttp, "ClientSession", fail_if_http_session_opens)
+
+    with pytest.raises(BlockedHost, match="127.0.0.1"):
+        await files.download_file("http://127.0.0.1:45427/private")

--- a/tests/unit/test_ssrf_protection.py
+++ b/tests/unit/test_ssrf_protection.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from skyvern.exceptions import BlockedHost, InvalidUrl
+from skyvern.forge.sdk.core import aiohttp_helper
+from skyvern.forge.sdk.core.aiohttp_helper import SSRFGuardedResolver
+from skyvern.forge.sdk.core.ssrf import (
+    create_public_network_trace_config,
+    validate_public_http_url,
+)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:45427/private",
+        "http://169.254.169.254/private",
+        "http://10.0.0.10/internal",
+        "http://100.64.0.1/internal",
+        "http://[fc00::1]/internal",
+    ],
+)
+def test_validate_public_http_url_blocks_internal_literals(url: str) -> None:
+    with pytest.raises(BlockedHost):
+        validate_public_http_url(url)
+
+
+def test_validate_public_http_url_allows_public_literal() -> None:
+    validate_public_http_url("https://8.8.8.8/dns-query")
+
+
+def test_validate_public_http_url_rejects_overlong_url() -> None:
+    with pytest.raises(InvalidUrl):
+        validate_public_http_url(f"https://example.com/{'a' * 2084}")
+
+
+@pytest.mark.asyncio
+async def test_strict_ssrf_guarded_resolver_blocks_any_non_public_dns_answer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolver = SSRFGuardedResolver(require_public_network=True)
+    monkeypatch.setattr(aiohttp_helper, "resolve_fetch_host_ips", lambda _host: ("93.184.216.34", "10.0.0.5"))
+
+    try:
+        with pytest.raises(BlockedHost, match="internal.example.test"):
+            await resolver.resolve("internal.example.test", 443)
+    finally:
+        await resolver.close()
+
+
+@pytest.mark.asyncio
+async def test_strict_ssrf_guarded_resolver_allows_public_dns_answer(monkeypatch: pytest.MonkeyPatch) -> None:
+    resolver = SSRFGuardedResolver(require_public_network=True)
+    monkeypatch.setattr(aiohttp_helper, "resolve_fetch_host_ips", lambda _host: ("93.184.216.34",))
+
+    try:
+        resolved = await resolver.resolve("example.com", 443)
+    finally:
+        await resolver.close()
+
+    assert resolved[0]["host"] == "93.184.216.34"
+
+
+@pytest.mark.asyncio
+async def test_public_network_trace_config_blocks_redirect_to_internal_target() -> None:
+    trace_config = create_public_network_trace_config()
+    redirect_handler = trace_config.on_request_redirect[0]
+    params = SimpleNamespace(
+        url="https://example.com/start",
+        response=SimpleNamespace(headers={"Location": "http://127.0.0.1/admin"}),
+    )
+
+    with pytest.raises(BlockedHost, match="127.0.0.1"):
+        await redirect_handler(None, None, params)

--- a/tests/unit/workflow/test_http_request_block.py
+++ b/tests/unit/workflow/test_http_request_block.py
@@ -220,6 +220,23 @@ class TestHttpRequestBlockSecretResponsePaths:
         client_session.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_execute_blocks_loopback_url_before_request(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        context = _make_context()
+        block = _http_block(url="http://127.0.0.1:45427/private", method="GET")
+        request_mock = AsyncMock(return_value=(200, {}, "internal response"))
+
+        monkeypatch.setattr(HttpRequestBlock, "get_workflow_run_context", lambda _self, _workflow_run_id: context)
+        monkeypatch.setattr(block_module, "aiohttp_request", request_mock)
+
+        result = await block.execute(workflow_run_id="wr-1", workflow_run_block_id="wrb-1")
+
+        assert result.success is False
+        assert result.status == BlockStatus.failed
+        assert result.failure_reason is not None
+        assert "blocked" in result.failure_reason.lower()
+        request_mock.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_execute_records_placeholder_and_masks_duplicate_echo(self, monkeypatch: pytest.MonkeyPatch) -> None:
         context = _make_context()
         response_body = {"data": {"token": "real-token"}, "echo": "real-token"}


### PR DESCRIPTION
## Bug
Workflow `http_request` blocks and file-oriented blocks that use `download_file()` could issue server-side HTTP(S) requests to loopback, private, link-local, metadata, or otherwise non-public network targets.

Linear: https://linear.app/skyvern/issue/SKY-11583/workflow-httpdownload-blocks-allow-non-blind-ssrf-to-internal-network

## Root cause
The direct HTTP block only validated that a URL had a scheme and netloc before calling `aiohttp_request()`. The shared HTTP downloader called `ClientSession.get()` without validating literal hosts, DNS answers, or redirect targets.

## Fix
Added a shared public-network guard for server-side aiohttp requests. It blocks non-global literal IPs, rejects DNS answers that resolve to non-public IPs, and validates redirect targets before following them. The workflow HTTP block opts into the guard for direct requests, and `download_file()` uses the guard for HTTP(S) downloads.

## Tests
- `uv sync --extra server --group dev`
- `uv run pytest tests/unit/test_ssrf_protection.py tests/unit/workflow/test_http_request_block.py tests/unit/test_files_resolve_local_or_download.py tests/unit/test_aiohttp_helper.py`
- `uv run ruff check skyvern && uv run ruff format --check skyvern`
- `uv run ruff check tests/unit/test_ssrf_protection.py tests/unit/test_aiohttp_helper.py tests/unit/test_files_resolve_local_or_download.py tests/unit/workflow/test_http_request_block.py && uv run ruff format --check tests/unit/test_ssrf_protection.py tests/unit/test_aiohttp_helper.py tests/unit/test_files_resolve_local_or_download.py tests/unit/workflow/test_http_request_block.py`
- `uv run pre-commit run mypy --all-files`
- `uv run pre-commit run --files skyvern/forge/sdk/core/ssrf.py skyvern/forge/sdk/core/aiohttp_helper.py skyvern/forge/sdk/api/files.py skyvern/forge/sdk/workflow/models/block.py tests/unit/test_ssrf_protection.py tests/unit/test_aiohttp_helper.py tests/unit/test_files_resolve_local_or_download.py tests/unit/workflow/test_http_request_block.py`
