### PR TITLE
fix(SKY-12325): harden Playwright resilience for transient/edge DOM states

### DIFF
--- a/skyvern/forge/agent.py
+++ b/skyvern/forge/agent.py
@@ -170,7 +170,7 @@ from skyvern.webeye.actions.responses import ActionResult, ActionSuccess
 from skyvern.webeye.browser_state import BrowserState
 from skyvern.webeye.cdp_download_interceptor import download_filename_from_suffix
 from skyvern.webeye.scraper.scraped_page import ElementTreeFormat, ScrapedPage
-from skyvern.webeye.utils.page import SkyvernFrame, build_open_tabs_context
+from skyvern.webeye.utils.page import SkyvernFrame, build_open_tabs_context, is_browser_crashed_error
 
 LOG = structlog.get_logger()
 BLANK_WORKFLOW_TASK_URLS = {"about:blank", ":"}
@@ -3304,8 +3304,14 @@ class ForgeAgent:
                             step=step,
                         )
                     )
-        except Exception:
-            LOG.exception("Failed to record html after action")
+        except Exception as e:
+            # Recording the HTML artifact is best-effort; a renderer/target crash here
+            # does not affect the action outcome. Downgrade the environmental crash to a
+            # warning; real artifact-recording failures stay loud. SKY-12344.
+            if is_browser_crashed_error(e):
+                LOG.warning("Browser crashed/closed while recording html after action; skipping html artifact")
+            else:
+                LOG.exception("Failed to record html after action")
 
         if artifacts:
             _tracer = otel_trace.get_tracer("skyvern")

