### PR TITLE
Add Tokenless WebVoyager evaluation instrumentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,20 @@ ENABLE_GEMINI=false
 # GEMINI_API_KEY: Your Gemini API key for accessing models like Gemini 2.5 Pro.
 GEMINI_API_KEY=""
 
+# OpenAI-compatible provider configuration. Set OPENAI_COMPATIBLE_USE_NATIVE_CLIENT=true
+# when the provider exposes response headers that must be retained, such as Tokenless's
+# X-Request-Id cost attribution header.
+ENABLE_OPENAI_COMPATIBLE=false
+OPENAI_COMPATIBLE_MODEL_NAME=""
+# Optional comma-separated aliases exposed by the same endpoint, for example
+# "tokenless-ultra-saver" when OPENAI_COMPATIBLE_MODEL_NAME="tokenless-pro".
+OPENAI_COMPATIBLE_ADDITIONAL_MODEL_NAMES=""
+OPENAI_COMPATIBLE_MODEL_KEY="OPENAI_COMPATIBLE"
+OPENAI_COMPATIBLE_API_KEY=""
+OPENAI_COMPATIBLE_API_BASE=""
+OPENAI_COMPATIBLE_SUPPORTS_VISION=false
+OPENAI_COMPATIBLE_USE_NATIVE_CLIENT=false
+
 # ENABLE_NOVITA: Set to true to enable Novita AI as a language model provider.
 ENABLE_NOVITA=false
 # NOVITA_API_KEY: Your Novita AI API key.

--- a/alembic/versions/2026_07_13_1200-7f0f6a4e8a9b_add_task_v2_llm_metrics.py
+++ b/alembic/versions/2026_07_13_1200-7f0f6a4e8a9b_add_task_v2_llm_metrics.py
@@ -1,0 +1,143 @@
+"""add durable Task V2 LLM and run metrics
+
+Revision ID: 7f0f6a4e8a9b
+Revises: a0d23605c574
+Create Date: 2026-07-13 12:00:00.000000+00:00
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+revision: str = "7f0f6a4e8a9b"
+down_revision: Union[str, None] = "a0d23605c574"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "task_v2_run_metrics",
+        sa.Column("task_v2_run_metrics_id", sa.String(), nullable=False),
+        sa.Column("task_v2_id", sa.String(), nullable=False),
+        sa.Column("organization_id", sa.String(), nullable=False),
+        sa.Column("workflow_run_id", sa.String(), nullable=False),
+        sa.Column("workflow_id", sa.String(), nullable=True),
+        sa.Column("workflow_permanent_id", sa.String(), nullable=True),
+        sa.Column("iteration_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("loop_item_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("retry_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("modified_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("task_v2_run_metrics_id"),
+        sa.UniqueConstraint("workflow_run_id"),
+    )
+    op.create_index(
+        "t2rm_org_created_at_index",
+        "task_v2_run_metrics",
+        ["organization_id", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "t2rm_org_wfr_index",
+        "task_v2_run_metrics",
+        ["organization_id", "workflow_run_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_task_v2_run_metrics_task_v2_id",
+        "task_v2_run_metrics",
+        ["task_v2_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "task_v2_llm_calls",
+        sa.Column("task_v2_llm_call_id", sa.String(), nullable=False),
+        sa.Column("task_v2_id", sa.String(), nullable=False),
+        sa.Column("organization_id", sa.String(), nullable=False),
+        sa.Column("workflow_run_id", sa.String(), nullable=False),
+        sa.Column("workflow_id", sa.String(), nullable=True),
+        sa.Column("workflow_permanent_id", sa.String(), nullable=True),
+        sa.Column("task_id", sa.String(), nullable=True),
+        sa.Column("step_id", sa.String(), nullable=True),
+        sa.Column("thought_id", sa.String(), nullable=True),
+        sa.Column("workflow_run_block_id", sa.String(), nullable=True),
+        sa.Column("call_type", sa.String(), nullable=False),
+        sa.Column("prompt_name", sa.String(), nullable=False),
+        sa.Column("task_type", sa.String(), nullable=True),
+        sa.Column("iteration", sa.Integer(), nullable=True),
+        sa.Column("loop_item_count", sa.Integer(), nullable=True),
+        sa.Column("loop_index", sa.Integer(), nullable=True),
+        sa.Column("retry_index", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("is_speculative", sa.Boolean(), server_default=sa.false(), nullable=False),
+        sa.Column("llm_key", sa.String(), nullable=True),
+        sa.Column("model", sa.String(), nullable=True),
+        sa.Column("requested_model", sa.String(), nullable=True),
+        sa.Column("provider_request_id", sa.String(), nullable=True),
+        sa.Column("input_token_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("output_token_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("reasoning_token_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("image_token_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("cached_token_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("llm_cost", sa.Numeric(), nullable=True),
+        sa.Column("status", sa.String(), server_default=sa.text("'completed'"), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("modified_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("task_v2_llm_call_id"),
+    )
+    op.create_index(
+        "t2llm_org_created_at_index",
+        "task_v2_llm_calls",
+        ["organization_id", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "t2llm_org_wfr_index",
+        "task_v2_llm_calls",
+        ["organization_id", "workflow_run_id"],
+        unique=False,
+    )
+    op.create_index(
+        "t2llm_wfr_prompt_index",
+        "task_v2_llm_calls",
+        ["workflow_run_id", "prompt_name"],
+        unique=False,
+    )
+    op.create_index(
+        "t2llm_wfr_model_index",
+        "task_v2_llm_calls",
+        ["workflow_run_id", "model"],
+        unique=False,
+    )
+    op.create_index(
+        "t2llm_wfr_provider_request_index",
+        "task_v2_llm_calls",
+        ["workflow_run_id", "provider_request_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_task_v2_llm_calls_task_v2_id",
+        "task_v2_llm_calls",
+        ["task_v2_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_task_v2_llm_calls_task_v2_id", table_name="task_v2_llm_calls")
+    op.drop_index("t2llm_wfr_provider_request_index", table_name="task_v2_llm_calls")
+    op.drop_index("t2llm_wfr_model_index", table_name="task_v2_llm_calls")
+    op.drop_index("t2llm_wfr_prompt_index", table_name="task_v2_llm_calls")
+    op.drop_index("t2llm_org_wfr_index", table_name="task_v2_llm_calls")
+    op.drop_index("t2llm_org_created_at_index", table_name="task_v2_llm_calls")
+    op.drop_table("task_v2_llm_calls")
+
+    op.drop_index("ix_task_v2_run_metrics_task_v2_id", table_name="task_v2_run_metrics")
+    op.drop_index("t2rm_org_wfr_index", table_name="task_v2_run_metrics")
+    op.drop_index("t2rm_org_created_at_index", table_name="task_v2_run_metrics")
+    op.drop_table("task_v2_run_metrics")

--- a/evaluation/core/__init__.py
+++ b/evaluation/core/__init__.py
@@ -14,7 +14,12 @@ from skyvern.forge.prompts import prompt_engine
 from skyvern.forge.sdk.api.files import create_folder_if_not_exist
 from skyvern.forge.sdk.schemas.task_v2 import TaskV2, TaskV2Request
 from skyvern.forge.sdk.schemas.tasks import TaskRequest, TaskResponse, TaskStatus
-from skyvern.forge.sdk.workflow.models.workflow import WorkflowRequestBody, WorkflowRunResponseBase, WorkflowRunStatus
+from skyvern.forge.sdk.workflow.models.workflow import (
+    WorkflowRequestBody,
+    WorkflowRunEvaluationCost,
+    WorkflowRunResponseBase,
+    WorkflowRunStatus,
+)
 from skyvern.schemas.runs import ProxyLocation
 
 
@@ -80,6 +85,21 @@ class SkyvernClient:
                 f"Expected to get workflow run response status 200, but got {response.status_code}"
             )
             return WorkflowRunResponseBase(**response.json())
+
+    async def get_workflow_run_evaluation_cost(
+        self,
+        workflow_pid: str,
+        workflow_run_id: str,
+    ) -> WorkflowRunEvaluationCost:
+        """Fetch exact target-agent LLM cost for one evaluation workflow run."""
+        url = f"{self.base_url}/workflows/{workflow_pid}/runs/{workflow_run_id}/evaluation-cost"
+        headers = {"x-api-key": self.credentials}
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=headers)
+            assert response.status_code == 200, (
+                f"Expected evaluation cost response status 200, but got {response.status_code}: {response.text}"
+            )
+            return WorkflowRunEvaluationCost(**response.json())
 
 
 class Evaluator:

--- a/evaluation/script/create_webvoyager_task_v2.py
+++ b/evaluation/script/create_webvoyager_task_v2.py
@@ -19,6 +19,7 @@ load_dotenv()
 async def create_task_v2(
     base_url: str,
     cred: str,
+    model_name: str | None = None,
 ) -> None:
     start_forge_app()
 
@@ -43,6 +44,7 @@ async def create_task_v2(
             request_body = TaskV2Request(
                 url=case_data.url,
                 user_prompt=case_data.question,
+                model={"model_name": model_name} if model_name else None,
             )
             task_v2 = evaluator.queue_skyvern_task_v2(cruise_request=request_body, max_step=case_data.max_steps)
             dumped_data = case_data.model_dump()
@@ -64,8 +66,13 @@ async def create_task_v2(
 def main(
     base_url: str = typer.Option(..., "--base-url", help="base url for Skyvern client"),
     cred: str = typer.Option(..., "--cred", help="credential for Skyvern organization"),
+    model_name: str | None = typer.Option(
+        None,
+        "--model-name",
+        help="model name to use for Task V2, e.g. gemini-3.5-flash or tokenless-pro",
+    ),
 ) -> None:
-    asyncio.run(create_task_v2(base_url=base_url, cred=cred))
+    asyncio.run(create_task_v2(base_url=base_url, cred=cred, model_name=model_name))
 
 
 if __name__ == "__main__":

--- a/evaluation/script/eval_webvoyager_task_v2.py
+++ b/evaluation/script/eval_webvoyager_task_v2.py
@@ -25,6 +25,23 @@ csv_headers = [
     "is_updated",
     "workflow_permanent_id",
     "workflow_run_id",
+    "agent_cost_usd",
+    "input_tokens",
+    "output_tokens",
+    "reasoning_tokens",
+    "image_tokens",
+    "planner_call_count",
+    "check_completion_call_count",
+    "generate_extraction_task_call_count",
+    "generate_task_block_call_count",
+    "extract_actions_call_count",
+    "iteration_count",
+    "loop_item_count",
+    "retry_count",
+    "model_call_counts",
+    "prompt_call_counts",
+    "llm_calls",
+    "cost_status",
 ]
 
 BATCH_SIZE = 5
@@ -34,11 +51,32 @@ async def process_record(client: SkyvernClient, one_record: dict[str, Any]) -> d
     workflow_pid: str = one_record.get("workflow_permanent_id", "")
     workflow_run_id: str = one_record.get("workflow_run_id", "")
     workflow_run_response = await client.get_workflow_run(workflow_pid=workflow_pid, workflow_run_id=workflow_run_id)
+    evaluation_cost = await client.get_workflow_run_evaluation_cost(
+        workflow_pid=workflow_pid,
+        workflow_run_id=workflow_run_id,
+    )
     one_record.update(
         {
             "status": str(workflow_run_response.status),
-            "summary": workflow_run_response.task_v2.summary,
-            "output": workflow_run_response.task_v2.output,
+            "summary": workflow_run_response.task_v2.summary if workflow_run_response.task_v2 else None,
+            "output": workflow_run_response.task_v2.output if workflow_run_response.task_v2 else None,
+            "agent_cost_usd": evaluation_cost.agent_cost_usd,
+            "input_tokens": evaluation_cost.input_tokens,
+            "output_tokens": evaluation_cost.output_tokens,
+            "reasoning_tokens": evaluation_cost.reasoning_tokens,
+            "image_tokens": evaluation_cost.image_tokens,
+            "planner_call_count": evaluation_cost.planner_call_count,
+            "check_completion_call_count": evaluation_cost.check_completion_call_count,
+            "generate_extraction_task_call_count": evaluation_cost.generate_extraction_task_call_count,
+            "generate_task_block_call_count": evaluation_cost.generate_task_block_call_count,
+            "extract_actions_call_count": evaluation_cost.extract_actions_call_count,
+            "iteration_count": evaluation_cost.iteration_count,
+            "loop_item_count": evaluation_cost.loop_item_count,
+            "retry_count": evaluation_cost.retry_count,
+            "model_call_counts": json.dumps(evaluation_cost.model_call_counts, sort_keys=True),
+            "prompt_call_counts": json.dumps(evaluation_cost.prompt_call_counts, sort_keys=True),
+            "llm_calls": json.dumps([call.model_dump() for call in evaluation_cost.llm_calls]),
+            "cost_status": evaluation_cost.cost_status,
         }
     )
     if workflow_run_response.status != WorkflowRunStatus.completed:

--- a/evaluation/script/run_webvoyager_task_v2.py
+++ b/evaluation/script/run_webvoyager_task_v2.py
@@ -1,0 +1,341 @@
+"""Run paired WebVoyager Task V2 evaluations with exact model cost reporting."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import typer
+from dotenv import load_dotenv
+
+from evaluation.core import Evaluator, SkyvernClient
+from evaluation.core.utils import WebVoyagerTestCase, load_webvoyager_case_from_json
+from skyvern.config import settings
+from skyvern.forge import app
+from skyvern.forge.forge_app_initializer import start_forge_app
+from skyvern.forge.prompts import prompt_engine
+from skyvern.forge.sdk.api.llm.api_handler_factory import LLMAPIHandlerFactory
+from skyvern.forge.sdk.schemas.task_v2 import TaskV2Request
+from skyvern.forge.sdk.workflow.models.workflow import WorkflowRunResponseBase, WorkflowRunStatus
+
+load_dotenv()
+
+FIXED_JUDGE_LLM_KEY = "VERTEX_GEMINI_3.5_FLASH"
+
+
+def _web_name(case: WebVoyagerTestCase) -> str:
+    """Return the benchmark website name encoded in a WebVoyager case ID."""
+    return case.id.split("--", 1)[0]
+
+
+def _merge_counts(count_maps: Any) -> dict[str, int]:
+    """Sum string-keyed count maps across evaluation cases."""
+    merged: dict[str, int] = {}
+    for count_map in count_maps:
+        for key, value in count_map.items():
+            merged[key] = merged.get(key, 0) + value
+    return merged
+
+
+async def _normalize_cases(
+    dataset_path: str,
+    output_path: Path,
+    limit: int | None = None,
+    web_name: str | None = None,
+) -> list[WebVoyagerTestCase]:
+    """Normalize each WebVoyager prompt once using the fixed judge model."""
+    group_id = str(uuid4())
+    cases: list[WebVoyagerTestCase] = []
+    for case in load_webvoyager_case_from_json(dataset_path, group_id=group_id):
+        if web_name and _web_name(case).casefold() != web_name.casefold():
+            continue
+        if limit is not None and len(cases) >= limit:
+            break
+        prompt = prompt_engine.load_prompt(
+            "check-evaluation-goal",
+            user_goal=case.question,
+            local_datetime=datetime.now().isoformat(),
+        )
+        response = await app.LLM_API_HANDLER(prompt=prompt, prompt_name="check-evaluation-goal")
+        tweaked_user_goal = response.get("tweaked_user_goal")
+        if isinstance(tweaked_user_goal, str) and tweaked_user_goal.strip():
+            case.is_updated = tweaked_user_goal != case.question
+            case.question = tweaked_user_goal
+        cases.append(case)
+
+    with output_path.open("w", encoding="utf-8") as output_file:
+        for case in cases:
+            output_file.write(case.model_dump_json() + "\n")
+    return cases
+
+
+async def _submit_case(
+    client: SkyvernClient,
+    case: WebVoyagerTestCase,
+    model_name: str,
+    semaphore: asyncio.Semaphore,
+    proxy_url: str | None,
+) -> dict[str, Any]:
+    """Submit one case to one target model."""
+    async with semaphore:
+        task = await asyncio.to_thread(
+            client.create_task_v2,
+            TaskV2Request(
+                url=case.url,
+                user_prompt=case.question,
+                proxy_location={"url": proxy_url} if proxy_url else None,
+                model={"model_name": model_name},
+            ),
+            case.max_steps,
+        )
+    return {
+        "id": case.id,
+        "model": model_name,
+        "question": case.question,
+        "answer": case.answer,
+        "is_updated": case.is_updated,
+        "workflow_permanent_id": task.workflow_permanent_id,
+        "workflow_run_id": task.workflow_run_id,
+        "task_v2_id": task.observer_cruise_id,
+    }
+
+
+async def _wait_for_completion(
+    client: SkyvernClient,
+    record: dict[str, Any],
+    semaphore: asyncio.Semaphore,
+    poll_interval_seconds: float,
+) -> WorkflowRunResponseBase:
+    """Poll one workflow run until it reaches a terminal state."""
+    while True:
+        async with semaphore:
+            response = await client.get_workflow_run(
+                workflow_pid=record["workflow_permanent_id"],
+                workflow_run_id=record["workflow_run_id"],
+            )
+        if response.status.is_final():
+            return response
+        await asyncio.sleep(poll_interval_seconds)
+
+
+async def _score_record(
+    client: SkyvernClient,
+    record: dict[str, Any],
+    workflow_run_response: WorkflowRunResponseBase,
+    semaphore: asyncio.Semaphore,
+) -> dict[str, Any]:
+    """Score one completed run and collect exact target-agent cost."""
+    passed = False
+    failure_reason = workflow_run_response.failure_reason or ""
+    if workflow_run_response.status == WorkflowRunStatus.completed:
+        evaluator = Evaluator(client=client, artifact_folder="")
+        try:
+            async with semaphore:
+                await evaluator.eval_skyvern_workflow_run(
+                    workflow_pid=record["workflow_permanent_id"],
+                    workflow_run_id=record["workflow_run_id"],
+                    question=record["question"],
+                    answer=record["answer"],
+                    is_updated=record["is_updated"],
+                )
+            passed = True
+        except Exception as exc:  # noqa: BLE001 - each case must produce a result
+            failure_reason = str(exc)
+    else:
+        failure_reason = failure_reason or f"workflow ended with {workflow_run_response.status}"
+
+    async with semaphore:
+        cost = await client.get_workflow_run_evaluation_cost(
+            workflow_pid=record["workflow_permanent_id"],
+            workflow_run_id=record["workflow_run_id"],
+        )
+    return {
+        "id": record["id"],
+        "model": record["model"],
+        "workflow_run_id": record["workflow_run_id"],
+        "status": str(workflow_run_response.status),
+        "passed": passed,
+        "failure_reason": failure_reason,
+        "agent_cost_usd": cost.agent_cost_usd,
+        "input_tokens": cost.input_tokens,
+        "output_tokens": cost.output_tokens,
+        "reasoning_tokens": cost.reasoning_tokens,
+        "image_tokens": cost.image_tokens,
+        "tokenless_request_count": cost.tokenless_request_count,
+        "cost_status": cost.cost_status,
+        "planner_call_count": cost.planner_call_count,
+        "check_completion_call_count": cost.check_completion_call_count,
+        "generate_extraction_task_call_count": cost.generate_extraction_task_call_count,
+        "generate_task_block_call_count": cost.generate_task_block_call_count,
+        "extract_actions_call_count": cost.extract_actions_call_count,
+        "iteration_count": cost.iteration_count,
+        "loop_item_count": cost.loop_item_count,
+        "retry_count": cost.retry_count,
+        "model_call_counts": cost.model_call_counts,
+        "prompt_call_counts": cost.prompt_call_counts,
+        "llm_calls": [call.model_dump() for call in cost.llm_calls],
+    }
+
+
+async def run_eval(
+    base_url: str,
+    cred: str,
+    dataset_path: str,
+    output_dir: str,
+    model_names: list[str],
+    concurrency: int,
+    poll_interval_seconds: float,
+    limit: int | None = None,
+    web_name: str | None = None,
+    proxy_url: str | None = None,
+) -> dict[str, Any]:
+    """Run paired WebVoyager cases and write compact result files."""
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+    manifest_path = output_path / "normalized_manifest.jsonl"
+    cases = await _normalize_cases(dataset_path, manifest_path, limit=limit, web_name=web_name)
+    if not cases:
+        selection = f" for website {web_name!r}" if web_name else ""
+        raise ValueError(f"No WebVoyager cases selected{selection}")
+    client = SkyvernClient(base_url=base_url, credentials=cred)
+    semaphore = asyncio.Semaphore(concurrency)
+
+    submissions = await asyncio.gather(
+        *(_submit_case(client, case, model_name, semaphore, proxy_url) for case in cases for model_name in model_names)
+    )
+    completed_runs = await asyncio.gather(
+        *(_wait_for_completion(client, record, semaphore, poll_interval_seconds) for record in submissions)
+    )
+    results = await asyncio.gather(
+        *(
+            _score_record(client, record, workflow_run_response, semaphore)
+            for record, workflow_run_response in zip(submissions, completed_runs, strict=True)
+        )
+    )
+
+    summary: dict[str, Any] = {
+        "dataset": dataset_path,
+        "judge_model": FIXED_JUDGE_LLM_KEY,
+        "models": {},
+        "total_cases_per_model": len(cases),
+        "concurrency": concurrency,
+        "web_name": web_name,
+        "proxy_configured": bool(proxy_url),
+    }
+    for model_name in model_names:
+        model_results = [result for result in results if result["model"] == model_name]
+        passed_cases = sum(1 for result in model_results if result["passed"])
+        costs = [result["agent_cost_usd"] for result in model_results]
+        cost_status = "exact" if all(result["cost_status"] == "exact" for result in model_results) else "incomplete"
+        summary["models"][model_name] = {
+            "total_cases": len(model_results),
+            "passed_cases": passed_cases,
+            "pass_rate": passed_cases / len(model_results) if model_results else 0.0,
+            "agent_cost_usd": sum(costs) if cost_status == "exact" else None,
+            "input_tokens": sum(result["input_tokens"] for result in model_results),
+            "output_tokens": sum(result["output_tokens"] for result in model_results),
+            "reasoning_tokens": sum(result["reasoning_tokens"] for result in model_results),
+            "image_tokens": sum(result["image_tokens"] for result in model_results),
+            "tokenless_request_count": sum(result["tokenless_request_count"] for result in model_results),
+            "planner_call_count": sum(result["planner_call_count"] for result in model_results),
+            "check_completion_call_count": sum(
+                result["check_completion_call_count"] for result in model_results
+            ),
+            "generate_extraction_task_call_count": sum(
+                result["generate_extraction_task_call_count"] for result in model_results
+            ),
+            "generate_task_block_call_count": sum(
+                result["generate_task_block_call_count"] for result in model_results
+            ),
+            "extract_actions_call_count": sum(result["extract_actions_call_count"] for result in model_results),
+            "iteration_count": sum(result["iteration_count"] for result in model_results),
+            "loop_item_count": sum(result["loop_item_count"] for result in model_results),
+            "retry_count": sum(result["retry_count"] for result in model_results),
+            "model_call_counts": _merge_counts(result["model_call_counts"] for result in model_results),
+            "prompt_call_counts": _merge_counts(result["prompt_call_counts"] for result in model_results),
+            "cost_status": cost_status,
+        }
+
+    with (output_path / "results.jsonl").open("w", encoding="utf-8") as result_file:
+        for result in results:
+            result_file.write(json.dumps(result) + "\n")
+    with (output_path / "summary.json").open("w", encoding="utf-8") as summary_file:
+        json.dump(summary, summary_file, indent=2)
+        summary_file.write("\n")
+
+    for tokenless_model_name in settings.get_openai_compatible_model_names():
+        tokenless_summary = summary["models"].get(tokenless_model_name)
+        if tokenless_summary and tokenless_summary["cost_status"] != "exact":
+            raise RuntimeError(
+                f"Tokenless cost resolution is incomplete for {tokenless_model_name}; "
+                "refusing to report the evaluation as exact"
+            )
+    return summary
+
+
+def main(
+    base_url: str = typer.Option(
+        ...,
+        "--base-url",
+        help="Skyvern API base URL, e.g. http://localhost:8000/api/v1",
+    ),
+    cred: str = typer.Option(..., "--cred", help="Skyvern organization API credential"),
+    dataset_path: str = typer.Option(
+        "evaluation/datasets/webvoyager_tasks.jsonl",
+        "--dataset-path",
+        help="WebVoyager dataset JSONL path",
+    ),
+    output_dir: str = typer.Option("evaluation/results/webvoyager_task_v2", "--output-dir"),
+    models: str = typer.Option(
+        "gemini-3.5-flash,tokenless-pro,tokenless-ultra-saver",
+        "--models",
+    ),
+    limit: int | None = typer.Option(None, "--limit", min=1, help="Run only the first N selected dataset cases"),
+    web_name: str | None = typer.Option(
+        None,
+        "--web-name",
+        help="Restrict the run to one benchmark website, e.g. ArXiv or Allrecipes",
+    ),
+    proxy_url: str | None = typer.Option(
+        None,
+        "--proxy-url",
+        envvar="WEBVOYAGER_PROXY_URL",
+        help="Custom HTTP/SOCKS proxy URL for anti-bot-sensitive websites",
+    ),
+    concurrency: int = typer.Option(
+        8,
+        "--concurrency",
+        min=1,
+        help="Maximum active submissions/polls/scores",
+    ),
+    poll_interval_seconds: float = typer.Option(5.0, "--poll-interval-seconds", min=0.1),
+) -> None:
+    """Run the paired evaluation with Gemini 3.5 Flash as the fixed ADC judge."""
+    start_forge_app()
+    app.LLM_API_HANDLER = LLMAPIHandlerFactory.get_llm_api_handler(FIXED_JUDGE_LLM_KEY)
+    model_names = [model.strip() for model in models.split(",") if model.strip()]
+    if not model_names:
+        raise typer.BadParameter("--models must contain at least one model")
+    summary = asyncio.run(
+        run_eval(
+            base_url=base_url,
+            cred=cred,
+            dataset_path=dataset_path,
+            output_dir=output_dir,
+            model_names=model_names,
+            concurrency=concurrency,
+            poll_interval_seconds=poll_interval_seconds,
+            limit=limit,
+            web_name=web_name,
+            proxy_url=proxy_url,
+        )
+    )
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -416,6 +416,9 @@ class Settings(BaseSettings):
 
     # OPENAI COMPATIBLE
     OPENAI_COMPATIBLE_MODEL_NAME: str | None = None
