### PR TITLE
fix(db): escape LIKE wildcards in list-search search_key

### DIFF
--- a/skyvern/forge/sdk/db/repositories/browser_sessions.py
+++ b/skyvern/forge/sdk/db/repositories/browser_sessions.py
@@ -174,11 +174,10 @@ class BrowserSessionsRepository(BaseRepository):
             if managed is not None:
                 query = query.filter(BrowserProfileModel.is_managed.is_(managed))
             if search_key:
-                search_like = f"%{search_key}%"
                 query = query.filter(
                     or_(
-                        BrowserProfileModel.name.ilike(search_like),
-                        BrowserProfileModel.description.ilike(search_like),
+                        BrowserProfileModel.name.icontains(search_key, autoescape=True),
+                        BrowserProfileModel.description.icontains(search_key, autoescape=True),
                     )
                 )
             # The id tie-break only needs to be deterministic so pagination stays

--- a/skyvern/forge/sdk/db/repositories/workflow_runs.py
+++ b/skyvern/forge/sdk/db/repositories/workflow_runs.py
@@ -512,9 +512,8 @@ class WorkflowRunsRepository(BaseRepository):
                 workflow_run_query = workflow_run_query.filter(WorkflowRunModel.debug_session_id.is_(None))
 
             if search_key:
-                key_like = f"%{search_key}%"
                 # Match workflow_run_id directly
-                id_matches = WorkflowRunModel.workflow_run_id.ilike(key_like)
+                id_matches = WorkflowRunModel.workflow_run_id.icontains(search_key, autoescape=True)
                 # Match parameter key or description (only for non-deleted parameter definitions)
                 param_key_desc_exists = exists(
                     select(1)
@@ -527,8 +526,8 @@ class WorkflowRunsRepository(BaseRepository):
                     .where(WorkflowParameterModel.deleted_at.is_(None))
                     .where(
                         or_(
-                            WorkflowParameterModel.key.ilike(key_like),
-                            WorkflowParameterModel.description.ilike(key_like),
+                            WorkflowParameterModel.key.icontains(search_key, autoescape=True),
+                            WorkflowParameterModel.description.icontains(search_key, autoescape=True),
                         )
                     )
                 )
@@ -537,12 +536,12 @@ class WorkflowRunsRepository(BaseRepository):
                     select(1)
                     .select_from(WorkflowRunParameterModel)
                     .where(WorkflowRunParameterModel.workflow_run_id == WorkflowRunModel.workflow_run_id)
-                    .where(WorkflowRunParameterModel.value.ilike(key_like))
+                    .where(WorkflowRunParameterModel.value.icontains(search_key, autoescape=True))
                 )
                 # Match extra HTTP headers (cast JSON to text for search, skip NULLs)
                 extra_headers_match = and_(
                     WorkflowRunModel.extra_http_headers.isnot(None),
-                    func.cast(WorkflowRunModel.extra_http_headers, Text()).ilike(key_like),
+                    func.cast(WorkflowRunModel.extra_http_headers, Text()).icontains(search_key, autoescape=True),
                 )
                 workflow_run_query = workflow_run_query.where(
                     or_(id_matches, param_key_desc_exists, param_value_exists, extra_headers_match)

--- a/skyvern/forge/sdk/db/repositories/workflows.py
+++ b/skyvern/forge/sdk/db/repositories/workflows.py
@@ -508,9 +508,8 @@ class WorkflowsRepository(BaseRepository):
                 for subquery in workflow_tag_wpid_subqueries(workflow_tags, organization_id):
                     main_query = main_query.where(WorkflowModel.workflow_permanent_id.in_(subquery))
             if search_key:
-                search_like = f"%{search_key}%"
-                title_like = WorkflowModel.title.ilike(search_like)
-                folder_title_like = FolderModel.title.ilike(search_like)
+                title_like = WorkflowModel.title.icontains(search_key, autoescape=True)
+                folder_title_like = FolderModel.title.icontains(search_key, autoescape=True)
                 workflow_permanent_id_like = WorkflowModel.workflow_permanent_id.icontains(search_key, autoescape=True)
 
                 parameter_filters = [
@@ -522,9 +521,9 @@ class WorkflowsRepository(BaseRepository):
                         .where(WorkflowParameterModel.deleted_at.is_(None))
                         .where(
                             or_(
-                                WorkflowParameterModel.key.ilike(search_like),
-                                WorkflowParameterModel.description.ilike(search_like),
-                                WorkflowParameterModel.default_value.ilike(search_like),
+                                WorkflowParameterModel.key.icontains(search_key, autoescape=True),
+                                WorkflowParameterModel.description.icontains(search_key, autoescape=True),
+                                WorkflowParameterModel.default_value.icontains(search_key, autoescape=True),
                             )
                         )
                     ),
@@ -536,8 +535,8 @@ class WorkflowsRepository(BaseRepository):
                         .where(OutputParameterModel.deleted_at.is_(None))
                         .where(
                             or_(
-                                OutputParameterModel.key.ilike(search_like),
-                                OutputParameterModel.description.ilike(search_like),
+                                OutputParameterModel.key.icontains(search_key, autoescape=True),
+                                OutputParameterModel.description.icontains(search_key, autoescape=True),
                             )
                         )
                     ),