--- a/skyvern/forge/sdk/event/default.py
+++ b/skyvern/forge/sdk/event/default.py
@@ -5,6 +5,7 @@ the feature flag disables custom strategies at runtime.
 """
 
 import structlog
+from playwright.async_api import Error as PlaywrightError
 from playwright.async_api import Locator, Page
 
 from skyvern.config import settings
@@ -52,7 +53,17 @@ class DefaultInputStrategy(InputEventStrategy):
             await page.keyboard.type(text)
 
     async def clear_field(self, page: Page, locator: Locator, char_count: int) -> None:
-        await locator.clear(timeout=settings.BROWSER_ACTION_TIMEOUT_MS)
+        try:
+            await locator.clear(timeout=settings.BROWSER_ACTION_TIMEOUT_MS)
+        except PlaywrightError as e:
+            # Clearing a non-editable element (not an <input>/<textarea>/[contenteditable])
+            # is a no-op by definition -- swallow that specific validation error instead of
+            # crashing the action. Real failures (timeout, detached, etc.) still propagate.
+            # SKY-12337.
+            if "contenteditable" in str(e):
+                LOG.info("Skip clearing a non-editable element", exc_info=True)
+                return
+            raise
 
 
 class DefaultScrollStrategy(ScrollEventStrategy):

--- a/skyvern/forge/sdk/event/default.py
+++ b/skyvern/forge/sdk/event/default.py
@@ -56,12 +56,14 @@ class DefaultInputStrategy(InputEventStrategy):
         try:
             await locator.clear(timeout=settings.BROWSER_ACTION_TIMEOUT_MS)
         except PlaywrightError as e:
-            # Clearing a non-editable element (not an <input>/<textarea>/[contenteditable])
-            # is a no-op by definition -- swallow that specific validation error instead of
-            # crashing the action. Real failures (timeout, detached, etc.) still propagate.
-            # SKY-12337.
-            if "contenteditable" in str(e):
-                LOG.info("Skip clearing a non-editable element", exc_info=True)
+            # Clearing a non-editable element is a no-op by definition -- swallow only
+            # Playwright's exact validation diagnostic. Match the full phrase, not just
+            # "contenteditable": a genuine clear() timeout embeds the resolved element
+            # (e.g. <div contenteditable="true">) in its call log, and swallowing that
+            # would leave stale text for the next type() to append onto. Real failures
+            # (timeout, detached, target closed) still propagate. SKY-12337.
+            if "is not an <input>, <textarea> or [contenteditable] element" in str(e):
+                LOG.info("Skip clearing a non-editable element")
                 return
             raise
 

--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -52,6 +52,7 @@ from skyvern.exceptions import (
     MissingElement,
     MissingElementDict,
     MissingElementInCSSMap,
+    MissingElementInIframe,
     MissingFileUrl,
     MultipleElementsFound,
     NoAutoCompleteOptionMeetCondition,
@@ -59,6 +60,7 @@ from skyvern.exceptions import (
     NoElementMatchedForTargetOption,
     NoIncrementalElementFoundForAutoCompletion,
     NoIncrementalElementFoundForCustomSelection,
+    NoneFrameError,
     NoSuitableAutoCompleteOption,
     OptionIndexOutOfBound,
     PhoneNumberInputMismatch,
@@ -2257,7 +2259,18 @@ class ActionHandler:
                 )
                 actions_result.append(ActionFailure(Exception(f"Unsupported action type: {type(action)}")))
                 return actions_result
-        except MissingElement as e:
+        except (
+            MissingElement,
+            MissingElementDict,
+            MissingElementInCSSMap,
+            MissingElementInIframe,
+            NoneFrameError,
+        ) as e:
+            # The element/iframe the action referenced is no longer resolvable in the
+            # live DOM (detached iframe, stale element id from a re-render or a
+            # dynamically injected captcha). This is an expected, recoverable race --
+            # fail the action so the agent re-scrapes and retries, but don't log it as
+            # an unhandled exception. SKY-12325, SKY-12317.
             LOG.info(
                 "Known exceptions",
                 action=action,

--- a/skyvern/webeye/real_browser_state.py
+++ b/skyvern/webeye/real_browser_state.py
@@ -29,7 +29,7 @@ from skyvern.webeye.navigation import is_permanent_navigation_error, navigate_wi
 from skyvern.webeye.scraper import scraper
 from skyvern.webeye.scraper.scraped_page import CleanupElementTreeFunc, ScrapedPage, ScrapeExcludeFunc
 from skyvern.webeye.session_cookies import persist_session_cookies
-from skyvern.webeye.utils.page import ScreenshotMode, SkyvernFrame
+from skyvern.webeye.utils.page import ScreenshotMode, SkyvernFrame, is_browser_crashed_error
 
 LOG = structlog.get_logger()
 
@@ -311,11 +311,17 @@ class RealBrowserState(BrowserState):
         try:
             skyvern_frame = await SkyvernFrame.create_instance(frame=page)
             html = await skyvern_frame.get_content()
-        except Exception:
-            LOG.error(
-                "Error happened while getting the first page content",
-                exc_info=True,
-            )
+        except Exception as e:
+            # A crashed/closed target correctly means "context not usable" -- returning
+            # False triggers recovery. Log the environmental crash as a warning instead
+            # of an error; genuine content-read failures stay loud. SKY-12344.
+            if is_browser_crashed_error(e):
+                LOG.warning("Browser crashed/closed while validating page content; treating context as invalid")
+            else:
+                LOG.error(
+                    "Error happened while getting the first page content",
+                    exc_info=True,
+                )
             return False
 
         if "Bad gateway error" in html:

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -34,7 +34,7 @@ from skyvern.webeye.scraper.scraped_page import (
     ScrapeExcludeFunc,
     json_to_html,
 )
-from skyvern.webeye.utils.page import SkyvernFrame
+from skyvern.webeye.utils.page import SkyvernFrame, is_browser_crashed_error
 
 LOG = structlog.get_logger()
 
@@ -546,12 +546,15 @@ async def scrape_web_unsafe(
         html = await skyvern_frame.get_content()
         if page.viewport_size:
             window_dimension = Resolution(width=page.viewport_size["width"], height=page.viewport_size["height"])
-    except Exception:
-        LOG.error(
-            "Failed out to get HTML content",
-            url=url,
-            exc_info=True,
-        )
+    except Exception as e:
+        # The element tree was already captured above; an empty html here degrades only
+        # the HTML artifact and a secondary heuristic. A renderer/target crash is an
+        # environmental event the run already tolerates -- log it as a warning rather
+        # than polluting error-tracking. Real content-read bugs stay loud. SKY-12344.
+        if is_browser_crashed_error(e):
+            LOG.warning("Browser crashed/closed while reading page HTML; continuing with empty HTML", url=url)
+        else:
+            LOG.error("Failed out to get HTML content", url=url, exc_info=True)
 
     _record_scrape_span_attrs(
         elements=elements,

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -274,6 +274,26 @@ async def scrape_website(
         )
 
 
+async def _frame_element_is_visible(
+    frame_element: ElementHandle,
+    timeout: float = settings.BROWSER_ACTION_TIMEOUT_MS / 1000,
+) -> bool:
+    """Bounded visibility probe for an iframe's ElementHandle.
+
+    ``ElementHandle.is_visible()`` takes no timeout and falls back to Playwright's
+    built-in 30s action timeout; on a detached / mid-navigation cross-process frame
+    it can stall the whole scrape and then raise ``Timeout 30000ms exceeded``
+    (SKY-12311). Bound it and treat a hang/error as "not visible" so we skip the
+    frame instead of stalling or crashing.
+    """
+    try:
+        async with asyncio.timeout(timeout):
+            return await frame_element.is_visible()
+    except Exception:
+        LOG.warning("Frame element visibility check failed or timed out; skipping frame", exc_info=True)
+        return False
+
+
 async def get_frame_text(iframe: Frame, scrape_exclude: ScrapeExcludeFunc | None = None) -> str:
     """
     Get all the visible text in the iframe.
