### PR TITLE
[templating] Rewrite renamed Jinja identifiers inside {% %} statements and mid-expression

### DIFF
--- a/skyvern/utils/templating.py
+++ b/skyvern/utils/templating.py
@@ -8,8 +8,48 @@ class Constants:
     MissingVariablePattern = var_pattern = r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_.\[\]'\"]*)\s*\}\}"
 
 
-# Closed Jinja expression/statement spans. DOTALL because expressions may span lines.
-_JINJA_SPAN_PATTERN = re.compile(r"\{\{.*?\}\}|\{%.*?%\}", re.DOTALL)
+# Characters that may precede a full-token occurrence of a key (identifier chars would
+# make it a longer identifier; a dot would make it an attribute access like foo.key).
+_TOKEN_BOUNDARY_BEFORE = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.")
+# Characters that may not follow a full-token occurrence (identifier continuation).
+_TOKEN_BOUNDARY_AFTER = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
+
+
+def _rewrite_span_tokens(span: str, old_key: str, new_key: str) -> str:
+    """Rewrites full-token occurrences of old_key in one Jinja span, skipping string literals.
+
+    Single left-to-right pass. Quoted regions ('...' or "...", honoring backslash escapes)
+    are copied verbatim, so a key embedded anywhere inside a string literal is never touched.
+    """
+    parts: list[str] = []
+    i = 0
+    n = len(span)
+    key_len = len(old_key)
+    while i < n:
+        if span.startswith(old_key, i):
+            prev = span[i - 1] if i > 0 else ""
+            nxt = span[i + key_len] if i + key_len < n else ""
+            if (not prev or prev not in _TOKEN_BOUNDARY_BEFORE) and (not nxt or nxt not in _TOKEN_BOUNDARY_AFTER):
+                parts.append(new_key)
+                i += key_len
+                continue
+        char = span[i]
+        parts.append(char)
+        i += 1
+        if char in "'\"":
+            # Copy the whole string literal verbatim (backslash escapes included) so
+            # embedded occurrences of the key are never rewritten.
+            quote = char
+            while i < n:
+                literal_char = span[i]
+                parts.append(literal_char)
+                i += 1
+                if literal_char == "\\" and i < n:
+                    parts.append(span[i])
+                    i += 1
+                elif literal_char == quote:
+                    break
+    return "".join(parts)
 
 
 def replace_jinja_reference(text: str, old_key: str, new_key: str) -> str:
@@ -20,8 +60,12 @@ def replace_jinja_reference(text: str, old_key: str, new_key: str) -> str:
     {{ other < oldKey }}, {% if oldKey %}, {% for x in oldKey %}.
 
     Left untouched: occurrences outside Jinja delimiters, attribute accesses (foo.oldKey),
-    quoted string literals ('oldKey'), and longer identifiers that merely contain the key
-    (oldKeyExtended).
+    anything inside quoted string literals ('...oldKey...'), and longer identifiers that
+    merely contain the key (oldKeyExtended).
+
+    The scan is a single left-to-right pass: each span search resumes where the previous
+    span ended, so malformed input (e.g. thousands of unmatched braces) stays linear
+    instead of rescanning to the end from every opener.
 
     Args:
         text: The text to search in
