### PR TITLE
fix(security): restrict internal_auth to loopback-only (closes #6890)

### DIFF
--- a/skyvern/forge/sdk/routes/internal_auth.py
+++ b/skyvern/forge/sdk/routes/internal_auth.py
@@ -41,9 +41,12 @@ def _is_local_request(request: Request) -> bool:
     except ValueError:
         LOG.warning("Invalid IP address in request", host=host)
         return False
-    # Check if request is from Docker host (gateway IP)
-    # Docker typically uses 172.x.x.x or 192.168.x.x for bridge networks
-    is_local = addr.is_loopback or addr.is_private
+    # Only loopback (127.0.0.1 / ::1) is trusted as local. Private RFC1918
+    # addresses (e.g. a Docker bridge address like 172.17.0.2) must NOT bypass
+    # the localhost-only gate: these internal routes mint/return a real API key,
+    # so trusting the whole private network is a credential-disclosure hole.
+    # See Skyvern-AI/skyvern#6890.
+    is_local = addr.is_loopback
     LOG.info(
         "Checking if request is local",
         host=host,

--- a/tests/unit_tests/test_internal_auth.py
+++ b/tests/unit_tests/test_internal_auth.py
@@ -25,9 +25,23 @@ def test_is_local_request_accepts_loopback() -> None:
     assert _is_local_request(request) is True
 
 
-def test_is_local_request_accepts_private_networks() -> None:
-    request = _make_request("192.168.1.20")
+def test_is_local_request_accepts_ipv6_loopback() -> None:
+    request = _make_request("::1")
     assert _is_local_request(request) is True
+
+
+def test_is_local_request_rejects_private_networks() -> None:
+    # RFC1918 private addresses must NOT be treated as local: trusting them lets
+    # a private-network caller bypass the localhost gate on these key-minting
+    # internal routes. See Skyvern-AI/skyvern#6890.
+    request = _make_request("192.168.1.20")
+    assert _is_local_request(request) is False
+
+
+def test_is_local_request_rejects_docker_bridge_address() -> None:
+    # Exact reproduction address from issue #6890.
+    request = _make_request("172.17.0.2")
+    assert _is_local_request(request) is False
 
 
 def test_is_local_request_handles_missing_client() -> None:


### PR DESCRIPTION
Closes #6890

## Root cause
`_is_local_request()` in `skyvern/forge/sdk/routes/internal_auth.py` gated the internal auth routes with:

```python
is_local = addr.is_loopback or addr.is_private
```

`is_private` treats **any** RFC1918 address as local. The internal routes are meant to be localhost-only in `ENV=local`, but `POST /api/v1/internal/auth/repair` → `repair_api_key()` regenerates and returns a **full raw API key** in its JSON body. So a private-network caller (e.g. a Docker bridge address like `172.17.0.2`) bypasses the localhost gate and receives a real credential — a trust-boundary bypass → API-key disclosure.

## Fix
Trust **only loopback** (`127.0.0.1` / `::1`) — drop the `is_private` branch. This is exactly the issue's Expected behavior.

- **Production is unaffected:** non-local deploys set `ENV != "local"`, so `_require_local_access()` already returns 403 before the IP check ever runs.
- **Not blanket-trusting RFC1918:** no env allowlist added in this PR (see the tracked follow-up below).
- **Raw-key echo retained deliberately:** the local frontend self-heal banner (`SelfHealApiKeyBanner.tsx`) consumes `api_key` via `setApiKeyHeader(apiKey)`, so it's a legitimate interactive caller. Fix #1 already makes `/repair` unreachable by non-loopback callers, satisfying the defense-in-depth requirement without breaking the real flow.

## ⚠️ Known intentional tradeoff (accepted)
The self-heal **"Repair" button used from a browser against a Dockerized backend** (`ENV=local`) **will now 403** — that request arrives at the container from the Docker **gateway IP** (a private address), not loopback. Bare-metal `skyvern run all` is unaffected (the browser hits `127.0.0.1` directly).

**Loopback-only is deliberate per #6890.** A narrow, opt-in, **env-gated gateway allowlist** (trust exactly the operator's Docker gateway IP, not all of RFC1918) is a tracked **FOLLOW-UP: #7177** — intentionally out of scope here to keep the security default clean.

## Test
Updated `tests/unit_tests/test_internal_auth.py`: the prior `test_is_local_request_accepts_private_networks` (which asserted the buggy behavior) now rejects; added the issue's exact `172.17.0.2` repro case and IPv6 loopback `::1`. All 6 tests pass; ruff/format/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)