@@ -314,7 +334,7 @@ async def get_frame_text(iframe: Frame, scrape_exclude: ScrapeExcludeFunc | None
             continue
 
         # it will get stuck when we `frame.evaluate()` on an invisible iframe
-        if not await child_frame_element.is_visible():
+        if not await _frame_element_is_visible(child_frame_element):
             continue
 
         text += await get_frame_text(child_frame, scrape_exclude)
@@ -617,7 +637,7 @@ async def add_frame_interactable_elements(
     try:
         frame_element = await frame.frame_element()
         # it will get stuck when we `frame.evaluate()` on an invisible iframe
-        if not await frame_element.is_visible():
+        if not await _frame_element_is_visible(frame_element):
             return elements, element_tree
         skyvern_id = await frame_element.get_attribute(SKYVERN_ID_ATTR)
         if not skyvern_id:

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 import structlog
 from opentelemetry import trace as otel_trace
-from playwright._impl._errors import TimeoutError
+from playwright._impl._errors import TargetClosedError, TimeoutError
 from playwright.async_api import ElementHandle, Frame, Locator, Page
 
 from skyvern.config import settings
@@ -289,6 +289,11 @@ async def _frame_element_is_visible(
     try:
         async with asyncio.timeout(timeout):
             return await frame_element.is_visible()
+    except TargetClosedError:
+        # The page/context/browser is gone -- surface this loudly instead of masking a
+        # dead browser as an invisible frame, which would let the scrape return partial
+        # content as success. SKY-12311.
+        raise
     except Exception:
         LOG.warning("Frame element visibility check failed or timed out; skipping frame", exc_info=True)
         return False

--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -38,6 +38,14 @@ LOG = structlog.get_logger()
 COMMON_INPUT_TAGS = {"input", "textarea", "select"}
 
 
+def _is_detached_frame_error(exc: PlaywrightError) -> bool:
+    """A Playwright error meaning the element/iframe left the DOM mid-resolution
+    ("Element is not attached to the DOM", "Frame was detached"). Distinct from a
+    closed/crashed target (``TargetClosedError``), which must NOT be swallowed."""
+    msg = str(exc).lower()
+    return "not attached to the dom" in msg or "detached" in msg
+
+
 def is_post_dispatch_click_timeout(exc: BaseException) -> bool:
     """A Playwright `TimeoutError` whose message references the post-click
     auto-wait for scheduled navigations means the click was physically
@@ -73,18 +81,21 @@ async def resolve_locator(scrape_page: ScrapedPage, page: Page, frame: str, css:
     while len(iframe_path) > 0:
         child_frame = iframe_path.pop()
 
-        frame_handler = await current_frame.query_selector(f"[{SKYVERN_ID_ATTR}='{child_frame}']")
-        if frame_handler is None:
-            raise NoneFrameError(frame_id=child_frame)
-
         try:
+            frame_handler = await current_frame.query_selector(f"[{SKYVERN_ID_ATTR}='{child_frame}']")
+            if frame_handler is None:
+                raise NoneFrameError(frame_id=child_frame)
             content_frame = await frame_handler.content_frame()
         except PlaywrightError as e:
-            # The iframe detached between query_selector and content_frame (e.g.
-            # navigation / re-render). That is the same "frame is gone" condition
-            # NoneFrameError already signals, so normalize instead of leaking the
-            # raw Playwright error. SKY-12186.
-            raise NoneFrameError(frame_id=child_frame) from e
+            # A detached iframe -- at query_selector on an already-detached parent
+            # frame, or at content_frame if it detaches in between (navigation /
+            # re-render) -- is the same "frame is gone" condition NoneFrameError
+            # signals. Normalize only that; re-raise anything else (e.g. a closed
+            # target/browser) so a real failure is not masked as a DOM race.
+            # SKY-12186.
+            if _is_detached_frame_error(e):
+                raise NoneFrameError(frame_id=child_frame) from e
+            raise
         if content_frame is None:
             raise NoneFrameError(frame_id=child_frame)
         current_frame = content_frame
@@ -928,17 +939,6 @@ class SkyvernElement:
         await self.get_locator().fill(text, timeout=timeout)
 
     async def input_clear(self, timeout: float = settings.BROWSER_ACTION_TIMEOUT_MS) -> None:
-        # Only editable / text-input-capable elements can be cleared. Clearing a
-        # non-text element (e.g. an h2 the LLM mis-picked) raises
-        # "not an <input>, <textarea> or [contenteditable] element" -- skip it
-        # instead so the doomed clear and its noisy exception never run. SKY-12337.
-        if not await self.supports_text_input():
-            LOG.info(
-                "Skip clearing a non-text-input element",
-                element_id=self.get_id(),
-                tag_name=self.get_tag_name(),
-            )
-            return
         locator = self.get_locator()
         await EventStrategyFactory.clear_field(locator.page, locator, char_count=0)
 

--- a/skyvern/webeye/utils/dom.py
+++ b/skyvern/webeye/utils/dom.py
@@ -8,7 +8,9 @@ from random import uniform
 from urllib.parse import urljoin, urlparse
 
 import structlog
-from playwright.async_api import ElementHandle, FloatRect, Frame, FrameLocator, Locator, Page, TimeoutError
+from playwright.async_api import ElementHandle
+from playwright.async_api import Error as PlaywrightError
+from playwright.async_api import FloatRect, Frame, FrameLocator, Locator, Page, TimeoutError
 
 from skyvern.config import settings
 from skyvern.constants import SKYVERN_ID_ATTR
@@ -75,7 +77,14 @@ async def resolve_locator(scrape_page: ScrapedPage, page: Page, frame: str, css:
         if frame_handler is None:
             raise NoneFrameError(frame_id=child_frame)
 
-        content_frame = await frame_handler.content_frame()
+        try:
+            content_frame = await frame_handler.content_frame()
+        except PlaywrightError as e:
+            # The iframe detached between query_selector and content_frame (e.g.
+            # navigation / re-render). That is the same "frame is gone" condition
+            # NoneFrameError already signals, so normalize instead of leaking the
+            # raw Playwright error. SKY-12186.
+            raise NoneFrameError(frame_id=child_frame) from e
         if content_frame is None:
             raise NoneFrameError(frame_id=child_frame)
         current_frame = content_frame
@@ -919,6 +928,17 @@ class SkyvernElement:
         await self.get_locator().fill(text, timeout=timeout)
 
     async def input_clear(self, timeout: float = settings.BROWSER_ACTION_TIMEOUT_MS) -> None:
+        # Only editable / text-input-capable elements can be cleared. Clearing a
+        # non-text element (e.g. an h2 the LLM mis-picked) raises
+        # "not an <input>, <textarea> or [contenteditable] element" -- skip it
+        # instead so the doomed clear and its noisy exception never run. SKY-12337.
+        if not await self.supports_text_input():
+            LOG.info(
+                "Skip clearing a non-text-input element",
+                element_id=self.get_id(),
+                tag_name=self.get_tag_name(),
+            )
+            return
         locator = self.get_locator()
         await EventStrategyFactory.clear_field(locator.page, locator, char_count=0)
 

--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -449,6 +449,15 @@ def _all_page_frames(page: Page) -> list[Frame]:
     return frames
 
 
+def is_browser_crashed_error(exc: BaseException) -> bool:
+    """True for an environmental renderer/target crash or a closed page/context/browser
+    (e.g. ``Page.content: Target crashed``, ``Target closed``). These are not Skyvern
+    defects and every ``get_content`` caller already degrades gracefully, so they warrant
+    a warning rather than an error in tracking. SKY-12344."""
+    msg = str(exc).lower()
+    return "target crashed" in msg or "page crashed" in msg or "target closed" in msg or "has been closed" in msg
+
+
 class SkyvernFrame:
     @staticmethod
     async def evaluate(

--- a/tests/unit/test_browser_crashed_error.py
+++ b/tests/unit/test_browser_crashed_error.py
@@ -1,0 +1,36 @@
+"""SKY-12344: classify an environmental renderer/target crash so callers can
+downgrade its log. The crash is already caught and the run continues (degraded)
+at every get_content caller, so it is noise in error-tracking, not a failure --
+but a genuine (non-crash) get_content bug must still be classified loud."""
+
+import pytest
+from playwright._impl._errors import Error as PlaywrightError
+from playwright._impl._errors import TargetClosedError
+from playwright._impl._errors import TimeoutError as PlaywrightTimeoutError
+
+from skyvern.webeye.utils.page import is_browser_crashed_error
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        PlaywrightError("Page.content: Target crashed"),
+        PlaywrightError("Page.content: Target closed"),
+        TargetClosedError("Target page, context or browser has been closed"),
+        PlaywrightError("Page crashed"),
+    ],
+)
+def test_browser_crashed_error_true_for_crash_and_closed(exc: BaseException) -> None:
+    assert is_browser_crashed_error(exc) is True
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        PlaywrightTimeoutError("Page.content: Timeout 300000ms exceeded."),
+        PlaywrightError("Some other content extraction bug"),
+        ValueError("unrelated"),
+    ],
+)
+def test_browser_crashed_error_false_for_real_failures(exc: BaseException) -> None:
+    assert is_browser_crashed_error(exc) is False

--- a/tests/unit/test_frame_element_visibility_guard.py
+++ b/tests/unit/test_frame_element_visibility_guard.py
@@ -12,6 +12,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from playwright._impl._errors import TargetClosedError
 from playwright._impl._errors import TimeoutError as PlaywrightTimeoutError
 
 from skyvern.webeye.scraper import scraper
@@ -31,6 +32,17 @@ async def test_frame_element_is_visible_false_on_playwright_timeout() -> None:
         side_effect=PlaywrightTimeoutError("ElementHandle.is_visible: Timeout 30000ms exceeded.")
     )
     assert await scraper._frame_element_is_visible(handle) is False
+
+
+@pytest.mark.asyncio
+async def test_frame_element_is_visible_reraises_target_closed() -> None:
+    # A dead browser/page must surface, not be masked as an invisible (skippable) frame.
+    handle = MagicMock()
+    handle.is_visible = AsyncMock(
+        side_effect=TargetClosedError("ElementHandle.is_visible: Target page, context or browser has been closed")
+    )
+    with pytest.raises(TargetClosedError):
+        await scraper._frame_element_is_visible(handle)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_frame_element_visibility_guard.py
+++ b/tests/unit/test_frame_element_visibility_guard.py
@@ -1,0 +1,75 @@
+"""SKY-12311: probing an iframe's ElementHandle.is_visible must not hang the scrape.
+
+``ElementHandle.is_visible()`` takes no timeout argument and falls back to
+Playwright's built-in 30s action timeout. On a detached / mid-navigation
+cross-process iframe it can stall for the full 30s and then raise
+``ElementHandle.is_visible: Timeout 30000ms exceeded``. The scrape must treat an
+unreadable frame as "not visible" and skip it -- bounded and fast -- instead of
+stalling or crashing.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from playwright._impl._errors import TimeoutError as PlaywrightTimeoutError
+
+from skyvern.webeye.scraper import scraper
+
+
+@pytest.mark.asyncio
+async def test_frame_element_is_visible_true_when_handle_visible() -> None:
+    handle = MagicMock()
+    handle.is_visible = AsyncMock(return_value=True)
+    assert await scraper._frame_element_is_visible(handle) is True
+
+
+@pytest.mark.asyncio
+async def test_frame_element_is_visible_false_on_playwright_timeout() -> None:
+    handle = MagicMock()
+    handle.is_visible = AsyncMock(
+        side_effect=PlaywrightTimeoutError("ElementHandle.is_visible: Timeout 30000ms exceeded.")
+    )
+    assert await scraper._frame_element_is_visible(handle) is False
+
+
+@pytest.mark.asyncio
+async def test_frame_element_is_visible_bounds_a_hang_and_returns_false_fast() -> None:
+    async def _never_returns() -> bool:
+        await asyncio.sleep(60)
+        return True
+
+    handle = MagicMock()
+    handle.is_visible = AsyncMock(side_effect=_never_returns)
+
+    # A tiny bound must win long before the (mocked) 60s hang would resolve.
+    result = await asyncio.wait_for(scraper._frame_element_is_visible(handle, timeout=0.05), timeout=5)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_get_frame_text_skips_child_whose_visibility_probe_fails() -> None:
+    """A child frame whose visibility probe blows up must be skipped, not fatal."""
+    child = MagicMock()
+    child.url = "https://embed.example.invalid/iframe"
+    child.child_frames = []
+    child.is_detached = MagicMock(return_value=False)
+    child.page = MagicMock()
+
+    bad_element = MagicMock()
+    bad_element.is_visible = AsyncMock(
+        side_effect=PlaywrightTimeoutError("ElementHandle.is_visible: Timeout 30000ms exceeded.")
+    )
+    child.frame_element = AsyncMock(return_value=bad_element)
+
+    main = MagicMock()
+    main.url = "https://example.com/"
+    main.child_frames = [child]
+    main.is_detached = MagicMock(return_value=False)
+    main.page = MagicMock()
+
+    with patch.object(scraper.SkyvernFrame, "evaluate", new=AsyncMock(return_value="root-text")):
+        text = await scraper.get_frame_text(main)
+
+    # Main frame text still returned; the unreadable child contributed nothing and did not raise.
+    assert text == "root-text"

--- a/tests/unit/test_handle_action_known_exceptions.py
+++ b/tests/unit/test_handle_action_known_exceptions.py
@@ -1,0 +1,93 @@
+"""SKY-12325 & SKY-12317: element/frame-gone conditions are expected, not crashes.
+
+When the LLM references an element or iframe that is no longer resolvable in the
+live DOM (detached iframe -> ``NoneFrameError``; stale element id, e.g. on a
+dynamically injected captcha -> ``MissingElementDict``), the action handler must
+convert it into an ``ActionFailure`` (so the agent re-scrapes and retries) AND
+log it as a known/expected condition -- not as ``"Unhandled exception in action
+handler"`` (``LOG.exception``), which surfaces every transient DOM race as an
+error in tracking.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from skyvern.exceptions import (
+    MissingElementDict,
+    MissingElementInCSSMap,
+    MissingElementInIframe,
+    NoneFrameError,
+)
+from skyvern.forge.sdk.models import StepStatus
+from skyvern.webeye.actions.actions import ClickAction
+from skyvern.webeye.actions.handler import ActionHandler
+from skyvern.webeye.actions.responses import ActionFailure
+from skyvern.webeye.scraper.scraped_page import ScrapedPage
+from tests.unit.helpers import make_organization, make_step, make_task
+
+
+def _make_context() -> tuple:
+    now = datetime.now(UTC)
+    organization = make_organization(now)
+    task = make_task(now, organization, workflow_run_id="wr-1", browser_session_id=None)
+    step = make_step(now, task, step_id="step-1", status=StepStatus.created, order=0, output=None)
+    page = MagicMock()
+    page.url = "https://example.com/"
+    scraped_page = ScrapedPage(
+        elements=[],
+        element_tree=[],
+        element_tree_trimmed=[],
+        _browser_state=MagicMock(),
+        _clean_up_func=AsyncMock(return_value=[]),
+        _scrape_exclude=None,
+    )
+    # x/y set => check_for_invalid_web_action short-circuits before element resolution.
+    action = ClickAction(
+        element_id="el-1",
+        x=1,
+        y=1,
+        organization_id=task.organization_id,
+        task_id=task.task_id,
+        step_id=step.step_id,
+    )
+    return task, step, page, scraped_page, action
+
+
+def _first_args(mock_method: MagicMock) -> list:
+    return [call.args[0] if call.args else None for call in mock_method.call_args_list]
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        NoneFrameError(frame_id="iframe-1"),
+        MissingElementDict("el-1"),
+        MissingElementInIframe("el-1"),
+        MissingElementInCSSMap("el-1"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_handle_action_treats_frame_element_gone_as_known_failure(exc: Exception) -> None:
+    task, step, page, scraped_page, action = _make_context()
+
+    async def _raise(*_args, **_kwargs):
+        raise exc
+
+    mock_log = MagicMock()
+    with (
+        patch.object(ActionHandler, "_handled_action_types", {action.action_type: _raise}),
+        patch("skyvern.webeye.actions.handler.app.AGENT_FUNCTION.wait_for_challenge_solver", new=AsyncMock()),
+        patch("skyvern.webeye.actions.handler.LOG", new=mock_log),
+    ):
+        results = await ActionHandler._handle_action(scraped_page, task, step, page, action)
+
+    # Still converted to a (recoverable) ActionFailure carrying the right exception.
+    assert len(results) == 1
+    assert isinstance(results[0], ActionFailure)
+    assert results[0].exception_type == type(exc).__name__
+
+    # Must be classified as a known/expected condition, not an unhandled exception.
+    assert "Known exceptions" in _first_args(mock_log.info)
+    assert "Unhandled exception in action handler" not in _first_args(mock_log.exception)

--- a/tests/unit/test_input_clear_non_editable.py
+++ b/tests/unit/test_input_clear_non_editable.py
@@ -1,74 +1,56 @@
-"""SKY-12337: clearing must only target text-input-capable elements.
+"""SKY-12337: clearing must only no-op on Playwright's exact non-editable error.
 
-When the LLM picks a non-editable element (e.g. an ``h2``) for an input action,
-``Locator.clear`` raises ``Element is not an <input>, <textarea> or
-[contenteditable] element``. Two guards:
-
-1. ``SkyvernElement.input_clear`` no-ops when the element cannot accept text, so
-   the doomed ``clear`` (and its noisy exception log) never runs.
-2. ``DefaultInputStrategy.clear_field`` swallows the specific "not editable"
-   Playwright validation error as a safety net (clearing a non-editable element
-   is a no-op by definition), while still propagating real failures.
+`DefaultInputStrategy.clear_field` is the shared choke point for every agent
+`input_clear`. Clearing a non-editable element (e.g. an LLM-mispicked `h2`)
+raises `Element is not an <input>, <textarea> or [contenteditable] element`;
+that specific validation error is a safe no-op. Everything else -- including a
+genuine clear() timeout whose call log happens to mention `contenteditable` --
+must still propagate, or stale text survives for the next `type()` to append to.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from playwright._impl._errors import Error as PlaywrightError
 from playwright._impl._errors import TimeoutError as PlaywrightTimeoutError
 
 from skyvern.forge.sdk.event.default import DefaultInputStrategy
-from skyvern.forge.sdk.event.factory import EventStrategyFactory
-from skyvern.webeye.utils.dom import SkyvernElement
 
 _NOT_EDITABLE_MESSAGE = "Locator.clear: Error: Element is not an <input>, <textarea> or [contenteditable] element"
-
-
-def _make_element(tag_name: str) -> SkyvernElement:
-    locator = MagicMock()
-    locator.page = MagicMock()
-    return SkyvernElement(locator, MagicMock(), {"id": "el-1", "tagName": tag_name, "attributes": {}})
-
-
-@pytest.mark.asyncio
-async def test_input_clear_skips_non_text_input_element() -> None:
-    element = _make_element("h2")
-    element.supports_text_input = AsyncMock(return_value=False)  # type: ignore[method-assign]
-
-    with patch.object(EventStrategyFactory, "clear_field", new=AsyncMock()) as mock_clear:
-        await element.input_clear()
-
-    mock_clear.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_input_clear_runs_for_text_input_element() -> None:
-    element = _make_element("input")
-    element.supports_text_input = AsyncMock(return_value=True)  # type: ignore[method-assign]
-
-    with patch.object(EventStrategyFactory, "clear_field", new=AsyncMock()) as mock_clear:
-        await element.input_clear()
-
-    mock_clear.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_clear_field_swallows_non_editable_validation_error() -> None:
     strategy = DefaultInputStrategy()
-    page = MagicMock()
     locator = MagicMock()
     locator.clear = AsyncMock(side_effect=PlaywrightError(_NOT_EDITABLE_MESSAGE))
 
     # Must not raise -- clearing a non-editable element is a no-op.
-    await strategy.clear_field(page, locator, char_count=0)
+    await strategy.clear_field(MagicMock(), locator, char_count=0)
+
+
+@pytest.mark.asyncio
+async def test_clear_field_propagates_timeout_even_when_call_log_mentions_contenteditable() -> None:
+    # A real timeout on a valid contenteditable field embeds the resolved element in
+    # its call log; that must NOT be swallowed as a no-op (would leave stale content).
+    strategy = DefaultInputStrategy()
+    locator = MagicMock()
+    locator.clear = AsyncMock(
+        side_effect=PlaywrightTimeoutError(
+            "Locator.clear: Timeout 5000ms exceeded.\nCall log:\n  - waiting for locator resolved to "
+            '<div contenteditable="true">…</div>'
+        )
+    )
+
+    with pytest.raises(PlaywrightTimeoutError):
+        await strategy.clear_field(MagicMock(), locator, char_count=0)
 
 
 @pytest.mark.asyncio
 async def test_clear_field_propagates_other_errors() -> None:
     strategy = DefaultInputStrategy()
-    page = MagicMock()
     locator = MagicMock()
     locator.clear = AsyncMock(side_effect=PlaywrightTimeoutError("Locator.clear: Timeout 5000ms exceeded."))
 
     with pytest.raises(PlaywrightTimeoutError):
-        await strategy.clear_field(page, locator, char_count=0)
+        await strategy.clear_field(MagicMock(), locator, char_count=0)

--- a/tests/unit/test_input_clear_non_editable.py
+++ b/tests/unit/test_input_clear_non_editable.py
@@ -1,0 +1,74 @@
+"""SKY-12337: clearing must only target text-input-capable elements.
+
+When the LLM picks a non-editable element (e.g. an ``h2``) for an input action,
+``Locator.clear`` raises ``Element is not an <input>, <textarea> or
+[contenteditable] element``. Two guards:
+
+1. ``SkyvernElement.input_clear`` no-ops when the element cannot accept text, so
+   the doomed ``clear`` (and its noisy exception log) never runs.
+2. ``DefaultInputStrategy.clear_field`` swallows the specific "not editable"
+   Playwright validation error as a safety net (clearing a non-editable element
+   is a no-op by definition), while still propagating real failures.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from playwright._impl._errors import Error as PlaywrightError
+from playwright._impl._errors import TimeoutError as PlaywrightTimeoutError
+
+from skyvern.forge.sdk.event.default import DefaultInputStrategy
+from skyvern.forge.sdk.event.factory import EventStrategyFactory
+from skyvern.webeye.utils.dom import SkyvernElement
+
+_NOT_EDITABLE_MESSAGE = "Locator.clear: Error: Element is not an <input>, <textarea> or [contenteditable] element"
+
+
+def _make_element(tag_name: str) -> SkyvernElement:
+    locator = MagicMock()
+    locator.page = MagicMock()
+    return SkyvernElement(locator, MagicMock(), {"id": "el-1", "tagName": tag_name, "attributes": {}})
+
+
+@pytest.mark.asyncio
+async def test_input_clear_skips_non_text_input_element() -> None:
+    element = _make_element("h2")
+    element.supports_text_input = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+    with patch.object(EventStrategyFactory, "clear_field", new=AsyncMock()) as mock_clear:
+        await element.input_clear()
+
+    mock_clear.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_input_clear_runs_for_text_input_element() -> None:
+    element = _make_element("input")
+    element.supports_text_input = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+    with patch.object(EventStrategyFactory, "clear_field", new=AsyncMock()) as mock_clear:
+        await element.input_clear()
+
+    mock_clear.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_clear_field_swallows_non_editable_validation_error() -> None:
+    strategy = DefaultInputStrategy()
+    page = MagicMock()
+    locator = MagicMock()
+    locator.clear = AsyncMock(side_effect=PlaywrightError(_NOT_EDITABLE_MESSAGE))
+
+    # Must not raise -- clearing a non-editable element is a no-op.
+    await strategy.clear_field(page, locator, char_count=0)
+
+
+@pytest.mark.asyncio
+async def test_clear_field_propagates_other_errors() -> None:
+    strategy = DefaultInputStrategy()
+    page = MagicMock()
+    locator = MagicMock()
+    locator.clear = AsyncMock(side_effect=PlaywrightTimeoutError("Locator.clear: Timeout 5000ms exceeded."))
+
+    with pytest.raises(PlaywrightTimeoutError):
+        await strategy.clear_field(page, locator, char_count=0)

--- a/tests/unit/test_resolve_locator_detached_frame.py
+++ b/tests/unit/test_resolve_locator_detached_frame.py
@@ -11,6 +11,7 @@ already signals with ``NoneFrameError`` -- so it must be normalized to
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from playwright._impl._errors import TargetClosedError
 from playwright.async_api import Error as PlaywrightError
 
 from skyvern.exceptions import NoneFrameError
@@ -38,6 +39,34 @@ async def test_resolve_locator_normalizes_detached_content_frame_to_none_frame_e
     page.query_selector = AsyncMock(return_value=detached_handle)
 
     with pytest.raises(NoneFrameError):
+        await resolve_locator(scrape_page, page, frame_id, "div.target")
+
+
+@pytest.mark.asyncio
+async def test_resolve_locator_normalizes_detached_query_selector_to_none_frame_error() -> None:
+    # An already-detached parent frame fails at query_selector, not content_frame.
+    frame_id = "iframe-1"
+    scrape_page = _scrape_page_with_single_iframe(frame_id)
+
+    page = MagicMock()
+    page.query_selector = AsyncMock(side_effect=PlaywrightError("Frame was detached"))
+
+    with pytest.raises(NoneFrameError):
+        await resolve_locator(scrape_page, page, frame_id, "div.target")
+
+
+@pytest.mark.asyncio
+async def test_resolve_locator_reraises_target_closed_error() -> None:
+    # A closed/crashed target is NOT a DOM race -- it must surface, not be masked as NoneFrameError.
+    frame_id = "iframe-1"
+    scrape_page = _scrape_page_with_single_iframe(frame_id)
+
+    handle = MagicMock()
+    handle.content_frame = AsyncMock(side_effect=TargetClosedError("Target page, context or browser has been closed"))
+    page = MagicMock()
+    page.query_selector = AsyncMock(return_value=handle)
+
+    with pytest.raises(TargetClosedError):
         await resolve_locator(scrape_page, page, frame_id, "div.target")
 
 

--- a/tests/unit/test_resolve_locator_detached_frame.py
+++ b/tests/unit/test_resolve_locator_detached_frame.py
@@ -1,0 +1,57 @@
+"""SKY-12186: a detached iframe handle must not leak a raw Playwright error.
+
+``resolve_locator`` calls ``query_selector`` then ``content_frame`` on the
+returned handle. When the iframe detaches between those two awaits, Playwright
+raises ``ElementHandle.content_frame: Element is not attached to the DOM``.
+That means the scraped frame is gone -- the same condition ``resolve_locator``
+already signals with ``NoneFrameError`` -- so it must be normalized to
+``NoneFrameError`` rather than surfacing the raw Playwright error.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from playwright.async_api import Error as PlaywrightError
+
+from skyvern.exceptions import NoneFrameError
+from skyvern.webeye.utils.dom import resolve_locator
+
+
+def _scrape_page_with_single_iframe(frame_id: str) -> MagicMock:
+    scrape_page = MagicMock()
+    # The frame's parent is the main frame, so resolve_locator walks exactly one hop.
+    scrape_page.id_to_element_dict = {frame_id: {"frame": "main.frame"}}
+    return scrape_page
+
+
+@pytest.mark.asyncio
+async def test_resolve_locator_normalizes_detached_content_frame_to_none_frame_error() -> None:
+    frame_id = "iframe-1"
+    scrape_page = _scrape_page_with_single_iframe(frame_id)
+
+    detached_handle = MagicMock()
+    detached_handle.content_frame = AsyncMock(
+        side_effect=PlaywrightError("ElementHandle.content_frame: Element is not attached to the DOM")
+    )
+
+    page = MagicMock()
+    page.query_selector = AsyncMock(return_value=detached_handle)
+
+    with pytest.raises(NoneFrameError):
+        await resolve_locator(scrape_page, page, frame_id, "div.target")
+
+
+@pytest.mark.asyncio
+async def test_resolve_locator_raises_none_frame_error_when_content_frame_is_none() -> None:
+    # Existing contract must be preserved: a None content_frame is still NoneFrameError.
+    frame_id = "iframe-1"
+    scrape_page = _scrape_page_with_single_iframe(frame_id)
+
+    handle = MagicMock()
+    handle.content_frame = AsyncMock(return_value=None)
+
+    page = MagicMock()
+    page.query_selector = AsyncMock(return_value=handle)
+
+    with pytest.raises(NoneFrameError):
+        await resolve_locator(scrape_page, page, frame_id, "div.target")


### PR DESCRIPTION
## Description

Several Datadog-reported browser-automation crashes share one root cause: a Playwright action or scrape runs against a DOM/frame/page that has changed since it was scraped — a detached iframe, a stale element id, a non-editable target, a cross-process frame mid-navigation, or a crashed renderer. Rather than patch each caller, this guards the shared choke points so these transient/environmental races degrade gracefully instead of crashing the run or spamming error tracking. Guards are deliberately narrow — they normalize/skip only the intended condition and re-raise real failures (a closed/dead browser is never masked).

- **SKY-12186** (`ElementHandle.content_frame: Element is not attached to the DOM`): `resolve_locator` now wraps both the `query_selector` and `content_frame` calls and normalizes **only** a detached-frame error into `NoneFrameError` (the same "frame is gone" signal it already raises for a `None` handle/content frame). A closed/crashed target (`TargetClosedError`) is re-raised, not masked.
- **SKY-12325** (`NoneFrameError: frame content is none`) and **SKY-12317** (`MissingElementDict: Invalid element id` on captcha steps): `ActionHandler._handle_action` now classifies `NoneFrameError`, `MissingElementDict`, `MissingElementInIframe`, and `MissingElementInCSSMap` as known, recoverable `ActionFailure`s (logged at info) instead of falling through to the catch-all `LOG.exception("Unhandled exception in action handler")`. Behavior is unchanged (still an `ActionFailure` that stops the action and lets the agent re-scrape); it just stops surfacing every transient DOM race as an error.
- **SKY-12311** (`ElementHandle.is_visible: Timeout 30000ms exceeded`): `ElementHandle.is_visible()` takes no timeout and falls back to Playwright's built-in 30s default; on a detached/mid-navigation cross-process iframe it can stall the whole scrape and then raise. A shared `_frame_element_is_visible` helper bounds the probe and treats a hang/transient error as "not visible" so the frame is skipped fast — while re-raising `TargetClosedError` so a dead browser is not masked as an invisible frame (partial-scrape "success"). Applied at both frame-visibility call sites.
- **SKY-12337** (`Locator.clear: Element is not an <input>, <textarea> or [contenteditable] element` on an `h2`): the default `clear_field` strategy now swallows **only** Playwright's exact non-editable validation diagnostic (clearing a non-editable element is a no-op by definition), while a genuine `clear()` timeout — including on a valid contenteditable field whose call log mentions `contenteditable` — still propagates. This is the shared choke point for every agent `input_clear`.
- **SKY-12344** (`Page.content: Target crashed`): a renderer/target crash. Every `get_content` caller already catches it and continues (the scraper keeps its independently-captured element tree and proceeds with empty html; `validate_browser_context` returns `False` to trigger recovery; artifact recording is best-effort) — none abort the step. A new `is_browser_crashed_error()` predicate downgrades the recognized crash/closed-target class from `LOG.error`/`LOG.exception` to a warning at the three content-read sites, while genuine (non-crash) content-read failures stay loud. Log-level only — no behavior change to the existing catch-and-continue handling.

Not in this PR:
- **SKY-12094** (`connect_over_cdp: getaddrinfo ENOTFOUND example`): closed as not-a-bug / invalid input. No code path constructs a host of `example`; it is caller-supplied placeholder input to `skyvern_get_html`'s `cdp_url`, passed verbatim to `connect_over_cdp`.

## How Has This Been Tested?

New unit tests (TDD, red→green) under `tests/unit/`:
- `test_resolve_locator_detached_frame.py` — detached `content_frame` **and** detached `query_selector` → `NoneFrameError`; `TargetClosedError` propagates (not masked); `None` content frame still raises `NoneFrameError`.
- `test_handle_action_known_exceptions.py` — each of the four frame/element-gone exceptions is returned as an `ActionFailure` and logged as "Known exceptions", not an unhandled exception.
- `test_frame_element_visibility_guard.py` — the bounded helper returns correctly, bounds a hang, skips (doesn't crash on) a failed probe, and re-raises `TargetClosedError`.
- `test_input_clear_non_editable.py` — `clear_field` swallows the exact non-editable error but re-raises a real timeout (even when its call log mentions `contenteditable`) and other failures.
- `test_browser_crashed_error.py` — the crash predicate is True for the crash/closed class and False for a real timeout / unrelated content bug.

Commands run locally (all green):
- `uv run python -m py_compile` on every changed file
- `uv run ruff check` / `ruff format` and full `pre-commit` (isort, mypy, etc.)
- `uv run mypy` on all changed source files
- `uv run pytest tests/unit/...` — the new suites plus the existing webeye/action/scraper/handler suites that exercise the changed paths (no regressions).

This PR was additionally run through a second-pass review gate before merge; three over-broad-catch findings (masking a real `clear()` timeout, masking a `TargetClosedError` as an invisible frame, and a detached nested-frame `query_selector` still raising raw) were caught and fixed with tests, and CI is green.

## Artifacts (if appropriate):

N/A — backend resilience change, no UI surface.