@@ -32,21 +76,34 @@ def replace_jinja_reference(text: str, old_key: str, new_key: str) -> str:
         The text with references replaced
     """
     escaped_old_key = re.escape(old_key)
-    # A full-token occurrence: not preceded by an identifier character, a dot (attribute
-    # access), or a quote (string literal), and not followed by an identifier character or
-    # a quote. A trailing dot/bracket stays allowed so {{oldKey.field}} and {{oldKey[0]}}
-    # keep their access path with only the root renamed.
-    token_pattern = re.compile(rf"(?<![a-zA-Z0-9_.'\"]){escaped_old_key}(?![a-zA-Z0-9_'\"])")
+    # An unclosed "{{ oldKey" has always been rewritten at the leading position; spans
+    # that never close fall back to this legacy leading-position rewrite. The pattern is
+    # anchored on the literal "{{" with no wildcards, so it scans linearly.
+    leading_pattern = re.compile(rf"\{{\{{(\s*){escaped_old_key}(?![a-zA-Z0-9_])")
 
-    def _rewrite_span(span: re.Match[str]) -> str:
-        return token_pattern.sub(lambda _: new_key, span.group(0))
-
-    text = _JINJA_SPAN_PATTERN.sub(_rewrite_span, text)
-
-    # An unclosed "{{ oldKey" has always been rewritten at the leading position; the span
-    # pattern above can't see it, so keep the legacy leading-position rewrite as a fallback.
-    leading_pattern = rf"\{{\{{(\s*){escaped_old_key}(?![a-zA-Z0-9_])"
-    return re.sub(leading_pattern, lambda m: "{{" + m.group(1) + new_key, text)
+    parts: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        # Find the next opener; -1 sentinels normalized to n so min() picks the earliest.
+        expr_start = text.find("{{", i)
+        stmt_start = text.find("{%", i)
+        starts = [pos for pos in (expr_start, stmt_start) if pos != -1]
+        if not starts:
+            parts.append(text[i:])
+            break
+        start = min(starts)
+        parts.append(text[i:start])
+        closer = "}}" if text.startswith("{{", start) else "%}"
+        end = text.find(closer, start + 2)
+        if end == -1:
+            # Unclosed span: the remainder gets only the legacy leading-position rewrite.
+            parts.append(leading_pattern.sub(lambda m: "{{" + m.group(1) + new_key, text[start:]))
+            break
+        span_end = end + 2
+        parts.append(_rewrite_span_tokens(text[start:span_end], old_key, new_key))
+        i = span_end
+    return "".join(parts)
 
 
 def get_missing_variables(template_source: str, template_data: dict) -> set[str]:

--- a/skyvern/utils/templating.py
+++ b/skyvern/utils/templating.py
@@ -64,8 +64,9 @@ def replace_jinja_reference(text: str, old_key: str, new_key: str) -> str:
     merely contain the key (oldKeyExtended).
 
     The scan is a single left-to-right pass: each span search resumes where the previous
-    span ended, so malformed input (e.g. thousands of unmatched braces) stays linear
-    instead of rescanning to the end from every opener.
+    span ended, and an unclosed opener is stepped over after its leading-position rewrite,
+    so malformed input (e.g. thousands of unmatched braces) stays linear while well-formed
+    spans after an unclosed opener are still fully rewritten.
 
     Args:
         text: The text to search in
@@ -76,30 +77,50 @@ def replace_jinja_reference(text: str, old_key: str, new_key: str) -> str:
         The text with references replaced
     """
     escaped_old_key = re.escape(old_key)
-    # An unclosed "{{ oldKey" has always been rewritten at the leading position; spans
-    # that never close fall back to this legacy leading-position rewrite. The pattern is
-    # anchored on the literal "{{" with no wildcards, so it scans linearly.
+    # An unclosed "{{ oldKey" has always been rewritten at the leading position; openers
+    # that never close get this legacy leading-position rewrite. The pattern is anchored
+    # on the literal "{{" with no wildcards, so it scans linearly.
     leading_pattern = re.compile(rf"\{{\{{(\s*){escaped_old_key}(?![a-zA-Z0-9_])")
 
     parts: list[str] = []
     i = 0
     n = len(text)
+    # Opener positions are cached until the scan passes them, and a closer type known to
+    # be absent from the rest of the text is never searched for again, so every find()
+    # covers a distinct stretch of input — the scan stays linear even when thousands of
+    # openers never close.
+    expr_start = text.find("{{")
+    stmt_start = text.find("{%")
+    have_expr_closer = True
+    have_stmt_closer = True
     while i < n:
-        # Find the next opener; -1 sentinels normalized to n so min() picks the earliest.
-        expr_start = text.find("{{", i)
-        stmt_start = text.find("{%", i)
+        if expr_start != -1 and expr_start < i:
+            expr_start = text.find("{{", i)
+        if stmt_start != -1 and stmt_start < i:
+            stmt_start = text.find("{%", i)
         starts = [pos for pos in (expr_start, stmt_start) if pos != -1]
         if not starts:
             parts.append(text[i:])
             break
         start = min(starts)
         parts.append(text[i:start])
