### PR TITLE
Bump version to 1.0.46

### DIFF
--- a/packages/skyvern-ui/pyproject.toml
+++ b/packages/skyvern-ui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skyvern-ui"
-version = "1.0.45"
+version = "1.0.46"
 description = "Prebuilt Skyvern UI assets for the Skyvern CLI"
 authors = [{ name = "Skyvern AI", email = "info@skyvern.com" }]
 requires-python = ">=3.11,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skyvern"
-version = "1.0.45"
+version = "1.0.46"
 description = ""
 authors = [{ name = "Skyvern AI", email = "info@skyvern.com" }]
 requires-python = ">=3.11,<3.14"

--- a/skyvern-ts/client/package-lock.json
+++ b/skyvern-ts/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@skyvern/client",
-    "version": "1.0.45",
+    "version": "1.0.46",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@skyvern/client",
-            "version": "1.0.45",
+            "version": "1.0.46",
             "dependencies": {
                 "playwright": "^1.48.0"
             },

--- a/skyvern-ts/client/package.json
+++ b/skyvern-ts/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@skyvern/client",
-    "version": "1.0.45",
+    "version": "1.0.46",
     "private": false,
     "repository": {
         "type": "git",

--- a/uv.lock
+++ b/uv.lock
@@ -5776,7 +5776,7 @@ wheels = [
 
 [[package]]
 name = "skyvern"
-version = "1.0.45"
+version = "1.0.46"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary
Bump Skyvern OSS version to 1.0.46.

`fern/openapi/` is unchanged since the 1.0.45 release, so this is a **version-only bump** — no Fern SDK regeneration was needed.

## Changes
- `pyproject.toml` → 1.0.46
- `packages/skyvern-ui/pyproject.toml` → 1.0.46
- `uv.lock` (`skyvern` entry) → 1.0.46
- `skyvern-ts/client/package.json` + `package-lock.json` → 1.0.46

## Deployment
After merge, GitHub Actions will automatically:
- Publish the Python package to PyPI (version change in `pyproject.toml`)
- Publish the TypeScript package to NPM (version change in `package.json`)
- The skyvern-ui Docker image builds on GitHub Release published

🤖 Generated with [Claude Code](https://claude.com/claude-code)