+    # Comma-separated aliases served by the same endpoint. Task V2 preserves the
+    # selected alias and the native client sends it as the request model.
+    OPENAI_COMPATIBLE_ADDITIONAL_MODEL_NAMES: str | None = None
     OPENAI_COMPATIBLE_API_KEY: str | None = None
     OPENAI_COMPATIBLE_API_BASE: str | None = None
     OPENAI_COMPATIBLE_API_VERSION: str | None = None
@@ -424,6 +427,7 @@ class Settings(BaseSettings):
     OPENAI_COMPATIBLE_SUPPORTS_VISION: bool = False
     OPENAI_COMPATIBLE_ADD_ASSISTANT_PREFIX: bool = False
     OPENAI_COMPATIBLE_MODEL_KEY: str = "OPENAI_COMPATIBLE"
+    OPENAI_COMPATIBLE_USE_NATIVE_CLIENT: bool = False
     OPENAI_COMPATIBLE_REASONING_EFFORT: str | None = None
     OPENAI_COMPATIBLE_GITHUB_COPILOT_DOMAIN: str = "githubcopilot.com"
 
@@ -775,6 +779,20 @@ class Settings(BaseSettings):
     # script generation settings
     WORKFLOW_START_BLOCK_LABEL: str = "__start_block__"
 
