### PR TITLE
Bump version to 1.0.48

### DIFF
--- a/packages/skyvern-ui/pyproject.toml
+++ b/packages/skyvern-ui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skyvern-ui"
-version = "1.0.47"
+version = "1.0.48"
 description = "Prebuilt Skyvern UI assets for the Skyvern CLI"
 authors = [{ name = "Skyvern AI", email = "info@skyvern.com" }]
 requires-python = ">=3.11,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skyvern"
-version = "1.0.47"
+version = "1.0.48"
 description = ""
 authors = [{ name = "Skyvern AI", email = "info@skyvern.com" }]
 requires-python = ">=3.11,<3.14"

--- a/skyvern-ts/client/package-lock.json
+++ b/skyvern-ts/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@skyvern/client",
-    "version": "1.0.47",
+    "version": "1.0.48",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@skyvern/client",
-            "version": "1.0.47",
+            "version": "1.0.48",
             "dependencies": {
                 "playwright": "^1.48.0"
             },

--- a/skyvern-ts/client/package.json
+++ b/skyvern-ts/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@skyvern/client",
-    "version": "1.0.47",
+    "version": "1.0.48",
     "private": false,
     "repository": {
         "type": "git",

--- a/uv.lock
+++ b/uv.lock
@@ -5877,7 +5877,7 @@ wheels = [
 
 [[package]]
 name = "skyvern"
-version = "1.0.47"
+version = "1.0.48"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary
Version-only bump of the Skyvern OSS version to **1.0.48**. No SDK regeneration — `skyvern/client` and `skyvern-ts/client/src` are untouched.

## Changes
- `pyproject.toml` — `1.0.47` → `1.0.48`
- `packages/skyvern-ui/pyproject.toml` — `1.0.47` → `1.0.48`
- `uv.lock` — `skyvern` editable entry `1.0.47` → `1.0.48`
- `skyvern-ts/client/package.json` — `1.0.47` → `1.0.48`
- `skyvern-ts/client/package-lock.json` — root + `packages[""]` `1.0.47` → `1.0.48`

## Note
`fern/openapi/skyvern_openapi.json` has drifted since v1.0.47; this bump intentionally does **not** regenerate the SDKs, so those spec changes are not reflected in the 1.0.48 client. A future Fern regen will fold them in.

## Deployment
On merge, GitHub Actions publishes the Python package to PyPI and the TS client to NPM; the skyvern-ui Docker image builds on GitHub Release publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)