### PR TITLE
fix(SKY-12019): guard clear/fill actions from targeting non-editable elements

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -2793,6 +2793,19 @@ async def handle_input_text_action(
         )
         return [ActionFailure(InteractWithDisabledElement(skyvern_element.get_id()))]
 
+    # Guard: clear/fill actions must target an editable element (input, textarea,
+    # select, or contenteditable). The planner occasionally selects a non-editable
+    # element such as an iframe (e.g. an hCaptcha iframe), which would otherwise
+    # cause Locator.clear/fill to fail mid-execution. Reject early with a clear error.
+    if not await skyvern_element.supports_text_input():
+        LOG.warning(
+            "Target element does not support text input, skipping input text action",
+            action_type=action.action_type,
+            element_id=skyvern_element.get_id(),
+            tag_name=tag_name,
+        )
+        return [ActionFailure(InvalidElementForTextInput(element_id=action.element_id, tag_name=tag_name))]
+
     select_action = SelectOptionAction(
         reasoning=action.reasoning,
         element_id=skyvern_element.get_id(),

--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -366,6 +366,24 @@ class SkyvernElement:
             )
             return False
 
+    async def supports_text_input(self) -> bool:
+        """
+        Whether this element is a valid target for text input (clear/fill).
+
+        Editable inputs, textareas, selects, and contenteditable elements are
+        supported. Non-editable elements such as iframes (e.g. an hCaptcha
+        iframe) must never be targeted by clear/fill actions, otherwise
+        `Locator.clear`/`Locator.fill` fails.
+        """
+        if self.get_tag_name().lower() in COMMON_INPUT_TAGS:
+            return True
+        if await self.is_editable():
+            return True
+        contenteditable = await self.get_attr("contenteditable")
+        if contenteditable is not None and str(contenteditable).lower() != "false":
+            return True
+        return False
+
     async def is_child_of_pdf_object(self, timeout: float = settings.BROWSER_ACTION_TIMEOUT_MS) -> bool:
         parent_locator = self.get_locator().locator("..")
         tag_name: str | None = await parent_locator.evaluate("el => el.tagName", timeout=timeout)

