### PR TITLE
test: loosen wall-clock tolerances in download handler tests (CI flake)

### DIFF
--- a/tests/unit/test_download_file_action_handler.py
+++ b/tests/unit/test_download_file_action_handler.py
@@ -784,7 +784,8 @@ async def test_handle_action_timeout_bounds_browser_download_handler_drain(
                     timeout=0.5,
                 )
 
-        assert time.monotonic() - started_at < 0.2
+        # Keep wall-clock bounds loose to tolerate scheduling jitter on shared CI runners.
+        assert time.monotonic() - started_at < 1.0
         assert not interceptor._browser_download_tasks
 
 
@@ -844,7 +845,8 @@ async def test_handle_action_download_completion_may_exceed_signal_budget(
         elapsed = time.monotonic() - started_at
 
     assert elapsed >= 0.05
-    assert elapsed < 0.5
+    # Keep wall-clock bounds loose to tolerate scheduling jitter on shared CI runners.
+    assert elapsed < 1.0
     assert results[-1].download_triggered is True
     assert results[-1].downloaded_files == ["report.pdf"]
 
@@ -1147,7 +1149,8 @@ async def test_handle_action_download_completion_budget_bounds_hanging_settle(
 
         elapsed = time.monotonic() - started_at
 
-    assert elapsed < 0.2
+    # Keep wall-clock bounds loose to tolerate scheduling jitter on shared CI runners.
+    assert elapsed < 1.0
 
 
 def test_remove_download_listener_uses_playwright_remove_listener_when_off_unavailable() -> None:
@@ -2320,7 +2323,8 @@ async def test_handle_action_download_in_flight_request_does_not_extend_custom_t
             )
         elapsed = time.monotonic() - started_at
 
-    assert elapsed < 0.1
+    # Keep wall-clock bounds loose to tolerate scheduling jitter on shared CI runners.
+    assert elapsed < 0.5
     assert results[-1].download_triggered is False
     assert action.download_triggered is False
     span_attrs = _download_wait_span_attrs(span_exporter)


### PR DESCRIPTION
## Summary

- loosen only the tight wall-clock upper bounds in the download handler tests
- keep timeout inputs, lower bounds, cleanup checks, and logic assertions unchanged
- document that the ceilings allow for scheduling jitter on shared CI runners

## Context

This addresses two flakes on PRs unrelated to the test file:

- [run 29945960477](https://github.com/Skyvern-AI/skyvern/actions/runs/29945960477): test_handle_action_timeout_bounds_browser_download_handler_drain took about 0.214s against a 0.2s ceiling
- [run 29956252756](https://github.com/Skyvern-AI/skyvern/actions/runs/29956252756): test_handle_action_download_in_flight_request_does_not_extend_custom_timeout took about 0.181s against a 0.1s ceiling

These tests validate bounded timeout behavior and whether an in-flight request extends the configured timeout; exact sub-second wall-clock scheduling is not part of that contract. The looser upper ceilings preserve those properties while tolerating shared-runner jitter.

## Validation

- ran tests/unit/test_download_file_action_handler.py five times: 77 passed on every run
- uv run pre-commit run --all-files