-        closer = "}}" if text.startswith("{{", start) else "%}"
-        end = text.find(closer, start + 2)
+        if text.startswith("{{", start):
+            end = text.find("}}", start + 2) if have_expr_closer else -1
+            have_expr_closer = end != -1
+        else:
+            end = text.find("%}", start + 2) if have_stmt_closer else -1
+            have_stmt_closer = end != -1
         if end == -1:
-            # Unclosed span: the remainder gets only the legacy leading-position rewrite.
-            parts.append(leading_pattern.sub(lambda m: "{{" + m.group(1) + new_key, text[start:]))
-            break
+            # Unclosed opener: apply the legacy leading-position rewrite at this opener
+            # only, then keep scanning — later well-formed spans still get full coverage.
+            head = leading_pattern.match(text, start)
+            if head is not None:
+                parts.append("{{" + head.group(1) + new_key)
+                i = head.end()
+            else:
+                parts.append(text[start : start + 2])
+                i = start + 2
+            continue
         span_end = end + 2
         parts.append(_rewrite_span_tokens(text[start:span_end], old_key, new_key))
         i = span_end

--- a/skyvern/utils/templating.py
+++ b/skyvern/utils/templating.py
@@ -8,10 +8,20 @@ class Constants:
     MissingVariablePattern = var_pattern = r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_.\[\]'\"]*)\s*\}\}"
 
 
+# Closed Jinja expression/statement spans. DOTALL because expressions may span lines.
+_JINJA_SPAN_PATTERN = re.compile(r"\{\{.*?\}\}|\{%.*?%\}", re.DOTALL)
+
+
 def replace_jinja_reference(text: str, old_key: str, new_key: str) -> str:
     """Replaces jinja-style references in a string.
 
-    Handles patterns like {{oldKey}}, {{oldKey.field}}, {{oldKey | filter}}, {{oldKey[0]}}
+    Rewrites the key wherever it appears as a full token inside {{ ... }} expressions or
+    {% ... %} statements: {{oldKey}}, {{oldKey.field}}, {{oldKey | filter}}, {{oldKey[0]}},
+    {{ other < oldKey }}, {% if oldKey %}, {% for x in oldKey %}.
+
+    Left untouched: occurrences outside Jinja delimiters, attribute accesses (foo.oldKey),
+    quoted string literals ('oldKey'), and longer identifiers that merely contain the key
+    (oldKeyExtended).
 
     Args:
         text: The text to search in
@@ -21,13 +31,22 @@ def replace_jinja_reference(text: str, old_key: str, new_key: str) -> str:
     Returns:
         The text with references replaced
     """
-    # Match {{oldKey}} or {{oldKey.something}} or {{oldKey | filter}} or {{oldKey[0]}} etc.
-    # Use negative lookahead to ensure key is not followed by identifier characters,
-    # which prevents matching {{keyOther}} when searching for {{key}}
-    # Capture whitespace after {{ to preserve formatting (e.g., "{{ key }}" stays "{{ newKey }}")
     escaped_old_key = re.escape(old_key)
-    pattern = rf"\{{\{{(\s*){escaped_old_key}(?![a-zA-Z0-9_])"
-    return re.sub(pattern, rf"{{{{\1{new_key}", text)
+    # A full-token occurrence: not preceded by an identifier character, a dot (attribute
+    # access), or a quote (string literal), and not followed by an identifier character or
+    # a quote. A trailing dot/bracket stays allowed so {{oldKey.field}} and {{oldKey[0]}}
+    # keep their access path with only the root renamed.
+    token_pattern = re.compile(rf"(?<![a-zA-Z0-9_.'\"]){escaped_old_key}(?![a-zA-Z0-9_'\"])")
+
+    def _rewrite_span(span: re.Match[str]) -> str:
+        return token_pattern.sub(lambda _: new_key, span.group(0))
+
+    text = _JINJA_SPAN_PATTERN.sub(_rewrite_span, text)
+
+    # An unclosed "{{ oldKey" has always been rewritten at the leading position; the span
+    # pattern above can't see it, so keep the legacy leading-position rewrite as a fallback.
+    leading_pattern = rf"\{{\{{(\s*){escaped_old_key}(?![a-zA-Z0-9_])"
+    return re.sub(leading_pattern, lambda m: "{{" + m.group(1) + new_key, text)
 
 
 def get_missing_variables(template_source: str, template_data: dict) -> set[str]:

