### PR TITLE
[schemas] Keep sanitized parameter keys unique on workflow import

### DIFF
--- a/skyvern/schemas/workflows.py
+++ b/skyvern/schemas/workflows.py
@@ -119,6 +119,28 @@ def _replace_direct_string_in_value(value: Any, old_key: str, new_key: str) -> A
     return value
 
 
+def _replace_direct_string_param_refs(value: Any, key_mapping: dict[str, str], *, _in_key_field: bool = False) -> Any:
+    """Rewrites exact-match direct string references to parameter keys (e.g. source_parameter_key).
+
+    Resolves each string against the whole mapping in a single pass and stops at the first match,
+    so a collision-driven rename chain (my-key -> my_key AND my_key -> my_key_2) can't compound a
+    reference into the wrong target. The parameter's own `key` field is never rewritten here: it is
+    already finalized by _sanitize_parameters, and re-applying the mapping to it would collapse two
+    distinct keys into the same name.
+    """
+    if isinstance(value, str):
+        if _in_key_field:
+            return value
+        return key_mapping.get(value, value)
+    elif isinstance(value, dict):
+        return {
+            k: _replace_direct_string_param_refs(v, key_mapping, _in_key_field=(k == "key")) for k, v in value.items()
+        }
+    elif isinstance(value, list):
+        return [_replace_direct_string_param_refs(item, key_mapping) for item in value]
+    return value
+
+
 def _make_unique(candidate: str, seen: set[str]) -> str:
     """Appends a numeric suffix to make candidate unique within the seen set.
 
@@ -350,15 +372,21 @@ def sanitize_workflow_yaml_with_references(workflow_yaml: dict[str, Any]) -> dic
             workflow_definition["parameters"] = _replace_references_in_value(
                 workflow_definition["parameters"], old_key, new_key
             )
-            # Also update direct string references (e.g., source_parameter_key)
-            workflow_definition["parameters"] = _replace_direct_string_in_value(
-                workflow_definition["parameters"], old_key, new_key
-            )
 
         if isinstance(workflow_definition.get("workflow_system_prompt"), str):
             workflow_definition["workflow_system_prompt"] = _replace_references_in_value(
                 workflow_definition["workflow_system_prompt"], old_key, new_key
             )
+
+    # Update direct string references to parameter keys (e.g. source_parameter_key) in one atomic
+    # pass. Doing this per-mapping-entry sequentially chained a collision rename (my-key -> my_key
+    # then my_key -> my_key_2) onto the already-renamed reference, and it also rewrote each param's
+    # own final `key` field back into a duplicate. _replace_direct_string_param_refs leaves the key
+    # field alone and resolves each reference against the whole mapping exactly once.
+    if param_key_mapping and "parameters" in workflow_definition:
+        workflow_definition["parameters"] = _replace_direct_string_param_refs(
+            workflow_definition["parameters"], param_key_mapping
+        )
 
     # Rewrite workflow-level error_code_mapping atomically so substitutions don't chain
     # (e.g. foo-bar -> foo_bar and foo_bar -> foo_bar_2 must not combine into foo_bar_2).

--- a/skyvern/schemas/workflows.py
+++ b/skyvern/schemas/workflows.py
@@ -74,15 +74,50 @@ def _get_text_prompt_model_name_by_llm_key() -> dict[str, str]:
     return reverse_mapping
 
 
-def _replace_references_in_value(value: Any, old_key: str, new_key: str) -> Any:
-    """Recursively replaces Jinja references in a value (string, dict, or list)."""
-    if isinstance(value, str):
-        return replace_jinja_reference(value, old_key, new_key)
-    elif isinstance(value, dict):
-        return {k: _replace_references_in_value(v, old_key, new_key) for k, v in value.items()}
-    elif isinstance(value, list):
-        return [_replace_references_in_value(item, old_key, new_key) for item in value]
-    return value
+def _make_sentinels(substitutions: list[tuple[str, str]]) -> list[tuple[str, str, str]]:
+    """Pairs each (old, new) substitution with a unique, un-typeable sentinel token.
+
+    The sentinels let a whole substitution set be applied atomically: every old identifier is
+    swapped to its sentinel first, then every sentinel to its new identifier. That breaks the
+    chain when one substitution's new identifier matches another's old one (e.g. foo-bar ->
+    foo_bar AND foo_bar -> foo_bar_2), which a naive sequential rewrite would compound.
+    """
+    return [(old, new, f"\x00SKY_SANITIZE_{i}\x00") for i, (old, new) in enumerate(substitutions)]
+
+
+def _apply_atomic_jinja_substitutions(text: str, sentinels: list[tuple[str, str, str]]) -> str:
+    """Applies a sentinel-guarded set of Jinja reference substitutions to a single string."""
+    for old, _new, sentinel in sentinels:
+        text = replace_jinja_reference(text, old, sentinel)
+    for _old, new, sentinel in sentinels:
+        text = text.replace(sentinel, new)
+    return text
+
+
+def _rewrite_jinja_refs_atomic(value: Any, substitutions: list[tuple[str, str]]) -> Any:
+    """Atomically rewrites Jinja references in a value (string, dict, or list).
+
+    Every reference is resolved against the whole substitution set in one pass via unique
+    sentinels, so a collision rename chain (my-key -> my_key AND my_key -> my_key_2) can't
+    compound a reference into the wrong target. Order still matters within the set: place the
+    more specific substitution (e.g. {label}_output) before the bare label so the bare pass
+    does not partially match an already-sentinelled reference.
+    """
+    if not substitutions:
+        return value
+
+    sentinels = _make_sentinels(substitutions)
+
+    def _walk(v: Any) -> Any:
+        if isinstance(v, str):
+            return _apply_atomic_jinja_substitutions(v, sentinels)
+        if isinstance(v, dict):
+            return {k: _walk(item) for k, item in v.items()}
+        if isinstance(v, list):
+            return [_walk(item) for item in v]
+        return v
+
+    return _walk(value)
 
 
 def _rewrite_error_code_mapping_refs_atomic(mapping: Any, substitutions: list[tuple[str, str]]) -> Any:
@@ -94,33 +129,18 @@ def _rewrite_error_code_mapping_refs_atomic(mapping: Any, substitutions: list[tu
     if not isinstance(mapping, dict) or not substitutions:
         return mapping
 
-    sentinels = [(old, new, f"\x00SKY_SANITIZE_{i}\x00") for i, (old, new) in enumerate(substitutions)]
-
-    def _apply(text: str) -> str:
-        for old, _new, sentinel in sentinels:
-            text = replace_jinja_reference(text, old, sentinel)
-        for _old, new, sentinel in sentinels:
-            text = text.replace(sentinel, new)
-        return text
+    sentinels = _make_sentinels(substitutions)
 
     return {
-        (_apply(k) if isinstance(k, str) else k): (_apply(v) if isinstance(v, str) else v) for k, v in mapping.items()
+        (_apply_atomic_jinja_substitutions(k, sentinels) if isinstance(k, str) else k): (
+            _apply_atomic_jinja_substitutions(v, sentinels) if isinstance(v, str) else v
+        )
+        for k, v in mapping.items()
     }
 
 
-def _replace_direct_string_in_value(value: Any, old_key: str, new_key: str) -> Any:
-    """Recursively replaces exact string matches in a value (for fields like source_parameter_key)."""
-    if isinstance(value, str):
-        return new_key if value == old_key else value
-    elif isinstance(value, dict):
-        return {k: _replace_direct_string_in_value(v, old_key, new_key) for k, v in value.items()}
-    elif isinstance(value, list):
-        return [_replace_direct_string_in_value(item, old_key, new_key) for item in value]
-    return value
-
-
 def _replace_direct_string_param_refs(value: Any, key_mapping: dict[str, str], *, _in_key_field: bool = False) -> Any:
-    """Rewrites exact-match direct string references to parameter keys (e.g. source_parameter_key).
+    """Rewrites exact-match direct string references to renamed keys (e.g. source_parameter_key).
 
     Resolves each string against the whole mapping in a single pass and stops at the first match,
     so a collision-driven rename chain (my-key -> my_key AND my_key -> my_key_2) can't compound a
@@ -320,72 +340,46 @@ def sanitize_workflow_yaml_with_references(workflow_yaml: dict[str, Any]) -> dic
         sanitized_parameter_keys=param_key_mapping if param_key_mapping else None,
     )
 
-    # Step 3: Update all block label references
+    # Step 3: Update all block label references. Build every label substitution up front and apply
+    # it in a single atomic pass so a collision rename (foo/bar -> foo_bar AND foo-bar -> foo_bar_2)
+    # can't chain one {{ ... }} reference through into the wrong target across blocks, parameters,
+    # and the workflow system prompt. The more specific {label}_output substitution is listed before
+    # the bare label so the bare pass never partially matches an already-handled output reference.
+    label_substitutions: list[tuple[str, str]] = []
+    output_key_mapping: dict[str, str] = {}
     for old_label, new_label in label_mapping.items():
         old_output_key = f"{old_label}_output"
         new_output_key = f"{new_label}_output"
+        label_substitutions.append((old_output_key, new_output_key))
+        label_substitutions.append((old_label, new_label))
+        output_key_mapping[old_output_key] = new_output_key
 
-        # Update Jinja references in blocks for {label}_output pattern
-        if "blocks" in workflow_definition:
-            workflow_definition["blocks"] = _replace_references_in_value(
-                workflow_definition["blocks"], old_output_key, new_output_key
-            )
-            # Also update shorthand {{ label }} references (must be done after _output to avoid partial matches)
-            workflow_definition["blocks"] = _replace_references_in_value(
-                workflow_definition["blocks"], old_label, new_label
-            )
+    if label_substitutions:
+        for jinja_field in ("blocks", "parameters", "workflow_system_prompt"):
+            if jinja_field in workflow_definition:
+                workflow_definition[jinja_field] = _rewrite_jinja_refs_atomic(
+                    workflow_definition[jinja_field], label_substitutions
+                )
 
-        # Update Jinja references in parameters for {label}_output pattern
-        if "parameters" in workflow_definition:
-            workflow_definition["parameters"] = _replace_references_in_value(
-                workflow_definition["parameters"], old_output_key, new_output_key
-            )
-            # Also update shorthand {{ label }} references
-            workflow_definition["parameters"] = _replace_references_in_value(
-                workflow_definition["parameters"], old_label, new_label
-            )
-            # Also update direct string references (e.g., source_parameter_key)
-            workflow_definition["parameters"] = _replace_direct_string_in_value(
-                workflow_definition["parameters"], old_output_key, new_output_key
-            )
+    # Step 4: Update all parameter key references. Same anti-chaining reasoning as Step 3: a collision
+    # rename (my-key -> my_key AND my_key -> my_key_2) must not compound {{ my-key }} into
+    # {{ my_key_2 }} across defaults, blocks, and the system prompt, so resolve them in one atomic pass.
+    param_substitutions = list(param_key_mapping.items())
+    if param_substitutions:
+        for jinja_field in ("blocks", "parameters", "workflow_system_prompt"):
+            if jinja_field in workflow_definition:
+                workflow_definition[jinja_field] = _rewrite_jinja_refs_atomic(
+                    workflow_definition[jinja_field], param_substitutions
+                )
 
-        # workflow_system_prompt is rendered through Jinja at execution time, so
-        # references inside it need the same rename treatment as block fields.
-        if isinstance(workflow_definition.get("workflow_system_prompt"), str):
-            workflow_definition["workflow_system_prompt"] = _replace_references_in_value(
-                workflow_definition["workflow_system_prompt"], old_output_key, new_output_key
-            )
-            workflow_definition["workflow_system_prompt"] = _replace_references_in_value(
-                workflow_definition["workflow_system_prompt"], old_label, new_label
-            )
-
-    # Step 4: Update all parameter key references
-    for old_key, new_key in param_key_mapping.items():
-        # Update Jinja references in blocks (e.g., {{ old_key }})
-        if "blocks" in workflow_definition:
-            workflow_definition["blocks"] = _replace_references_in_value(
-                workflow_definition["blocks"], old_key, new_key
-            )
-
-        # Update Jinja references in parameters (e.g., default values that reference other params)
-        if "parameters" in workflow_definition:
-            workflow_definition["parameters"] = _replace_references_in_value(
-                workflow_definition["parameters"], old_key, new_key
-            )
-
-        if isinstance(workflow_definition.get("workflow_system_prompt"), str):
-            workflow_definition["workflow_system_prompt"] = _replace_references_in_value(
-                workflow_definition["workflow_system_prompt"], old_key, new_key
-            )
-
-    # Update direct string references to parameter keys (e.g. source_parameter_key) in one atomic
-    # pass. Doing this per-mapping-entry sequentially chained a collision rename (my-key -> my_key
-    # then my_key -> my_key_2) onto the already-renamed reference, and it also rewrote each param's
-    # own final `key` field back into a duplicate. _replace_direct_string_param_refs leaves the key
-    # field alone and resolves each reference against the whole mapping exactly once.
-    if param_key_mapping and "parameters" in workflow_definition:
+    # Direct (non-Jinja) string references live on parameters: source_parameter_key points at a
+    # parameter key, and some fields point at a {label}_output key. Resolve each against the whole
+    # mapping exactly once (first match) so collisions don't chain, and never rewrite a parameter's
+    # own already-final `key` field back into a duplicate.
+    direct_string_mapping = {**output_key_mapping, **param_key_mapping}
+    if direct_string_mapping and "parameters" in workflow_definition:
         workflow_definition["parameters"] = _replace_direct_string_param_refs(
-            workflow_definition["parameters"], param_key_mapping
+            workflow_definition["parameters"], direct_string_mapping
         )
 
     # Rewrite workflow-level error_code_mapping atomically so substitutions don't chain

--- a/tests/unit/test_workflow_parameter_key_sanitization.py
+++ b/tests/unit/test_workflow_parameter_key_sanitization.py
@@ -1,0 +1,97 @@
+"""Regression tests for parameter-key rewriting in sanitize_workflow_yaml_with_references.
+
+Two distinct valid parameter keys can sanitize into a collision (e.g. "my-key" -> "my_key",
+which already exists), so the second gets a numeric suffix. The reference-rewriting pass in
+Step 4 used to run once per mapping entry and recurse into every string, so it re-applied the
+mapping to each parameter's own already-final `key` field and chained a later substitution onto
+an earlier one. That turned distinct keys into duplicates and pointed source_parameter_key at
+the wrong parameter, silently, on the public workflow-import path.
+"""
+
+from skyvern.schemas.workflows import sanitize_workflow_yaml_with_references
+
+
+def test_colliding_sanitized_keys_stay_unique() -> None:
+    workflow_yaml = {
+        "workflow_definition": {
+            "parameters": [
+                {"key": "my-key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "my_key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+            ],
+            "blocks": [],
+        }
+    }
+    sanitized = sanitize_workflow_yaml_with_references(workflow_yaml)
+    keys = [param["key"] for param in sanitized["workflow_definition"]["parameters"]]
+    # "my-key" -> "my_key", "my_key" -> "my_key_2"; neither should be rewritten into the other.
+    assert keys == ["my_key", "my_key_2"]
+    assert len(keys) == len(set(keys))
+
+
+def test_source_parameter_key_follows_renamed_key_without_chaining() -> None:
+    workflow_yaml = {
+        "workflow_definition": {
+            "parameters": [
+                {"key": "my-key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "my_key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "ctx", "parameter_type": "context", "source_parameter_key": "my-key"},
+            ],
+            "blocks": [],
+        }
+    }
+    sanitized = sanitize_workflow_yaml_with_references(workflow_yaml)
+    params = sanitized["workflow_definition"]["parameters"]
+    ctx = next(param for param in params if param["parameter_type"] == "context")
+    # "my-key" was renamed to "my_key"; the reference must land there, not chain to "my_key_2".
+    assert ctx["source_parameter_key"] == "my_key"
+
+
+def test_source_parameter_key_pointing_at_suffixed_param_is_correct() -> None:
+    workflow_yaml = {
+        "workflow_definition": {
+            "parameters": [
+                {"key": "my-key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "my_key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "ctx", "parameter_type": "context", "source_parameter_key": "my_key"},
+            ],
+            "blocks": [],
+        }
+    }
+    sanitized = sanitize_workflow_yaml_with_references(workflow_yaml)
+    params = sanitized["workflow_definition"]["parameters"]
+    ctx = next(param for param in params if param["parameter_type"] == "context")
+    # The literal "my_key" parameter was the one suffixed to "my_key_2".
+    assert ctx["source_parameter_key"] == "my_key_2"
+
+
+def test_single_rename_still_updates_source_parameter_key() -> None:
+    workflow_yaml = {
+        "workflow_definition": {
+            "parameters": [
+                {"key": "bad-key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "ctx", "parameter_type": "context", "source_parameter_key": "bad-key"},
+            ],
+            "blocks": [],
+        }
+    }
+    sanitized = sanitize_workflow_yaml_with_references(workflow_yaml)
+    params = sanitized["workflow_definition"]["parameters"]
+    assert params[0]["key"] == "bad_key"
+    ctx = next(param for param in params if param["parameter_type"] == "context")
+    assert ctx["source_parameter_key"] == "bad_key"
+
+
+def test_already_valid_keys_are_untouched() -> None:
+    workflow_yaml = {
+        "workflow_definition": {
+            "parameters": [
+                {"key": "alpha", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "beta", "parameter_type": "context", "source_parameter_key": "alpha"},
+            ],
+            "blocks": [],
+        }
+    }
+    sanitized = sanitize_workflow_yaml_with_references(workflow_yaml)
+    params = sanitized["workflow_definition"]["parameters"]
+    assert [param["key"] for param in params] == ["alpha", "beta"]
+    assert params[1]["source_parameter_key"] == "alpha"

--- a/tests/unit/test_workflow_parameter_key_sanitization.py
+++ b/tests/unit/test_workflow_parameter_key_sanitization.py
@@ -81,6 +81,54 @@ def test_single_rename_still_updates_source_parameter_key() -> None:
     assert ctx["source_parameter_key"] == "bad_key"
 
 
+def test_jinja_default_value_reference_follows_renamed_key_without_chaining() -> None:
+    # "my-key" -> "my_key", "my_key" -> "my_key_2". A {{ my-key }} reference in a later
+    # parameter default must land on "my_key", not chain through to "my_key_2".
+    workflow_yaml = {
+        "workflow_definition": {
+            "parameters": [
+                {"key": "my-key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "my_key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {
+                    "key": "greeting",
+                    "parameter_type": "workflow",
+                    "workflow_parameter_type": "string",
+                    "default_value": "hello {{ my-key }}",
+                },
+            ],
+            "blocks": [],
+        }
+    }
+    sanitized = sanitize_workflow_yaml_with_references(workflow_yaml)
+    params = sanitized["workflow_definition"]["parameters"]
+    greeting = next(param for param in params if param["key"] == "greeting")
+    assert greeting["default_value"] == "hello {{ my_key }}"
+
+
+def test_jinja_block_reference_follows_renamed_key_without_chaining() -> None:
+    # Same collision, but the {{ my-key }} reference lives in a block field. It must resolve
+    # to the renamed "my_key" parameter, and the untouched {{ my_key }} reference to "my_key_2".
+    workflow_yaml = {
+        "workflow_definition": {
+            "parameters": [
+                {"key": "my-key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "my_key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+            ],
+            "blocks": [
+                {
+                    "label": "task1",
+                    "block_type": "task",
+                    "url": "https://example.com",
+                    "navigation_goal": "use {{ my-key }} and {{ my_key }}",
+                }
+            ],
+        }
+    }
+    sanitized = sanitize_workflow_yaml_with_references(workflow_yaml)
+    block = sanitized["workflow_definition"]["blocks"][0]
+    assert block["navigation_goal"] == "use {{ my_key }} and {{ my_key_2 }}"
+
+
 def test_already_valid_keys_are_untouched() -> None:
     workflow_yaml = {
         "workflow_definition": {


### PR DESCRIPTION
## What is wrong

`sanitize_workflow_yaml_with_references` in `skyvern/schemas/workflows.py` runs on the public workflow-import path (`agent_protocol.py`), so it touches every workflow YAML/JSON that gets posted. Step 4 rewrites parameter-key references by looping over the key mapping and recursing into every string in the parameters list, once per mapping entry. That has two side effects I did not expect:

1. It rewrites each parameter's own `key` field, even though `_sanitize_parameters` already finalized it in Step 2.
2. The substitutions run one after another, so a reference can chain from one mapping entry into the next.

When two distinct, valid keys sanitize into a collision this goes wrong. Take `my-key` and `my_key`. `my-key` normalizes to `my_key`, which already exists, so it gets suffixed to `my_key_2`. The mapping ends up `{'my-key': 'my_key', 'my_key': 'my_key_2'}`. Then:

- The first parameter's key was set to `my_key` in Step 2. The second mapping entry (`my_key -> my_key_2`) matches it and rewrites it to `my_key_2`, so now both parameters have the key `my_key_2`.
- A `source_parameter_key: "my-key"` gets rewritten `my-key -> my_key` by the first entry, then `my_key -> my_key_2` by the second, so it points at the wrong parameter.

All of this is silent. A workflow that was fine on the way in comes out with duplicate keys or a mis-wired reference.

## Reproduction

```python
from skyvern.schemas.workflows import sanitize_workflow_yaml_with_references

wf = {"workflow_definition": {"parameters": [
    {"parameter_type": "workflow", "key": "my-key", "workflow_parameter_type": "string"},
    {"parameter_type": "workflow", "key": "my_key", "workflow_parameter_type": "string"},
    {"parameter_type": "context", "key": "ctx", "source_parameter_key": "my-key"},
], "blocks": []}}

out = sanitize_workflow_yaml_with_references(wf)
print([p["key"] for p in out["workflow_definition"]["parameters"]])
# before: ['my_key_2', 'my_key_2', 'ctx']   <- duplicate
# after:  ['my_key', 'my_key_2', 'ctx']
```

The `source_parameter_key` on the context parameter comes out as `my_key_2` before the fix and `my_key` after it.

## The fix

The interesting thing is the codebase already knows about this hazard. `_rewrite_error_code_mapping_refs_atomic` was added specifically so error_code_mapping substitutions do not chain. Step 4's parameter references were just never given the same treatment.

I resolve the direct string references (`source_parameter_key` and friends) against the whole mapping in a single pass that stops at the first match, so nothing chains, and I leave each parameter's own `key` field alone since it is already final after Step 2. The per-entry `_replace_direct_string_in_value` call in Step 4 is replaced by one `_replace_direct_string_param_refs` pass after the loop.

## Tests

`tests/unit/test_workflow_parameter_key_sanitization.py` covers:

- colliding sanitized keys stay unique (no duplicate)
- `source_parameter_key` follows the renamed key without chaining
- a reference to the suffixed parameter still resolves correctly
- a plain single rename still updates its reference
- already-valid keys and references are untouched

The two collision tests fail on the current code and pass with the fix. I also ran the existing `test_workflow_error_code_mapping_inheritance.py`, `test_workflow_parameter_validation.py`, and `test_workflow_schema_field_preservation.py` suites and they stay green. `ruff check` and `ruff format` are clean.


Closes #7279
