### PR TITLE
[schemas] Fix chained Jinja reference rewrites when sanitized workflow identifiers collide

### DIFF
--- a/skyvern/schemas/workflows.py
+++ b/skyvern/schemas/workflows.py
@@ -2,7 +2,7 @@ import abc
 import functools
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Callable, Literal
 
 import structlog
 from pydantic import BaseModel, Field, field_serializer, field_validator, model_validator
@@ -74,26 +74,12 @@ def _get_text_prompt_model_name_by_llm_key() -> dict[str, str]:
     return reverse_mapping
 
 
-def _replace_references_in_value(value: Any, old_key: str, new_key: str) -> Any:
-    """Recursively replaces Jinja references in a value (string, dict, or list)."""
-    if isinstance(value, str):
-        return replace_jinja_reference(value, old_key, new_key)
-    elif isinstance(value, dict):
-        return {k: _replace_references_in_value(v, old_key, new_key) for k, v in value.items()}
-    elif isinstance(value, list):
-        return [_replace_references_in_value(item, old_key, new_key) for item in value]
-    return value
-
-
-def _rewrite_error_code_mapping_refs_atomic(mapping: Any, substitutions: list[tuple[str, str]]) -> Any:
-    """Atomically rewrites Jinja references (keys and values) in an error_code_mapping dict.
+def _build_atomic_jinja_rewriter(substitutions: list[tuple[str, str]]) -> Callable[[str], str]:
+    """Builds a rewriter that applies all Jinja-reference substitutions to a string in one pass.
 
     Uses unique sentinels so chained rewrites don't occur when one substitution's new
     identifier matches another's old identifier (e.g. foo-bar -> foo_bar AND foo_bar -> foo_bar_2).
     """
-    if not isinstance(mapping, dict) or not substitutions:
-        return mapping
-
     sentinels = [(old, new, f"\x00SKY_SANITIZE_{i}\x00") for i, (old, new) in enumerate(substitutions)]
 
     def _apply(text: str) -> str:
@@ -103,9 +89,58 @@ def _rewrite_error_code_mapping_refs_atomic(mapping: Any, substitutions: list[tu
             text = text.replace(sentinel, new)
         return text
 
+    return _apply
+
+
+def _rewrite_error_code_mapping_refs_atomic(mapping: Any, substitutions: list[tuple[str, str]]) -> Any:
+    """Atomically rewrites Jinja references (keys and values) in an error_code_mapping dict."""
+    if not isinstance(mapping, dict) or not substitutions:
+        return mapping
+
+    _apply = _build_atomic_jinja_rewriter(substitutions)
     return {
         (_apply(k) if isinstance(k, str) else k): (_apply(v) if isinstance(v, str) else v) for k, v in mapping.items()
     }
+
+
+def _rewrite_jinja_refs_atomic(value: Any, substitutions: list[tuple[str, str]]) -> Any:
+    """Recursively rewrites Jinja references in a value (string, dict, or list) in one atomic pass.
+
+    Same chaining guard as _rewrite_error_code_mapping_refs_atomic: applying substitutions
+    one at a time lets a later rename re-hit an earlier rename's output.
+    """
+    if not substitutions:
+        return value
+
+    _apply = _build_atomic_jinja_rewriter(substitutions)
+
+    def _walk(value: Any) -> Any:
+        if isinstance(value, str):
+            return _apply(value)
+        elif isinstance(value, dict):
+            return {k: _walk(v) for k, v in value.items()}
+        elif isinstance(value, list):
+            return [_walk(item) for item in value]
+        return value
+
+    return _walk(value)
+
+
+def _build_rename_substitutions(
+    label_mapping: dict[str, str], param_key_mapping: dict[str, str]
+) -> list[tuple[str, str]]:
+    """Builds the ordered substitution list for the collected renames.
+
+    More specific {label}_output substitutions come before the bare label so the output
+    reference is claimed before the shorthand pattern can touch it.
+    """
+    substitutions: list[tuple[str, str]] = []
+    for old_label, new_label in label_mapping.items():
+        substitutions.append((f"{old_label}_output", f"{new_label}_output"))
+        substitutions.append((old_label, new_label))
+    for old_key, new_key in param_key_mapping.items():
+        substitutions.append((old_key, new_key))
+    return substitutions
 
 
 def _replace_direct_string_in_value(value: Any, old_key: str, new_key: str) -> Any:
@@ -320,62 +355,29 @@ def sanitize_workflow_yaml_with_references(workflow_yaml: dict[str, Any]) -> dic
         sanitized_parameter_keys=param_key_mapping if param_key_mapping else None,
     )
 
-    # Step 3: Update all block label references
-    for old_label, new_label in label_mapping.items():
-        old_output_key = f"{old_label}_output"
-        new_output_key = f"{new_label}_output"
+    # Steps 3 & 4: Update all Jinja references to renamed block labels ({{ label_output }},
+    # {{ label }}) and parameter keys ({{ old_key }}) in blocks, parameters, and the
+    # workflow_system_prompt (all rendered through Jinja at execution time). All renames are
+    # applied to each string in one atomic pass: applying them one at a time lets a later
+    # substitution re-hit an earlier one's output when collision-driven renames overlap
+    # (e.g. "user email" -> user_email AND user_email -> user_email_2), leaving a repaired
+    # reference pointing at the wrong parameter.
+    substitutions = _build_rename_substitutions(label_mapping, param_key_mapping)
+    if "blocks" in workflow_definition:
+        workflow_definition["blocks"] = _rewrite_jinja_refs_atomic(workflow_definition["blocks"], substitutions)
+    if "parameters" in workflow_definition:
+        workflow_definition["parameters"] = _rewrite_jinja_refs_atomic(workflow_definition["parameters"], substitutions)
+    if isinstance(workflow_definition.get("workflow_system_prompt"), str):
+        workflow_definition["workflow_system_prompt"] = _rewrite_jinja_refs_atomic(
+            workflow_definition["workflow_system_prompt"], substitutions
+        )
 
-        # Update Jinja references in blocks for {label}_output pattern
-        if "blocks" in workflow_definition:
-            workflow_definition["blocks"] = _replace_references_in_value(
-                workflow_definition["blocks"], old_output_key, new_output_key
-            )
-            # Also update shorthand {{ label }} references (must be done after _output to avoid partial matches)
-            workflow_definition["blocks"] = _replace_references_in_value(
-                workflow_definition["blocks"], old_label, new_label
-            )
-
-        # Update Jinja references in parameters for {label}_output pattern
-        if "parameters" in workflow_definition:
-            workflow_definition["parameters"] = _replace_references_in_value(
-                workflow_definition["parameters"], old_output_key, new_output_key
-            )
-            # Also update shorthand {{ label }} references
-            workflow_definition["parameters"] = _replace_references_in_value(
-                workflow_definition["parameters"], old_label, new_label
-            )
-            # Also update direct string references (e.g., source_parameter_key)
+    # Direct string references (e.g., source_parameter_key) are exact-match replacements,
+    # disjoint from the Jinja rewrites above (a {{ ... }} template string is never key-equal).
+    if "parameters" in workflow_definition:
+        for old_label, new_label in label_mapping.items():
             workflow_definition["parameters"] = _replace_direct_string_in_value(
-                workflow_definition["parameters"], old_output_key, new_output_key
-            )
-
-        # workflow_system_prompt is rendered through Jinja at execution time, so
-        # references inside it need the same rename treatment as block fields.
-        if isinstance(workflow_definition.get("workflow_system_prompt"), str):
-            workflow_definition["workflow_system_prompt"] = _replace_references_in_value(
-                workflow_definition["workflow_system_prompt"], old_output_key, new_output_key
-            )
-            workflow_definition["workflow_system_prompt"] = _replace_references_in_value(
-                workflow_definition["workflow_system_prompt"], old_label, new_label
-            )
-
-    # Step 4: Update all parameter key references
-    for old_key, new_key in param_key_mapping.items():
-        # Update Jinja references in blocks (e.g., {{ old_key }})
-        if "blocks" in workflow_definition:
-            workflow_definition["blocks"] = _replace_references_in_value(
-                workflow_definition["blocks"], old_key, new_key
-            )
-
-        # Update Jinja references in parameters (e.g., default values that reference other params)
-        if "parameters" in workflow_definition:
-            workflow_definition["parameters"] = _replace_references_in_value(
-                workflow_definition["parameters"], old_key, new_key
-            )
-
-        if isinstance(workflow_definition.get("workflow_system_prompt"), str):
-            workflow_definition["workflow_system_prompt"] = _replace_references_in_value(
-                workflow_definition["workflow_system_prompt"], old_key, new_key
+                workflow_definition["parameters"], f"{old_label}_output", f"{new_label}_output"
             )
 
     # Update direct string references to parameter keys (e.g. source_parameter_key) in one atomic
@@ -391,13 +393,6 @@ def sanitize_workflow_yaml_with_references(workflow_yaml: dict[str, Any]) -> dic
     # Rewrite workflow-level error_code_mapping atomically so substitutions don't chain
     # (e.g. foo-bar -> foo_bar and foo_bar -> foo_bar_2 must not combine into foo_bar_2).
     if "error_code_mapping" in workflow_definition:
-        substitutions: list[tuple[str, str]] = []
-        for old_label, new_label in label_mapping.items():
-            # More specific output-key substitution must come before the bare label.
-            substitutions.append((f"{old_label}_output", f"{new_label}_output"))
-            substitutions.append((old_label, new_label))
-        for old_key, new_key in param_key_mapping.items():
-            substitutions.append((old_key, new_key))
         workflow_definition["error_code_mapping"] = _rewrite_error_code_mapping_refs_atomic(
             workflow_definition["error_code_mapping"], substitutions
         )

--- a/skyvern/schemas/workflows.py
+++ b/skyvern/schemas/workflows.py
@@ -119,6 +119,28 @@ def _replace_direct_string_in_value(value: Any, old_key: str, new_key: str) -> A
     return value
 
 
+def _replace_direct_string_param_refs(value: Any, key_mapping: dict[str, str], *, _in_key_field: bool = False) -> Any:
+    """Rewrites exact-match direct string references to parameter keys (e.g. source_parameter_key).
+
+    Resolves each string against the whole mapping in a single pass and stops at the first match,
+    so a collision-driven rename chain (my-key -> my_key AND my_key -> my_key_2) can't compound a
+    reference into the wrong target. The parameter's own `key` field is never rewritten here: it is
+    already finalized by _sanitize_parameters, and re-applying the mapping to it would collapse two
+    distinct keys into the same name.
+    """
+    if isinstance(value, str):
+        if _in_key_field:
+            return value
+        return key_mapping.get(value, value)
+    elif isinstance(value, dict):
+        return {
+            k: _replace_direct_string_param_refs(v, key_mapping, _in_key_field=(k == "key")) for k, v in value.items()
+        }
+    elif isinstance(value, list):
+        return [_replace_direct_string_param_refs(item, key_mapping) for item in value]
+    return value
+
+
 def _make_unique(candidate: str, seen: set[str]) -> str:
     """Appends a numeric suffix to make candidate unique within the seen set.
 