--- a/tests/unit/test_workflow_parameter_validation.py
+++ b/tests/unit/test_workflow_parameter_validation.py
@@ -182,6 +182,21 @@ class TestReplaceJinjaReference:
                 id="outside-delimiters-unchanged",
             ),
             pytest.param("{{ old_key", "{{ new_key", id="unclosed-expression-leading-rewritten"),
+            pytest.param(
+                "{{ oops {% if old_key %}",
+                "{{ oops {% if new_key %}",
+                id="closed-statement-after-unclosed-expression-rewritten",
+            ),
+            pytest.param(
+                "{% oops {{ x < old_key }}",
+                "{% oops {{ x < new_key }}",
+                id="closed-expression-after-unclosed-statement-rewritten",
+            ),
+            pytest.param(
+                "{{ old_key {{ old_key",
+                "{{ new_key {{ new_key",
+                id="repeated-unclosed-leading-rewritten",
+            ),
         ],
     )
     def test_replace_jinja_reference(self, text: str, expected: str) -> None:

--- a/tests/unit/test_workflow_parameter_validation.py
+++ b/tests/unit/test_workflow_parameter_validation.py
@@ -129,6 +129,33 @@ class TestReplaceJinjaReference:
             ),
             pytest.param("{{ old_key_extended }}", "{{ old_key_extended }}", id="partial-match-unchanged"),
             pytest.param("{{ other_key }}", "{{ other_key }}", id="different-key-unchanged"),
+            pytest.param(
+                "{{ current_index < old_key }}",
+                "{{ current_index < new_key }}",
+                id="mid-expression-comparison",
+            ),
+            pytest.param(
+                "{{ old_key + old_key }}",
+                "{{ new_key + new_key }}",
+                id="repeated-within-expression",
+            ),
+            pytest.param("{% if old_key %}yes{% endif %}", "{% if new_key %}yes{% endif %}", id="if-statement"),
+            pytest.param(
+                "{% for item in old_key %}{{ item }}{% endfor %}",
+                "{% for item in new_key %}{{ item }}{% endfor %}",
+                id="for-statement",
+            ),
+            pytest.param("{%- if old_key -%}", "{%- if new_key -%}", id="whitespace-control-statement"),
+            pytest.param("{{\n  old_key\n  | trim }}", "{{\n  new_key\n  | trim }}", id="multiline-expression"),
+            pytest.param("{% if old_key_extended %}", "{% if old_key_extended %}", id="statement-partial-unchanged"),
+            pytest.param("{{ foo.old_key }}", "{{ foo.old_key }}", id="attribute-position-unchanged"),
+            pytest.param("{{ func('old_key') }}", "{{ func('old_key') }}", id="string-literal-unchanged"),
+            pytest.param(
+                "old_key outside delimiters",
+                "old_key outside delimiters",
+                id="outside-delimiters-unchanged",
+            ),
+            pytest.param("{{ old_key", "{{ new_key", id="unclosed-expression-leading-rewritten"),
         ],
     )
     def test_replace_jinja_reference(self, text: str, expected: str) -> None:
@@ -245,6 +272,54 @@ class TestSanitizeWorkflowYamlWithReferences:
         result = sanitize_workflow_yaml_with_references(workflow_yaml)
         assert result["workflow_definition"]["blocks"][0]["label"] == "block_1"
         assert result["workflow_definition"]["parameters"][0]["source_parameter_key"] == "block_1_output"
