### PR TITLE
security: bump json-repair to 0.60.1 (HIGH DoS #837)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ local = [
     "aiofiles>=24.1.0,<25",
     "pyotp>=2.9.0,<3",
     "json5>=0.13.0,<1",
-    "json-repair>=0.59.5,<0.60",
+    "json-repair>=0.60.1,<0.61",
     "pypdf>=6.12.0,<7",
     "pdfplumber>=0.11.0,<0.12",
     "psutil>=7.0.0",
@@ -134,7 +134,7 @@ server = [
     "pyotp>=2.9.0,<3",
     "asyncpg>=0.30.0,<0.32",
     "json5>=0.13.0,<1",
-    "json-repair>=0.59.5,<0.60",
+    "json-repair>=0.60.1,<0.61",
     "pypdf>=6.12.0,<7",
     "pdfplumber>=0.11.0,<0.12",
     # <3.4: 3.4.3 enables HostOriginGuardMiddleware by default (421 on public hosts, SKY-12003).

--- a/skyvern/forge/sdk/api/llm/utils_test.py
+++ b/skyvern/forge/sdk/api/llm/utils_test.py
@@ -3,7 +3,6 @@ Tests for methods in utils.py that use commentjson.loads
 """
 
 import json
-from unittest.mock import Mock
 
 import litellm
 import pytest
@@ -15,13 +14,17 @@ from skyvern.forge.sdk.api.llm.utils import _fix_cutoff_json, _fix_unescaped_quo
 class TestParseApiResponse:
     """Tests for parse_api_response function"""
 
-    def _create_mock_response(self, content: str | None) -> Mock:
-        """Helper method to create a mock LiteLLM response with the given content"""
-        response = Mock(spec=litellm.ModelResponse)
-        response.choices = [Mock()]
-        response.choices[0].message = Mock()
-        response.choices[0].message.content = content
-        return response
+    def _create_mock_response(self, content: str | None) -> litellm.ModelResponse:
+        """Helper method to create a LiteLLM response with the given content.
+
+        Uses a real ModelResponse rather than a Mock so that structlog's
+        exc_info rendering (which iterates the response on parse failures)
+        does not choke on a Mock during the error-path tests.
+        """
+        return litellm.ModelResponse(
+            choices=[litellm.Choices(message=litellm.Message(content=content, role="assistant"))],
+            model="gpt-4o",
+        )
 
     def test_parse_api_response_valid_json(self) -> None:
         """Test parsing a valid JSON response"""

--- a/uv.lock
+++ b/uv.lock
@@ -2354,11 +2354,11 @@ wheels = [
 
 [[package]]
 name = "json-repair"
-version = "0.59.5"
+version = "0.60.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b7/67/eba7fad54ff6f5cce6db4e01f596fc68156b5c7e864af0aa07ad48e880a1/json_repair-0.59.5.tar.gz", hash = "sha256:bb886ee054e99066be8a337b67a986b6a50d79be9a5ad37ae81966e698990784", size = 48632, upload-time = "2026-04-24T11:41:38.133Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a6/d69888cb4ffde30e80db1e6c32caaadd2f984a80067d5ea72c2cb3f61c3f/json_repair-0.60.1.tar.gz", hash = "sha256:841661cdd2df507c9a4e189097f38ca6bc372e06d4b4e36d72e590f68176c290", size = 49451, upload-time = "2026-06-03T17:28:44.451Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/aa/0529dee460b745b93f6abc97b56b7527314c5167ba29ab7a5bd5c08de01f/json_repair-0.59.5-py3-none-any.whl", hash = "sha256:6869965bd1cc1aaaa04dc85865c26fbb76d9a2d83a20010f5eae2563b1567827", size = 47282, upload-time = "2026-04-24T11:41:36.653Z" },
+    { url = "https://files.pythonhosted.org/packages/32/1f/2a2b5eea8ef5762a86ad3f8fddddaaba2c0d76dd44e644b9158900868bec/json_repair-0.60.1-py3-none-any.whl", hash = "sha256:ba6ff974f2a8bef2f7768144a7f03f870a816443f03da27a49cdd0ec31a78049", size = 48045, upload-time = "2026-06-03T17:28:43.038Z" },
 ]
 
 [[package]]
@@ -6069,8 +6069,8 @@ requires-dist = [
     { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
     { name = "jinja2", marker = "extra == 'local'", specifier = ">=3.1.2,<4" },
     { name = "jinja2", marker = "extra == 'server'", specifier = ">=3.1.2,<4" },
-    { name = "json-repair", marker = "extra == 'local'", specifier = ">=0.59.5,<0.60" },
-    { name = "json-repair", marker = "extra == 'server'", specifier = ">=0.59.5,<0.60" },
+    { name = "json-repair", marker = "extra == 'local'", specifier = ">=0.60.1,<0.61" },
+    { name = "json-repair", marker = "extra == 'server'", specifier = ">=0.60.1,<0.61" },
     { name = "json5", marker = "extra == 'local'", specifier = ">=0.13.0,<1" },
     { name = "json5", marker = "extra == 'server'", specifier = ">=0.13.0,<1" },
     { name = "jsonschema", marker = "extra == 'local'", specifier = ">=4.23.0" },


### PR DESCRIPTION
## Summary

Bumps json-repair 0.59.5 -> 0.60.1 to clear HIGH alert #837 (circular JSON
Schema `$ref` -> unbounded-CPU DoS in `resolve_schema()`). Raises the pinned
ceiling in both extras: `>=0.59.5,<0.60` -> `>=0.60.1,<0.61`.

Skyvern uses json_repair only for plain LLM-output repair (never the schema
path), so the vulnerable code isn't reachable. Real parsing behavior verified
unchanged (valid/fenced/trailing-comma/unescaped-quote parse identically;
empty -> InvalidLLMResponseFormat; garbage -> `{"actions": []}` sentinel).

## Test fix

`utils_test.py`'s two edge-case tests used `Mock(spec=ModelResponse)`; under
0.60.1 `json_repair.loads(None)` raises TypeError whose exc_info logging made
structlog/rich choke iterating the Mock. Switched to a real
`litellm.ModelResponse`; assertions unchanged.

## Test plan
- [x] uv lock --check clean
- [x] utils_test.py + test_script_reviewer_extract.py: 58/58 pass
- [x] pre-commit clean
