### PR TITLE
[frontend] Stop reporting a restricted auth diagnostics endpoint as an API key failure

### DIFF
--- a/skyvern-frontend/src/hooks/useAuthDiagnostics.test.tsx
+++ b/skyvern-frontend/src/hooks/useAuthDiagnostics.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+
+vi.mock("@/api/AxiosClient", () => ({
+  getClient: async () => ({ get: mockGet }),
+}));
+
+import { useAuthDiagnostics } from "./useAuthDiagnostics";
+
+function axiosErrorWithStatus(status: number) {
+  return Object.assign(new Error(`Request failed with status code ${status}`), {
+    isAxiosError: true,
+    response: { status },
+  });
+}
+
+function renderDiagnostics() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return renderHook(() => useAuthDiagnostics(), {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  });
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useAuthDiagnostics", () => {
+  it("passes through a diagnostics payload from the backend", async () => {
+    mockGet.mockResolvedValue({ data: { status: "invalid" } });
+    const { result } = renderDiagnostics();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: "invalid" });
+  });
+
+  it("treats a 403 (endpoint restricted to loopback) as ok", async () => {
+    mockGet.mockRejectedValue(axiosErrorWithStatus(403));
+    const { result } = renderDiagnostics();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: "ok" });
+  });
+
+  it("treats a 404 (endpoint not present) as ok", async () => {
+    mockGet.mockRejectedValue(axiosErrorWithStatus(404));
+    const { result } = renderDiagnostics();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ status: "ok" });
+  });
+
+  it("surfaces other HTTP errors", async () => {
+    mockGet.mockRejectedValue(axiosErrorWithStatus(500));
+    const { result } = renderDiagnostics();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("surfaces non-HTTP errors", async () => {
+    mockGet.mockRejectedValue(new Error("Network Error"));
+    const { result } = renderDiagnostics();
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/skyvern-frontend/src/hooks/useAuthDiagnostics.ts
+++ b/skyvern-frontend/src/hooks/useAuthDiagnostics.ts
@@ -29,8 +29,16 @@ async function fetchDiagnostics(): Promise<AuthDiagnosticsResponse> {
     );
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response?.status === 404) {
-      return { status: "ok" };
+    if (axios.isAxiosError(error)) {
+      const status = error.response?.status;
+      // 404: the diagnostics endpoint doesn't exist (e.g. cloud). 403: it exists
+      // but the backend restricts it to loopback, which a browser request to a
+      // Dockerized backend can't satisfy. Neither says anything about the API
+      // key, so don't surface a banner; genuine auth failures still raise it
+      // via AuthIssueStore when real requests are rejected.
+      if (status === 404 || status === 403) {
+        return { status: "ok" };
+      }
     }
     throw error;
   }


### PR DESCRIPTION
Fixes #3782

## Description

`SelfHealApiKeyBanner` probes `GET /internal/auth/status` on load. The backend deliberately restricts that endpoint (localhost access), so in a Docker Compose self-hosted setup the browser's request — which reaches the container from the bridge network, not loopback — gets a **403 by design**. `useAuthDiagnostics` only special-cased **404** (endpoint not present) as `{ status: "ok" }`; the 403 rejected the query, and the banner rendered **"Unable to verify Skyvern API key. The UI could not reach the diagnostics endpoint. Ensure the backend is running locally."** — while every real API request was succeeding with 200. Exactly the false alarm diagnosed in #3782 (open since Oct 2025, confirmed still reproducing on `main` in the issue thread).

The fix treats the 403 like the existing 404 branch: backend reachable, diagnostics restricted by design, no information about the API key → no banner.

This can't mask a genuine auth failure: real request rejections are tracked separately in `AuthIssueStore`, which raises the banner through the `request_auth_error` path with its own copy — that path is untouched. The diagnostics probe's 403 carries no auth signal at all, since the backend refuses to answer before looking at the key.

Timing note: this becomes more visible with the in-flight security hardening — #7176 narrows `internal/auth` trust from all-private-IPs to loopback-only, and #7177 records the known consequence that Dockerized browser→published-port requests will 403. Once that lands, every Docker Compose UI hits this code path on load; this PR makes that 403 silent instead of a false "your API key is broken" banner. Frontend-only, so it composes with #7176 in either merge order.

## How Has This Been Tested

- New `useAuthDiagnostics.test.tsx` covers: payload passthrough on 200, **403 → ok (the fix)**, 404 → ok (pre-existing pin), 500 surfaces as error, network error surfaces as error. The 403 case fails on `main` and passes with the fix; the other four pass on both revisions.
- Full frontend suite green: 3,306 tests across 378 files (`npm test`); pre-commit `Frontend Precommit (lint-staged)` and `vitest` hooks pass.

---
*Disclosure: prepared with AI assistance (Claude); I reviewed the diff, the AuthIssueStore fallback reasoning, and the local test runs before opening.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)