### PR TITLE
test: loosen wall-clock tolerances in download handler tests (CI flake)

### DIFF
--- a/tests/unit/test_download_file_action_handler.py
+++ b/tests/unit/test_download_file_action_handler.py
@@ -781,10 +781,12 @@ async def test_handle_action_timeout_bounds_browser_download_handler_drain(
                         page=page,
                         action=action,
                     ),
-                    timeout=0.5,
+                    timeout=5,
                 )
 
-        assert time.monotonic() - started_at < 0.2
+        # Keep this loose for shared CI-runner jitter while still proving the
+        # handler deadline fires well before the 5s wait_for safety net.
+        assert time.monotonic() - started_at < 1.0
         assert not interceptor._browser_download_tasks
 
 
@@ -2322,7 +2324,8 @@ async def test_handle_action_download_in_flight_request_does_not_extend_custom_t
             )
         elapsed = time.monotonic() - started_at
 
-    assert elapsed < 0.1
+    # Keep wall-clock bounds loose to tolerate scheduling jitter on shared CI runners.
+    assert elapsed < 0.5
     assert results[-1].download_triggered is False
     assert action.download_triggered is False
     span_attrs = _download_wait_span_attrs(span_exporter)


### PR DESCRIPTION
## Summary

- loosen the two remaining tight wall-clock upper bounds in `test_download_file_action_handler.py`
- keep the behavioral assertions intact, including the custom-timeout telemetry checks and browser-download task cleanup
- preserve the "handler deadline finishes well before the safety net" ordering with a 1-second guard and a 5-second outer safety timeout

## Why

Shared CI runners can pause these async tests long enough to violate sub-200ms wall-clock assertions even though the timeout behavior is correct:

- [run 29945960477](https://github.com/Skyvern-AI/skyvern/actions/runs/29945960477): the `< 0.2` drain bound observed 0.214 seconds
- [run 29956252756](https://github.com/Skyvern-AI/skyvern/actions/runs/29956252756): the `< 0.1` custom-timeout bound observed 0.181 seconds

The new 1.0-second and 0.5-second guards remain bounded runaway checks while allowing ordinary CI-runner scheduling jitter. Comments next to each bound document that intent.

## Testing

- `for i in 1 2 3 4 5; do uv run pytest tests/unit/test_download_file_action_handler.py -q || break; done` (5/5 passed, 79 tests per run)
- `uv run pre-commit run --all-files`