### PR TITLE
7028-custom-url-browser-session-url

### DIFF
--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -11039,6 +11039,18 @@
       },
       "CreateBrowserSessionRequest": {
         "properties": {
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url",
+            "description": "Optional URL to open when the standalone browser session starts."
+          },
           "timeout": {
             "anyOf": [
               {

--- a/docs/sdk-reference/browser-sessions/create-browser-session.mdx
+++ b/docs/sdk-reference/browser-sessions/create-browser-session.mdx
@@ -15,12 +15,18 @@ Spin up a new cloud browser session.
 
 <CodeGroup>
 ```python Python
-session = await client.create_browser_session(timeout=60)
+session = await client.create_browser_session(
+    url="https://example.com",
+    timeout=60,
+)
 print(session.browser_session_id)  # pbs_abc123
 ```
 
 ```typescript TypeScript
-const session = await skyvern.createBrowserSession({ timeout: 60 });
+const session = await skyvern.createBrowserSession({
+  url: "https://example.com",
+  timeout: 60,
+});
 console.log(session.browser_session_id); // pbs_abc123
 ```
 </CodeGroup>
@@ -29,6 +35,7 @@ console.log(session.browser_session_id); // pbs_abc123
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
+| `url` | `str` | No | `None` | Optional URL to open when the standalone browser session starts. Omit to start from a blank page. |
 | `timeout` | `int` | No | `60` | Session timeout in minutes (5–1440). Timer starts after the session is ready. |
 | `proxy_location` | `ProxyLocation` | No | `None` | Route browser traffic through a geographic proxy. |
 | `extensions` | `list[Extensions]` | No | `None` | Browser extensions to install. Options: `"ad-blocker"`, `"captcha-solver"`. |

--- a/fern/browser-sessions/introduction.mdx
+++ b/fern/browser-sessions/introduction.mdx
@@ -19,10 +19,12 @@ from skyvern import Skyvern
 
 skyvern = Skyvern(api_key="YOUR_API_KEY")
 browser_session = await skyvern.create_browser_session(
+	url="https://example.com",
 	timeout=60,
 )
 ```
 
+- The `url` parameter opens the browser session to that page when the session starts. Omit it to start from a blank page.
 - The `timeout` parameter (`>=5, <=10080`) is the max time in minutes that the browser session can run. By default, the timeout is 60 minutes.
 - The `browser_session_id` the session ID you should note.
 

--- a/fern/openapi/skyvern_openapi.json
+++ b/fern/openapi/skyvern_openapi.json
@@ -10698,6 +10698,18 @@
       },
       "CreateBrowserSessionRequest": {
         "properties": {
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url",
+            "description": "Optional URL to open when the standalone browser session starts."
+          },
           "timeout": {
             "anyOf": [
               {

--- a/skyvern-ts/client/src/api/client/requests/CreateBrowserSessionRequest.ts
+++ b/skyvern-ts/client/src/api/client/requests/CreateBrowserSessionRequest.ts
@@ -7,6 +7,8 @@ import type * as Skyvern from "../../index.js";
  *     {}
  */
 export interface CreateBrowserSessionRequest {
+    /** Optional URL to open when the standalone browser session starts. */
+    url?: string;
     /** Timeout in minutes for the session. Timeout is applied after the session is started. Must be between 5 and 1440. Defaults to 60. */
     timeout?: number;
     /**

--- a/skyvern/client/client.py
+++ b/skyvern/client/client.py
@@ -2135,6 +2135,7 @@ class Skyvern:
     def create_browser_session(
         self,
         *,
+        url: typing.Optional[str] = OMIT,
         timeout: typing.Optional[int] = OMIT,
         proxy_location: typing.Optional[CreateBrowserSessionRequestProxyLocation] = OMIT,
         proxy_session_id: typing.Optional[str] = OMIT,
@@ -2149,6 +2150,9 @@ class Skyvern:
 
         Parameters
         ----------
+        url : typing.Optional[str]
+            Optional URL to open when the standalone browser session starts.
+
         timeout : typing.Optional[int]
             Timeout in minutes for the session. Timeout is applied after the session is started. Must be between 5 and 1440. Defaults to 60.
 
@@ -2222,6 +2226,7 @@ class Skyvern:
         client.create_browser_session()
         """
         _response = self._raw_client.create_browser_session(
+            url=url,
             timeout=timeout,
             proxy_location=proxy_location,
             proxy_session_id=proxy_session_id,
@@ -6285,6 +6290,7 @@ class AsyncSkyvern:
     async def create_browser_session(
         self,
         *,
+        url: typing.Optional[str] = OMIT,
         timeout: typing.Optional[int] = OMIT,
         proxy_location: typing.Optional[CreateBrowserSessionRequestProxyLocation] = OMIT,
         proxy_session_id: typing.Optional[str] = OMIT,
@@ -6299,6 +6305,9 @@ class AsyncSkyvern:
 
         Parameters
         ----------
+        url : typing.Optional[str]
+            Optional URL to open when the standalone browser session starts.
+
         timeout : typing.Optional[int]
             Timeout in minutes for the session. Timeout is applied after the session is started. Must be between 5 and 1440. Defaults to 60.
 
@@ -6380,6 +6389,7 @@ class AsyncSkyvern:
         asyncio.run(main())
         """
         _response = await self._raw_client.create_browser_session(
+            url=url,
             timeout=timeout,
             proxy_location=proxy_location,
             proxy_session_id=proxy_session_id,

--- a/skyvern/client/raw_client.py
+++ b/skyvern/client/raw_client.py
@@ -3193,6 +3193,7 @@ class RawSkyvern:
     def create_browser_session(
         self,
         *,
+        url: typing.Optional[str] = OMIT,
         timeout: typing.Optional[int] = OMIT,
         proxy_location: typing.Optional[CreateBrowserSessionRequestProxyLocation] = OMIT,
         proxy_session_id: typing.Optional[str] = OMIT,
@@ -3207,6 +3208,9 @@ class RawSkyvern:
 
         Parameters
         ----------
+        url : typing.Optional[str]
+            Optional URL to open when the standalone browser session starts.
+
         timeout : typing.Optional[int]
             Timeout in minutes for the session. Timeout is applied after the session is started. Must be between 5 and 1440. Defaults to 60.
 
@@ -3274,6 +3278,7 @@ class RawSkyvern:
             "v1/browser_sessions",
             method="POST",
             json={
+                "url": url,
                 "timeout": timeout,
                 "proxy_location": convert_and_respect_annotation_metadata(
                     object_=proxy_location, annotation=CreateBrowserSessionRequestProxyLocation, direction="write"
@@ -8793,6 +8798,7 @@ class AsyncRawSkyvern:
     async def create_browser_session(
         self,
         *,
+        url: typing.Optional[str] = OMIT,
         timeout: typing.Optional[int] = OMIT,
         proxy_location: typing.Optional[CreateBrowserSessionRequestProxyLocation] = OMIT,
         proxy_session_id: typing.Optional[str] = OMIT,
@@ -8807,6 +8813,9 @@ class AsyncRawSkyvern:
 
         Parameters
         ----------
+        url : typing.Optional[str]
+            Optional URL to open when the standalone browser session starts.
+
         timeout : typing.Optional[int]
             Timeout in minutes for the session. Timeout is applied after the session is started. Must be between 5 and 1440. Defaults to 60.
 
@@ -8874,6 +8883,7 @@ class AsyncRawSkyvern:
             "v1/browser_sessions",
             method="POST",
             json={
+                "url": url,
                 "timeout": timeout,
                 "proxy_location": convert_and_respect_annotation_metadata(
                     object_=proxy_location, annotation=CreateBrowserSessionRequestProxyLocation, direction="write"

--- a/skyvern/forge/sdk/routes/browser_sessions.py
+++ b/skyvern/forge/sdk/routes/browser_sessions.py
@@ -201,6 +201,7 @@ async def create_browser_session(
 
     browser_session = await app.PERSISTENT_SESSIONS_MANAGER.create_session(
         organization_id=current_org.organization_id,
+        url=browser_session_request.url,
         timeout_minutes=browser_session_request.timeout,
         proxy_location=proxy_location,
         proxy_session_id=proxy_session_id,

--- a/skyvern/schemas/browser_sessions.py
+++ b/skyvern/schemas/browser_sessions.py
@@ -7,6 +7,7 @@ from skyvern.schemas.docs.doc_strings import PROXY_LOCATION_DOC_STRING
 from skyvern.schemas.proxy_pinning import validate_proxy_session_id
 from skyvern.schemas.runs import GeoTarget, ProxyLocationInput
 from skyvern.services.browser_recording.types import RecordingDraftStep
+from skyvern.utils.url_validators import validate_url
 
 MIN_TIMEOUT = 5
 MAX_TIMEOUT = 60 * 24  # 24 hours
@@ -14,6 +15,18 @@ DEFAULT_TIMEOUT = 60
 
 
 class CreateBrowserSessionRequest(BaseModel):
+    url: str | None = Field(
+        default=None,
+        description="Optional URL to open when the standalone browser session starts.",
+    )
+
+    @field_validator("url")
+    @classmethod
+    def validate_start_url(cls, value: str | None) -> str | None:
+        if not value:
+            return value
+        return validate_url(value)
+
     timeout: int | None = Field(
         default=DEFAULT_TIMEOUT,
         description=f"Timeout in minutes for the session. Timeout is applied after the session is started. Must be between {MIN_TIMEOUT} and {MAX_TIMEOUT}. Defaults to {DEFAULT_TIMEOUT}.",

--- a/tests/unit/test_browser_session_profile_export_gate.py
+++ b/tests/unit/test_browser_session_profile_export_gate.py
@@ -1,5 +1,11 @@
 from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+from skyvern.exceptions import SkyvernHTTPException
+from skyvern.forge.sdk.routes import browser_sessions as browser_sessions_mod
 from skyvern.forge.sdk.schemas.persistent_browser_sessions import (
     PersistentBrowserSession,
     export_profile_storage_id,
@@ -36,6 +42,53 @@ def test_should_export_profile_always_true_when_reusing_a_profile() -> None:
 
 def test_create_request_defaults_to_opt_out() -> None:
     assert CreateBrowserSessionRequest().generate_browser_profile is False
+
+
+def test_create_request_accepts_start_url() -> None:
+    request = CreateBrowserSessionRequest(url="https://example.com/path", generate_browser_profile=True)
+
+    assert request.url == "https://example.com/path"
+
+
+def test_create_request_rejects_invalid_start_url() -> None:
+    with pytest.raises(SkyvernHTTPException):
+        CreateBrowserSessionRequest(url="ftp://example.com")
+
+
+@pytest.mark.asyncio
+async def test_create_browser_session_passes_start_url_to_session_manager() -> None:
+    created_session = SimpleNamespace(persistent_browser_session_id="pbs_1")
+    response = SimpleNamespace(browser_session_id="pbs_1")
+    app_mock = MagicMock()
+    app_mock.PERSISTENT_SESSIONS_MANAGER.create_session = AsyncMock(return_value=created_session)
+    from_browser_session = AsyncMock(return_value=response)
+
+    with (
+        patch.object(browser_sessions_mod, "app", app_mock),
+        patch.object(browser_sessions_mod.BrowserSessionResponse, "from_browser_session", from_browser_session),
+    ):
+        result = await browser_sessions_mod.create_browser_session(
+            CreateBrowserSessionRequest(
+                url="https://example.com/login",
+                timeout=120,
+                generate_browser_profile=True,
+            ),
+            current_org=SimpleNamespace(organization_id="org_1"),
+        )
+
+    assert result is response
+    app_mock.PERSISTENT_SESSIONS_MANAGER.create_session.assert_awaited_once_with(
+        organization_id="org_1",
+        url="https://example.com/login",
+        timeout_minutes=120,
+        proxy_location=None,
+        proxy_session_id=None,
+        extensions=None,
+        browser_type=None,
+        browser_profile_id=None,
+        generate_browser_profile=True,
+    )
+    from_browser_session.assert_awaited_once_with(created_session)
 
 
 def test_update_request_carries_flag() -> None:


### PR DESCRIPTION
# [Browser Sessions] Add optional start URL to CreateBrowserSessionRequest

Closes #7028 

## Summary

This PR adds an optional `url` parameter to `CreateBrowserSessionRequest`, enabling users to specify a target URL to automatically navigate to when a standalone browser session initializes.

---

## Detailed Description of Changes

### 1. Schema & Validation (`skyvern/schemas/browser_sessions.py`)
- Added optional `url: str | None = Field(default=None, ...)` to `CreateBrowserSessionRequest`.
- Implemented a `@field_validator("url")` using `validate_url` to ensure any provided URL is valid prior to session creation.

### 2. Route & Service Layer (`skyvern/forge/sdk/routes/browser_sessions.py`)
- Updated the `create_browser_session` endpoint handler to pass `url=browser_session_request.url` directly to `PERSISTENT_SESSIONS_MANAGER.create_session(...)`.

### 3. Generated SDK Clients (`skyvern/client/`)
- Updated `Skyvern`, `AsyncSkyvern`, `RawSkyvern`, and `AsyncRawSkyvern` client implementations to accept optional `url` in `create_browser_session(...)`.
- Updated TypeScript SDK types in `skyvern-ts/src/client/requests/CreateBrowserSessionRequest.ts`.

### 4. API Docs & OpenAPI Specifications (`docs/`, `fern/`)
- Updated `openapi.json` specs and Fern documentation (`create-browser-session.mdx` & `introduction.mdx`) with parameter descriptions and usage examples.

### 5. Unit Tests (`tests/unit/test_browser_session_profile_export_gate.py`)
- Added `test_create_request_accepts_start_url()` to verify valid URLs are parsed into request schemas.
- Added `test_create_request_rejects_invalid_start_url()` to verify non-HTTP/invalid URLs raise `SkyvernHTTPException`.
- Added `test_create_browser_session_passes_start_url_to_session_manager()` to verify end-to-end parameter passing to `PERSISTENT_SESSIONS_MANAGER`.

---

## PR Checklist

- [x] Python 3.11+ type hints and standard formatting followed
- [x] Added unit tests for URL validation and route invocation
- [x] OpenAPI schema and Fern docs updated
- [x] Pre-commit quality checks passed