### PR TITLE
fix(SKY-12013): report missing dropdown option targets without error-tracking noise

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -3489,6 +3489,25 @@ async def handle_null_action(
     return [ActionSuccess(data=action.output)]
 
 
+# Terminal, expected outcomes of custom-select: the requested target option does
+# not exist on the page even after searching and scrolling. These are business
+# outcomes, not code faults, so we surface them as a clean ActionFailure without
+# emitting a stack trace to error tracking (which would otherwise create noisy,
+# unactionable error-tracking issues for missing options).
+EXPECTED_NO_OPTION_EXCEPTIONS = (
+    NoAvailableOptionFoundForCustomSelection,
+    NoElementMatchedForTargetOption,
+)
+
+
+def _log_custom_select_failure(message: str, exc: Exception) -> None:
+    """Log a custom-select failure, downgrading expected "option not available" outcomes to a warning."""
+    if isinstance(exc, EXPECTED_NO_OPTION_EXCEPTIONS):
+        LOG.warning(message, reason=str(exc))
+    else:
+        LOG.exception(message)
+
+
 @traced(name="skyvern.agent.action.select_option")
 async def handle_select_option_action(
     action: actions.SelectOptionAction,
@@ -3741,7 +3760,7 @@ async def handle_select_option_action(
         suggested_value = result.value
 
     except Exception as e:
-        LOG.exception("Custom select error")
+        _log_custom_select_failure("Custom select error", e)
         results.append(ActionFailure(exception=e))
         return results
     finally:
@@ -3796,7 +3815,7 @@ async def handle_select_option_action(
         return results
 
     except Exception as e:
-        LOG.exception("Custom select by value error")
+        _log_custom_select_failure("Custom select by value error", e)
         results.append(ActionFailure(exception=e))
         return results
 

--- a/tests/unit/test_no_available_option.py
+++ b/tests/unit/test_no_available_option.py
@@ -10,6 +10,7 @@ import pytest
 
 from skyvern.exceptions import (
     NoAvailableOptionFoundForCustomSelection,
+    NoElementMatchedForTargetOption,
     NoIncrementalElementFoundForCustomSelection,
 )
 from skyvern.forge.agent_functions import AgentFunction
@@ -18,6 +19,7 @@ from skyvern.webeye.actions.actions import InputOrSelectContext, SelectOption, S
 from skyvern.webeye.actions.handler import (
     _collect_option_texts,
     _custom_select_candidates_from_elements,
+    _log_custom_select_failure,
     _no_match_exception_for_dropdown,
     _select_deterministic_custom_option,
     _verify_custom_select_option,
@@ -1203,3 +1205,48 @@ class TestNoMatchExceptionForDropdown:
         )
         assert isinstance(exc, NoAvailableOptionFoundForCustomSelection)
         assert exc.observed_options_count == 2
+
+
+class TestLogCustomSelectFailure:
+    """The missing-option outcomes are expected business results, not code faults,
+    so they must be logged as warnings (no stack trace) to keep error tracking quiet,
+    while genuine faults keep their full exception traceback."""
+
+    def test_no_available_option_is_logged_as_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        warnings: list[str] = []
+        exceptions: list[str] = []
+        monkeypatch.setattr(handler.LOG, "warning", lambda msg, **kw: warnings.append(msg))
+        monkeypatch.setattr(handler.LOG, "exception", lambda msg, **kw: exceptions.append(msg))
+
+        handler._log_custom_select_failure(
+            "Custom select error",
+            NoAvailableOptionFoundForCustomSelection(reason="not present", observed_options=["Alpha"]),
+        )
+
+        assert warnings == ["Custom select error"]
+        assert exceptions == []
+
+    def test_no_element_matched_is_logged_as_warning(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        warnings: list[str] = []
+        exceptions: list[str] = []
+        monkeypatch.setattr(handler.LOG, "warning", lambda msg, **kw: warnings.append(msg))
+        monkeypatch.setattr(handler.LOG, "exception", lambda msg, **kw: exceptions.append(msg))
+
+        handler._log_custom_select_failure(
+            "Custom select by value error",
+            NoElementMatchedForTargetOption(target="Target", reason="No value matched after scrolling"),
+        )
+
+        assert warnings == ["Custom select by value error"]
+        assert exceptions == []
+
+    def test_unexpected_error_keeps_exception_traceback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        warnings: list[str] = []
+        exceptions: list[str] = []
+        monkeypatch.setattr(handler.LOG, "warning", lambda msg, **kw: warnings.append(msg))
+        monkeypatch.setattr(handler.LOG, "exception", lambda msg, **kw: exceptions.append(msg))
+
+        handler._log_custom_select_failure("Custom select error", RuntimeError("boom"))
+
+        assert exceptions == ["Custom select error"]
+        assert warnings == []


### PR DESCRIPTION
## Description

When a custom-select target option genuinely doesn't exist (no match after searching + scrolling), the dropdown flow raises `NoAvailableOptionFoundForCustomSelection` / `NoElementMatchedForTargetOption`. `handle_select_option_action` caught these with `LOG.exception`, emitting a full stack trace for what is actually an expected business outcome — producing noisy, unactionable error-tracking issues.

This classifies those "option not available" results as expected terminal outcomes: they're logged as warnings (with the reason, no traceback) while still surfaced as a clean `ActionFailure`. Genuine/unexpected faults keep full exception logging. The failure reporting itself is unchanged (the `OPTION_NOT_AVAILABLE` code and observed-option excerpt already flow through the exception).

## How Has This Been Tested?

Added unit tests in `tests/unit/test_no_available_option.py` covering the log-level classification: expected no-option exceptions log as warnings, unexpected errors keep the exception traceback. (Note: the test runner isn't available in this sandbox, so tests were syntax-checked but not executed here.)

## Artifacts (if appropriate):

N/A