--- a/tests/unit/test_input_text_iframe_guard.py
+++ b/tests/unit/test_input_text_iframe_guard.py
@@ -1,0 +1,124 @@
+"""Regression tests for SKY-12019.
+
+The planner occasionally selects a non-editable element (e.g. an hCaptcha iframe)
+as the target for an INPUT_TEXT action. Execution would then attempt
+``Locator.clear``/``Locator.fill`` on that iframe and fail mid-step.
+
+``SkyvernElement.supports_text_input`` guards clear/fill so they only target
+editable elements (input/textarea/select/contenteditable), and
+``handle_input_text_action`` rejects everything else up front with a clear error.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from skyvern.exceptions import InvalidElementForTextInput
+from skyvern.forge.sdk.models import StepStatus
+from skyvern.webeye.actions.actions import InputTextAction
+from skyvern.webeye.actions.handler import handle_input_text_action
+from skyvern.webeye.actions.responses import ActionFailure
+from skyvern.webeye.utils.dom import SkyvernElement
+from tests.unit.helpers import make_organization, make_step, make_task
+
+_NOW = datetime.now(UTC)
+_ORG = make_organization(_NOW)
+_TASK = make_task(_NOW, _ORG, navigation_payload={}, navigation_goal="Log in")
+_STEP = make_step(_NOW, _TASK, step_id="stp-1", status=StepStatus.created, order=0, output=None)
+
+
+def _make_element(tag_name: str, *, editable: bool, attributes: dict | None = None) -> SkyvernElement:
+    locator = MagicMock()
+    locator.is_editable = AsyncMock(return_value=editable)
+    static_element = {"id": "EL", "tagName": tag_name, "attributes": attributes or {}}
+    return SkyvernElement(locator=locator, frame=MagicMock(), static_element=static_element)
+
+
+# --------------------------------------------------------------------------- #
+# SkyvernElement.supports_text_input
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_iframe_does_not_support_text_input() -> None:
+    element = _make_element("iframe", editable=False)
+    assert await element.supports_text_input() is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tag_name", ["input", "textarea", "select", "INPUT"])
+async def test_common_input_tags_support_text_input(tag_name: str) -> None:
+    # short-circuits on tag name, without consulting locator.is_editable
+    element = _make_element(tag_name, editable=False)
+    assert await element.supports_text_input() is True
+
+
+@pytest.mark.asyncio
+async def test_editable_element_supports_text_input() -> None:
+    element = _make_element("div", editable=True)
+    assert await element.supports_text_input() is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("value", ["", "true", "plaintext-only"])
+async def test_contenteditable_supports_text_input(value: str) -> None:
+    element = _make_element("div", editable=False, attributes={"contenteditable": value})
+    assert await element.supports_text_input() is True
+
+
+@pytest.mark.asyncio
+async def test_contenteditable_false_does_not_support_text_input() -> None:
+    element = _make_element("div", editable=False, attributes={"contenteditable": "false"})
+    assert await element.supports_text_input() is False
+
+
+# --------------------------------------------------------------------------- #
+# handle_input_text_action — iframe target is rejected before clear/fill
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_input_text_on_iframe_is_rejected() -> None:
+    skyvern_el = MagicMock()
+    skyvern_el.get_id.return_value = "IFRM"
+    skyvern_el.get_tag_name.return_value = "iframe"
+    skyvern_el.get_frame.return_value = MagicMock()
+    skyvern_el.get_locator.return_value = MagicMock()
+    skyvern_el.is_disabled = AsyncMock(return_value=False)
+    skyvern_el.supports_text_input = AsyncMock(return_value=False)
+    skyvern_el.input_clear = AsyncMock()
+    skyvern_el.input_fill = AsyncMock()
+    skyvern_el.get_selectable = AsyncMock(return_value=False)
+
+    dom_instance = MagicMock()
+    dom_instance.get_skyvern_element_by_id = AsyncMock(return_value=skyvern_el)
+
+    skyvern_frame = MagicMock()
+    skyvern_frame.safe_wait_for_animation_end = AsyncMock()
+
+    scraped_page = MagicMock()
+    scraped_page.id_to_element_dict = {"IFRM": {"tagName": "iframe"}}
+
+    action = InputTextAction(element_id="IFRM", text="hello", reasoning="fill the field")
+
+    with (
+        patch("skyvern.webeye.actions.handler.DomUtil", return_value=dom_instance),
+        patch(
+            "skyvern.webeye.actions.handler.SkyvernFrame.create_instance",
+            new=AsyncMock(return_value=skyvern_frame),
+        ),
+        patch("skyvern.webeye.actions.handler.IncrementalScrapePage", return_value=MagicMock()),
+        patch("skyvern.webeye.actions.handler.get_input_value", new=AsyncMock(return_value="")),
+        patch(
+            "skyvern.webeye.actions.handler.get_actual_value_of_parameter_if_secret_with_task",
+            return_value="hello",
+        ),
+    ):
+        results = await handle_input_text_action(
+            action=action, page=MagicMock(), scraped_page=scraped_page, task=_TASK, step=_STEP
+        )
+
+    assert len(results) == 1
+    assert isinstance(results[0], ActionFailure)
+    assert results[0].exception_type == InvalidElementForTextInput.__name__
+    skyvern_el.input_clear.assert_not_called()
+    skyvern_el.input_fill.assert_not_called()


### PR DESCRIPTION
## Description

The action planner occasionally selects a non-editable element — such as an hCaptcha iframe — as the target for an `INPUT_TEXT` action. Execution then attempted `Locator.clear`/`Locator.fill` on that iframe, which failed mid-step.

This adds an editable-element guard so clear/fill only target valid text inputs:

- New `SkyvernElement.supports_text_input()` — true for `input`/`textarea`/`select`, Playwright-editable elements, or `contenteditable` elements.
- `handle_input_text_action` now rejects the action up front with `InvalidElementForTextInput` when the target isn't editable, before any clear/fill attempt (so an iframe target fails cleanly instead of erroring inside `Locator.clear`).

The existing non-editable fill path only fired for `contenteditable` elements Playwright doesn't report as editable, which the new guard still permits; truly non-editable targets (iframes, plain divs) would have thrown from Playwright anyway and now get a clear error instead.

## How Has This Been Tested?

Added `tests/unit/test_input_text_iframe_guard.py`:
- `supports_text_input()` unit cases: iframe → rejected; input/textarea/select and editable/contenteditable → accepted; `contenteditable="false"` → rejected.
- Handler-level regression: an `INPUT_TEXT` action targeting an iframe returns `ActionFailure(InvalidElementForTextInput)` and never calls `input_clear`/`input_fill`.

(pytest isn't installed in this sandbox, so the suite wasn't executed here — CI should run it.)
