### PR TITLE
security: add ignore-scripts .npmrc to skyvern-ts/client (supply-chain alert)

### DIFF
--- a/skyvern-ts/client/.npmrc
+++ b/skyvern-ts/client/.npmrc
@@ -1,0 +1,5 @@
+# Supply chain protection: do not run lifecycle scripts (preinstall, install,
+# postinstall) on npm install. Blocks worms like "Shai-Hulud" from executing
+# on a compromised dependency before we notice. If a package genuinely needs
+# its install script, use @lavamoat/allow-scripts to allowlist it.
+ignore-scripts=true


### PR DESCRIPTION
## Summary

Adds `skyvern-ts/client/.npmrc` with `ignore-scripts=true`, closing the
"Elevated risk of supply chain compromise because dependencies can run
arbitrary scripts" code-scanning alert on `skyvern-ts/client/package-lock.json`.

## Why this dir specifically

The `ignore-scripts` guard is already present in the repo's three other
npm-lockfile directories:

- skyvern-frontend/.npmrc
- skyvern/cli/mcpb/claude_desktop/.npmrc
- tests/sdk/typescript_sdk/.npmrc

skyvern-ts/client was simply missed, which is why the alert fires only there.
This applies the same convention (identical content).

## Safety

- skyvern-ts/client declares no lifecycle scripts of its own; it builds via
  explicit tsc/webpack commands.
- A/B verification: `pnpm build` produces byte-identical output and the same
  (pre-existing, unrelated) result with vs without the .npmrc, confirming the
  guard changes nothing about the build.

## Test plan

- [x] Only skyvern-ts/client/.npmrc added (5 lines)
- [x] Matches the 3 sibling .npmrc files verbatim
- [x] A/B build unaffected by the change
