### PR TITLE
fix: add missing paused member to RunStatus enum

### DIFF
--- a/skyvern/schemas/run_enums.py
+++ b/skyvern/schemas/run_enums.py
@@ -37,6 +37,7 @@ class RunStatus(StrEnum):
     terminated = "terminated"
     completed = "completed"
     canceled = "canceled"
+    paused = "paused"
 
     def is_final(self) -> bool:
         return self.value in TERMINAL_STATUSES

--- a/tests/unit/services/test_get_workflow_run_response_passthrough.py
+++ b/tests/unit/services/test_get_workflow_run_response_passthrough.py
@@ -74,3 +74,49 @@ async def test_get_workflow_run_response_passes_through_all_fields() -> None:
     assert resp.step_count == 4
     assert resp.run_request is not None
     assert resp.run_request.browser_session_id == "pbs_123"
+
+
+@pytest.mark.asyncio
+async def test_get_workflow_run_response_handles_paused_status() -> None:
+    """WorkflowRunStatus.paused is a real, non-terminal status (set while a workflow run is
+    waiting on human-in-the-loop input, e.g. TOTP verification). RunStatus must be able to
+    represent it or this raises ValueError instead of returning a response."""
+    now = datetime.now(timezone.utc)
+    workflow_run = WorkflowRun(
+        workflow_run_id="wr_123",
+        workflow_id="w_123",
+        workflow_permanent_id="wpid_123",
+        organization_id="o_123",
+        status=WorkflowRunStatus.paused,
+        created_at=now,
+        modified_at=now,
+    )
+
+    status_resp = MagicMock(
+        outputs=None,
+        downloaded_files=None,
+        recording_url=None,
+        screenshot_urls=None,
+        failure_reason=None,
+        workflow_title="Test",
+        parameters={},
+        errors=None,
+        total_steps=1,
+    )
+
+    with (
+        patch(
+            "skyvern.services.workflow_service.app.DATABASE.workflow_runs.get_workflow_run",
+            new_callable=AsyncMock,
+            return_value=workflow_run,
+        ),
+        patch(
+            "skyvern.services.workflow_service.app.WORKFLOW_SERVICE.build_workflow_run_status_response_by_workflow_id",
+            new_callable=AsyncMock,
+            return_value=status_resp,
+        ),
+    ):
+        resp = await get_workflow_run_response("wr_123", organization_id="o_123")
+
+    assert resp is not None
+    assert resp.status == RunStatus.paused


### PR DESCRIPTION
## Description

`RunStatus` (`skyvern/schemas/run_enums.py`), the public-facing status enum used to build run responses, was missing the `paused` member. The internal DB enum `WorkflowRunStatus` (`skyvern/forge/sdk/workflow/models/workflow.py`) has had `paused` for a while — it's a real, non-terminal status set on workflow runs that are waiting on human-in-the-loop input (e.g. TOTP/2FA verification, see `skyvern/forge/sdk/workflow/models/block.py`).

Because `RunStatus` didn't know about `paused`, any code path that converts a paused `WorkflowRunStatus` via `RunStatus(workflow_run.status)` raised an unhandled `ValueError` instead of returning a response. This includes `get_workflow_run_response()` in `skyvern/services/workflow_service.py`, which backs the public "get run" endpoint — so a client polling the status of a run that is currently paused for human input would get a 500 instead of a normal response with `status: "paused"`. A few other call sites (`skyvern/services/webhook_service.py`, `skyvern/forge/sdk/workflow/service.py`, `skyvern/library/skyvern.py`) have the same issue.

Notably, the generated client type `skyvern/client/types/workflow_run_status.py` already lists `"paused"` among its literal values, confirming this status is meant to be representable end-to-end — `RunStatus` was just missing it.

The fix is a single line: add `paused = "paused"` to the `RunStatus` enum. No other behavior changes — `paused` is correctly excluded from `TERMINAL_STATUSES`, so `is_final()` continues to work as before for every status.

## How Has This Been Tested?

- Added a regression test in `tests/unit/services/test_get_workflow_run_response_passthrough.py` that builds a `WorkflowRun` with `status=WorkflowRunStatus.paused` and asserts `get_workflow_run_response()` returns normally with `status == RunStatus.paused`. Confirmed this test fails with `ValueError: <WorkflowRunStatus.paused: 'paused'> is not a valid RunStatus` against the pre-fix code, and passes after the one-line fix.
- Ran the full existing test suite for the touched enum's call sites (`workflow_service`, `webhook_service`, `forge/sdk/workflow/service`, `library/skyvern`, `skyvern_browser_page_agent`) plus the full `tests/unit/` suite: `uv run pytest tests/unit` — 14473 passed, 72 skipped, 1 xfailed, no regressions (purely additive enum change).
- `uv run pre-commit run --files skyvern/schemas/run_enums.py tests/unit/services/test_get_workflow_run_response_passthrough.py` — ruff, isort, mypy, and other hooks all pass.

## Artifacts (if appropriate):

N/A — pure backend logic fix, no UI change.

---

*AI-assisted contribution: this bug was found, the fix implemented, and the change verified by a human (with Claude Code assistance) before submission — not the output of an unsupervised autonomous agent.*
