### PR TITLE
fix: KEYPRESS recorder captures selector instead of key for page.press

### DIFF
--- a/skyvern/forge/sdk/workflow/models/code_block_recorder.py
+++ b/skyvern/forge/sdk/workflow/models/code_block_recorder.py
@@ -199,7 +199,7 @@ def _recorded_action_fields(
     elif action_type == ActionType.EXECUTE_JS:
         fields["js_code"] = _string_value(kwargs.get("expression", _arg(args, 0)))
     elif action_type == ActionType.KEYPRESS:
-        keys = kwargs.get("keys", _arg(args, 0))
+        keys = kwargs.get("keys", _arg(args, value_index))
         fields["keys"] = (
             [str(key) for key in keys] if isinstance(keys, list) else [str(keys)] if keys is not None else []
         )

--- a/tests/unit/workflow/test_code_block_recorder.py
+++ b/tests/unit/workflow/test_code_block_recorder.py
@@ -99,6 +99,9 @@ class FakePage:
     async def fill(self, selector, value, **kwargs):  # noqa: ANN001, ANN003, ANN201
         return None
 
+    async def press(self, selector, key, **kwargs):  # noqa: ANN001, ANN003, ANN201
+        return None
+
     def get_by_role(self, role, **kwargs):  # noqa: ANN001, ANN003, ANN201
         return self.inner
 
@@ -224,6 +227,17 @@ async def test_keyboard_press_records_keypress_action() -> None:
     recorded = page.recorded_actions()
     assert [a.action_type for a in recorded] == [ActionType.KEYPRESS]
     assert recorded[0].description and "Enter" in recorded[0].description
+
+
+@pytest.mark.asyncio
+async def test_direct_page_press_records_the_key_not_the_selector() -> None:
+    # page.press(selector, key) takes the selector first, unlike keyboard.press(key)/
+    # locator.press(key); the recorded KEYPRESS action must still capture the key.
+    page = RecordingPage(FakePage())
+    await page.press("#search-input", "Enter")
+    recorded = page.recorded_actions()
+    assert [a.action_type for a in recorded] == [ActionType.KEYPRESS]
+    assert recorded[0].keys == ["Enter"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What
`_recorded_action_fields`'s `KEYPRESS` branch used a hardcoded `_arg(args, 0)`, while its `UPLOAD_FILE`/`SELECT_OPTION` siblings correctly use the already-computed `value_index` (`_page_value_index(name, target)`, which is `1` for a direct `page.X(selector, value)` call and `0` for `locator.X(value)`/`keyboard.X(value)`).

For `page.press(selector, key)`, `args = (selector, key)` and `value_index == 1`, so the KEYPRESS branch's `_arg(args, 0)` stored the **selector** as the recorded key instead of the key. `keyboard.press(key)` and `locator.press(key)` are unaffected (single positional arg, `value_index == 0`), which is why this only surfaces for the direct `page.press(selector, key)` call form.

This pollutes the recorded action history consumed by the timeline UI and the self-heal/replay path.

Repro (before fix):
```python
page = RecordingPage(FakePage())
await page.press("#search-input", "Enter")
page.recorded_actions()[0].keys  # ['#search-input'] -- should be ['Enter']
```

## Fix
One-line change: `_arg(args, 0)` -> `_arg(args, value_index)`, mirroring the pattern already used by the `UPLOAD_FILE`/`SELECT_OPTION` branches above it.

## Testing
- New regression test `test_direct_page_press_records_the_key_not_the_selector` — red before the fix (confirmed), green after.
- Full `tests/unit/workflow/test_code_block_recorder.py` (44 tests) passes.
- `ruff check` / `ruff format --check` clean on both changed files.

## AI disclosure
Investigated and implemented with Claude Code (Claude Opus 4.8); I reviewed the diff, ran the repro and full test suite myself before opening this PR.