+    def get_openai_compatible_model_names(self) -> list[str]:
+        """Return configured OpenAI-compatible model names in stable order."""
+        candidates = [self.OPENAI_COMPATIBLE_MODEL_NAME]
+        if self.OPENAI_COMPATIBLE_ADDITIONAL_MODEL_NAMES:
+            candidates.extend(self.OPENAI_COMPATIBLE_ADDITIONAL_MODEL_NAMES.split(","))
+        names: list[str] = []
+        for candidate in candidates:
+            if not candidate:
+                continue
+            name = candidate.strip()
+            if name and name not in names:
+                names.append(name)
+        return names
+
     def get_model_name_to_llm_key(self, organization_id: str | None = None) -> dict[str, dict[str, str]]:
         """
         Keys are model names available to blocks in the frontend. These map to key names
@@ -848,6 +866,13 @@ class Settings(BaseSettings):
         ]
         for model_name, azure_enabled, azure_key, openai_key, label in gpt_models:
             mapping[model_name] = {"llm_key": azure_key if azure_enabled else openai_key, "label": label}
+
+        if self.ENABLE_OPENAI_COMPATIBLE:
+            for model_name in self.get_openai_compatible_model_names():
+                mapping[model_name] = {
+                    "llm_key": self.OPENAI_COMPATIBLE_MODEL_KEY,
+                    "label": f"OpenAI-compatible: {model_name}",
+                }
 
         # Anthropic models: prefer Bedrock when enabled, fall back to direct API
         if self.ENABLE_BEDROCK_ANTHROPIC:

--- a/skyvern/forge/sdk/api/llm/api_handler_factory.py
+++ b/skyvern/forge/sdk/api/llm/api_handler_factory.py
@@ -4,6 +4,8 @@ import json
 import time
 import warnings
 from asyncio import CancelledError
+from contextvars import ContextVar
+from datetime import UTC, datetime
 from typing import Any, AsyncIterator, Protocol, runtime_checkable
 
 import litellm
@@ -33,6 +35,7 @@ from skyvern.forge.sdk.api.llm.exceptions import (
     LLMProviderErrorRetryableTask,
 )
 from skyvern.forge.sdk.api.llm.litellm_transport import configure_litellm_transport
+from skyvern.forge.sdk.api.llm.tokenless_usage import tokenless_usage_tracker
 from skyvern.forge.sdk.api.llm.ui_tars_response import UITarsResponse
 from skyvern.forge.sdk.api.llm.utils import (
     is_content_filtered_response,
@@ -107,6 +110,7 @@ CONTENT_FILTER_RESCUE_LLM_NAME_FLAG = "CONTENT_FILTER_RESCUE_LLM_NAME"
 _CONTENT_FILTER_RESCUE_CONTROL_VARIANTS = {None, False, "False", "false", "", "control"}
 _content_filter_rescue_handler_cache: dict[str, LLMAPIHandler] = {}
 _content_filter_rescue_logged: set[str] = set()
+_provider_request_id: ContextVar[str | None] = ContextVar("provider_request_id", default=None)
 
 
 def _content_filter_rescue_log_once(dedup_key: str) -> bool:
@@ -203,6 +207,50 @@ def _set_llm_context_attrs(
     span.set_attribute("screenshots_included", bool(screenshots))
     span.set_attribute("screenshot_count", len(screenshots) if screenshots else 0)
     span.set_attribute("speculative", bool(is_speculative_step))
+    context = skyvern_context.current()
+    if context and context.task_v2_id:
+        task_v2_attributes = {
+            "task_v2_id": context.task_v2_id,
+            "task_v2_iteration": context.task_v2_iteration,
+            "task_v2_task_type": context.task_v2_task_type,
+            "task_v2_loop_item_count": context.task_v2_loop_item_count,
+            "task_v2_loop_index": context.task_v2_loop_index,
+            "task_v2_retry_index": context.task_v2_retry_index,
+        }
+        for name, value in task_v2_attributes.items():
+            if value is not None:
+                span.set_attribute(name, value)
+
+
+def _get_tokenless_session_id(task_v2: TaskV2 | None = None) -> str | None:
+    """Return a stable evaluation session ID for the current task."""
+    context = skyvern_context.current()
+    task_id = (
+        (context.task_v2_id if context else None)
+        or (context.task_id if context else None)
+        or (task_v2.observer_cruise_id if task_v2 else None)
+    )
+    if not task_id:
+        return None
+
+    session_prefix = f"eval_skyvern_{task_id}_"
+    if context is not None:
+        if context.tokenless_session_id and context.tokenless_session_id.startswith(session_prefix):
+            return context.tokenless_session_id
+        context.tokenless_session_id = f"{session_prefix}{datetime.now(UTC).strftime('%Y%m%dT%H%M%S.%fZ')}"
+        return context.tokenless_session_id
+    return f"{session_prefix}{datetime.now(UTC).strftime('%Y%m%dT%H%M%S.%fZ')}"
+
+
+def _get_openai_compatible_request_model(task_v2: TaskV2 | None = None) -> str | None:
+    """Return the validated model alias selected for the current Task V2 run."""
+    context = skyvern_context.current()
+    requested_model = context.task_v2_requested_model if context else None
+    if not requested_model and task_v2 and task_v2.model:
+        requested_model = task_v2.model.get("model_name")
+    if requested_model in settings.get_openai_compatible_model_names():
+        return requested_model
+    return None
 
 
 def _enrich_llm_span(
@@ -415,6 +463,7 @@ class LLMCallStats(BaseModel):
     reasoning_tokens: int | None = None
     cached_tokens: int | None = None
     llm_cost: float | None = None
+    provider_request_id: str | None = None
 
 
 def _get_artifact_targets_and_persist_flag(
@@ -525,6 +574,114 @@ async def _persist_block_llm_cost(
             llm_cost=llm_cost,
             prompt_name=prompt_name,
         )
+
+
+_TASK_V2_CALL_TYPE_BY_PROMPT: dict[str, str] = {
+    "task_v2": "planner",
+    "task_v2_check_completion": "check_completion",
+    "task_v2_generate_extraction_task": "generate_extraction_task",
+    "task_v2_generate_task_block": "generate_task_block",
+    EXTRACT_ACTION_PROMPT_NAME: "extract_actions",
+}
+
+
+async def _persist_task_v2_llm_call(
+    *,
+    prompt_name: str,
+    task_v2: TaskV2 | None,
+    step: Step | None,
+    thought: Thought | None,
+    workflow_run_block_id: str | None,
+    llm_key: str | None,
+    configured_model: str | None,
+    actual_model: str | None,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    reasoning_tokens: int | None,
+    cached_tokens: int | None,
+    image_tokens: int | None,
+    llm_cost: float | None,
+    provider_request_id: str | None = None,
+) -> str | None:
+    """Persist safe per-call Task V2 metrics without recording prompts or credentials."""
+    context = skyvern_context.current()
+    if context is not None:
+        context.task_v2_last_llm_call_id = None
+
+    task_v2_id = context.task_v2_id if context else None
+    if task_v2_id is None and task_v2 is not None:
+        task_v2_id = task_v2.observer_cruise_id
+    workflow_run_id = context.workflow_run_id if context else None
+    if workflow_run_id is None and task_v2 is not None:
+        workflow_run_id = task_v2.workflow_run_id
+    organization_id = (context.organization_id if context else None) or (
+        step.organization_id if step else (thought.organization_id if thought else None)
+    )
+    if not task_v2_id or not workflow_run_id or not organization_id:
+        return None
+
+    retry_index = step.retry_index if step is not None else (context.task_v2_retry_index if context else 0)
+    requested_model = context.task_v2_requested_model if context else None
+    if task_v2 is not None and task_v2.model:
+        requested_model = requested_model or task_v2.model.get("model_name")
+    requested_model = requested_model or configured_model
+    call_id: str | None = None
+    try:
+        call_id = await app.DATABASE.observer.create_task_v2_llm_call(
+            task_v2_id=task_v2_id,
+            organization_id=organization_id,
+            workflow_run_id=workflow_run_id,
+            workflow_id=context.workflow_id if context else task_v2.workflow_id if task_v2 else None,
+            workflow_permanent_id=(
+                context.workflow_permanent_id if context else task_v2.workflow_permanent_id if task_v2 else None
+            ),
+            task_id=step.task_id if step else context.task_id if context else None,
+            step_id=step.step_id if step else None,
+            thought_id=thought.observer_thought_id if thought else None,
+            workflow_run_block_id=workflow_run_block_id,
+            call_type=_TASK_V2_CALL_TYPE_BY_PROMPT.get(prompt_name, "other"),
+            prompt_name=prompt_name,
+            task_type=context.task_v2_task_type if context else None,
+            iteration=context.task_v2_iteration if context else None,
+            loop_item_count=context.task_v2_loop_item_count if context else None,
+            loop_index=context.task_v2_loop_index if context else None,
+            retry_index=max(retry_index or 0, 0),
+            is_speculative=bool(step and step.is_speculative),
+            llm_key=llm_key,
+            model=actual_model or configured_model,
+            requested_model=requested_model,
+            provider_request_id=provider_request_id,
+            input_token_count=int(input_tokens or 0),
+            output_token_count=int(output_tokens or 0),
+            reasoning_token_count=int(reasoning_tokens or 0),
+            image_token_count=int(image_tokens or 0),
+            cached_token_count=int(cached_tokens or 0),
+            # Tokenless's exact cost is resolved from its request detail API after the run.
+            llm_cost=None if provider_request_id else llm_cost,
+        )
+        if step is not None and retry_index and retry_index > 0:
+            await app.DATABASE.observer.increment_task_v2_retry_count(
+                workflow_run_id=workflow_run_id,
+                organization_id=organization_id,
+            )
+        if provider_request_id:
+            await tokenless_usage_tracker.record_request(
+                workflow_run_id=workflow_run_id,
+                request_id=provider_request_id,
+                call_id=call_id,
+            )
+        if context is not None:
+            context.task_v2_last_llm_call_id = call_id
+        return call_id
+    except Exception:
+        # Metrics must never make an otherwise valid browser run fail.
+        LOG.warning(
+            "Failed to persist Task V2 LLM call metrics",
+            workflow_run_id=workflow_run_id,
+            prompt_name=prompt_name,
+            exc_info=True,
+        )
+        return None
 
 
 def _convert_allowed_fails_policy(policy: LLMAllowedFailsPolicy | None) -> AllowedFailsPolicy | None:
@@ -1774,6 +1931,22 @@ class LLMAPIHandlerFactory:
                 image_count, image_tokens, image_cost, image_source = _image_metrics_for_call(
                     screenshots, model_used or main_model_group, response
                 )
+                await _persist_task_v2_llm_call(
+                    prompt_name=prompt_name,
+                    task_v2=task_v2,
+                    step=step,
+                    thought=thought,
+                    workflow_run_block_id=workflow_run_block_id,
+                    llm_key=llm_key,
+                    configured_model=main_model_group,
+                    actual_model=actual_model,
+                    input_tokens=prompt_tokens,
+                    output_tokens=completion_tokens,
+                    reasoning_tokens=reasoning_tokens,
+                    cached_tokens=cached_tokens,
+                    image_tokens=image_tokens,
+                    llm_cost=llm_cost,
+                )
                 LOG.info(
                     "LLM API handler duration metrics",
                     llm_key=llm_key,
@@ -1890,8 +2063,11 @@ class LLMAPIHandlerFactory:
             llm_caller = LLMCaller(llm_key=llm_key, base_parameters=base_parameters)
             return llm_caller.call
 
-        # For GitHub Copilot via OPENAI_COMPATIBLE, use LLMCaller for a custom header
-        if llm_key == "OPENAI_COMPATIBLE" and LLMAPIHandlerFactory.is_github_copilot_endpoint():
+        # OpenAI-compatible endpoints that need response metadata (for example, Tokenless's
+        # X-Request-Id) use the native client instead of LiteLLM's conversion path.
+        if (llm_key == settings.OPENAI_COMPATIBLE_MODEL_KEY and settings.OPENAI_COMPATIBLE_USE_NATIVE_CLIENT) or (
+            llm_key == "OPENAI_COMPATIBLE" and LLMAPIHandlerFactory.is_github_copilot_endpoint()
+        ):
             llm_caller = LLMCaller(llm_key=llm_key, base_parameters=base_parameters)
             return llm_caller.call
 
@@ -2325,6 +2501,22 @@ class LLMAPIHandlerFactory:
                 image_count, image_tokens, image_cost, image_source = _image_metrics_for_call(
                     screenshots, actual_model or llm_config.model_name, response
                 )
+                await _persist_task_v2_llm_call(
+                    prompt_name=prompt_name,
+                    task_v2=task_v2,
+                    step=step,
+                    thought=thought,
+                    workflow_run_block_id=workflow_run_block_id,
+                    llm_key=llm_key,
+                    configured_model=llm_config.model_name,
+                    actual_model=actual_model,
+                    input_tokens=prompt_tokens,
+                    output_tokens=completion_tokens,
+                    reasoning_tokens=reasoning_tokens,
+                    cached_tokens=cached_tokens,
+                    image_tokens=image_tokens,
+                    llm_cost=llm_cost,
+                )
                 LOG.info(
                     "LLM API handler duration metrics",
                     llm_key=llm_key,
@@ -2521,6 +2713,7 @@ class LLMCaller:
             self.screenshot_resize_target_dimension = get_resize_target_dimension(self.browser_window_dimension)
 
         self.openai_client = None
+        self._native_openai_compatible = False
         openrouter_model_name = LLMAPIHandlerFactory._openrouter_model_name(self.llm_key, self.llm_config)
         # openrouter/ keys always resolve to LLMConfig, never LLMRouterConfig
         if openrouter_model_name and isinstance(self.llm_config, LLMConfig):
@@ -2534,6 +2727,14 @@ class LLMCaller:
         elif self.llm_key == "OPENAI_COMPATIBLE" and LLMAPIHandlerFactory.is_github_copilot_endpoint():
             # For GitHub Copilot, use the actual model name from OPENAI_COMPATIBLE_MODEL_NAME
             self.llm_key = settings.OPENAI_COMPATIBLE_MODEL_NAME or self.llm_key
+            self.openai_client = AsyncOpenAI(
+                api_key=settings.OPENAI_COMPATIBLE_API_KEY,
+                base_url=settings.OPENAI_COMPATIBLE_API_BASE,
+                http_client=ForgeAsyncHttpxClientWrapper(),
+            )
+        elif self.llm_key == settings.OPENAI_COMPATIBLE_MODEL_KEY and settings.OPENAI_COMPATIBLE_USE_NATIVE_CLIENT:
+            self.llm_key = settings.OPENAI_COMPATIBLE_MODEL_NAME or self.llm_key
+            self._native_openai_compatible = True
             self.openai_client = AsyncOpenAI(
                 api_key=settings.OPENAI_COMPATIBLE_API_KEY,
                 base_url=settings.OPENAI_COMPATIBLE_API_BASE,
@@ -2588,6 +2789,11 @@ class LLMCaller:
             active_parameters.update(self.llm_config.litellm_params)  # type: ignore
 
         context = skyvern_context.current()
+        openai_compatible_request_model = (
+            _get_openai_compatible_request_model(task_v2) if self._native_openai_compatible else None
+        )
+        if openai_compatible_request_model:
+            _llm_span.set_attribute("llm_model", openai_compatible_request_model)
         is_speculative_step = step.is_speculative if step else False
         should_persist_llm_artifacts, artifact_targets = _get_artifact_targets_and_persist_flag(
             step, is_speculative_step, task_v2, thought, ai_suggestion
@@ -2694,7 +2900,8 @@ class LLMCaller:
                     message_pattern=message_pattern,
                 )
             llm_request_payload = {
-                "model": self.llm_key if openrouter_model_name and self.openai_client else self.llm_config.model_name,
+                "model": openai_compatible_request_model
+                or (self.llm_key if openrouter_model_name and self.openai_client else self.llm_config.model_name),
                 "messages": messages,
                 # we're not using active_parameters here because it may contain sensitive information
                 **parameters,
@@ -2720,6 +2927,8 @@ class LLMCaller:
                 response = await self._dispatch_llm_call(
                     messages=messages,
                     tools=tools,
+                    task_v2=task_v2,
+                    request_model=openai_compatible_request_model,
                     **active_parameters,
                 )
                 llm_duration_seconds = time.perf_counter() - t_llm_request
@@ -2790,6 +2999,11 @@ class LLMCaller:
                     )
 
             call_stats = await self.get_call_stats(response)
+            if call_stats.provider_request_id and context and context.workflow_run_id:
+                await tokenless_usage_tracker.record_request(
+                    workflow_run_id=context.workflow_run_id,
+                    request_id=call_stats.provider_request_id,
+                )
             actual_model = _normalize_llm_model(getattr(response, "model", None) or self.llm_config.model_name)
             if step and not is_speculative_step:
                 await app.DATABASE.tasks.update_step(
@@ -2828,6 +3042,23 @@ class LLMCaller:
             duration_seconds = time.perf_counter() - start_time
             image_count, image_tokens, image_cost, image_source = _image_metrics_for_call(
                 screenshots, actual_model or self.llm_config.model_name, response
+            )
+            await _persist_task_v2_llm_call(
+                prompt_name=prompt_name or "<unknown>",
+                task_v2=task_v2,
+                step=step,
+                thought=thought,
+                workflow_run_block_id=workflow_run_block_id,
+                llm_key=self.llm_key,
+                configured_model=self.llm_config.model_name,
+                actual_model=actual_model,
+                input_tokens=call_stats.input_tokens,
+                output_tokens=call_stats.output_tokens,
+                reasoning_tokens=call_stats.reasoning_tokens,
+                cached_tokens=call_stats.cached_tokens,
+                image_tokens=image_tokens,
+                llm_cost=call_stats.llm_cost,
+                provider_request_id=call_stats.provider_request_id,
             )
             LOG.info(
                 "LLM API handler duration metrics",
@@ -2968,15 +3199,22 @@ class LLMCaller:
         self,
         messages: list[dict[str, Any]],
         tools: list | None = None,
+        task_v2: TaskV2 | None = None,
+        request_model: str | None = None,
         timeout: float = settings.LLM_CONFIG_TIMEOUT,
         **active_parameters: dict[str, Any],
     ) -> ModelResponse | CustomStreamWrapper | AnthropicMessage | UITarsResponse:
+        _provider_request_id.set(None)
         if self.openai_client:
             # Extract OpenRouter-specific and GitHub Copilot-specific parameters
             extra_headers = {}
             if settings.SKYVERN_APP_URL:
                 extra_headers["HTTP-Referer"] = settings.SKYVERN_APP_URL
                 extra_headers["X-Title"] = "Skyvern"
+            if self._native_openai_compatible:
+                tokenless_session_id = _get_tokenless_session_id(task_v2)
+                if tokenless_session_id:
+                    extra_headers["Session-Id"] = tokenless_session_id
 
             # Add required headers for GitHub Copilot API
             if LLMAPIHandlerFactory.is_github_copilot_endpoint():
@@ -3002,12 +3240,15 @@ class LLMCaller:
                 openai_params["reasoning_effort"] = active_parameters["reasoning_effort"]
 
             completion = await self.openai_client.chat.completions.create(
-                model=self.llm_key,
+                model=request_model or self.llm_key,
                 messages=messages,
+                tools=tools or None,
                 extra_headers=extra_headers if extra_headers else None,
                 timeout=timeout,
                 **openai_params,
             )
+            if self._native_openai_compatible:
+                _provider_request_id.set(getattr(completion, "_request_id", None))
             # Convert OpenAI ChatCompletion to litellm ModelResponse format
             # litellm.utils.convert_to_model_response_object expects a dict
             response_dict = completion.model_dump()
@@ -3180,7 +3421,11 @@ class LLMCaller:
         empty_call_stats = LLMCallStats()
 
         # Handle OPENAI_COMPATIBLE provider GitHub Copilot
-        if self.original_llm_key == "OPENAI_COMPATIBLE" and isinstance(response, (ModelResponse, CustomStreamWrapper)):
+        if (
+            self.original_llm_key == "OPENAI_COMPATIBLE"
+            and LLMAPIHandlerFactory.is_github_copilot_endpoint()
+            and isinstance(response, (ModelResponse, CustomStreamWrapper))
+        ):
             input_tokens, output_tokens, reasoning_tokens, cached_tokens = LLMAPIHandlerFactory._extract_token_counts(
                 response
             )
@@ -3190,6 +3435,7 @@ class LLMCaller:
                 output_tokens=output_tokens,
                 cached_tokens=cached_tokens,
                 reasoning_tokens=reasoning_tokens,
+                provider_request_id=_provider_request_id.get(),
             )
 
         # Handle UI-TARS response (UITarsResponse object from _call_ui_tars)
@@ -3240,6 +3486,7 @@ class LLMCaller:
                 output_tokens=output_tokens,
                 cached_tokens=cached_tokens,
                 reasoning_tokens=reasoning_tokens,
+                provider_request_id=_provider_request_id.get(),
             )
         return empty_call_stats
 

--- a/skyvern/forge/sdk/api/llm/tokenless_usage.py
+++ b/skyvern/forge/sdk/api/llm/tokenless_usage.py
@@ -1,0 +1,267 @@
+"""Tokenless routed-request cost tracking.
+
+Tokenless reports the cost of a complete routed request through its usage API.  The
+OpenAI-compatible response carries the request identifier in ``X-Request-Id``;
+callers must retain that identifier and resolve it after the workflow finishes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from dataclasses import dataclass, replace
+from typing import Any
+from urllib.parse import quote, urlsplit
+
+import httpx
+import structlog
+
+from skyvern.config import settings
+
+TOKENLESS_NANOS_PER_USD = 1_000_000_000
+_MAX_CONCURRENT_LOOKUPS = 8
+_MAX_LOOKUP_ATTEMPTS = 3
+_TRANSIENT_STATUS_CODES = {408, 429, 500, 502, 503, 504, 529}
+
+LOG = structlog.get_logger()
+
+
+class TokenlessUsageError(RuntimeError):
+    """Raised when a Tokenless routed-request cost cannot be resolved."""
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+@dataclass(frozen=True)
+class TokenlessRequestCost:
+    """Cost and usage returned for one Tokenless routed request."""
+
+    request_id: str
+    cost_nanos: int
+    input_tokens: int
+    output_tokens: int
+    call_id: str | None = None
+
+
+@dataclass(frozen=True)
+class TokenlessRunCost:
+    """Aggregated Tokenless cost for one workflow run."""
+
+    agent_cost_usd: float | None
+    input_tokens: int
+    output_tokens: int
+    tokenless_request_count: int
+    cost_status: str
+    resolved_call_costs: tuple[TokenlessRequestCost, ...] = ()
+
+
+def _usage_api_base_url(api_base_url: str | None) -> str:
+    """Derive the Tokenless usage API origin from the model API base URL."""
+    if not api_base_url:
+        raise TokenlessUsageError("OPENAI_COMPATIBLE_API_BASE is required for Tokenless cost lookup")
+
+    parsed = urlsplit(api_base_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise TokenlessUsageError("OPENAI_COMPATIBLE_API_BASE must be an absolute URL")
+    return f"{parsed.scheme}://{parsed.netloc}/v1/usage"
+
+
+def _integer_field(payload: dict[str, Any], field_name: str) -> int:
+    """Read a non-negative integer usage field from a Tokenless response."""
+    value = payload.get(field_name)
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise TokenlessUsageError(f"Tokenless usage response omitted {field_name}") from exc
+    if parsed < 0:
+        raise TokenlessUsageError(f"Tokenless usage response returned negative {field_name}")
+    return parsed
+
+
+class TokenlessUsageTracker:
+    """Track and resolve Tokenless request IDs grouped by workflow run.
+
+    The in-memory map supports the hot path; callers may also supply mappings read
+    from Skyvern's internal call ledger so resolution survives worker boundaries
+    and process restarts.
+    """
+
+    def __init__(self) -> None:
+        self._request_ids_by_workflow_run: dict[str, set[str]] = {}
+        self._call_ids_by_workflow_run: dict[str, dict[str, str]] = {}
+        self._lock = asyncio.Lock()
+
+    async def record_request(self, workflow_run_id: str, request_id: str, call_id: str | None = None) -> None:
+        """Associate a Tokenless request with a workflow run, deduplicating IDs."""
+        if not workflow_run_id or not request_id:
+            return
+        async with self._lock:
+            self._request_ids_by_workflow_run.setdefault(workflow_run_id, set()).add(request_id)
+            if call_id:
+                self._call_ids_by_workflow_run.setdefault(workflow_run_id, {})[request_id] = call_id
+
+    async def request_ids(self, workflow_run_id: str) -> set[str]:
+        """Return a copy of the request IDs recorded for a workflow run."""
+        async with self._lock:
+            return set(self._request_ids_by_workflow_run.get(workflow_run_id, set()))
+
+    async def clear(self, workflow_run_id: str) -> None:
+        """Discard request IDs after an evaluation report has been written."""
+        async with self._lock:
+            self._request_ids_by_workflow_run.pop(workflow_run_id, None)
+            self._call_ids_by_workflow_run.pop(workflow_run_id, None)
+
+    async def _fetch_request_cost(
+        self,
+        client: httpx.AsyncClient,
+        request_id: str,
+    ) -> TokenlessRequestCost:
+        """Fetch one routed-request cost with bounded transient retries."""
+        usage_base_url = _usage_api_base_url(settings.OPENAI_COMPATIBLE_API_BASE)
+        request_url = f"{usage_base_url}/requests/{quote(request_id, safe='')}"
+        if not settings.OPENAI_COMPATIBLE_API_KEY:
+            raise TokenlessUsageError("OPENAI_COMPATIBLE_API_KEY is required for Tokenless cost lookup")
+        headers = {"Authorization": f"Bearer {settings.OPENAI_COMPATIBLE_API_KEY}"}
+
+        for attempt in range(_MAX_LOOKUP_ATTEMPTS):
+            try:
+                response = await client.get(request_url, headers=headers)
+            except httpx.TransportError as exc:
+                if attempt + 1 == _MAX_LOOKUP_ATTEMPTS:
+                    raise TokenlessUsageError("Tokenless usage request failed") from exc
+                await self._sleep_before_retry(attempt, retry_after=None)
+                continue
+
+            if response.status_code in _TRANSIENT_STATUS_CODES:
+                if attempt + 1 == _MAX_LOOKUP_ATTEMPTS:
+                    raise TokenlessUsageError(
+                        "Tokenless usage request remained transiently unavailable",
+                        status_code=response.status_code,
+                    )
+                await self._sleep_before_retry(attempt, retry_after=response.headers.get("retry-after"))
+                continue
+
+            if response.status_code == 404:
+                raise TokenlessUsageError("Tokenless routed request was not found", status_code=404)
+
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                raise TokenlessUsageError(
+                    "Tokenless usage request was rejected",
+                    status_code=response.status_code,
+                ) from exc
+
+            try:
+                payload = response.json()
+            except ValueError as exc:
+                raise TokenlessUsageError("Tokenless usage response was not valid JSON") from exc
+
+            if not isinstance(payload, dict):
+                raise TokenlessUsageError("Tokenless usage response was not an object")
+
+            returned_request_id = payload.get("request_id")
+            if returned_request_id and returned_request_id != request_id:
+                raise TokenlessUsageError("Tokenless usage response request ID did not match the lookup")
+
+            return TokenlessRequestCost(
+                request_id=request_id,
+                cost_nanos=_integer_field(payload, "total_cost_nanos"),
+                input_tokens=_integer_field(payload, "total_input_tokens"),
+                output_tokens=_integer_field(payload, "total_output_tokens"),
+            )
+
+        raise TokenlessUsageError("Tokenless usage request could not be resolved")
+
+    @staticmethod
+    async def _sleep_before_retry(attempt: int, retry_after: str | None) -> None:
+        """Honor Retry-After with bounded exponential backoff and jitter."""
+        delay: float | None = None
+        if retry_after:
+            try:
+                delay = max(0.0, float(retry_after))
+            except ValueError:
+                delay = None
+        if delay is None:
+            delay = 1.0 * (2**attempt) + random.uniform(0.0, 0.25)
+        await asyncio.sleep(min(delay, 10.0))
+
+    async def resolve(
+        self,
+        workflow_run_id: str,
+        persisted_request_call_ids: dict[str, str] | None = None,
+    ) -> TokenlessRunCost:
+        """Resolve all known request IDs for a workflow run into an exact total."""
+        request_ids = await self.request_ids(workflow_run_id)
+        async with self._lock:
+            call_ids = dict(self._call_ids_by_workflow_run.get(workflow_run_id, {}))
+        if persisted_request_call_ids:
+            request_ids.update(persisted_request_call_ids)
+            call_ids.update(persisted_request_call_ids)
+        if not request_ids:
+            return TokenlessRunCost(
+                agent_cost_usd=None,
+                input_tokens=0,
+                output_tokens=0,
+                tokenless_request_count=0,
+                cost_status="incomplete",
+            )
+
+        semaphore = asyncio.Semaphore(_MAX_CONCURRENT_LOOKUPS)
+        unresolved_statuses: dict[int | None, int] = {}
+
+        async def fetch(client: httpx.AsyncClient, request_id: str) -> TokenlessRequestCost | None:
+            async with semaphore:
+                try:
+                    return await self._fetch_request_cost(client, request_id)
+                except TokenlessUsageError as exc:
+                    unresolved_statuses[exc.status_code] = unresolved_statuses.get(exc.status_code, 0) + 1
+                    return None
+
+        limits = httpx.Limits(
+            max_connections=_MAX_CONCURRENT_LOOKUPS,
+            max_keepalive_connections=_MAX_CONCURRENT_LOOKUPS,
+        )
+        async with httpx.AsyncClient(timeout=settings.LLM_CONFIG_TIMEOUT, limits=limits) as client:
+            resolved = [
+                cost
+                for cost in await asyncio.gather(*(fetch(client, request_id) for request_id in request_ids))
+                if cost
+            ]
+        status = "exact" if len(resolved) == len(request_ids) else "incomplete"
+        if status != "exact":
+            LOG.warning(
+                "Tokenless usage cost resolution incomplete",
+                workflow_run_id=workflow_run_id,
+                request_count=len(request_ids),
+                resolved_count=len(resolved),
+                unresolved_statuses=unresolved_statuses,
+            )
+            return TokenlessRunCost(
+                agent_cost_usd=None,
+                input_tokens=sum(cost.input_tokens for cost in resolved),
+                output_tokens=sum(cost.output_tokens for cost in resolved),
+                tokenless_request_count=len(request_ids),
+                cost_status=status,
+                resolved_call_costs=tuple(
+                    replace(cost, call_id=call_ids.get(cost.request_id))
+                    for cost in resolved
+                ),
+            )
+
+        total_cost_nanos = sum(cost.cost_nanos for cost in resolved)
+        return TokenlessRunCost(
+            agent_cost_usd=total_cost_nanos / TOKENLESS_NANOS_PER_USD,
+            input_tokens=sum(cost.input_tokens for cost in resolved),
+            output_tokens=sum(cost.output_tokens for cost in resolved),
+            tokenless_request_count=len(request_ids),
+            cost_status=status,
+            resolved_call_costs=tuple(
+                replace(cost, call_id=call_ids.get(cost.request_id)) for cost in resolved
+            ),
+        )
+
+
+tokenless_usage_tracker = TokenlessUsageTracker()

--- a/skyvern/forge/sdk/core/skyvern_context.py
+++ b/skyvern/forge/sdk/core/skyvern_context.py
@@ -83,6 +83,15 @@ class SkyvernContext:
     workflow_run_id: str | None = None
     root_workflow_run_id: str | None = None
     task_v2_id: str | None = None
+    # Task V2 evaluation dimensions propagated to every LLM call in the run.
+    task_v2_iteration: int | None = None
+    task_v2_task_type: str | None = None
+    task_v2_loop_item_count: int | None = None
+    task_v2_loop_index: int | None = None
+    task_v2_retry_index: int = 0
+    task_v2_last_llm_call_id: str | None = None
+    task_v2_requested_model: str | None = None
+    tokenless_session_id: str | None = None
     max_steps_override: int | None = None
     browser_session_id: str | None = None
     browser_runtime: str | None = None

--- a/skyvern/forge/sdk/db/id.py
+++ b/skyvern/forge/sdk/db/id.py
@@ -49,6 +49,8 @@ GOOGLE_OAUTH_CREDENTIAL_PREFIX = "goac"
 MICROSOFT_OAUTH_CREDENTIAL_PREFIX = "moac"
 ORGANIZATION_BITWARDEN_COLLECTION_PREFIX = "obc"
 TASK_V2_ID = "tsk_v2"
+TASK_V2_LLM_CALL_PREFIX = "t2c"
+TASK_V2_RUN_METRICS_PREFIX = "t2m"
 THOUGHT_ID = "ot"
 ORGANIZATION_AUTH_TOKEN_PREFIX = "oat"
 ORG_PREFIX = "o"
@@ -210,6 +212,16 @@ def generate_action_id() -> str:
 def generate_task_v2_id() -> str:
     int_id = generate_id()
     return f"{TASK_V2_ID}_{int_id}"
+
+
+def generate_task_v2_llm_call_id() -> str:
+    int_id = generate_id()
+    return f"{TASK_V2_LLM_CALL_PREFIX}_{int_id}"
+
+
+def generate_task_v2_run_metrics_id() -> str:
+    int_id = generate_id()
+    return f"{TASK_V2_RUN_METRICS_PREFIX}_{int_id}"
 
 
 def generate_thought_id() -> str:

--- a/skyvern/forge/sdk/db/models.py
+++ b/skyvern/forge/sdk/db/models.py
@@ -63,6 +63,8 @@ from skyvern.forge.sdk.db.id import (
     generate_task_id,
     generate_task_run_id,
     generate_task_v2_id,
+    generate_task_v2_llm_call_id,
+    generate_task_v2_run_metrics_id,
     generate_thought_id,
     generate_totp_code_id,
     generate_workflow_copilot_chat_id,
@@ -1233,6 +1235,77 @@ class TaskV2Model(Base):
     modified_at = Column(DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow, nullable=False)
     model = Column(JSON, nullable=True)
     failure_category = Column(JSON, nullable=True)
+
+
+class TaskV2RunMetricsModel(Base):
+    """Durable run-level counters for Task V2 evaluations."""
+
+    __tablename__ = "task_v2_run_metrics"
+    __table_args__ = (
+        Index("t2rm_org_created_at_index", "organization_id", "created_at"),
+        Index("t2rm_org_wfr_index", "organization_id", "workflow_run_id"),
+    )
+
+    task_v2_run_metrics_id = Column(String, primary_key=True, default=generate_task_v2_run_metrics_id)
+    task_v2_id = Column(String, nullable=False, index=True)
+    organization_id = Column(String, nullable=False)
+    workflow_run_id = Column(String, nullable=False, unique=True)
+    workflow_id = Column(String, nullable=True)
+    workflow_permanent_id = Column(String, nullable=True)
+    iteration_count = Column(Integer, nullable=False, default=0, server_default="0")
+    loop_item_count = Column(Integer, nullable=False, default=0, server_default="0")
+    retry_count = Column(Integer, nullable=False, default=0, server_default="0")
+    created_at = Column(DateTime, default=datetime.datetime.utcnow, nullable=False)
+    modified_at = Column(DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow, nullable=False)
+
+
+class TaskV2LLMCallModel(Base):
+    """One durable record for every successful LLM response associated with Task V2."""
+
+    __tablename__ = "task_v2_llm_calls"
+    __table_args__ = (
+        Index("t2llm_org_created_at_index", "organization_id", "created_at"),
+        Index("t2llm_org_wfr_index", "organization_id", "workflow_run_id"),
+        Index("t2llm_wfr_prompt_index", "workflow_run_id", "prompt_name"),
+        Index("t2llm_wfr_model_index", "workflow_run_id", "model"),
+        Index("t2llm_wfr_provider_request_index", "workflow_run_id", "provider_request_id"),
+    )
+
+    task_v2_llm_call_id = Column(String, primary_key=True, default=generate_task_v2_llm_call_id)
+    task_v2_id = Column(String, nullable=False, index=True)
+    organization_id = Column(String, nullable=False)
+    workflow_run_id = Column(String, nullable=False)
+    workflow_id = Column(String, nullable=True)
+    workflow_permanent_id = Column(String, nullable=True)
+    task_id = Column(String, nullable=True)
+    step_id = Column(String, nullable=True)
+    thought_id = Column(String, nullable=True)
+    workflow_run_block_id = Column(String, nullable=True)
+
+    call_type = Column(String, nullable=False)
+    prompt_name = Column(String, nullable=False)
+    task_type = Column(String, nullable=True)
+    iteration = Column(Integer, nullable=True)
+    loop_item_count = Column(Integer, nullable=True)
+    loop_index = Column(Integer, nullable=True)
+    retry_index = Column(Integer, nullable=False, default=0, server_default="0")
+    is_speculative = Column(Boolean, nullable=False, default=False, server_default=sqlalchemy.false())
+
+    llm_key = Column(String, nullable=True)
+    model = Column(String, nullable=True)
+    requested_model = Column(String, nullable=True)
+    # Internal-only Tokenless attribution key. It is intentionally excluded from API models and logs.
+    provider_request_id = Column(String, nullable=True)
+    input_token_count = Column(Integer, nullable=False, default=0, server_default="0")
+    output_token_count = Column(Integer, nullable=False, default=0, server_default="0")
+    reasoning_token_count = Column(Integer, nullable=False, default=0, server_default="0")
+    image_token_count = Column(Integer, nullable=False, default=0, server_default="0")
+    cached_token_count = Column(Integer, nullable=False, default=0, server_default="0")
+    llm_cost = Column(Numeric, nullable=True)
+
+    status = Column(String, nullable=False, default="completed", server_default="'completed'")
+    created_at = Column(DateTime, default=datetime.datetime.utcnow, nullable=False)
+    modified_at = Column(DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow, nullable=False)
 
 
 class ThoughtModel(Base):

--- a/skyvern/forge/sdk/db/repositories/observer.py
+++ b/skyvern/forge/sdk/db/repositories/observer.py
@@ -16,7 +16,9 @@ if TYPE_CHECKING:
     from skyvern.forge.sdk.db.base_alchemy_db import _SessionFactory
 
 from skyvern.forge.sdk.db.models import (
+    TaskV2LLMCallModel,
     TaskV2Model,
+    TaskV2RunMetricsModel,
     ThoughtModel,
     WorkflowRunBlockModel,
 )
@@ -141,6 +143,24 @@ class ObserverRepository(BaseRepository):
             total = (await session.execute(query)).scalar_one()
             return float(total)
 
+    @db_operation("get_thought_token_sums_by_workflow_run_id")
+    async def get_thought_token_sums_by_workflow_run_id(
+        self,
+        workflow_run_id: str,
+        organization_id: str,
+    ) -> tuple[int, int]:
+        """Sum input and output LLM tokens across thoughts for a workflow run."""
+        async with self.Session() as session:
+            query = select(
+                func.coalesce(func.sum(ThoughtModel.input_token_count), 0),
+                func.coalesce(func.sum(ThoughtModel.output_token_count), 0),
+            ).where(
+                ThoughtModel.workflow_run_id == workflow_run_id,
+                ThoughtModel.organization_id == organization_id,
+            )
+            input_tokens, output_tokens = (await session.execute(query)).one()
+            return int(input_tokens), int(output_tokens)
+
     @db_operation("get_block_llm_cost_sum_by_workflow_run_id")
     async def get_block_llm_cost_sum_by_workflow_run_id(self, workflow_run_id: str, organization_id: str) -> float:
         """Sum `llm_cost` across all workflow_run_blocks for this workflow_run_id."""
@@ -152,6 +172,171 @@ class ObserverRepository(BaseRepository):
             )
             total = (await session.execute(query)).scalar_one()
             return float(total)
+
+    @db_operation("ensure_task_v2_run_metrics")
+    async def ensure_task_v2_run_metrics(
+        self,
+        *,
+        task_v2_id: str,
+        workflow_run_id: str,
+        organization_id: str,
+        workflow_id: str | None = None,
+        workflow_permanent_id: str | None = None,
+    ) -> None:
+        """Create the durable Task V2 run counter row if it does not exist."""
+        async with self.Session() as session:
+            metrics = (
+                await session.scalars(
+                    select(TaskV2RunMetricsModel).where(
+                        TaskV2RunMetricsModel.workflow_run_id == workflow_run_id,
+                        TaskV2RunMetricsModel.organization_id == organization_id,
+                    )
+                )
+            ).first()
+            if metrics is None:
+                session.add(
+                    TaskV2RunMetricsModel(
+                        task_v2_id=task_v2_id,
+                        workflow_run_id=workflow_run_id,
+                        organization_id=organization_id,
+                        workflow_id=workflow_id,
+                        workflow_permanent_id=workflow_permanent_id,
+                    )
+                )
+                await session.commit()
+
+    @db_operation("record_task_v2_iteration")
+    async def record_task_v2_iteration(
+        self,
+        *,
+        workflow_run_id: str,
+        organization_id: str,
+        iteration_count: int,
+    ) -> None:
+        """Persist the number of planning iterations reached by a Task V2 run."""
+        async with self.Session() as session:
+            metrics = (
+                await session.scalars(
+                    select(TaskV2RunMetricsModel).where(
+                        TaskV2RunMetricsModel.workflow_run_id == workflow_run_id,
+                        TaskV2RunMetricsModel.organization_id == organization_id,
+                    )
+                )
+            ).first()
+            if metrics is not None:
+                metrics.iteration_count = max(metrics.iteration_count or 0, iteration_count)
+                await session.commit()
+
+    @db_operation("increment_task_v2_loop_item_count")
+    async def increment_task_v2_loop_item_count(
+        self,
+        *,
+        workflow_run_id: str,
+        organization_id: str,
+        item_count: int,
+    ) -> None:
+        """Add generated loop items to a Task V2 run's durable counter."""
+        if item_count <= 0:
+            return
+        async with self.Session() as session:
+            await session.execute(
+                update(TaskV2RunMetricsModel)
+                .where(
+                    TaskV2RunMetricsModel.workflow_run_id == workflow_run_id,
+                    TaskV2RunMetricsModel.organization_id == organization_id,
+                )
+                .values(loop_item_count=TaskV2RunMetricsModel.loop_item_count + item_count)
+            )
+            await session.commit()
+
+    @db_operation("increment_task_v2_retry_count")
+    async def increment_task_v2_retry_count(
+        self,
+        *,
+        workflow_run_id: str,
+        organization_id: str,
+    ) -> None:
+        """Increment the durable count of LLM calls made on a retry attempt."""
+        async with self.Session() as session:
+            await session.execute(
+                update(TaskV2RunMetricsModel)
+                .where(
+                    TaskV2RunMetricsModel.workflow_run_id == workflow_run_id,
+                    TaskV2RunMetricsModel.organization_id == organization_id,
+                )
+                .values(retry_count=TaskV2RunMetricsModel.retry_count + 1)
+            )
+            await session.commit()
+
+    @db_operation("get_task_v2_run_metrics")
+    async def get_task_v2_run_metrics(
+        self,
+        workflow_run_id: str,
+        organization_id: str,
+    ) -> TaskV2RunMetricsModel | None:
+        """Return durable Task V2 run counters."""
+        async with self.Session() as session:
+            return (
+                await session.scalars(
+                    select(TaskV2RunMetricsModel).where(
+                        TaskV2RunMetricsModel.workflow_run_id == workflow_run_id,
+                        TaskV2RunMetricsModel.organization_id == organization_id,
+                    )
+                )
+            ).first()
+
+    @db_operation("create_task_v2_llm_call")
+    async def create_task_v2_llm_call(self, **values: Any) -> str:
+        """Persist one successful LLM response associated with a Task V2 run."""
+        async with self.Session() as session:
+            call = TaskV2LLMCallModel(**values)
+            session.add(call)
+            await session.flush()
+            call_id = call.task_v2_llm_call_id
+            await session.commit()
+            return call_id
+
+    @db_operation("update_task_v2_llm_call")
+    async def update_task_v2_llm_call(
+        self,
+        task_v2_llm_call_id: str,
+        organization_id: str,
+        **values: Any,
+    ) -> None:
+        """Update dimensions learned after an LLM response, such as task type."""
+        if not values:
+            return
+        async with self.Session() as session:
+            await session.execute(
+                update(TaskV2LLMCallModel)
+                .where(
+                    TaskV2LLMCallModel.task_v2_llm_call_id == task_v2_llm_call_id,
+                    TaskV2LLMCallModel.organization_id == organization_id,
+                )
+                .values(**values)
+            )
+            await session.commit()
+
+    @db_operation("get_task_v2_llm_calls_by_workflow_run_id")
+    async def get_task_v2_llm_calls_by_workflow_run_id(
+        self,
+        workflow_run_id: str,
+        organization_id: str,
+    ) -> list[TaskV2LLMCallModel]:
+        """Return Task V2 LLM calls in creation order for a workflow run."""
+        async with self.Session() as session:
+            return list(
+                (
+                    await session.scalars(
+                        select(TaskV2LLMCallModel)
+                        .where(
+                            TaskV2LLMCallModel.workflow_run_id == workflow_run_id,
+                            TaskV2LLMCallModel.organization_id == organization_id,
+                        )
+                        .order_by(TaskV2LLMCallModel.created_at, TaskV2LLMCallModel.task_v2_llm_call_id)
+                    )
+                ).all()
+            )
 
     @db_operation("increment_workflow_run_block_llm_cost")
     async def increment_workflow_run_block_llm_cost(

--- a/skyvern/forge/sdk/db/repositories/tasks.py
+++ b/skyvern/forge/sdk/db/repositories/tasks.py
@@ -254,6 +254,20 @@ class TasksRepository(BaseRepository):
             total = (await session.execute(query)).scalar_one()
             return float(total)
 
+    @db_operation("get_step_token_sums_by_task_ids")
+    async def get_step_token_sums_by_task_ids(self, task_ids: list[str], organization_id: str) -> tuple[int, int]:
+        """Sum input and output LLM tokens across steps belonging to the task IDs."""
+        if not task_ids:
+            return 0, 0
+
+        async with self.Session() as session:
+            query = select(
+                func.coalesce(func.sum(StepModel.input_token_count), 0),
+                func.coalesce(func.sum(StepModel.output_token_count), 0),
+            ).where(StepModel.task_id.in_(task_ids), StepModel.organization_id == organization_id)
+            input_tokens, output_tokens = (await session.execute(query)).one()
+            return int(input_tokens), int(output_tokens)
+
     @db_operation("get_workflow_run_progress_timestamps")
     async def get_workflow_run_progress_timestamps(
         self,

--- a/skyvern/forge/sdk/routes/agent_protocol.py
+++ b/skyvern/forge/sdk/routes/agent_protocol.py
@@ -129,6 +129,7 @@ from skyvern.forge.sdk.workflow.models.workflow import (
     Workflow,
     WorkflowRequestBody,
     WorkflowRun,
+    WorkflowRunEvaluationCost,
     WorkflowRunResponseBase,
     WorkflowRunStatus,
     WorkflowRunWithWorkflowResponse,
@@ -4400,6 +4401,30 @@ async def get_workflow_runs_by_id_legacy(
         created_at_start=created_at_start,
         created_at_end=created_at_end,
         exclude_child_runs=False,
+    )
+
+
+@legacy_base_router.get(
+    "/workflows/{workflow_id}/runs/{workflow_run_id}/evaluation-cost",
+    response_model=WorkflowRunEvaluationCost,
+    tags=["agent"],
+)
+async def get_workflow_run_evaluation_cost(
+    workflow_id: str,
+    workflow_run_id: str,
+    current_org: Organization = Depends(org_auth_service.get_current_org),
+) -> WorkflowRunEvaluationCost:
+    """Return exact target-agent LLM usage for an evaluation workflow run."""
+    workflow = await app.WORKFLOW_SERVICE.get_workflow_by_workflow_run_id(
+        workflow_run_id=workflow_run_id,
+        organization_id=current_org.organization_id,
+        filter_deleted=False,
+    )
+    if workflow.workflow_permanent_id != workflow_id:
+        raise WorkflowNotFound(workflow_permanent_id=workflow_id)
+    return await app.WORKFLOW_SERVICE.get_workflow_run_evaluation_cost(
+        workflow_run_id=workflow_run_id,
+        organization_id=current_org.organization_id,
     )
 
 

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -2398,6 +2398,7 @@ class ForLoopBlock(Block):
         outputs_with_loop_values: list[list[dict[str, Any]]] = []
         block_outputs: list[BlockResult] = []
         current_block: BlockTypeVar | None = None
+        task_v2_context = skyvern_context.current()
 
         start_label, label_to_block, default_next_map = self._build_loop_graph(self.loop_blocks)
         conditional_scopes = compute_conditional_scopes(label_to_block, default_next_map)
@@ -2529,14 +2530,21 @@ class ForLoopBlock(Block):
                     if cond_label in conditional_wrb_ids:
                         parent_wrb_id = conditional_wrb_ids[cond_label]
 
-                block_output = await loop_block.execute_safe(
-                    workflow_run_id=workflow_run_id,
-                    parent_workflow_run_block_id=parent_wrb_id,
-                    organization_id=organization_id,
-                    browser_session_id=browser_session_id,
-                    current_value=str(loop_over_value),
-                    current_index=loop_idx,
-                )
+                previous_task_v2_loop_index = task_v2_context.task_v2_loop_index if task_v2_context else None
+                if task_v2_context and task_v2_context.task_v2_id:
+                    task_v2_context.task_v2_loop_index = loop_idx
+                try:
+                    block_output = await loop_block.execute_safe(
+                        workflow_run_id=workflow_run_id,
+                        parent_workflow_run_block_id=parent_wrb_id,
+                        organization_id=organization_id,
+                        browser_session_id=browser_session_id,
+                        current_value=str(loop_over_value),
+                        current_index=loop_idx,
+                    )
+                finally:
+                    if task_v2_context and task_v2_context.task_v2_id:
+                        task_v2_context.task_v2_loop_index = previous_task_v2_loop_index
 
                 # Track conditional workflow_run_block_ids so branch targets
                 # can be parented to them.
@@ -2728,6 +2736,8 @@ class ForLoopBlock(Block):
         # ensures stale per-iteration baselines don't leak into subsequent blocks.
         outer_context = skyvern_context.current()
         outer_loop_state = outer_context.loop_internal_state if outer_context else None
+        outer_task_v2_loop_item_count = outer_context.task_v2_loop_item_count if outer_context else None
+        outer_task_v2_loop_index = outer_context.task_v2_loop_index if outer_context else None
         try:
             return await self._run_loop(
                 workflow_run_id=workflow_run_id,
@@ -2739,6 +2749,8 @@ class ForLoopBlock(Block):
         finally:
             if outer_context:
                 outer_context.loop_internal_state = outer_loop_state
+                outer_context.task_v2_loop_item_count = outer_task_v2_loop_item_count
+                outer_context.task_v2_loop_index = outer_task_v2_loop_index
 
     async def _run_loop(
         self,
@@ -2770,6 +2782,23 @@ class ForLoopBlock(Block):
             organization_id=organization_id,
             loop_values=loop_over_values,
         )
+        task_v2_context = skyvern_context.current()
+        task_v2_organization_id = organization_id or (task_v2_context.organization_id if task_v2_context else None)
+        if task_v2_context and task_v2_context.task_v2_id:
+            task_v2_context.task_v2_loop_item_count = len(loop_over_values)
+            if task_v2_organization_id:
+                try:
+                    await app.DATABASE.observer.increment_task_v2_loop_item_count(
+                        workflow_run_id=workflow_run_id,
+                        organization_id=task_v2_organization_id,
+                        item_count=len(loop_over_values),
+                    )
+                except Exception:
+                    LOG.warning(
+                        "Failed to persist Task V2 loop item metrics",
+                        workflow_run_id=workflow_run_id,
+                        exc_info=True,
+                    )
 
         LOG.info(
             f"Number of loop_over values: {len(loop_over_values)}",

--- a/skyvern/forge/sdk/workflow/models/workflow.py
+++ b/skyvern/forge/sdk/workflow/models/workflow.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import StrEnum
-from typing import Any, List
+from typing import Any, List, Literal
 
 from pydantic import BaseModel, Field, computed_field, field_serializer, field_validator
 from typing_extensions import deprecated
@@ -400,3 +400,59 @@ class WorkflowRunResponseBase(BaseModel):
 
 class WorkflowRunWithWorkflowResponse(WorkflowRunResponseBase):
     workflow: Workflow
+
+
+class WorkflowRunEvaluationLLMCall(BaseModel):
+    """Safe, prompt/response metadata for one Task V2 LLM call."""
+
+    call_id: str
+    prompt_name: str
+    call_type: str
+    task_type: str | None = None
+    organization_id: str | None = None
+    workflow_run_id: str
+    workflow_id: str | None = None
+    workflow_permanent_id: str | None = None
+    task_v2_id: str
+    task_id: str | None = None
+    step_id: str | None = None
+    thought_id: str | None = None
+    workflow_run_block_id: str | None = None
+    iteration: int | None = None
+    loop_item_count: int | None = None
+    loop_index: int | None = None
+    retry_index: int = 0
+    is_speculative: bool = False
+    llm_key: str | None = None
+    model: str | None = None
+    requested_model: str | None = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    reasoning_tokens: int = 0
+    image_tokens: int = 0
+    cached_tokens: int = 0
+    llm_cost_usd: float | None = None
+
+
+class WorkflowRunEvaluationCost(BaseModel):
+    """Exact agent LLM usage and Task V2 dimensions for an evaluation run."""
+
+    workflow_run_id: str
+    agent_cost_usd: float | None = None
+    input_tokens: int = 0
+    output_tokens: int = 0
+    reasoning_tokens: int = 0
+    image_tokens: int = 0
+    tokenless_request_count: int = 0
+    cost_status: Literal["exact", "incomplete"]
+    planner_call_count: int = 0
+    check_completion_call_count: int = 0
+    generate_extraction_task_call_count: int = 0
+    generate_task_block_call_count: int = 0
+    extract_actions_call_count: int = 0
+    iteration_count: int = 0
+    loop_item_count: int = 0
+    retry_count: int = 0
+    model_call_counts: dict[str, int] = Field(default_factory=dict)
+    prompt_call_counts: dict[str, int] = Field(default_factory=dict)
+    llm_calls: list[WorkflowRunEvaluationLLMCall] = Field(default_factory=list)

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -54,6 +54,7 @@ from skyvern.exceptions import (
 from skyvern.forge import app
 from skyvern.forge.failure_classifier import classify_from_failure_reason
 from skyvern.forge.prompts import prompt_engine
+from skyvern.forge.sdk.api.llm.tokenless_usage import tokenless_usage_tracker
 from skyvern.forge.sdk.artifact.models import Artifact, ArtifactType
 from skyvern.forge.sdk.artifact.storage.base import _file_infos_from_download_artifacts
 from skyvern.forge.sdk.cache import extraction_cache
@@ -133,6 +134,8 @@ from skyvern.forge.sdk.workflow.models.workflow import (
     WorkflowDefinition,
     WorkflowRequestBody,
     WorkflowRun,
+    WorkflowRunEvaluationCost,
+    WorkflowRunEvaluationLLMCall,
     WorkflowRunOutputParameter,
     WorkflowRunParameter,
     WorkflowRunResponseBase,
@@ -579,6 +582,133 @@ def _build_managed_browser_profile_name(workflow_title: str | None, rendered_key
     suffix = f" (auto-saved: {key})"
     title = _truncate_managed_browser_profile_part(title, MANAGED_BROWSER_PROFILE_NAME_MAX_LENGTH - len(suffix))
     return f"{title}{suffix}"
+
+
+def _build_task_v2_evaluation_metrics(
+    workflow_run_id: str,
+    calls: list[Any],
+    run_metrics: Any | None,
+) -> dict[str, Any]:
+    """Convert durable Task V2 call rows into the evaluator's safe report shape."""
+    call_type_counts = {
+        "planner": 0,
+        "check_completion": 0,
+        "generate_extraction_task": 0,
+        "generate_task_block": 0,
+        "extract_actions": 0,
+    }
+    model_call_counts: dict[str, int] = {}
+    prompt_call_counts: dict[str, int] = {}
+    llm_calls: list[WorkflowRunEvaluationLLMCall] = []
+    reasoning_tokens = 0
+    image_tokens = 0
+    for call in calls:
+        call_type = getattr(call, "call_type", "")
+        if call_type in call_type_counts:
+            call_type_counts[call_type] += 1
+        model = getattr(call, "model", None) or getattr(call, "requested_model", None)
+        if model:
+            model_call_counts[model] = model_call_counts.get(model, 0) + 1
+        prompt_name = getattr(call, "prompt_name", None)
+        if prompt_name:
+            prompt_call_counts[prompt_name] = prompt_call_counts.get(prompt_name, 0) + 1
+        reasoning_tokens += int(getattr(call, "reasoning_token_count", 0) or 0)
+        image_tokens += int(getattr(call, "image_token_count", 0) or 0)
+        llm_calls.append(
+            WorkflowRunEvaluationLLMCall(
+                call_id=call.task_v2_llm_call_id,
+                prompt_name=prompt_name or "unknown",
+                call_type=call_type or "other",
+                task_type=getattr(call, "task_type", None),
+                organization_id=getattr(call, "organization_id", None),
+                workflow_run_id=workflow_run_id,
+                workflow_id=getattr(call, "workflow_id", None),
+                workflow_permanent_id=getattr(call, "workflow_permanent_id", None),
+                task_v2_id=call.task_v2_id,
+                task_id=getattr(call, "task_id", None),
+                step_id=getattr(call, "step_id", None),
+                thought_id=getattr(call, "thought_id", None),
+                workflow_run_block_id=getattr(call, "workflow_run_block_id", None),
+                iteration=getattr(call, "iteration", None),
+                loop_item_count=getattr(call, "loop_item_count", None),
+                loop_index=getattr(call, "loop_index", None),
+                retry_index=int(getattr(call, "retry_index", 0) or 0),
+                is_speculative=bool(getattr(call, "is_speculative", False)),
+                llm_key=getattr(call, "llm_key", None),
+                model=getattr(call, "model", None),
+                requested_model=getattr(call, "requested_model", None),
+                input_tokens=int(getattr(call, "input_token_count", 0) or 0),
+                output_tokens=int(getattr(call, "output_token_count", 0) or 0),
+                reasoning_tokens=int(getattr(call, "reasoning_token_count", 0) or 0),
+                image_tokens=int(getattr(call, "image_token_count", 0) or 0),
+                cached_tokens=int(getattr(call, "cached_token_count", 0) or 0),
+                llm_cost_usd=(float(call.llm_cost) if call.llm_cost is not None else None),
+            )
+        )
+
+    iteration_count = int(getattr(run_metrics, "iteration_count", 0) or 0)
+    loop_item_count = int(getattr(run_metrics, "loop_item_count", 0) or 0)
+    retry_count = int(getattr(run_metrics, "retry_count", 0) or 0)
+    if calls:
+        iteration_count = max(
+            iteration_count,
+            max((getattr(call, "iteration", -1) or -1) + 1 for call in calls),
+        )
+        loop_item_count = max(
+            loop_item_count,
+            max(getattr(call, "loop_item_count", 0) or 0 for call in calls),
+        )
+        retry_count = max(
+            retry_count,
+            sum(1 for call in calls if (getattr(call, "retry_index", 0) or 0) > 0),
+        )
+
+    return {
+        "reasoning_tokens": reasoning_tokens,
+        "image_tokens": image_tokens,
+        "planner_call_count": call_type_counts["planner"],
+        "check_completion_call_count": call_type_counts["check_completion"],
+        "generate_extraction_task_call_count": call_type_counts["generate_extraction_task"],
+        "generate_task_block_call_count": call_type_counts["generate_task_block"],
+        "extract_actions_call_count": call_type_counts["extract_actions"],
+        "iteration_count": iteration_count,
+        "loop_item_count": loop_item_count,
+        "retry_count": retry_count,
+        "model_call_counts": model_call_counts,
+        "prompt_call_counts": prompt_call_counts,
+        "llm_calls": llm_calls,
+    }
+
+
+async def _get_task_v2_observability(
+    workflow_run_id: str,
+    organization_id: str,
+) -> tuple[list[Any], Any | None]:
+    """Read optional Task V2 metrics without breaking legacy/fake database adapters."""
+    observer = app.DATABASE.observer
+    calls: list[Any] = []
+    run_metrics = None
+    get_calls = getattr(observer, "get_task_v2_llm_calls_by_workflow_run_id", None)
+    if get_calls is not None:
+        try:
+            calls = await get_calls(workflow_run_id=workflow_run_id, organization_id=organization_id)
+        except Exception:
+            LOG.warning(
+                "Failed to read Task V2 LLM call metrics",
+                workflow_run_id=workflow_run_id,
+                exc_info=True,
+            )
+    get_run_metrics = getattr(observer, "get_task_v2_run_metrics", None)
+    if get_run_metrics is not None:
+        try:
+            run_metrics = await get_run_metrics(workflow_run_id, organization_id)
+        except Exception:
+            LOG.warning(
+                "Failed to read Task V2 run metrics",
+                workflow_run_id=workflow_run_id,
+                exc_info=True,
+            )
+    return calls, run_metrics
 
 
 class WorkflowService:
@@ -6805,6 +6935,101 @@ class WorkflowService:
             block_task,
         )
         return step_cost_sum + thought_cost_sum + block_llm_cost_sum
+
+    async def get_workflow_run_evaluation_cost(
+        self,
+        workflow_run_id: str,
+        organization_id: str,
+    ) -> WorkflowRunEvaluationCost:
+        """Return target-agent LLM cost and token usage for an evaluation run.
+
+        Tokenless costs are resolved from its per-request usage API because the
+        router can fan out to multiple underlying model calls. Other providers use
+        Skyvern's existing database-backed LLM cost aggregation.
+        """
+        task_v2 = await app.DATABASE.observer.get_task_v2_by_workflow_run_id(
+            workflow_run_id=workflow_run_id,
+            organization_id=organization_id,
+        )
+        tokenless_llm_key = settings.OPENAI_COMPATIBLE_MODEL_KEY
+        is_tokenless_run = task_v2 is not None and task_v2.llm_key == tokenless_llm_key
+
+        if is_tokenless_run:
+            persisted_calls, run_metrics = await _get_task_v2_observability(workflow_run_id, organization_id)
+            persisted_request_call_ids = {
+                call.provider_request_id: call.task_v2_llm_call_id
+                for call in persisted_calls
+                if getattr(call, "provider_request_id", None)
+            }
+            tokenless_cost = await tokenless_usage_tracker.resolve(
+                workflow_run_id,
+                persisted_request_call_ids=persisted_request_call_ids,
+            )
+            observer = app.DATABASE.observer
+            update_call = getattr(observer, "update_task_v2_llm_call", None)
+            if update_call is not None:
+                for call_cost in tokenless_cost.resolved_call_costs:
+                    if call_cost.call_id is None:
+                        continue
+                    try:
+                        await update_call(
+                            call_cost.call_id,
+                            organization_id,
+                            llm_cost=call_cost.cost_nanos / 1_000_000_000,
+                            input_token_count=call_cost.input_tokens,
+                            output_token_count=call_cost.output_tokens,
+                        )
+                    except Exception:
+                        LOG.warning(
+                            "Failed to persist resolved Tokenless call cost",
+                            workflow_run_id=workflow_run_id,
+                            exc_info=True,
+                        )
+            calls, run_metrics = await _get_task_v2_observability(workflow_run_id, organization_id)
+            return WorkflowRunEvaluationCost(
+                workflow_run_id=workflow_run_id,
+                agent_cost_usd=tokenless_cost.agent_cost_usd,
+                input_tokens=tokenless_cost.input_tokens,
+                output_tokens=tokenless_cost.output_tokens,
+                tokenless_request_count=tokenless_cost.tokenless_request_count,
+                cost_status=tokenless_cost.cost_status,
+                **_build_task_v2_evaluation_metrics(workflow_run_id, calls, run_metrics),
+            )
+
+        workflow_run_tasks = await app.DATABASE.tasks.get_tasks_by_workflow_run_id(workflow_run_id=workflow_run_id)
+        task_ids = [task.task_id for task in workflow_run_tasks]
+        step_cost, thought_cost, block_cost, step_tokens, thought_tokens = await asyncio.gather(
+            app.DATABASE.tasks.get_step_cost_sum_by_task_ids(
+                task_ids=task_ids,
+                organization_id=organization_id,
+            ),
+            app.DATABASE.observer.get_thought_cost_sum_by_workflow_run_id(
+                workflow_run_id=workflow_run_id,
+                organization_id=organization_id,
+            ),
+            app.DATABASE.observer.get_block_llm_cost_sum_by_workflow_run_id(
+                workflow_run_id=workflow_run_id,
+                organization_id=organization_id,
+            ),
+            app.DATABASE.tasks.get_step_token_sums_by_task_ids(
+                task_ids=task_ids,
+                organization_id=organization_id,
+            ),
+            app.DATABASE.observer.get_thought_token_sums_by_workflow_run_id(
+                workflow_run_id=workflow_run_id,
+                organization_id=organization_id,
+            ),
+        )
+        calls, run_metrics = await _get_task_v2_observability(workflow_run_id, organization_id)
+        task_v2_metrics = _build_task_v2_evaluation_metrics(workflow_run_id, calls, run_metrics)
+        return WorkflowRunEvaluationCost(
+            workflow_run_id=workflow_run_id,
+            agent_cost_usd=step_cost + thought_cost + block_cost,
+            input_tokens=step_tokens[0] + thought_tokens[0],
+            output_tokens=step_tokens[1] + thought_tokens[1],
+            cost_status="exact",
+            **task_v2_metrics,
+        )
 
     async def build_workflow_run_status_response_by_workflow_id(
         self,

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -100,6 +100,19 @@ NAVIGATE_TERMINAL_OUTPUT_MAX_CHARS = 2000
 NAVIGATE_STRUCTURED_OUTPUT_MAX_CHARS = 10 * NAVIGATE_TERMINAL_OUTPUT_MAX_CHARS
 
 
+async def _best_effort_task_v2_metrics(method_name: str, **kwargs: Any) -> Any:
+    """Persist Task V2 metrics without allowing observability to break execution."""
+    observer = getattr(getattr(app, "DATABASE", None), "observer", None)
+    method = getattr(observer, method_name, None)
+    if method is None:
+        return None
+    try:
+        return await method(**kwargs)
+    except Exception:
+        LOG.warning("Task V2 metrics persistence failed", method=method_name, exc_info=True)
+        return None
+
+
 class InvalidTaskV2ModelError(ValueError):
     pass
 
@@ -729,9 +742,19 @@ async def run_task_v2_helper(
     context.root_workflow_run_id = root_workflow_run_id
     context.request_id = request_id
     context.task_v2_id = task_v2_id
+    context.task_v2_requested_model = task_v2.model.get("model_name") if task_v2.model else None
     context.run_id = current_run_id
     context.browser_session_id = browser_session_id
     context.max_screenshot_scrolls = task_v2.max_screenshot_scrolls
+
+    await _best_effort_task_v2_metrics(
+        "ensure_task_v2_run_metrics",
+        task_v2_id=task_v2_id,
+        workflow_run_id=workflow_run_id,
+        organization_id=organization_id,
+        workflow_id=workflow_id,
+        workflow_permanent_id=workflow.workflow_permanent_id,
+    )
 
     task_v2 = await app.DATABASE.observer.update_task_v2(
         task_v2_id=task_v2_id, organization_id=organization_id, status=TaskV2Status.running
@@ -777,6 +800,18 @@ async def run_task_v2_helper(
     # This is managed at the ForLoop level by calling run_task_v2 for each iteration
     # The max_iterations limit applies to this single TaskV2 execution
     for i in range(max_iterations):
+        context.task_v2_iteration = i
+        context.task_v2_task_type = None
+        context.task_v2_loop_item_count = None
+        context.task_v2_loop_index = None
+        context.task_v2_retry_index = 0
+        context.task_v2_last_llm_call_id = None
+        await _best_effort_task_v2_metrics(
+            "record_task_v2_iteration",
+            workflow_run_id=workflow_run_id,
+            organization_id=organization_id,
+            iteration_count=i + 1,
+        )
         # validate the task execution
         await app.AGENT_FUNCTION.validate_task_execution(
             organization_id=organization_id,
@@ -948,6 +983,14 @@ async def run_task_v2_helper(
                     "termination_reason": termination_reason,
                 },
             )
+            context.task_v2_task_type = task_type or None
+            if context.task_v2_last_llm_call_id and task_type:
+                await _best_effort_task_v2_metrics(
+                    "update_task_v2_llm_call",
+                    task_v2_llm_call_id=context.task_v2_last_llm_call_id,
+                    organization_id=organization_id,
+                    task_type=task_type,
+                )
 
             if user_goal_achieved is True:
                 LOG.info(
@@ -1519,6 +1562,8 @@ async def _generate_loop_task(
             raise Exception("is_loop_value_link not found in the output parameter of the extraction block")
         loop_values = output_value_obj.get(loop_values_key, [])
         is_loop_value_link = output_value_obj.get("is_loop_value_link")
+        context = skyvern_context.ensure_context()
+        context.task_v2_loop_item_count = len(loop_values) if isinstance(loop_values, list) else None
     except Exception:
         LOG.error(
             "Failed to validate the output parameter of the extraction block for the loop task",
@@ -1701,26 +1746,36 @@ async def _generate_extraction_task(
     max_retries = 3
     last_exc: Exception | None = None
     generate_extraction_task_response: dict[str, Any] | None = None
-    for attempt in range(max_retries):
-        try:
-            generate_extraction_task_response = await _get_task_v2_llm_api_handler(task_v2)(
-                generate_extraction_task_prompt,
-                task_v2=task_v2,
-                prompt_name="task_v2_generate_extraction_task",
-                organization_id=task_v2.organization_id,
-                system_prompt=task_v2.workflow_system_prompt,
-            )
-            break
-        except (InvalidLLMResponseFormat, EmptyLLMResponseError) as e:
-            LOG.warning(
-                "Empty or invalid LLM response during extraction task generation, retrying",
-                attempt=attempt + 1,
-                max_attempts=max_retries,
-                error=str(e),
-            )
-            last_exc = e
-    else:
-        raise last_exc  # type: ignore[misc]
+    try:
+        for attempt in range(max_retries):
+            context.task_v2_retry_index = attempt
+            try:
+                generate_extraction_task_response = await _get_task_v2_llm_api_handler(task_v2)(
+                    generate_extraction_task_prompt,
+                    task_v2=task_v2,
+                    prompt_name="task_v2_generate_extraction_task",
+                    organization_id=task_v2.organization_id,
+                    system_prompt=task_v2.workflow_system_prompt,
+                )
+                break
+            except (InvalidLLMResponseFormat, EmptyLLMResponseError) as e:
+                LOG.warning(
+                    "Empty or invalid LLM response during extraction task generation, retrying",
+                    attempt=attempt + 1,
+                    max_attempts=max_retries,
+                    error=str(e),
+                )
+                if attempt + 1 < max_retries:
+                    await _best_effort_task_v2_metrics(
+                        "increment_task_v2_retry_count",
+                        workflow_run_id=workflow_run_id,
+                        organization_id=task_v2.organization_id,
+                    )
+                last_exc = e
+        else:
+            raise last_exc  # type: ignore[misc]
+    finally:
+        context.task_v2_retry_index = 0
 
     assert generate_extraction_task_response is not None
     LOG.info("Data extraction response", data_extraction_response=generate_extraction_task_response)

--- a/tests/unit/test_api_handler_factory.py
+++ b/tests/unit/test_api_handler_factory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from asyncio import CancelledError
 from datetime import datetime
 from types import SimpleNamespace
@@ -14,12 +15,103 @@ from skyvern.forge.sdk.api.llm.api_handler_factory import (
     EXTRACT_ACTION_PROMPT_NAME,
     GEMINI_SAFETY_SETTINGS,
     LLMAPIHandlerFactory,
+    LLMCaller,
 )
 from skyvern.forge.sdk.api.llm.models import LLMConfig
 from skyvern.forge.sdk.artifact.models import ArtifactType
 from skyvern.forge.sdk.models import Step, StepStatus
 from skyvern.schemas.llm import LLMRouterConfig, LLMRouterModelConfig
 from tests.unit.helpers import FakeLLMResponse
+
+
+@pytest.mark.asyncio
+async def test_native_openai_compatible_capture_request_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Native OpenAI-compatible calls retain Tokenless's routed request ID."""
+    request_kwargs: list[dict[str, Any]] = []
+
+    class FakeCompletion:
+        _request_id = "req_tokenless_123"
+
+        def model_dump(self) -> dict[str, Any]:
+            return {
+                "id": "chatcmpl_123",
+                "object": "chat.completion",
+                "model": "tokenless-ultra-saver",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+            }
+
+    class FakeCompletions:
+        async def create(self, **kwargs: Any) -> FakeCompletion:
+            request_kwargs.append(kwargs)
+            assert kwargs["model"] == "tokenless-ultra-saver"
+            assert kwargs["tools"] is None
+            return FakeCompletion()
+
+    class FakeClient:
+        chat = type("Chat", (), {"completions": FakeCompletions()})()
+
+    caller = object.__new__(LLMCaller)
+    caller.openai_client = FakeClient()
+    caller._native_openai_compatible = True
+    caller.original_llm_key = "OPENAI_COMPATIBLE"
+    caller.llm_key = "tokenless-pro"
+    caller.llm_config = SimpleNamespace(model_name="openai/tokenless-pro")
+
+    monkeypatch.setattr(api_handler_factory.settings, "SKYVERN_APP_URL", "")
+    monkeypatch.setattr(api_handler_factory.settings, "OPENAI_COMPATIBLE_MODEL_NAME", "tokenless-pro")
+    monkeypatch.setattr(
+        api_handler_factory.settings,
+        "OPENAI_COMPATIBLE_ADDITIONAL_MODEL_NAMES",
+        "tokenless-ultra-saver",
+    )
+    context = SimpleNamespace(
+        task_v2_id="tsk_eval_123",
+        task_id=None,
+        task_v2_requested_model="tokenless-ultra-saver",
+        tokenless_session_id=None,
+    )
+    monkeypatch.setattr(api_handler_factory.skyvern_context, "current", lambda: context)
+
+    response = await caller._dispatch_llm_call(messages=[{"role": "user", "content": "hello"}])
+    await caller._dispatch_llm_call(messages=[{"role": "user", "content": "hello again"}])
+
+    assert response.model == "tokenless-ultra-saver"
+    stats = await caller.get_call_stats(response)
+    assert stats.provider_request_id == "req_tokenless_123"
+    assert stats.input_tokens == 3
+    assert stats.output_tokens == 2
+    session_ids = [kwargs["extra_headers"]["Session-Id"] for kwargs in request_kwargs]
+    assert session_ids[0] == session_ids[1]
+    assert re.fullmatch(r"eval_skyvern_tsk_eval_123_\d{8}T\d{6}\.\d{6}Z", session_ids[0])
+
+
+def test_native_openai_compatible_handler_uses_llm_caller(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The factory must select the native path when Tokenless instrumentation is enabled."""
+    llm_config = LLMConfig(
+        model_name="openai/tokenless-pro",
+        required_env_vars=[],
+        supports_vision=True,
+        add_assistant_prefix=False,
+    )
+    monkeypatch.setattr(api_handler_factory.LLMConfigRegistry, "get_config", lambda _: llm_config)
+    monkeypatch.setattr(api_handler_factory.LLMConfigRegistry, "is_router_config", lambda _: False)
+    monkeypatch.setattr(api_handler_factory.settings, "OPENAI_COMPATIBLE_MODEL_KEY", "OPENAI_COMPATIBLE")
+    monkeypatch.setattr(api_handler_factory.settings, "OPENAI_COMPATIBLE_MODEL_NAME", "tokenless-pro")
+    monkeypatch.setattr(api_handler_factory.settings, "OPENAI_COMPATIBLE_USE_NATIVE_CLIENT", True)
+    monkeypatch.setattr(api_handler_factory.settings, "OPENAI_COMPATIBLE_API_KEY", "test-key")
+    monkeypatch.setattr(api_handler_factory.settings, "OPENAI_COMPATIBLE_API_BASE", "https://example.com/openai/v1")
+    monkeypatch.setattr(api_handler_factory, "AsyncOpenAI", MagicMock())
+
+    handler = LLMAPIHandlerFactory.get_llm_api_handler("OPENAI_COMPATIBLE")
+
+    assert handler.__self__._native_openai_compatible is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_openai_compatible_model_mapping.py
+++ b/tests/unit/test_openai_compatible_model_mapping.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from skyvern.config import settings
+
+
+def test_configured_openai_compatible_model_is_selectable(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "ENABLE_OPENAI_COMPATIBLE", True)
+    monkeypatch.setattr(settings, "OPENAI_COMPATIBLE_MODEL_NAME", "tokenless-pro")
+    monkeypatch.setattr(settings, "OPENAI_COMPATIBLE_ADDITIONAL_MODEL_NAMES", " tokenless-ultra-saver,tokenless-pro ")
+    monkeypatch.setattr(settings, "OPENAI_COMPATIBLE_MODEL_KEY", "OPENAI_COMPATIBLE")
+
+    mapping = settings.get_model_name_to_llm_key()
+
+    assert mapping["tokenless-pro"] == {
+        "llm_key": "OPENAI_COMPATIBLE",
+        "label": "OpenAI-compatible: tokenless-pro",
+    }
+    assert mapping["tokenless-ultra-saver"] == {
+        "llm_key": "OPENAI_COMPATIBLE",
+        "label": "OpenAI-compatible: tokenless-ultra-saver",
+    }
+    assert settings.get_openai_compatible_model_names() == ["tokenless-pro", "tokenless-ultra-saver"]

--- a/tests/unit/test_tokenless_usage.py
+++ b/tests/unit/test_tokenless_usage.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from skyvern.forge.sdk.api.llm import tokenless_usage
+
+
+@pytest.mark.asyncio
+async def test_tokenless_tracker_deduplicates_request_ids_and_sums_cost(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracker = tokenless_usage.TokenlessUsageTracker()
+    await tracker.record_request("wr_123", "req_a", call_id="call_a")
+    await tracker.record_request("wr_123", "req_a", call_id="call_a")
+    await tracker.record_request("wr_123", "req_b", call_id="call_b")
+
+    costs = {
+        "req_a": tokenless_usage.TokenlessRequestCost("req_a", 1_250_000_000, 10, 20),
+        "req_b": tokenless_usage.TokenlessRequestCost("req_b", 750_000_000, 30, 40),
+    }
+    monkeypatch.setattr(
+        tracker,
+        "_fetch_request_cost",
+        AsyncMock(side_effect=lambda _client, request_id: costs[request_id]),
+    )
+
+    summary = await tracker.resolve("wr_123")
+
+    assert summary.agent_cost_usd == 2.0
+    assert summary.input_tokens == 40
+    assert summary.output_tokens == 60
+    assert summary.tokenless_request_count == 2
+    assert summary.cost_status == "exact"
+    assert {cost.call_id for cost in summary.resolved_call_costs} == {"call_a", "call_b"}
+
+
+@pytest.mark.asyncio
+async def test_tokenless_tracker_keeps_concurrent_workflow_runs_separate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent model calls must not associate a request with the wrong run."""
+    tracker = tokenless_usage.TokenlessUsageTracker()
+    await asyncio.gather(
+        *(tracker.record_request(run_id, request_id) for run_id, request_id in [("wr_1", "req_1"), ("wr_2", "req_2")])
+    )
+
+    costs = {
+        "req_1": tokenless_usage.TokenlessRequestCost("req_1", 100, 1, 2),
+        "req_2": tokenless_usage.TokenlessRequestCost("req_2", 900, 3, 4),
+    }
+    monkeypatch.setattr(
+        tracker,
+        "_fetch_request_cost",
+        AsyncMock(side_effect=lambda _client, request_id: costs[request_id]),
+    )
+
+    run_1, run_2 = await asyncio.gather(tracker.resolve("wr_1"), tracker.resolve("wr_2"))
+
+    assert (run_1.agent_cost_usd, run_1.input_tokens, run_1.output_tokens) == (0.0000001, 1, 2)
+    assert (run_2.agent_cost_usd, run_2.input_tokens, run_2.output_tokens) == (0.0000009, 3, 4)
+
+
+@pytest.mark.asyncio
+async def test_tokenless_tracker_marks_missing_request_cost_incomplete(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracker = tokenless_usage.TokenlessUsageTracker()
+    await tracker.record_request("wr_123", "req_a")
+    await tracker.record_request("wr_123", "req_missing")
+
+    async def fetch(
+        _client: httpx.AsyncClient,
+        request_id: str,
+    ) -> tokenless_usage.TokenlessRequestCost:
+        if request_id == "req_missing":
+            raise tokenless_usage.TokenlessUsageError("missing")
+        return tokenless_usage.TokenlessRequestCost(request_id, 100, 2, 3)
+
+    monkeypatch.setattr(tracker, "_fetch_request_cost", fetch)
+
+    summary = await tracker.resolve("wr_123")
+
+    assert summary.agent_cost_usd is None
+    assert summary.input_tokens == 2
+    assert summary.output_tokens == 3
+    assert summary.tokenless_request_count == 2
+    assert summary.cost_status == "incomplete"
+
+
+@pytest.mark.asyncio
+async def test_fetch_request_cost_retries_transient_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        tokenless_usage.settings,
+        "OPENAI_COMPATIBLE_API_BASE",
+        "https://api.example.com/openai/v1",
+    )
+    monkeypatch.setattr(tokenless_usage.settings, "OPENAI_COMPATIBLE_API_KEY", "test-key")
+    requests_seen: list[httpx.Request] = []
+    responses = iter(
+        [
+            httpx.Response(503, request=httpx.Request("GET", "https://api.example.com")),
+            httpx.Response(
+                200,
+                json={
+                    "request_id": "req_a",
+                    "total_cost_nanos": 123,
+                    "total_input_tokens": 4,
+                    "total_output_tokens": 5,
+                },
+                request=httpx.Request("GET", "https://api.example.com"),
+            ),
+        ]
+    )
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        requests_seen.append(request)
+        return next(responses)
+
+    transport = httpx.MockTransport(handle_request)
+    client = httpx.AsyncClient(transport=transport)
+    monkeypatch.setattr(tokenless_usage.asyncio, "sleep", AsyncMock())
+
+    try:
+        result = await tokenless_usage.TokenlessUsageTracker()._fetch_request_cost(client, "req_a")
+    finally:
+        await client.aclose()
+
+    assert result.cost_nanos == 123
+    assert result.input_tokens == 4
+    assert result.output_tokens == 5
+    assert requests_seen[0].url == "https://api.example.com/v1/usage/requests/req_a"
+    assert requests_seen[0].headers["authorization"] == "Bearer test-key"
+
+
+@pytest.mark.asyncio
+async def test_fetch_request_cost_retries_529_and_honors_retry_after(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        tokenless_usage.settings,
+        "OPENAI_COMPATIBLE_API_BASE",
+        "https://api.example.com/openai/v1",
+    )
+    monkeypatch.setattr(tokenless_usage.settings, "OPENAI_COMPATIBLE_API_KEY", "test-key")
+    sleep = AsyncMock()
+    monkeypatch.setattr(tokenless_usage.asyncio, "sleep", sleep)
+    responses = iter(
+        [
+            httpx.Response(
+                529,
+                headers={"Retry-After": "3"},
+                request=httpx.Request("GET", "https://api.example.com"),
+            ),
+            httpx.Response(
+                200,
+                json={
+                    "request_id": "req_a",
+                    "total_cost_nanos": 123,
+                    "total_input_tokens": 4,
+                    "total_output_tokens": 5,
+                },
+                request=httpx.Request("GET", "https://api.example.com"),
+            ),
+        ]
+    )
+    client = httpx.AsyncClient(transport=httpx.MockTransport(lambda _request: next(responses)))
+
+    try:
+        result = await tokenless_usage.TokenlessUsageTracker()._fetch_request_cost(client, "req_a")
+    finally:
+        await client.aclose()
+
+    assert result.cost_nanos == 123
+    sleep.assert_awaited_once_with(3.0)
+
+
+@pytest.mark.asyncio
+async def test_fetch_request_cost_treats_404_as_unresolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        tokenless_usage.settings,
+        "OPENAI_COMPATIBLE_API_BASE",
+        "https://api.example.com/openai/v1",
+    )
+    monkeypatch.setattr(tokenless_usage.settings, "OPENAI_COMPATIBLE_API_KEY", "test-key")
+    request = httpx.Request("GET", "https://api.example.com/v1/usage/requests/req_missing")
+    client = httpx.AsyncClient(transport=httpx.MockTransport(lambda _request: httpx.Response(404, request=request)))
+
+    try:
+        with pytest.raises(tokenless_usage.TokenlessUsageError):
+            await tokenless_usage.TokenlessUsageTracker()._fetch_request_cost(client, "req_missing")
+    finally:
+        await client.aclose()

--- a/tests/unit/test_webvoyager_runner.py
+++ b/tests/unit/test_webvoyager_runner.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from evaluation.core.utils import WebVoyagerTestCase
+from evaluation.script.run_webvoyager_task_v2 import _submit_case, _web_name
+
+
+def test_webvoyager_case_web_name_comes_from_case_id() -> None:
+    case = WebVoyagerTestCase(
+        group_id="group",
+        id="ArXiv--7",
+        url="https://arxiv.org/",
+        question="Find a paper.",
+        answer="A paper",
+    )
+
+    assert _web_name(case) == "ArXiv"
+
+
+@pytest.mark.asyncio
+async def test_submit_case_passes_custom_proxy_to_task_v2() -> None:
+    client = Mock()
+    client.create_task_v2.return_value = SimpleNamespace(
+        workflow_permanent_id="wpid_1",
+        workflow_run_id="wr_1",
+        observer_cruise_id="tsk_v2_1",
+    )
+    case = WebVoyagerTestCase(
+        group_id="group",
+        id="Allrecipes--7",
+        url="https://www.allrecipes.com/",
+        question="Find a recipe.",
+        answer="A recipe",
+    )
+
+    result = await _submit_case(client, case, "tokenless-pro", asyncio.Semaphore(1), "http://proxy:8080")
+
+    request = client.create_task_v2.call_args.args[0]
+    assert request.proxy_location == {"url": "http://proxy:8080"}
+    assert result["workflow_run_id"] == "wr_1"

--- a/tests/unit/test_workflow_evaluation_cost.py
+++ b/tests/unit/test_workflow_evaluation_cost.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from skyvern.forge.sdk.api.llm.tokenless_usage import TokenlessRequestCost, TokenlessRunCost
+from skyvern.forge.sdk.workflow import service as workflow_service
+from skyvern.forge.sdk.workflow.service import WorkflowService
+
+
+@pytest.mark.asyncio
+async def test_evaluation_cost_uses_tokenless_request_cost(monkeypatch: pytest.MonkeyPatch) -> None:
+    database = SimpleNamespace(
+        observer=SimpleNamespace(
+            get_task_v2_by_workflow_run_id=AsyncMock(return_value=SimpleNamespace(llm_key="OPENAI_COMPATIBLE")),
+        ),
+        tasks=SimpleNamespace(),
+    )
+    monkeypatch.setattr(workflow_service, "app", SimpleNamespace(DATABASE=database))
+    monkeypatch.setattr(
+        workflow_service.tokenless_usage_tracker,
+        "resolve",
+        AsyncMock(
+            return_value=TokenlessRunCost(
+                agent_cost_usd=1.25,
+                input_tokens=10,
+                output_tokens=20,
+                tokenless_request_count=2,
+                cost_status="exact",
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        workflow_service.settings,
+        "OPENAI_COMPATIBLE_MODEL_KEY",
+        "OPENAI_COMPATIBLE",
+    )
+
+    result = await WorkflowService().get_workflow_run_evaluation_cost("wr_123", "org_123")
+
+    assert result.agent_cost_usd == 1.25
+    assert result.input_tokens == 10
+    assert result.output_tokens == 20
+    assert result.tokenless_request_count == 2
+    assert result.cost_status == "exact"
+
+
+@pytest.mark.asyncio
+async def test_evaluation_cost_uses_existing_gemini_aggregation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    database = SimpleNamespace(
+        observer=SimpleNamespace(
+            get_task_v2_by_workflow_run_id=AsyncMock(return_value=SimpleNamespace(llm_key="VERTEX_GEMINI_3.5_FLASH")),
+            get_thought_cost_sum_by_workflow_run_id=AsyncMock(return_value=0.25),
+            get_block_llm_cost_sum_by_workflow_run_id=AsyncMock(return_value=0.5),
+            get_thought_token_sums_by_workflow_run_id=AsyncMock(return_value=(3, 4)),
+        ),
+        tasks=SimpleNamespace(
+            get_tasks_by_workflow_run_id=AsyncMock(return_value=[SimpleNamespace(task_id="task_1")]),
+            get_step_cost_sum_by_task_ids=AsyncMock(return_value=1.0),
+            get_step_token_sums_by_task_ids=AsyncMock(return_value=(10, 20)),
+        ),
+    )
+    monkeypatch.setattr(workflow_service, "app", SimpleNamespace(DATABASE=database))
+    monkeypatch.setattr(
+        workflow_service.settings,
+        "OPENAI_COMPATIBLE_MODEL_KEY",
+        "OPENAI_COMPATIBLE",
+    )
+
+    result = await WorkflowService().get_workflow_run_evaluation_cost("wr_123", "org_123")
+
+    assert result.agent_cost_usd == 1.75
+    assert result.input_tokens == 13
+    assert result.output_tokens == 24
+    assert result.tokenless_request_count == 0
+    assert result.cost_status == "exact"
+
+
+@pytest.mark.asyncio
+async def test_evaluation_cost_reports_task_v2_call_dimensions_and_resolves_costs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    call = SimpleNamespace(
+        task_v2_llm_call_id="call_1",
+        task_v2_id="task_v2_1",
+        organization_id="org_123",
+        workflow_id="workflow_1",
+        workflow_permanent_id="workflow_perm_1",
+        call_type="planner",
+        prompt_name="task_v2",
+        task_type="navigate",
+        iteration=2,
+        loop_item_count=4,
+        loop_index=1,
+        retry_index=1,
+        is_speculative=False,
+        llm_key="TOKENLESS",
+        model="tokenless-pro",
+        requested_model="tokenless-pro",
+        input_token_count=10,
+        output_token_count=20,
+        reasoning_token_count=3,
+        image_token_count=5,
+        cached_token_count=2,
+        llm_cost=None,
+    )
+    update_call = AsyncMock()
+    database = SimpleNamespace(
+        observer=SimpleNamespace(
+            get_task_v2_by_workflow_run_id=AsyncMock(return_value=SimpleNamespace(llm_key="OPENAI_COMPATIBLE")),
+            update_task_v2_llm_call=update_call,
+            get_task_v2_llm_calls_by_workflow_run_id=AsyncMock(return_value=[call]),
+            get_task_v2_run_metrics=AsyncMock(
+                return_value=SimpleNamespace(iteration_count=3, loop_item_count=4, retry_count=1)
+            ),
+        ),
+        tasks=SimpleNamespace(),
+    )
+    monkeypatch.setattr(workflow_service, "app", SimpleNamespace(DATABASE=database))
+    monkeypatch.setattr(
+        workflow_service.tokenless_usage_tracker,
+        "resolve",
+        AsyncMock(
+            return_value=TokenlessRunCost(
+                agent_cost_usd=0.75,
+                input_tokens=10,
+                output_tokens=20,
+                tokenless_request_count=1,
+                cost_status="exact",
+                resolved_call_costs=(TokenlessRequestCost("req_1", 750_000_000, 10, 20, "call_1"),),
+            )
+        ),
+    )
+    monkeypatch.setattr(workflow_service.settings, "OPENAI_COMPATIBLE_MODEL_KEY", "OPENAI_COMPATIBLE")
+
+    result = await WorkflowService().get_workflow_run_evaluation_cost("wr_123", "org_123")
+
+    assert result.planner_call_count == 1
+    assert result.iteration_count == 3
+    assert result.loop_item_count == 4
+    assert result.retry_count == 1
+    assert result.reasoning_tokens == 3
+    assert result.image_tokens == 5
+    assert result.model_call_counts == {"tokenless-pro": 1}
+    assert result.prompt_call_counts == {"task_v2": 1}
+    assert result.llm_calls[0].workflow_id == "workflow_1"
+    update_call.assert_awaited_once_with(
+        "call_1",
+        "org_123",
+        llm_cost=0.75,
+        input_token_count=10,
+        output_token_count=20,
+    )


### PR DESCRIPTION
## Summary

- add exact per-request Tokenless cost attribution using routed request IDs
- persist Task V2 LLM call, iteration, loop, retry, model, prompt, and token metrics
- expose workflow evaluation-cost reporting and add a multi-model WebVoyager runner
- support OpenAI-compatible model routing and Tokenless evaluation session IDs

## Why

WebVoyager evaluations need comparable pass-rate and agent-cost reporting across Gemini and Tokenless models, including enough call-level telemetry to diagnose cost and behavior differences.

## Impact

Evaluation runs can report exact Tokenless request costs, existing Gemini aggregate costs, detailed Task V2 execution metrics, and per-model summaries while keeping judge and normalization costs separate.

## Validation

- 113 focused backend tests passed
- pre-commit run --all-files passed
- 2,948 frontend tests passed through the pre-commit suite
- staged diff scanned for Tokenless credential patterns