@@ -549,8 +548,8 @@ class WorkflowsRepository(BaseRepository):
                         .where(AWSSecretParameterModel.deleted_at.is_(None))
                         .where(
                             or_(
-                                AWSSecretParameterModel.key.ilike(search_like),
-                                AWSSecretParameterModel.description.ilike(search_like),
+                                AWSSecretParameterModel.key.icontains(search_key, autoescape=True),
+                                AWSSecretParameterModel.description.icontains(search_key, autoescape=True),
                             )
                         )
                     ),
@@ -562,8 +561,10 @@ class WorkflowsRepository(BaseRepository):
                         .where(BitwardenLoginCredentialParameterModel.deleted_at.is_(None))
                         .where(
                             or_(
-                                BitwardenLoginCredentialParameterModel.key.ilike(search_like),
-                                BitwardenLoginCredentialParameterModel.description.ilike(search_like),
+                                BitwardenLoginCredentialParameterModel.key.icontains(search_key, autoescape=True),
+                                BitwardenLoginCredentialParameterModel.description.icontains(
+                                    search_key, autoescape=True
+                                ),
                             )
                         )
                     ),
@@ -575,8 +576,10 @@ class WorkflowsRepository(BaseRepository):
                         .where(BitwardenSensitiveInformationParameterModel.deleted_at.is_(None))
                         .where(
                             or_(
-                                BitwardenSensitiveInformationParameterModel.key.ilike(search_like),
-                                BitwardenSensitiveInformationParameterModel.description.ilike(search_like),
+                                BitwardenSensitiveInformationParameterModel.key.icontains(search_key, autoescape=True),
+                                BitwardenSensitiveInformationParameterModel.description.icontains(
+                                    search_key, autoescape=True
+                                ),
                             )
                         )
                     ),
@@ -588,8 +591,10 @@ class WorkflowsRepository(BaseRepository):
                         .where(BitwardenCreditCardDataParameterModel.deleted_at.is_(None))
                         .where(
                             or_(
-                                BitwardenCreditCardDataParameterModel.key.ilike(search_like),
-                                BitwardenCreditCardDataParameterModel.description.ilike(search_like),
+                                BitwardenCreditCardDataParameterModel.key.icontains(search_key, autoescape=True),
+                                BitwardenCreditCardDataParameterModel.description.icontains(
+                                    search_key, autoescape=True
+                                ),
                             )
                         )
                     ),
@@ -601,8 +606,8 @@ class WorkflowsRepository(BaseRepository):
                         .where(OnePasswordCredentialParameterModel.deleted_at.is_(None))
                         .where(
                             or_(
-                                OnePasswordCredentialParameterModel.key.ilike(search_like),
-                                OnePasswordCredentialParameterModel.description.ilike(search_like),
+                                OnePasswordCredentialParameterModel.key.icontains(search_key, autoescape=True),
+                                OnePasswordCredentialParameterModel.description.icontains(search_key, autoescape=True),
                             )
                         )
                     ),
