### PR TITLE
fix: restore vertical flex-col layout in WorkflowPage/RunHistory (revert #7458 bundled items-center flip)

### DIFF
--- a/skyvern-frontend/src/routes/history/RunHistory.tsx
+++ b/skyvern-frontend/src/routes/history/RunHistory.tsx
@@ -476,7 +476,7 @@ function RunHistory() {
             className="max-w-0 truncate"
             title={run.title ?? undefined}
           >
-            <div className="flex min-w-0 items-center gap-2">
+            <div className="flex min-w-0 flex-col gap-1">
               <div className="min-w-0 truncate">{titleContent}</div>
               {taggingEnabled && runTags && runTags.length > 0 ? (
                 <TagChipList

--- a/skyvern-frontend/src/routes/workflows/WorkflowPage.tsx
+++ b/skyvern-frontend/src/routes/workflows/WorkflowPage.tsx
@@ -470,7 +470,7 @@ function WorkflowPage() {
                             />
                           )}
                           <TableCell className="font-mono text-xs text-muted-foreground">
-                            <div className="flex min-w-0 items-center gap-2">
+                            <div className="flex flex-col gap-1">
                               <span className="min-w-0 truncate">
                                 {workflowRunId}
                               </span>


### PR DESCRIPTION
## Summary

- Restore the vertical `flex-col` layout in `WorkflowPage` and `RunHistory`.
- Revert only the two layout class changes bundled into #7458; the self-heal test change is untouched.

## Context

`items-center` arrived as an unintended sync-mirror residual bundled into self-heal fix #7458. This restores the #7426 `flex-col` form per maintainer decision. Fresh mirrors still carry `items-center`, so this is flagged for frontend confirmation.

## Verification

- `cd skyvern-frontend && npm run lint`
- `cd skyvern-frontend && npm run build`
- `uv run pre-commit run --all-files`
