### PR TITLE
fix: strip userinfo credentials from _jinja_domain_filter's netloc

### DIFF
--- a/skyvern/services/workflow_script_service.py
+++ b/skyvern/services/workflow_script_service.py
@@ -219,7 +219,8 @@ def _jinja_domain_filter(url: str) -> str:
         "https://boards.greenhouse.io/robinhood/jobs/123" → "boards.greenhouse.io"
     """
     try:
-        return urllib.parse.urlparse(str(url)).netloc or str(url)
+        netloc = urllib.parse.urlparse(str(url)).netloc
+        return netloc.rpartition("@")[2] or str(url)
     except Exception:
         return str(url)
 

--- a/tests/unit/workflow/test_cache_key_domain.py
+++ b/tests/unit/workflow/test_cache_key_domain.py
@@ -80,12 +80,20 @@ class TestJinjaDomainFilter:
     def test_returns_input_for_empty_string(self) -> None:
         assert _jinja_domain_filter("") == ""
 
+    def test_strips_userinfo_credentials_from_netloc(self) -> None:
+        assert _jinja_domain_filter("https://user:hunter2@example.com/login") == "example.com"
+
 
 class TestExtractFirstBlockDomain:
     def test_extracts_domain_from_first_block_with_url(self) -> None:
         blocks = [_task_block("step1", url="https://www.fanr.gov.ae/documents")]
         wf = _workflow(blocks)
         assert _extract_first_block_domain(wf, {}) == "www.fanr.gov.ae"
+
+    def test_strips_userinfo_credentials_from_url(self) -> None:
+        blocks = [_task_block("step1", url="https://user:hunter2@example.com/login")]
+        wf = _workflow(blocks)
+        assert _extract_first_block_domain(wf, {}) == "example.com"
 
     def test_skips_blocks_without_url(self) -> None:
         blocks = [


### PR DESCRIPTION
## Description

`_jinja_domain_filter` (`skyvern/services/workflow_script_service.py`) returns `urlparse(url).netloc` verbatim. `netloc` includes any embedded userinfo (`user:pass@host`) — if a workflow block's URL (rendered from parameters/Jinja) has embedded credentials, they end up in the returned "domain".

This feeds the workflow-script cache key: `resolve_cache_key_value()` calls `_extract_first_block_domain()` (which calls `_jinja_domain_filter` on the resolved first-block URL) to enrich the cache key when the workflow's own `cache_key` template resolves to `"default"`/`""`. The resulting `cache_key_value` is then logged (`LOG.info(..., cache_key_value=rendered_cache_key_value, ...)` at multiple call sites) and used as a DB lookup key (`get_workflow_script_by_cache_key_value`) — so a first block URL with embedded credentials leaks the credentials into logs/DB via the cache key.

The sibling function `resolve_target_domain_for_run_provenance` (same file) already strips userinfo via `.rpartition("@")[2].lower()` for exactly this reason — it has its own dedicated comment/tests for this case. `_jinja_domain_filter` never got the same treatment, even though it's used in a directly comparable place.

## How Has This Been Tested?

- Added 2 regression tests to `tests/unit/workflow/test_cache_key_domain.py`: `test_strips_userinfo_credentials_from_netloc` (unit-level on `_jinja_domain_filter` directly) and `test_strips_userinfo_credentials_from_url` (end-to-end via `_extract_first_block_domain` with a workflow block whose URL is `https://user:hunter2@example.com/login`). Both fail against pre-fix code (return `"user:hunter2@example.com"` instead of `"example.com"`), pass after the fix.
- Ran the full `tests/unit/workflow/test_cache_key_domain.py` suite (22 tests) plus every test module in `tests/unit/` that imports `workflow_script_service` (208 tests total) — all pass, no regressions.
- `uv run ruff check` / `uv run ruff format --check` clean on the changed files.

## Artifacts (if appropriate):

N/A — pure backend logic fix, no UI change.

---

*AI-assisted contribution: this bug was found, the fix implemented, and the change verified by a human (with Claude Code assistance) before submission — not the output of an unsupervised autonomous agent.*