@@ -614,8 +619,8 @@ class WorkflowsRepository(BaseRepository):
                         .where(AzureVaultCredentialParameterModel.deleted_at.is_(None))
                         .where(
                             or_(
-                                AzureVaultCredentialParameterModel.key.ilike(search_like),
-                                AzureVaultCredentialParameterModel.description.ilike(search_like),
+                                AzureVaultCredentialParameterModel.key.icontains(search_key, autoescape=True),
+                                AzureVaultCredentialParameterModel.description.icontains(search_key, autoescape=True),
                             )
                         )
                     ),
@@ -627,8 +632,8 @@ class WorkflowsRepository(BaseRepository):
                         .where(CredentialParameterModel.deleted_at.is_(None))
                         .where(
                             or_(
-                                CredentialParameterModel.key.ilike(search_like),
-                                CredentialParameterModel.description.ilike(search_like),
+                                CredentialParameterModel.key.icontains(search_key, autoescape=True),
+                                CredentialParameterModel.description.icontains(search_key, autoescape=True),
                             )
                         )
                     ),

--- a/tests/unit/forge/sdk/db/test_search_key_escaping.py
+++ b/tests/unit/forge/sdk/db/test_search_key_escaping.py
@@ -1,0 +1,106 @@
+"""Regression tests: list-search ``search_key`` must escape SQL LIKE wildcards.
+
+``get_workflows_by_organization_id``, ``get_all_runs`` and ``list_browser_profiles``
+built their ``ilike`` filters from a raw ``f"%{search_key}%"``. Because ``_`` and
+``%`` are LIKE wildcards, a search term like ``wr_abc`` (repo IDs are underscore
+separated) matched far more rows than the literal text — e.g. ``wr_abc`` also
+matched ``wrXabc``. The repo already had the correct pattern
+(``icontains(search_key, autoescape=True)``, used by ``workflow_permanent_id`` and
+``_apply_workflow_run_search_key_filter``); these three call sites just omitted it.
+
+Each test compiles the WHERE clause and asserts the underscore is escaped
+(``ab/_cd`` with an ``ESCAPE`` clause) rather than left as a bare wildcard.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from skyvern.forge.sdk.db.repositories.browser_sessions import BrowserSessionsRepository
+from skyvern.forge.sdk.db.repositories.workflow_runs import WorkflowRunsRepository
+from skyvern.forge.sdk.db.repositories.workflows import WorkflowsRepository
+
+SEARCH_KEY = "ab_cd"
+
+
+class _SessionContext:
+    def __init__(self, session: MagicMock) -> None:
+        self._session = session
+
+    async def __aenter__(self) -> MagicMock:
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class _AllResult:
+    def all(self) -> list[Any]:
+        return []
+
+
+def _assert_escaped(where_sql: str) -> None:
+    # The escaped literal proves the searched column is wired up AND autoescaped.
+    assert "ab/_cd" in where_sql, where_sql
+    # No bare, unescaped occurrence of the search term may remain (the `_` would
+    # otherwise be a single-char wildcard).
+    assert "ab_cd" not in where_sql, where_sql
+    assert "ESCAPE" in where_sql, where_sql
+
+
+@pytest.mark.asyncio
+async def test_get_workflows_by_organization_id_escapes_search_key() -> None:
+    captured: dict[str, Any] = {}
+
+    async def _scalars(query: Any) -> _AllResult:
+        captured.setdefault("query", query)
+        return _AllResult()
+
+    session = MagicMock()
+    session.scalars = AsyncMock(side_effect=_scalars)
+
+    repo = WorkflowsRepository(session_factory=lambda: _SessionContext(session), debug_enabled=False)
+    await repo.get_workflows_by_organization_id(organization_id="o_test", search_key=SEARCH_KEY)
+
+    where_sql = str(captured["query"].whereclause.compile(compile_kwargs={"literal_binds": True}))
+    _assert_escaped(where_sql)
+
+
+@pytest.mark.asyncio
+async def test_get_all_runs_escapes_search_key() -> None:
+    captured: dict[str, Any] = {}
+
+    async def _execute(query: Any) -> _AllResult:
+        captured.setdefault("query", query)
+        return _AllResult()
+
+    session = MagicMock()
+    session.execute = AsyncMock(side_effect=_execute)
+    session.scalars = AsyncMock(side_effect=lambda query: _AllResult())
+
+    repo = WorkflowRunsRepository(session_factory=lambda: _SessionContext(session), debug_enabled=False)
+    await repo.get_all_runs(organization_id="o_test", search_key=SEARCH_KEY)
+
+    where_sql = str(captured["query"].whereclause.compile(compile_kwargs={"literal_binds": True}))
+    _assert_escaped(where_sql)
+
+
+@pytest.mark.asyncio
+async def test_list_browser_profiles_escapes_search_key() -> None:
+    captured: dict[str, Any] = {}
+
+    async def _scalars(query: Any) -> _AllResult:
+        captured.setdefault("query", query)
+        return _AllResult()
+
+    session = MagicMock()
+    session.scalars = AsyncMock(side_effect=_scalars)
+
+    repo = BrowserSessionsRepository(session_factory=lambda: _SessionContext(session), debug_enabled=False)
+    await repo.list_browser_profiles(organization_id="o_test", search_key=SEARCH_KEY)
+
+    where_sql = str(captured["query"].whereclause.compile(compile_kwargs={"literal_binds": True}))
+    _assert_escaped(where_sql)

--- a/tests/unit/forge/sdk/db/test_workflows_repository_search.py
+++ b/tests/unit/forge/sdk/db/test_workflows_repository_search.py
@@ -56,5 +56,7 @@ async def test_get_workflows_by_organization_id_search_key_matches_workflow_perm
 
     # The search filter must reference the workflow_permanent_id column directly so
     # that pasting a wpid_* into the workflows page search box finds the workflow.
+    # The `_` is autoescaped (`/_`) so it matches literally rather than as a
+    # single-char LIKE wildcard.
     assert "workflows.workflow_permanent_id" in compiled_where
-    assert "wpid_510867674757598984" in compiled_where
+    assert "wpid/_510867674757598984" in compiled_where


### PR DESCRIPTION
## Description

The list-search on workflows, workflow runs, and browser profiles builds its `ilike` filters from a raw `f"%{search_key}%"`, so `_` and `%` in a user's search term are treated as SQL `LIKE` wildcards instead of literal characters. Because most resource IDs are underscore-separated (`wr_...`, `wpid_...`, `tsk_...`, `wpid_...`), searching one of them silently matches more rows than intended — e.g. searching `wr_abc` also matches `wrXabc`.

The codebase already uses the correct pattern in adjacent code:
- `get_workflows_by_organization_id`: `workflow_permanent_id_like` uses `icontains(search_key, autoescape=True)` while the neighboring `title` / `folder_title` / parameter filters in the *same* `if search_key:` block do not — a clear omission rather than a design choice.
- `workflow_runs.py`: `_apply_workflow_run_search_key_filter` and the task-run search already use `icontains(..., autoescape=True)` for the same columns that `get_all_runs` matches with a raw `ilike`.

This PR switches every user-search `ilike` in `get_workflows_by_organization_id`, `get_all_runs`, and `list_browser_profiles` to `icontains(search_key, autoescape=True)`. Behavior is unchanged except that `_` / `%` now match literally, which is what a search box should do.

## How Has This Been Tested

- New `tests/unit/forge/sdk/db/test_search_key_escaping.py` compiles the WHERE clause for each of the three functions with a `_`-containing search key and asserts the wildcard is escaped (`ab/_cd` + `ESCAPE`) rather than left bare. Verified the tests fail on `main` (unescaped `LIKE lower('%ab_cd%')`) and pass with the fix.
- Updated the existing `test_get_workflows_by_organization_id_search_key_matches_workflow_permanent_id` to expect the now-escaped literal (it previously matched the raw string only because the buggy `title` filter left it unescaped).
- Full `tests/unit/forge/sdk/db/` suite passes (143 passed); `ruff check` / `ruff format` / `mypy` clean on the changed files.

---
*Disclosure: this change was prepared with AI assistance (Claude); the diff, the root-cause trace against the existing autoescaped call sites, and the local test runs were reviewed by me before opening.*