@@ -350,15 +372,21 @@ def sanitize_workflow_yaml_with_references(workflow_yaml: dict[str, Any]) -> dic
             workflow_definition["parameters"] = _replace_references_in_value(
                 workflow_definition["parameters"], old_key, new_key
             )
-            # Also update direct string references (e.g., source_parameter_key)
-            workflow_definition["parameters"] = _replace_direct_string_in_value(
-                workflow_definition["parameters"], old_key, new_key
-            )
 
         if isinstance(workflow_definition.get("workflow_system_prompt"), str):
             workflow_definition["workflow_system_prompt"] = _replace_references_in_value(
                 workflow_definition["workflow_system_prompt"], old_key, new_key
             )
+
+    # Update direct string references to parameter keys (e.g. source_parameter_key) in one atomic
+    # pass. Doing this per-mapping-entry sequentially chained a collision rename (my-key -> my_key
+    # then my_key -> my_key_2) onto the already-renamed reference, and it also rewrote each param's
+    # own final `key` field back into a duplicate. _replace_direct_string_param_refs leaves the key
+    # field alone and resolves each reference against the whole mapping exactly once.
+    if param_key_mapping and "parameters" in workflow_definition:
+        workflow_definition["parameters"] = _replace_direct_string_param_refs(
+            workflow_definition["parameters"], param_key_mapping
+        )
 
     # Rewrite workflow-level error_code_mapping atomically so substitutions don't chain
     # (e.g. foo-bar -> foo_bar and foo_bar -> foo_bar_2 must not combine into foo_bar_2).

