### PR TITLE
fix: make unique step counting SQLite-compatible

### DIFF
--- a/skyvern/forge/sdk/db/repositories/tasks.py
+++ b/skyvern/forge/sdk/db/repositories/tasks.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 from typing import Any, Sequence
 
 import structlog
-from sqlalchemy import and_, delete, distinct, func, select, tuple_, update
+from sqlalchemy import and_, delete, func, select, update
 
 from skyvern.forge.sdk.db._error_handling import db_operation
 from skyvern.forge.sdk.db.base_alchemy_db import read_retry
@@ -300,18 +300,17 @@ class TasksRepository(BaseRepository):
         task_ids: list[str],
         organization_id: str,
     ) -> int:
-        """
-        Get the total count of unique (step.task_id, step.order) pairs of StepModel for the given task ids
-        Basically translate this sql query into a SQLAlchemy query: select count(distinct(s.task_id, s.order)) from steps s
-        where s.task_id in task_ids
-        """
+        """Count unique ``(task_id, order)`` pairs for the given tasks."""
         async with self.Session() as session:
-            query = (
-                select(func.count(distinct(tuple_(StepModel.task_id, StepModel.order))))
+            distinct_steps = (
+                select(StepModel.task_id, StepModel.order)
                 .where(StepModel.task_id.in_(task_ids))
                 .where(StepModel.organization_id == organization_id)
+                .distinct()
+                .subquery()
             )
-            return (await session.execute(query)).scalar()
+            query = select(func.count()).select_from(distinct_steps)
+            return (await session.execute(query)).scalar_one()
 
     @db_operation("get_task_step_models")
     async def get_task_step_models(self, task_id: str, organization_id: str | None = None) -> Sequence[StepModel]:

--- a/tests/unit/forge/sdk/db/test_tasks_repository.py
+++ b/tests/unit/forge/sdk/db/test_tasks_repository.py
@@ -1,0 +1,61 @@
+"""TasksRepository tests against the default SQLite backend."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from skyvern.forge.sdk.db.base_alchemy_db import BaseAlchemyDB
+from skyvern.forge.sdk.db.models import OrganizationModel, StepModel, TaskModel
+from skyvern.forge.sdk.db.repositories.tasks import TasksRepository
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_unique_step_order_count_supports_sqlite(sqlite_engine: AsyncEngine) -> None:
+    database = BaseAlchemyDB(sqlite_engine)
+    repository = TasksRepository(database.Session, debug_enabled=False)
+
+    async with repository.Session() as session:
+        session.add_all(
+            [
+                OrganizationModel(organization_id="org_test", organization_name="Test"),
+                OrganizationModel(organization_id="org_other", organization_name="Other"),
+            ]
+        )
+        session.add_all(
+            [
+                TaskModel(task_id="task_a", organization_id="org_test"),
+                TaskModel(task_id="task_b", organization_id="org_test"),
+                TaskModel(task_id="task_not_requested", organization_id="org_test"),
+                TaskModel(task_id="task_other_org", organization_id="org_other"),
+            ]
+        )
+        session.add_all(
+            [
+                StepModel(step_id="step_a_0", organization_id="org_test", task_id="task_a", order=0),
+                StepModel(step_id="step_a_0_retry", organization_id="org_test", task_id="task_a", order=0),
+                StepModel(step_id="step_a_1", organization_id="org_test", task_id="task_a", order=1),
+                StepModel(step_id="step_b_0", organization_id="org_test", task_id="task_b", order=0),
+                StepModel(
+                    step_id="step_not_requested",
+                    organization_id="org_test",
+                    task_id="task_not_requested",
+                    order=0,
+                ),
+                StepModel(
+                    step_id="step_other_org",
+                    organization_id="org_other",
+                    task_id="task_other_org",
+                    order=0,
+                ),
+            ]
+        )
+        await session.commit()
+
+    count = await repository.get_total_unique_step_order_count_by_task_ids(
+        task_ids=["task_a", "task_b"],
+        organization_id="org_test",
+    )
+
+    assert count == 3


### PR DESCRIPTION
## Description

Fixes #7763 by replacing the PostgreSQL-specific `COUNT(DISTINCT (task_id, order))` expression with a portable `COUNT(*)` over a `SELECT DISTINCT` subquery.

The two commits preserve the red/green progression:

1. Add a SQLite regression test covering duplicate retries, multiple task IDs, task filtering, and organization scoping.
2. Update the query so the same test passes on SQLite while preserving the existing count semantics.

Fixes #7763

## How Has This Been Tested?

```bash
uv run pytest tests/unit/forge/sdk/db/test_tasks_repository.py -q
uv run ruff check skyvern/forge/sdk/db/repositories/tasks.py tests/unit/forge/sdk/db/test_tasks_repository.py
uv run ruff format --check skyvern/forge/sdk/db/repositories/tasks.py tests/unit/forge/sdk/db/test_tasks_repository.py
```

Before the fix, the regression test failed with:

```text
sqlite3.OperationalError: row value misused
1 failed
```

After the fix:

```text
1 passed
All checks passed!
2 files already formatted
```

## Artifacts (if appropriate):

[Failing CI run on the regression-test commit](https://github.com/Skyvern-AI/skyvern/actions/runs/30729222948/job/91446371835)