+
+    def test_sanitize_updates_references_in_statements_and_mid_expression(self) -> None:
+        """Renamed keys are rewritten inside {% ... %} statements and mid-expression, not just after {{."""
+        workflow_yaml = {
+            "title": "Test Workflow",
+            "workflow_definition": {
+                "parameters": [{"key": "max attempts", "parameter_type": "workflow"}],
+                "blocks": [
+                    {
+                        "label": "retry_loop",
+                        "block_type": "while_loop",
+                        "complete_criterion": "{{ current_index < max attempts }}",
+                        "loop_blocks": [],
+                    },
+                    {
+                        "label": "notify",
+                        "block_type": "task",
+                        "navigation_goal": "{% if max attempts %}Retry up to {{ max attempts }} times{% endif %}",
+                    },
+                ],
+            },
+        }
+        result = sanitize_workflow_yaml_with_references(workflow_yaml)
+        blocks = result["workflow_definition"]["blocks"]
+        assert result["workflow_definition"]["parameters"][0]["key"] == "max_attempts"
+        assert blocks[0]["complete_criterion"] == "{{ current_index < max_attempts }}"
+        assert blocks[1]["navigation_goal"] == "{% if max_attempts %}Retry up to {{ max_attempts }} times{% endif %}"
+
+    def test_sanitize_updates_output_references_in_statements(self) -> None:
+        """Renamed block labels are rewritten in {label}_output references inside {% ... %} statements."""
+        workflow_yaml = {
+            "title": "Test Workflow",
+            "workflow_definition": {
+                "parameters": [],
+                "blocks": [
+                    {"label": "my-block", "block_type": "task"},
+                    {
+                        "label": "guard",
+                        "block_type": "task",
+                        "navigation_goal": "{% if my-block_output.success %}Continue{% endif %}",
+                    },
+                ],
+            },
+        }
+        result = sanitize_workflow_yaml_with_references(workflow_yaml)
+        blocks = result["workflow_definition"]["blocks"]
+        assert blocks[0]["label"] == "my_block"
+        assert blocks[1]["navigation_goal"] == "{% if my_block_output.success %}Continue{% endif %}"
 
     def test_sanitize_parameter_key(self) -> None:
         """Test that parameter keys with invalid characters are sanitized."""

