### PR TITLE
Reduce Task V2 token spend behind feature flags

### DIFF
--- a/skyvern/forge/agent_functions.py
+++ b/skyvern/forge/agent_functions.py
@@ -1042,7 +1042,31 @@ class AgentFunction:
         Returns:
             A list of actions to inject into the step (skipping LLM), or None for normal flow.
         """
-        return None
+        context = skyvern_context.current()
+        if not context or not context.task_v2_loop_replay_active:
+            return None
+        if not context.task_v2_loop_replay_source_task_id:
+            return None
+
+        # Import lazily: caching depends on the global app singleton initialized by forge.
+        from skyvern.webeye.actions.caching import retrieve_action_plan  # noqa: PLC0415
+
+        try:
+            scraped_page = await browser_state.scrape_website(
+                url=task.url,
+                cleanup_element_tree=self.cleanup_element_tree_factory(),
+                scrape_exclude=getattr(app, "scrape_exclude", None),
+            )
+            replay_actions = await retrieve_action_plan(task, step, scraped_page)
+        except Exception:
+            LOG.warning(
+                "Task V2 loop replay preparation failed; falling back to AI",
+                task_id=task.task_id,
+                source_task_id=context.task_v2_loop_replay_source_task_id,
+                exc_info=True,
+            )
+            return None
+        return replay_actions or None
 
     async def post_step_execution(self, task: Task, step: Step) -> None:
         if step.status == StepStatus.completed:

--- a/skyvern/forge/prompts/skyvern/task_v2.j2
+++ b/skyvern/forge/prompts/skyvern/task_v2.j2
@@ -74,7 +74,20 @@ Reply in JSON format with the following keys:
   "plan": str, // The mini goal to achieve to move towards the user goal. DO NOT come up or hallucinate any data that's not provided in the user goal. Be accurate and precise. Return null if the user goal has been achieved or if should_terminate is true.
   "task_type": str, // One of the available task types: navigate, extract, loop. Null if user_goal_achieved is true or should_terminate is true.
   "loop_values": list[str], // a list of string values to iterate through for loop task. null if it's not a loop task
-  "is_loop_value_link": bool, // true if the loop_values is a list of urls to go to before for each planning session inside the loop
+  "is_loop_value_link": bool{% if task_v2_loop_contract %}, // true if the loop_values is a list of urls to go to before for each planning session inside the loop
+  "loop_limit": int, // exact requested count when the user specifies one; otherwise null
+  "loop_source": str // "explicit" when values came from the goal, "discovered" when they must be found on the page
+  {% else %} // true if the loop_values is a list of urls to go to before for each planning session inside the loop
+  {% endif %}{% if task_v2_extraction_schema_reuse %},
+  "data_schema": json // extraction schema when task_type is extract; otherwise null
+  {% endif %}{% if task_v2_planning_deduplication %},
+  "loop_body": { // reusable loop-body metadata when task_type is loop; otherwise null
+    "navigation_goal": str,
+    "data_extraction_goal": str,
+    "data_schema": json,
+    "thoughts": str
+  }
+  {% endif %}
 }
 
 The URL of the page you're on right now is `{{ current_url }}`.

--- a/skyvern/forge/sdk/core/skyvern_context.py
+++ b/skyvern/forge/sdk/core/skyvern_context.py
@@ -104,6 +104,12 @@ class SkyvernContext:
     browser_container_ip: str | None = None
     browser_container_task_arn: str | None = None
     feature_flag_entries: dict[str, bool | str | None] = field(default_factory=dict)
+    # Immutable Task V2 optimization cohort, resolved once when a Task V2 run starts.
+    # A plain mapping avoids coupling the core context module to the service layer.
+    task_v2_optimization_flags: dict[str, bool] | None = None
+    task_v2_loop_replay_active: bool = False
+    task_v2_loop_replay_source_task_id: str | None = None
+    task_v2_loop_replay_current_value: Any = None
 
     # feature flags
     enable_page_ready_wait: bool = False

--- a/skyvern/forge/sdk/db/repositories/workflow_parameters.py
+++ b/skyvern/forge/sdk/db/repositories/workflow_parameters.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 
 from skyvern.config import settings
 from skyvern.forge.sdk.copilot.context import TurnNarrativePayload
+from skyvern.forge.sdk.core import skyvern_context
 from skyvern.forge.sdk.db._error_handling import db_operation
 from skyvern.forge.sdk.db._sentinels import _UNSET
 from skyvern.forge.sdk.db.base_repository import BaseRepository
@@ -875,6 +876,19 @@ class WorkflowParametersRepository(BaseRepository):
     @db_operation("retrieve_action_plan")
     async def retrieve_action_plan(self, task: Task) -> list[Action]:
         async with self.Session() as session:
+            context = skyvern_context.current()
+            replay_source_task_id = (
+                context.task_v2_loop_replay_source_task_id if context and context.task_v2_loop_replay_active else None
+            )
+            if replay_source_task_id:
+                query = (
+                    select(ActionModel)
+                    .filter(ActionModel.task_id == replay_source_task_id)
+                    .order_by(ActionModel.step_order, ActionModel.action_order, ActionModel.created_at)
+                )
+                actions = (await session.scalars(query)).all()
+                return [Action.model_validate(action) for action in actions]
+
             subquery = (
                 select(TaskModel.task_id)
                 .filter(TaskModel.url == task.url)

--- a/skyvern/forge/sdk/workflow/models/block.py
+++ b/skyvern/forge/sdk/workflow/models/block.py
@@ -1888,6 +1888,8 @@ class ForLoopBlock(Block):
     # There is a mypy bug with Literal. Without the type: ignore, mypy will raise an error:
     # Parameter 1 of Literal[...] cannot be of type "Any"
     block_type: Literal[BlockType.FOR_LOOP] = BlockType.FOR_LOOP  # type: ignore
+    max_loop_items: int | None = None
+    task_v2_loop_replay: bool = False
 
     loop_blocks: list[BlockTypeVar]
     loop_over: PARAMETER_TYPE | None = None
@@ -2399,22 +2401,29 @@ class ForLoopBlock(Block):
         block_outputs: list[BlockResult] = []
         current_block: BlockTypeVar | None = None
 
+        replay_context = skyvern_context.current()
+        if replay_context and self.task_v2_loop_replay:
+            replay_context.task_v2_loop_replay_active = False
+            replay_context.task_v2_loop_replay_source_task_id = None
+            replay_context.task_v2_loop_replay_current_value = None
+
         start_label, label_to_block, default_next_map = self._build_loop_graph(self.loop_blocks)
         conditional_scopes = compute_conditional_scopes(label_to_block, default_next_map)
 
+        effective_max_loop_items = self.max_loop_items or DEFAULT_MAX_LOOP_ITERATIONS
         for loop_idx, loop_over_value in enumerate(loop_over_values):
             # Check max_iterations limit
-            if loop_idx >= DEFAULT_MAX_LOOP_ITERATIONS:
+            if loop_idx >= effective_max_loop_items:
                 LOG.info(
-                    f"ForLoopBlock Reached max_iterations limit ({DEFAULT_MAX_LOOP_ITERATIONS}), stopping loop",
+                    f"ForLoopBlock Reached max_iterations limit ({effective_max_loop_items}), stopping loop",
                     workflow_run_id=workflow_run_id,
                     loop_idx=loop_idx,
-                    max_iterations=DEFAULT_MAX_LOOP_ITERATIONS,
+                    max_iterations=effective_max_loop_items,
                 )
                 failure_block_result = await self.build_block_result(
                     success=False,
                     status=BlockStatus.failed,
-                    failure_reason=f"Reached max_loop_iterations limit of {DEFAULT_MAX_LOOP_ITERATIONS}",
+                    failure_reason=f"Reached max_loop_iterations limit of {effective_max_loop_items}",
                     workflow_run_block_id=workflow_run_block_id,
                     organization_id=organization_id,
                     is_synthetic_loop_failure=True,
@@ -2529,14 +2538,45 @@ class ForLoopBlock(Block):
                     if cond_label in conditional_wrb_ids:
                         parent_wrb_id = conditional_wrb_ids[cond_label]
 
-                block_output = await loop_block.execute_safe(
-                    workflow_run_id=workflow_run_id,
-                    parent_workflow_run_block_id=parent_wrb_id,
-                    organization_id=organization_id,
-                    browser_session_id=browser_session_id,
-                    current_value=str(loop_over_value),
-                    current_index=loop_idx,
-                )
+                replay_context = skyvern_context.current()
+                if replay_context:
+                    replay_context.task_v2_loop_replay_active = bool(
+                        self.task_v2_loop_replay and loop_idx > 0 and replay_context.task_v2_loop_replay_source_task_id
+                    )
+                    replay_context.task_v2_loop_replay_current_value = loop_over_value
+                try:
+                    block_output = await loop_block.execute_safe(
+                        workflow_run_id=workflow_run_id,
+                        parent_workflow_run_block_id=parent_wrb_id,
+                        organization_id=organization_id,
+                        browser_session_id=browser_session_id,
+                        current_value=str(loop_over_value),
+                        current_index=loop_idx,
+                    )
+                finally:
+                    if replay_context:
+                        replay_context.task_v2_loop_replay_active = False
+                        replay_context.task_v2_loop_replay_current_value = None
+
+                if (
+                    self.task_v2_loop_replay
+                    and loop_idx == 0
+                    and block_output.success
+                    and block_output.workflow_run_block_id
+                    and replay_context
+                ):
+                    try:
+                        source_block = await app.DATABASE.observer.get_workflow_run_block(
+                            block_output.workflow_run_block_id,
+                            organization_id=organization_id,
+                        )
+                        replay_context.task_v2_loop_replay_source_task_id = source_block.task_id
+                    except Exception:
+                        LOG.warning(
+                            "Unable to capture Task V2 loop replay source; later items will use AI",
+                            workflow_run_block_id=block_output.workflow_run_block_id,
+                            exc_info=True,
+                        )
 
                 # Track conditional workflow_run_block_ids so branch targets
                 # can be parented to them.

--- a/skyvern/forge/sdk/workflow/workflow_definition_converter.py
+++ b/skyvern/forge/sdk/workflow/workflow_definition_converter.py
@@ -517,6 +517,8 @@ def block_yaml_to_block(
             loop_blocks=loop_blocks,
             complete_if_empty=block_yaml.complete_if_empty,
             data_schema=block_yaml.data_schema,
+            max_loop_items=block_yaml.max_loop_items,
+            task_v2_loop_replay=block_yaml.task_v2_loop_replay,
         )
     elif block_yaml.block_type == BlockType.WHILE_LOOP:
         loop_blocks = [block_yaml_to_block(loop_block, parameters) for loop_block in block_yaml.loop_blocks]

--- a/skyvern/schemas/workflows.py
+++ b/skyvern/schemas/workflows.py
@@ -768,6 +768,9 @@ class ForLoopBlockYAML(BlockYAML):
     loop_variable_reference: str | None = None
     complete_if_empty: bool = False
     data_schema: dict[str, Any] | str | None = None
+    # Task V2-generated loop controls. None/False preserve legacy authored loops.
+    max_loop_items: int | None = None
+    task_v2_loop_replay: bool = False
 
 
 class BranchCriteriaYAML(BaseModel):

--- a/skyvern/services/task_v2_optimizations.py
+++ b/skyvern/services/task_v2_optimizations.py
@@ -1,0 +1,168 @@
+"""Independently ablatable, run-sticky Task V2 token optimizations."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import structlog
+
+from skyvern.forge import app
+from skyvern.forge.sdk.core.skyvern_context import SkyvernContext
+
+LOG = structlog.get_logger()
+
+TASK_V2_FLAG_PREFIX = "TASK_V2_"
+DEFAULT_GENERATED_LOOP_ITEM_LIMIT = 25
+HARD_GENERATED_LOOP_ITEM_LIMIT = 50
+DEFAULT_COMPLETION_CHECK_INTERVAL = 3
+COMPACT_HISTORY_RECORD_LIMIT = 4
+COMPACT_HISTORY_FIELD_MAX_CHARS = 2000
+
+
+@dataclass(frozen=True)
+class TaskV2OptimizationFlags:
+    """The feature-flag cohort pinned to one Task V2 run."""
+
+    honor_iteration_override: bool = False
+    no_progress_breaker: bool = False
+    completion_scheduler: bool = False
+    observation_reuse: bool = False
+    compact_context: bool = False
+    loop_contract: bool = False
+    loop_guardrails: bool = False
+    loop_fail_fast: bool = False
+    planning_deduplication: bool = False
+    extraction_schema_reuse: bool = False
+    loop_replay: bool = False
+
+    def as_mapping(self) -> dict[str, bool]:
+        return asdict(self)
+
+
+FLAG_NAME_BY_FIELD = {
+    field_name: f"{TASK_V2_FLAG_PREFIX}{field_name.upper()}"
+    for field_name in TaskV2OptimizationFlags.__dataclass_fields__
+}
+
+
+async def resolve_task_v2_optimization_flags(context: SkyvernContext) -> TaskV2OptimizationFlags:
+    """Resolve every Task V2 optimization once and pin the result to ``context``."""
+
+    if context.task_v2_optimization_flags is not None:
+        return TaskV2OptimizationFlags(**context.task_v2_optimization_flags)
+
+    distinct_id = context.workflow_run_id or context.task_v2_id or context.run_id
+    provider = getattr(app, "EXPERIMENTATION_PROVIDER", None)
+    if not distinct_id or provider is None:
+        flags = TaskV2OptimizationFlags()
+        context.task_v2_optimization_flags = flags.as_mapping()
+        return flags
+
+    properties = {
+        "organization_id": context.organization_id,
+        "workflow_permanent_id": context.workflow_permanent_id,
+    }
+
+    async def resolve(field_name: str) -> tuple[str, bool]:
+        try:
+            enabled = await provider.is_feature_enabled_cached(
+                FLAG_NAME_BY_FIELD[field_name], distinct_id, properties=properties
+            )
+        except Exception:
+            LOG.warning(
+                "Failed to resolve Task V2 optimization flag; using control",
+                flag_name=FLAG_NAME_BY_FIELD[field_name],
+                task_v2_id=context.task_v2_id,
+                exc_info=True,
+            )
+            enabled = False
+        return field_name, bool(enabled)
+
+    resolved = dict(await asyncio.gather(*(resolve(name) for name in FLAG_NAME_BY_FIELD)))
+    flags = TaskV2OptimizationFlags(**resolved)
+    context.task_v2_optimization_flags = flags.as_mapping()
+    return flags
+
+
+def normalize_loop_values(
+    values: Any,
+    *,
+    requested_limit: int | None,
+    apply_guardrail: bool,
+) -> list[str]:
+    """Validate, deduplicate, and bound values generated for a Task V2 loop."""
+
+    if not isinstance(values, list):
+        return []
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        cleaned = value.strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        normalized.append(cleaned)
+
+    try:
+        parsed_limit = int(requested_limit) if requested_limit is not None else None
+    except (TypeError, ValueError):
+        parsed_limit = None
+    limit = parsed_limit if parsed_limit and parsed_limit > 0 else None
+    if apply_guardrail:
+        limit = min(limit or DEFAULT_GENERATED_LOOP_ITEM_LIMIT, HARD_GENERATED_LOOP_ITEM_LIMIT)
+    if limit is not None:
+        normalized = normalized[:limit]
+    return normalized
+
+
+def generated_loop_item_limit(requested_limit: Any) -> int:
+    """Resolve the configurable soft limit without ever exceeding the hard cap."""
+
+    try:
+        parsed_limit = int(requested_limit) if requested_limit is not None else None
+    except (TypeError, ValueError):
+        parsed_limit = None
+    return min(parsed_limit or DEFAULT_GENERATED_LOOP_ITEM_LIMIT, HARD_GENERATED_LOOP_ITEM_LIMIT)
+
+
+def compact_task_history(task_history: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Render a bounded copy of recent history while preserving the stored history."""
+
+    compacted = copy.deepcopy(task_history[-COMPACT_HISTORY_RECORD_LIMIT:])
+    for record in compacted:
+        for key, value in list(record.items()):
+            serialized = json.dumps(value, default=str) if not isinstance(value, str) else value
+            if len(serialized) > COMPACT_HISTORY_FIELD_MAX_CHARS:
+                record[key] = serialized[:COMPACT_HISTORY_FIELD_MAX_CHARS] + "...[truncated]"
+    return compacted
+
+
+def observation_fingerprint(url: str | None, scraped_page: Any, plan: str, task_type: str) -> str:
+    """Build a stable fingerprint for detecting repeated plans on unchanged pages."""
+
+    element_tree = getattr(scraped_page, "element_tree_trimmed", None)
+    payload = json.dumps(
+        {"url": url, "elements": element_tree, "plan": plan, "task_type": task_type},
+        sort_keys=True,
+        default=str,
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def should_run_completion_check(
+    *,
+    iteration: int,
+    task_type: str,
+    has_extracted_data: bool,
+    interval: int = DEFAULT_COMPLETION_CHECK_INTERVAL,
+) -> bool:
+    """Return whether the reduced-frequency completion gate is due."""
+
+    return iteration == 0 or task_type == "extract" or has_extracted_data or (iteration + 1) % interval == 0

--- a/skyvern/services/task_v2_service.py
+++ b/skyvern/services/task_v2_service.py
@@ -77,6 +77,15 @@ from skyvern.schemas.workflows import (
     WorkflowDefinitionYAML,
     WorkflowStatus,
 )
+from skyvern.services.task_v2_optimizations import (
+    TaskV2OptimizationFlags,
+    compact_task_history,
+    generated_loop_item_limit,
+    normalize_loop_values,
+    observation_fingerprint,
+    resolve_task_v2_optimization_flags,
+    should_run_completion_check,
+)
 from skyvern.services.webhook_delivery import deliver_webhook_with_retries
 from skyvern.utils.prompt_engine import load_prompt_with_elements
 from skyvern.utils.strings import generate_random_string
@@ -556,6 +565,9 @@ async def run_task_v2(
         trigger_type=parent_context.trigger_type if parent_context else None,
         use_flex_llm_routing=parent_context.use_flex_llm_routing if parent_context else False,
         consecutive_captcha_timeouts=parent_context.consecutive_captcha_timeouts if parent_context else 0,
+        task_v2_optimization_flags=(
+            copy.deepcopy(parent_context.task_v2_optimization_flags) if parent_context else None
+        ),
     )
     # SKY-7005: scoped() restores the parent context on exit, preserving
     # loop_internal_state so per-iteration download filtering continues to
@@ -617,15 +629,20 @@ async def run_task_v2(
     return task_v2
 
 
-def _resolve_max_iterations(max_iterations_override: str | int | None) -> int:
-    """Resolve the planner-iteration budget, never below the historical floor.
+def _resolve_max_iterations(max_iterations_override: str | int | None, *, honor_lower_override: bool = False) -> int:
+    """Resolve the planner budget, optionally allowing the ablation to lower it.
 
-    The planner always ran DEFAULT_MAX_ITERATIONS regardless of the block field, so workflows
-    persisted with the old (smaller) default must not regress — floor every value at it.
+    Control behavior retains the historical floor. The optimization cohort honors any
+    positive explicit override so lower iteration budgets can be evaluated safely.
     """
     if max_iterations_override:
         try:
-            return max(int(max_iterations_override), DEFAULT_MAX_ITERATIONS)
+            parsed_override = int(max_iterations_override)
+            if parsed_override <= 0:
+                return DEFAULT_MAX_ITERATIONS
+            if honor_lower_override:
+                return parsed_override
+            return max(parsed_override, DEFAULT_MAX_ITERATIONS)
         except (ValueError, TypeError):
             LOG.info(
                 "max_iterations_override isn't an integer, won't override",
@@ -733,6 +750,8 @@ async def run_task_v2_helper(
     context.browser_session_id = browser_session_id
     context.max_screenshot_scrolls = task_v2.max_screenshot_scrolls
 
+    optimization_flags = await resolve_task_v2_optimization_flags(context)
+
     task_v2 = await app.DATABASE.observer.update_task_v2(
         task_v2_id=task_v2_id, organization_id=organization_id, status=TaskV2Status.running
     )
@@ -771,7 +790,13 @@ async def run_task_v2_helper(
     url = str(task_v2.url)
 
     max_steps = int_max_steps_override or settings.MAX_STEPS_PER_TASK_V2
-    max_iterations = _resolve_max_iterations(max_iterations_override)
+    max_iterations = _resolve_max_iterations(
+        max_iterations_override,
+        honor_lower_override=optimization_flags.honor_iteration_override,
+    )
+    reusable_scraped_page: ScrapedPage | None = None
+    previous_progress_fingerprint: str | None = None
+    consecutive_no_progress = 0
 
     # When TaskV2 is inside a loop, each loop iteration should get fresh attempts
     # This is managed at the ForLoop level by calling run_task_v2 for each iteration
@@ -872,11 +897,15 @@ async def run_task_v2_helper(
                 )
         else:
             try:
-                scraped_page = await browser_state.scrape_website(
-                    url=url,
-                    cleanup_element_tree=app.AGENT_FUNCTION.cleanup_element_tree_factory(),
-                    scrape_exclude=app.scrape_exclude,
-                )
+                if optimization_flags.observation_reuse and reusable_scraped_page is not None:
+                    scraped_page = reusable_scraped_page
+                    reusable_scraped_page = None
+                else:
+                    scraped_page = await browser_state.scrape_website(
+                        url=url,
+                        cleanup_element_tree=app.AGENT_FUNCTION.cleanup_element_tree_factory(),
+                        scrape_exclude=app.scrape_exclude,
+                    )
                 if page is None:
                     page = await browser_state.get_working_page()
             except Exception:
@@ -897,9 +926,14 @@ async def run_task_v2_helper(
                 "task_v2",
                 current_url=current_url,
                 user_goal=user_prompt,
-                task_history=task_history,
+                task_history=(
+                    compact_task_history(task_history) if optimization_flags.compact_context else task_history
+                ),
                 open_tabs_context=open_tabs_context,
                 local_datetime=datetime.now(context.tz_info).isoformat(),
+                task_v2_loop_contract=optimization_flags.loop_contract,
+                task_v2_planning_deduplication=optimization_flags.planning_deduplication,
+                task_v2_extraction_schema_reuse=optimization_flags.extraction_schema_reuse,
             )
             thought = await app.DATABASE.observer.create_thought(
                 task_v2_id=task_v2_id,
@@ -934,6 +968,21 @@ async def run_task_v2_helper(
             thoughts: str = task_v2_response.get("thoughts", "")
             plan = task_v2_response.get("plan", "")
             task_type = task_v2_response.get("task_type", "")
+            if optimization_flags.no_progress_breaker and plan and task_type:
+                progress_fingerprint = observation_fingerprint(current_url, scraped_page, plan, task_type)
+                if progress_fingerprint == previous_progress_fingerprint:
+                    consecutive_no_progress += 1
+                else:
+                    previous_progress_fingerprint = progress_fingerprint
+                    consecutive_no_progress = 0
+                if consecutive_no_progress >= 2:
+                    task_v2 = await mark_task_v2_as_failed(
+                        task_v2_id=task_v2_id,
+                        workflow_run_id=workflow_run_id,
+                        failure_reason="Task made no progress after one recovery attempt.",
+                        organization_id=organization_id,
+                    )
+                    break
             # Create and save task thought
             await app.DATABASE.observer.update_thought(
                 thought_id=thought.observer_thought_id,
@@ -1007,6 +1056,10 @@ async def run_task_v2_helper(
                         scraped_page=scraped_page,
                         data_extraction_goal=plan,
                         task_history=task_history,
+                        data_schema=(
+                            task_v2_response.get("data_schema") if optimization_flags.extraction_schema_reuse else None
+                        ),
+                        max_attempts=2 if optimization_flags.extraction_schema_reuse else 3,
                     )
                     task_history_record = {"type": task_type, "task": plan}
                 except Exception:
@@ -1041,6 +1094,19 @@ async def run_task_v2_helper(
                         browser_state=browser_state,
                         original_url=url,
                         scraped_page=scraped_page,
+                        planner_loop_values=(
+                            task_v2_response.get("loop_values") if optimization_flags.loop_contract else None
+                        ),
+                        planner_is_loop_value_link=(
+                            task_v2_response.get("is_loop_value_link") if optimization_flags.loop_contract else None
+                        ),
+                        requested_loop_limit=(
+                            task_v2_response.get("loop_limit") if optimization_flags.loop_contract else None
+                        ),
+                        planner_loop_body=(
+                            task_v2_response.get("loop_body") if optimization_flags.planning_deduplication else None
+                        ),
+                        optimization_flags=optimization_flags,
                     )
                     task_history_record = {
                         "type": task_type,
@@ -1153,7 +1219,16 @@ async def run_task_v2_helper(
                 organization_id=organization_id,
             )
             break
-        if block_result.success is True:
+        completion_check_due = (
+            not optimization_flags.completion_scheduler
+            or i == max_iterations - 1
+            or should_run_completion_check(
+                iteration=i,
+                task_type=task_type,
+                has_extracted_data=extracted_data is not None,
+            )
+        )
+        if block_result.success is True and completion_check_due:
             completion_screenshots: list[bytes] = []
             completion_scraped_page: ScrapedPage | None = None
             completion_open_tabs_context: str | None = None
@@ -1170,9 +1245,13 @@ async def run_task_v2_helper(
                     scrape_exclude=app.scrape_exclude,
                 )
                 completion_screenshots = completion_scraped_page.screenshots
+                if optimization_flags.compact_context and i > 0 and task_type != "extract":
+                    completion_screenshots = []
             except Exception:
                 LOG.warning("Failed to scrape the website for task v2 completion check", exc_info=True)
             if completion_scraped_page is not None:
+                if optimization_flags.observation_reuse:
+                    reusable_scraped_page = completion_scraped_page
                 try:
                     completion_open_tabs_context = await build_open_tabs_context(
                         browser_state, await browser_state.get_working_page()
@@ -1184,7 +1263,9 @@ async def run_task_v2_helper(
             task_v2_completion_prompt = prompt_engine.load_prompt(
                 "task_v2_check_completion",
                 user_goal=user_prompt,
-                task_history=task_history,
+                task_history=(
+                    compact_task_history(task_history) if optimization_flags.compact_context else task_history
+                ),
                 open_tabs_context=completion_open_tabs_context,
                 local_datetime=datetime.now(context.tz_info).isoformat(),
             )
@@ -1451,7 +1532,13 @@ async def _generate_loop_task(
     browser_state: BrowserState,
     original_url: str,
     scraped_page: ScrapedPage,
+    planner_loop_values: Any = None,
+    planner_is_loop_value_link: bool | None = None,
+    requested_loop_limit: Any = None,
+    planner_loop_body: dict[str, Any] | None = None,
+    optimization_flags: TaskV2OptimizationFlags | None = None,
 ) -> tuple[ForLoopBlock, list[BLOCK_YAML_TYPES], list[PARAMETER_YAML_TYPES], dict[str, Any], dict[str, Any]]:
+    optimization_flags = optimization_flags or TaskV2OptimizationFlags()
     for_loop_parameter_yaml_list: list[PARAMETER_YAML_TYPES] = []
     loop_value_extraction_goal = prompt_engine.load_prompt(
         "task_v2_loop_task_extraction_goal",
@@ -1495,36 +1582,53 @@ async def _generate_loop_task(
         output_parameter=loop_value_extraction_output_parameter,
     )
 
-    # execute the extraction block
-    extraction_block_result = await extraction_block_for_loop.execute_safe(
-        workflow_run_id=workflow_run_id,
-        organization_id=task_v2.organization_id,
-    )
-    LOG.info("Extraction block result", extraction_block_result=extraction_block_result)
-    if extraction_block_result.success is False:
-        LOG.error(
-            "Failed to execute the extraction block for the loop task",
-            extraction_block_result=extraction_block_result,
+    parameter_value: dict[str, Any]
+    if optimization_flags.loop_contract and isinstance(planner_loop_values, list):
+        output_value_obj = {
+            loop_values_key: planner_loop_values,
+            "is_loop_value_link": bool(planner_is_loop_value_link),
+        }
+        parameter_value = {"extracted_information": output_value_obj}
+    else:
+        extraction_block_result = await extraction_block_for_loop.execute_safe(
+            workflow_run_id=workflow_run_id,
+            organization_id=task_v2.organization_id,
         )
-        # wofklow run and task v2 status update is handled in the upper caller layer
-        raise Exception("extraction_block failed")
-    # validate output parameter
-    try:
-        output_value_obj: dict[str, Any] = extraction_block_result.output_parameter_value.get("extracted_information")  # type: ignore
-        if not output_value_obj or not isinstance(output_value_obj, dict):
-            raise Exception("Invalid output parameter of the extraction block for the loop task")
-        if loop_values_key not in output_value_obj:
-            raise Exception("loop_values_key not found in the output parameter of the extraction block")
-        if "is_loop_value_link" not in output_value_obj:
-            raise Exception("is_loop_value_link not found in the output parameter of the extraction block")
-        loop_values = output_value_obj.get(loop_values_key, [])
-        is_loop_value_link = output_value_obj.get("is_loop_value_link")
-    except Exception:
-        LOG.error(
-            "Failed to validate the output parameter of the extraction block for the loop task",
-            extraction_block_result=extraction_block_result,
+        LOG.info("Extraction block result", extraction_block_result=extraction_block_result)
+        if extraction_block_result.success is False:
+            LOG.error(
+                "Failed to execute the extraction block for the loop task",
+                extraction_block_result=extraction_block_result,
+            )
+            raise RuntimeError("Loop-value extraction failed")
+        try:
+            parameter_value = extraction_block_result.output_parameter_value  # type: ignore[assignment]
+            output_value_obj = parameter_value.get("extracted_information")
+            if not output_value_obj or not isinstance(output_value_obj, dict):
+                raise ValueError("Invalid output parameter of the extraction block for the loop task")
+            if loop_values_key not in output_value_obj:
+                raise ValueError("loop_values_key not found in the output parameter of the extraction block")
+            if "is_loop_value_link" not in output_value_obj:
+                raise ValueError("is_loop_value_link not found in the output parameter of the extraction block")
+        except Exception:
+            LOG.error("Failed to validate loop-value extraction output", exc_info=True)
+            raise
+
+    raw_loop_values = output_value_obj.get(loop_values_key)
+    if optimization_flags.loop_contract or optimization_flags.loop_guardrails:
+        loop_values = normalize_loop_values(
+            raw_loop_values,
+            requested_limit=requested_loop_limit,
+            apply_guardrail=optimization_flags.loop_guardrails,
         )
-        raise
+    else:
+        loop_values = raw_loop_values
+    if not loop_values:
+        raise ValueError("Task V2 generated an empty loop-value list")
+    output_value_obj[loop_values_key] = loop_values
+    if optimization_flags.loop_contract or optimization_flags.loop_guardrails:
+        parameter_value = {"extracted_information": output_value_obj}
+    is_loop_value_link = output_value_obj.get("is_loop_value_link")
 
     # update the thought
     await app.DATABASE.observer.update_thought(
@@ -1549,7 +1653,7 @@ async def _generate_loop_task(
     await app.WORKFLOW_CONTEXT_MANAGER.set_parameter_values_for_output_parameter_dependent_blocks(
         workflow_run_id=workflow_run_id,
         output_parameter=loop_value_extraction_output_parameter,
-        value=extraction_block_result.output_parameter_value,
+        value=parameter_value,
     )
     url: str | None = None
     task_parameters: list[PARAMETER_TYPE] = []
@@ -1596,13 +1700,20 @@ async def _generate_loop_task(
         thought_type=ThoughtType.internal_plan,
         thought_scenario=ThoughtScenario.generate_task_in_loop,
     )
-    task_in_loop_metadata_response = await _get_task_v2_llm_api_handler(task_v2)(
-        task_in_loop_metadata_prompt,
-        screenshots=scraped_page.screenshots,
-        thought=thought_task_in_loop,
-        prompt_name="task_v2_generate_task_block",
-        system_prompt=task_v2.workflow_system_prompt,
-    )
+    if (
+        optimization_flags.planning_deduplication
+        and isinstance(planner_loop_body, dict)
+        and (planner_loop_body.get("navigation_goal") or planner_loop_body.get("data_extraction_goal"))
+    ):
+        task_in_loop_metadata_response = planner_loop_body
+    else:
+        task_in_loop_metadata_response = await _get_task_v2_llm_api_handler(task_v2)(
+            task_in_loop_metadata_prompt,
+            screenshots=scraped_page.screenshots,
+            thought=thought_task_in_loop,
+            prompt_name="task_v2_generate_task_block",
+            system_prompt=task_v2.workflow_system_prompt,
+        )
     LOG.info("Task in loop metadata response", task_in_loop_metadata_response=task_in_loop_metadata_response)
     navigation_goal = task_in_loop_metadata_response.get("navigation_goal")
     data_extraction_goal = task_in_loop_metadata_response.get("data_extraction_goal")
@@ -1619,6 +1730,8 @@ async def _generate_loop_task(
             navigation_goal
             + " Optimize for extracting as much data as possible. Complete when most data is seen even if some data is partially missing."
         )
+    continue_on_failure = not optimization_flags.loop_fail_fast
+    max_retries = 1 if optimization_flags.loop_fail_fast else 0
     block_yaml = TaskBlockYAML(
         label=task_in_loop_label,
         url=url,
@@ -1627,7 +1740,8 @@ async def _generate_loop_task(
         data_extraction_goal=data_extraction_goal,
         data_schema=data_extraction_schema,
         parameter_keys=[param.key for param in task_parameters],
-        continue_on_failure=True,
+        continue_on_failure=continue_on_failure,
+        max_retries=max_retries,
         complete_verification=False,
     )
     block_yaml_output_parameter = await app.WORKFLOW_SERVICE.create_output_parameter_for_block(
@@ -1643,7 +1757,8 @@ async def _generate_loop_task(
         data_schema=data_extraction_schema,
         output_parameter=block_yaml_output_parameter,
         parameters=task_parameters,
-        continue_on_failure=True,
+        continue_on_failure=continue_on_failure,
+        max_retries=max_retries,
         complete_verification=False,
     )
 
@@ -1652,6 +1767,10 @@ async def _generate_loop_task(
         label=f"loop_{generate_random_string()}",
         loop_over_parameter_key=loop_for_context_parameter.key,
         loop_blocks=[block_yaml],
+        max_loop_items=(
+            generated_loop_item_limit(requested_loop_limit) if optimization_flags.loop_guardrails else None
+        ),
+        task_v2_loop_replay=optimization_flags.loop_replay,
     )
     output_parameter = await app.WORKFLOW_SERVICE.create_output_parameter_for_block(
         workflow_id=workflow_id,
@@ -1664,6 +1783,8 @@ async def _generate_loop_task(
             loop_over=loop_for_context_parameter,
             loop_blocks=[task_in_loop_block],
             output_parameter=output_parameter,
+            max_loop_items=for_loop_yaml.max_loop_items,
+            task_v2_loop_replay=for_loop_yaml.task_v2_loop_replay,
         ),
         [extraction_block_yaml, for_loop_yaml],
         for_loop_parameter_yaml_list,
@@ -1685,6 +1806,8 @@ async def _generate_extraction_task(
     scraped_page: ScrapedPage,
     data_extraction_goal: str,
     task_history: list[dict] | None = None,
+    data_schema: dict[str, Any] | list | None = None,
+    max_attempts: int = 3,
 ) -> tuple[ExtractionBlock, list[BLOCK_YAML_TYPES], list[PARAMETER_YAML_TYPES]]:
     LOG.info("Generating extraction task", data_extraction_goal=data_extraction_goal, current_url=current_url)
     # extract the data
@@ -1698,29 +1821,31 @@ async def _generate_extraction_task(
         local_datetime=datetime.now(context.tz_info).isoformat(),
     )
 
-    max_retries = 3
-    last_exc: Exception | None = None
     generate_extraction_task_response: dict[str, Any] | None = None
-    for attempt in range(max_retries):
-        try:
-            generate_extraction_task_response = await _get_task_v2_llm_api_handler(task_v2)(
-                generate_extraction_task_prompt,
-                task_v2=task_v2,
-                prompt_name="task_v2_generate_extraction_task",
-                organization_id=task_v2.organization_id,
-                system_prompt=task_v2.workflow_system_prompt,
-            )
-            break
-        except (InvalidLLMResponseFormat, EmptyLLMResponseError) as e:
-            LOG.warning(
-                "Empty or invalid LLM response during extraction task generation, retrying",
-                attempt=attempt + 1,
-                max_attempts=max_retries,
-                error=str(e),
-            )
-            last_exc = e
+    if data_schema is not None:
+        generate_extraction_task_response = {"schema": data_schema}
     else:
-        raise last_exc  # type: ignore[misc]
+        last_exc: Exception | None = None
+        for attempt in range(max_attempts):
+            try:
+                generate_extraction_task_response = await _get_task_v2_llm_api_handler(task_v2)(
+                    generate_extraction_task_prompt,
+                    task_v2=task_v2,
+                    prompt_name="task_v2_generate_extraction_task",
+                    organization_id=task_v2.organization_id,
+                    system_prompt=task_v2.workflow_system_prompt,
+                )
+                break
+            except (InvalidLLMResponseFormat, EmptyLLMResponseError) as e:
+                LOG.warning(
+                    "Empty or invalid LLM response during extraction task generation, retrying",
+                    attempt=attempt + 1,
+                    max_attempts=max_attempts,
+                    error=str(e),
+                )
+                last_exc = e
+        else:
+            raise last_exc  # type: ignore[misc]
 
     assert generate_extraction_task_response is not None
     LOG.info("Data extraction response", data_extraction_response=generate_extraction_task_response)

--- a/skyvern/webeye/actions/caching.py
+++ b/skyvern/webeye/actions/caching.py
@@ -3,6 +3,7 @@ import structlog
 from skyvern.exceptions import CachedActionPlanError
 from skyvern.forge import app
 from skyvern.forge.prompts import prompt_engine
+from skyvern.forge.sdk.core import skyvern_context
 from skyvern.forge.sdk.models import Step
 from skyvern.forge.sdk.schemas.tasks import Task
 from skyvern.webeye.actions.action_types import ActionType
@@ -183,6 +184,15 @@ async def personalize_actions(
 async def get_user_detail_answers(
     task: Task, step: Step, scraped_page: ScrapedPage, queries_and_answers: dict[str, str | None]
 ) -> dict[str, str]:
+    context = skyvern_context.current()
+    if (
+        context
+        and context.task_v2_loop_replay_active
+        and context.task_v2_loop_replay_current_value is not None
+        and len(queries_and_answers) == 1
+    ):
+        query = next(iter(queries_and_answers))
+        return {query: str(context.task_v2_loop_replay_current_value)}
     try:
         question_answering_prompt = prompt_engine.load_prompt(
             "answer-user-detail-questions",

--- a/tests/unit/test_task_v2_optimizations.py
+++ b/tests/unit/test_task_v2_optimizations.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from skyvern.forge.sdk.core.skyvern_context import SkyvernContext
+from skyvern.forge.sdk.core import skyvern_context
+from skyvern.forge.agent_functions import AgentFunction
+from skyvern.services import task_v2_optimizations
+from skyvern.services.task_v2_optimizations import (
+    FLAG_NAME_BY_FIELD,
+    TaskV2OptimizationFlags,
+    compact_task_history,
+    generated_loop_item_limit,
+    normalize_loop_values,
+    resolve_task_v2_optimization_flags,
+    should_run_completion_check,
+)
+from skyvern.services.task_v2_service import _resolve_max_iterations
+
+
+@pytest.mark.asyncio
+async def test_flag_snapshot_resolves_once_per_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = SimpleNamespace(is_feature_enabled_cached=AsyncMock(return_value=True))
+    monkeypatch.setattr(task_v2_optimizations.app, "EXPERIMENTATION_PROVIDER", provider)
+    context = SkyvernContext(task_v2_id="tv2_1", organization_id="org_1")
+
+    first = await resolve_task_v2_optimization_flags(context)
+    second = await resolve_task_v2_optimization_flags(context)
+
+    assert first == second == TaskV2OptimizationFlags(**dict.fromkeys(FLAG_NAME_BY_FIELD, True))
+    assert provider.is_feature_enabled_cached.await_count == len(FLAG_NAME_BY_FIELD)
+
+
+def test_loop_values_are_deduplicated_and_bounded() -> None:
+    values = [" a ", "a", "b", 3, "", "c"]
+
+    assert normalize_loop_values(values, requested_limit=2, apply_guardrail=True) == ["a", "b"]
+    assert generated_loop_item_limit(None) == 25
+    assert generated_loop_item_limit("1000") == 50
+
+
+def test_compact_history_does_not_mutate_source() -> None:
+    history = [{"task": f"task-{index}", "data": "x" * 3000} for index in range(6)]
+
+    compacted = compact_task_history(history)
+
+    assert [item["task"] for item in compacted] == ["task-2", "task-3", "task-4", "task-5"]
+    assert compacted[0]["data"].endswith("...[truncated]")
+    assert len(history[0]["data"]) == 3000
+
+
+@pytest.mark.parametrize(
+    ("iteration", "task_type", "has_data", "expected"),
+    [
+        (0, "navigate", False, True),
+        (1, "navigate", False, False),
+        (2, "navigate", False, True),
+        (1, "extract", False, True),
+        (1, "navigate", True, True),
+    ],
+)
+def test_completion_scheduler(iteration: int, task_type: str, has_data: bool, expected: bool) -> None:
+    assert (
+        should_run_completion_check(
+            iteration=iteration,
+            task_type=task_type,
+            has_extracted_data=has_data,
+        )
+        is expected
+    )
+
+
+def test_lower_iteration_override_is_ablatable() -> None:
+    assert _resolve_max_iterations(10) == 50
+    assert _resolve_max_iterations(10, honor_lower_override=True) == 10
+    assert _resolve_max_iterations(0, honor_lower_override=True) == 50
+
+
+@pytest.mark.asyncio
+async def test_loop_replay_injects_cached_actions_and_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    from skyvern.webeye.actions import caching
+
+    cached_actions = [SimpleNamespace(action_type="click")]
+    retrieve = AsyncMock(side_effect=[cached_actions, []])
+    monkeypatch.setattr(caching, "retrieve_action_plan", retrieve)
+    browser_state = SimpleNamespace(scrape_website=AsyncMock(return_value=SimpleNamespace()))
+    agent_function = AgentFunction()
+    context = SkyvernContext(
+        task_v2_id="tv2_1",
+        task_v2_loop_replay_active=True,
+        task_v2_loop_replay_source_task_id="task_first_item",
+    )
+
+    with skyvern_context.scoped(context):
+        first = await agent_function.prepare_step_execution(
+            organization=None,
+            task=SimpleNamespace(task_id="task_second", url="https://example.com"),
+            step=SimpleNamespace(step_id="step_1"),
+            browser_state=browser_state,
+        )
+        fallback = await agent_function.prepare_step_execution(
+            organization=None,
+            task=SimpleNamespace(task_id="task_third", url="https://example.com"),
+            step=SimpleNamespace(step_id="step_2"),
+            browser_state=browser_state,
+        )
+
+    assert first == cached_actions
+    assert fallback is None
+    assert retrieve.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_loop_replay_parameterizes_single_input_without_llm() -> None:
+    from skyvern.webeye.actions.caching import get_user_detail_answers
+
+    context = SkyvernContext(
+        task_v2_loop_replay_active=True,
+        task_v2_loop_replay_current_value="CVPR2023",
+    )
+    with skyvern_context.scoped(context):
+        answers = await get_user_detail_answers(
+            task=SimpleNamespace(),
+            step=SimpleNamespace(),
+            scraped_page=SimpleNamespace(),
+            queries_and_answers={"search term": None},
+        )
+
+    assert answers == {"search term": "CVPR2023"}


### PR DESCRIPTION
## Summary

- add run-sticky, independently ablatable feature flags for Task V2 token optimizations
- constrain generated loops, reduce redundant completion/planning context, and reuse extraction schemas and observations
- replay the first successful loop item's cached actions for later items with selector validation and AI fallback

## Why

Task V2 repeatedly pays for action planning, completion checks, oversized loop expansion, and redundant schema/body generation. Generated loop items also rerun fresh AI reasoning even when the first item establishes a reusable path.

## Behavior and rollout

All optimizations default off and resolve once per Task V2 run through the existing experimentation provider. Existing authored loops and flags-off behavior remain unchanged. Replay only injects actions when cached selectors match uniquely; otherwise normal AI execution continues.

## Validation

- 68 focused Task V2 and loop tests
- 81 workflow and loop compatibility tests
- Ruff
- Python compileall
- `git diff --check`