--- a/tests/unit/test_workflow_parameter_key_sanitization.py
+++ b/tests/unit/test_workflow_parameter_key_sanitization.py
@@ -1,0 +1,97 @@
+"""Regression tests for parameter-key rewriting in sanitize_workflow_yaml_with_references.
+
+Two distinct valid parameter keys can sanitize into a collision (e.g. "my-key" -> "my_key",
+which already exists), so the second gets a numeric suffix. The reference-rewriting pass in
+Step 4 used to run once per mapping entry and recurse into every string, so it re-applied the
+mapping to each parameter's own already-final `key` field and chained a later substitution onto
+an earlier one. That turned distinct keys into duplicates and pointed source_parameter_key at
+the wrong parameter, silently, on the public workflow-import path.
+"""
+
+from skyvern.schemas.workflows import sanitize_workflow_yaml_with_references
+
+
+def test_colliding_sanitized_keys_stay_unique() -> None:
+    workflow_yaml = {
+        "workflow_definition": {
+            "parameters": [
+                {"key": "my-key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "my_key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+            ],
+            "blocks": [],
+        }
+    }
+    sanitized = sanitize_workflow_yaml_with_references(workflow_yaml)
+    keys = [param["key"] for param in sanitized["workflow_definition"]["parameters"]]
+    # "my-key" -> "my_key", "my_key" -> "my_key_2"; neither should be rewritten into the other.
+    assert keys == ["my_key", "my_key_2"]
+    assert len(keys) == len(set(keys))
+
+
+def test_source_parameter_key_follows_renamed_key_without_chaining() -> None:
+    workflow_yaml = {
+        "workflow_definition": {
+            "parameters": [
+                {"key": "my-key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "my_key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "ctx", "parameter_type": "context", "source_parameter_key": "my-key"},
+            ],
+            "blocks": [],
+        }
+    }
+    sanitized = sanitize_workflow_yaml_with_references(workflow_yaml)
+    params = sanitized["workflow_definition"]["parameters"]
+    ctx = next(param for param in params if param["parameter_type"] == "context")
+    # "my-key" was renamed to "my_key"; the reference must land there, not chain to "my_key_2".
+    assert ctx["source_parameter_key"] == "my_key"
+
+
+def test_source_parameter_key_pointing_at_suffixed_param_is_correct() -> None:
+    workflow_yaml = {
+        "workflow_definition": {
+            "parameters": [
+                {"key": "my-key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "my_key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "ctx", "parameter_type": "context", "source_parameter_key": "my_key"},
+            ],
+            "blocks": [],
+        }
+    }
+    sanitized = sanitize_workflow_yaml_with_references(workflow_yaml)
+    params = sanitized["workflow_definition"]["parameters"]
+    ctx = next(param for param in params if param["parameter_type"] == "context")
+    # The literal "my_key" parameter was the one suffixed to "my_key_2".
+    assert ctx["source_parameter_key"] == "my_key_2"
+
+
+def test_single_rename_still_updates_source_parameter_key() -> None:
+    workflow_yaml = {
+        "workflow_definition": {
+            "parameters": [
+                {"key": "bad-key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "ctx", "parameter_type": "context", "source_parameter_key": "bad-key"},
+            ],
+            "blocks": [],
+        }
+    }
+    sanitized = sanitize_workflow_yaml_with_references(workflow_yaml)
+    params = sanitized["workflow_definition"]["parameters"]
+    assert params[0]["key"] == "bad_key"
+    ctx = next(param for param in params if param["parameter_type"] == "context")
+    assert ctx["source_parameter_key"] == "bad_key"
+
+
+def test_already_valid_keys_are_untouched() -> None:
+    workflow_yaml = {
+        "workflow_definition": {
+            "parameters": [
+                {"key": "alpha", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "beta", "parameter_type": "context", "source_parameter_key": "alpha"},
+            ],
+            "blocks": [],
+        }
+    }
+    sanitized = sanitize_workflow_yaml_with_references(workflow_yaml)
+    params = sanitized["workflow_definition"]["parameters"]
+    assert [param["key"] for param in params] == ["alpha", "beta"]
+    assert params[1]["source_parameter_key"] == "alpha"

--- a/tests/unit/test_workflow_sanitizer_jinja_rewrites.py
+++ b/tests/unit/test_workflow_sanitizer_jinja_rewrites.py
@@ -1,0 +1,144 @@
+"""Regression tests: Jinja reference rewrites in sanitize_workflow_yaml_with_references must not chain.
+
+When two identifiers sanitize into a collision (e.g. "user email" -> user_email, forcing the
+pre-existing user_email to user_email_2), the reference-rewrite passes used to apply the renames
+one at a time, so the second substitution re-hit the first one's output and a repaired reference
+ended up pointing at the wrong parameter or block output. The error_code_mapping pass already
+guarded against this; these tests cover the same guarantee for blocks, parameters, and the
+workflow_system_prompt.
+"""
+
+from skyvern.schemas.workflows import sanitize_workflow_yaml_with_references
+
+
+def test_colliding_param_renames_do_not_chain_in_block_fields() -> None:
+    # "user email" -> user_email takes the name; the valid "user_email" is suffixed to user_email_2.
+    workflow_yaml = {
+        "workflow_definition": {
+            "parameters": [
+                {"key": "user email", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "user_email", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+            ],
+            "blocks": [
+                {
+                    "label": "send",
+                    "block_type": "task",
+                    "url": "https://example.com",
+                    "navigation_goal": "Send to {{ user email }} and CC {{ user_email }}",
+                }
+            ],
+        }
+    }
+    sanitized = sanitize_workflow_yaml_with_references(workflow_yaml)
+    goal = sanitized["workflow_definition"]["blocks"][0]["navigation_goal"]
+    # {{ user email }} must land on user_email (not chain on to user_email_2),
+    # while {{ user_email }} must follow its parameter to user_email_2.
+    assert goal == "Send to {{ user_email }} and CC {{ user_email_2 }}"
+
+
+def test_colliding_label_renames_do_not_chain_output_refs_in_block_fields() -> None:
+    # foo/bar -> foo_bar takes the name; the valid foo_bar label is suffixed to foo_bar_2.
+    workflow_yaml = {
+        "workflow_definition": {
+            "parameters": [],
+            "blocks": [
+                {"label": "foo/bar", "block_type": "task", "url": "https://example.com"},
+                {"label": "foo_bar", "block_type": "task", "url": "https://example.com"},
+                {
+                    "label": "summarize",
+                    "block_type": "task",
+                    "url": "https://example.com",
+                    "navigation_goal": "first {{ foo/bar_output }}, second {{ foo_bar_output }}, short {{ foo_bar }}",
+                },
+            ],
+        }
+    }
+    sanitized = sanitize_workflow_yaml_with_references(workflow_yaml)
+    goal = sanitized["workflow_definition"]["blocks"][2]["navigation_goal"]
+    # {{ foo/bar_output }} must land on foo_bar_output (not chain on to foo_bar_2_output),
+    # while the references to the original foo_bar block must follow it to foo_bar_2.
+    assert goal == "first {{ foo_bar_output }}, second {{ foo_bar_2_output }}, short {{ foo_bar_2 }}"
+
+
+def test_colliding_param_renames_do_not_chain_in_system_prompt_and_param_defaults() -> None:
+    workflow_yaml = {
+        "workflow_definition": {
+            "parameters": [
+                {"key": "user email", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "user_email", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {
+                    "key": "greeting",
+                    "parameter_type": "workflow",
+                    "workflow_parameter_type": "string",
+                    "default_value": "Hello {{ user email }}",
+                },
+            ],
+            "blocks": [{"label": "send", "block_type": "task", "url": "https://example.com"}],
+            "workflow_system_prompt": "Prefer {{ user email }} over {{ user_email }}",
+        }
+    }
+    sanitized = sanitize_workflow_yaml_with_references(workflow_yaml)
+    definition = sanitized["workflow_definition"]
+    assert definition["workflow_system_prompt"] == "Prefer {{ user_email }} over {{ user_email_2 }}"
+    greeting = next(p for p in definition["parameters"] if p["key"] == "greeting")
+    assert greeting["default_value"] == "Hello {{ user_email }}"
+
+
+def test_colliding_param_rename_is_consistent_across_keys_source_refs_and_jinja() -> None:
+    # End-to-end composition guard: a single collision must resolve consistently across all three
+    # surfaces at once -- the final parameter keys, direct string references (source_parameter_key),
+    # and Jinja references. The Jinja pass (this PR) and the direct-string parameter-ref pass (the
+    # parameter-key-uniqueness fix this stacks on) each fix one surface; only the combined result is
+    # a valid workflow. Previously the direct-string pass chained the collision rename back onto the
+    # already-renamed key field, producing duplicate keys and a source_parameter_key with no backing
+    # parameter even though the Jinja assertions passed.
+    workflow_yaml = {
+        "workflow_definition": {
+            "parameters": [
+                {"key": "user email", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "user_email", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+                {"key": "cc", "parameter_type": "context", "source_parameter_key": "user_email"},
+            ],
+            "blocks": [
+                {
+                    "label": "send",
+                    "block_type": "task",
+                    "url": "https://example.com",
+                    "navigation_goal": "To {{ user_email }} and CC {{ user email }}",
+                }
+            ],
+        }
+    }
+    sanitized = sanitize_workflow_yaml_with_references(workflow_yaml)
+    definition = sanitized["workflow_definition"]
+    parameters = definition["parameters"]
+
+    # Final parameter keys stay distinct: neither param is clobbered into the other's name.
+    assert [p["key"] for p in parameters] == ["user_email", "user_email_2", "cc"]
+    # source_parameter_key followed its target parameter (original user_email -> user_email_2).
+    cc = next(p for p in parameters if p["key"] == "cc")
+    assert cc["source_parameter_key"] == "user_email_2"
+    # Jinja: {{ user_email }} follows its parameter to user_email_2; {{ user email }} lands on
+    # user_email without chaining on to user_email_2.
+    assert definition["blocks"][0]["navigation_goal"] == "To {{ user_email_2 }} and CC {{ user_email }}"
+
+
+def test_non_colliding_renames_still_rewritten_and_unrelated_refs_untouched() -> None:
+    workflow_yaml = {
+        "workflow_definition": {
+            "parameters": [
+                {"key": "my-key", "parameter_type": "workflow", "workflow_parameter_type": "string"},
+            ],
+            "blocks": [
+                {
+                    "label": "send",
+                    "block_type": "task",
+                    "url": "https://example.com",
+                    "navigation_goal": "use {{ my-key }} but not {{ my_key_lookalike }} or {{ other }}",
+                }
+            ],
+        }
+    }
+    sanitized = sanitize_workflow_yaml_with_references(workflow_yaml)
+    goal = sanitized["workflow_definition"]["blocks"][0]["navigation_goal"]
+    assert goal == "use {{ my_key }} but not {{ my_key_lookalike }} or {{ other }}"


### PR DESCRIPTION
Fixes #7554

## Description

`sanitize_workflow_yaml_with_references` rewrites Jinja references once per renamed identifier, sequentially. When collision-driven renames overlap — `user email` -> `user_email` while the pre-existing `user_email` gets suffixed to `user_email_2` — the later substitution re-hits the earlier one's output, so a just-repaired reference chains on to the wrong parameter: `Send to {{ user email }} and CC {{ user_email }}` comes out as `Send to {{ user_email_2 }} and CC {{ user_email_2 }}`. Same thing for block labels via the `{label}_output` rewrites, which can collapse two different blocks' output references onto one block. Nothing errors at import or run time; the workflow just runs with the wrong values.

The codebase already solves this exact problem for `error_code_mapping`: `_rewrite_error_code_mapping_refs_atomic` applies all substitutions in a single sentinel-guarded pass so `foo-bar -> foo_bar` and `foo_bar -> foo_bar_2` can't combine, with a regression test pinning it. This PR extends that approach to the other three rewrite targets:

- the sentinel logic moves into a shared `_build_atomic_jinja_rewriter`; the error_code_mapping helper now uses it unchanged
- steps 3/4 build one ordered substitution list (`{label}_output` before the bare label, mirroring the error_code_mapping ordering) and rewrite blocks, parameters, and `workflow_system_prompt` in one atomic pass via `_rewrite_jinja_refs_atomic`
- the per-entry `_replace_references_in_value` had no remaining callers and is removed

The direct-string pass (`source_parameter_key` etc.) is intentionally left as-is — its chaining problem is scoped to #7278.

## How Has This Been Tested

- New `tests/unit/test_workflow_sanitizer_jinja_rewrites.py` covers param-key chaining in block fields, label `_output` chaining, system-prompt/param-default chaining, and pins non-colliding renames + lookalike identifiers as untouched. The three chaining tests fail on `main` and pass with the fix; the pin test passes on both.
- Drove the sanitizer through a 9-case before/after panel (5 broken collision cases, 4 unchanged-behavior pins): main resolves 4/9, the fix 9/9, and the pins pass on both revisions — the no-behavior-change evidence for imports without collisions.
- Full suite green: `uv run pytest` (16,649 passed, 84 skipped, 1 xfailed); pre-commit ruff / ruff-format / isort / mypy / pyupgrade / autoflake all pass.

---
*Disclosure: prepared with AI assistance (Claude); I reviewed the diff, the root-cause trace against the existing error_code_mapping guard, and the local test runs before opening.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