--- a/tests/unit/test_workflow_parameter_validation.py
+++ b/tests/unit/test_workflow_parameter_validation.py
@@ -4,6 +4,7 @@ These tests ensure that parameter keys and block labels are valid Python/Jinja2 
 preventing runtime errors like "'State_' is undefined" when using keys like "State_/_Province".
 """
 
+import time
 from collections.abc import Callable
 
 import pytest
@@ -151,6 +152,31 @@ class TestReplaceJinjaReference:
             pytest.param("{{ foo.old_key }}", "{{ foo.old_key }}", id="attribute-position-unchanged"),
             pytest.param("{{ func('old_key') }}", "{{ func('old_key') }}", id="string-literal-unchanged"),
             pytest.param(
+                "{{ notify('ping old_key now') }}",
+                "{{ notify('ping old_key now') }}",
+                id="embedded-in-single-quoted-literal-unchanged",
+            ),
+            pytest.param(
+                '{{ notify("ping old_key now") }}',
+                '{{ notify("ping old_key now") }}',
+                id="embedded-in-double-quoted-literal-unchanged",
+            ),
+            pytest.param(
+                "{% if 'use old_key here' == mode %}",
+                "{% if 'use old_key here' == mode %}",
+                id="embedded-in-statement-literal-unchanged",
+            ),
+            pytest.param(
+                r"{{ f('it\'s old_key here') }}",
+                r"{{ f('it\'s old_key here') }}",
+                id="escaped-quote-literal-unchanged",
+            ),
+            pytest.param(
+                "{{ f('old_key') + old_key }}",
+                "{{ f('old_key') + new_key }}",
+                id="literal-preserved-bare-token-rewritten",
+            ),
+            pytest.param(
                 "old_key outside delimiters",
                 "old_key outside delimiters",
                 id="outside-delimiters-unchanged",
@@ -160,6 +186,28 @@ class TestReplaceJinjaReference:
     )
     def test_replace_jinja_reference(self, text: str, expected: str) -> None:
         assert replace_jinja_reference(text, "old_key", "new_key") == expected
+
+    @pytest.mark.parametrize(
+        ("malformed",),
+        [
+            pytest.param("{{ " * 65536 + "old_key", id="unmatched-openers-with-spaces"),
+            pytest.param("{{" * 65536 + "old_key", id="unmatched-openers-dense"),
+            pytest.param("{% " * 65536 + "old_key", id="unmatched-statement-openers"),
+        ],
+    )
+    def test_malformed_delimiters_scan_linearly(self, malformed: str) -> None:
+        """Unmatched openers must not trigger quadratic rescans.
+
+        The span search resumes where the previous span ended, so an input full of
+        unmatched braces is scanned once. A lazy-regex implementation rescanned to the
+        end of the input from every opener (~0.5s at 16k openers, quadrupling with input
+        size); the generous absolute bound below fails that implementation at this size
+        while leaving two orders of magnitude of headroom for a linear scan on slow CI.
+        """
+        start = time.perf_counter()
+        replace_jinja_reference(malformed, "old_key", "new_key")
+        elapsed = time.perf_counter() - start
+        assert elapsed < 2.0, f"malformed-delimiter scan took {elapsed:.2f}s — quadratic rescan regression"
 
 
 class TestSanitizeWorkflowYamlWithReferences:


### PR DESCRIPTION
Fixes #7559

## Description

`replace_jinja_reference` matched an identifier only immediately after `{{` (`\{\{(\s*)key(?!...)`), so every rewrite path in the workflow import sanitizer — blocks, parameters, `workflow_system_prompt`, and the sentinel-guarded `error_code_mapping` pass — silently skipped references that don't sit at the head of an expression. When a parameter key or block label is renamed at import (invalid identifier, or a collision-driven `_2` suffix):

- `{{ current_index < max_attempts }}` — the documented while-loop condition shape — keeps its stale right-hand side
- `{% if my-block_output.success %}` / `{% for x in items %}` statements are never touched at all

With default lax templating nothing errors; conditions evaluate against undefined or wrong values, and after a collision rename the stale reference can silently bind to the other parameter that now owns the old name.

The fix widens the matcher to full-token occurrences inside closed `{{ ... }}` and `{% ... %}` spans:

- token boundaries exclude attribute accesses (`foo.oldKey`), quoted string literals (`'oldKey'`), and longer identifiers (`oldKeyExtended`); a trailing `.`/`[` stays allowed so `{{oldKey.field}}` / `{{oldKey[0]}}` keep their access path with only the root renamed
- text outside Jinja delimiters is never rewritten (a new pin the old implementation happened to satisfy only for non-leading text)
- the legacy leading-position rewrite is kept as a fallback for unclosed `{{ oldKey` spans, so the new behavior is a strict superset of the old — all 8 pre-existing parametrized cases pass unchanged

No callers change: the sanitizer's per-target passes and `_rewrite_error_code_mapping_refs_atomic`'s sentinel substitution both go through this function and pick up the widened coverage. This is orthogonal to #7555 (chaining vs. matching coverage); they compose in either merge order.

## How Has This Been Tested

- 11 new parametrized cases on `replace_jinja_reference` (mid-expression comparison, repeated occurrences in one expression, `{% if %}`, `{% for %}`, whitespace-control `{%- -%}`, multiline expressions, plus unchanged-behavior pins for statement partial matches, attribute positions, string literals, prose outside delimiters, and unclosed-span leading rewrites) and 2 end-to-end tests through `sanitize_workflow_yaml_with_references` (while-loop `complete_criterion` with a renamed parameter; `{label}_output` guard inside `{% if %}`).
- The 7 fix-sensitive tests fail on `main` and pass with the fix; the 71 pre-existing tests in the file pass on both revisions.
- Full suite green: `uv run pytest` (16,705 passed, 84 skipped, 1 xfailed); pre-commit ruff / ruff-format / isort / mypy / pyupgrade / autoflake all pass.

---
*Disclosure: prepared with AI assistance (Claude); I reviewed the diff, the boundary-rule design, and the local test runs before opening.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)