### PR TITLE
Fix docs canonical base: Mintlify drops the /docs hosting prefix from page paths

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -396,7 +396,7 @@
   "seo": {
     "indexing": "navigable",
     "metatags": {
-      "canonical": "https://www.skyvern.com"
+      "canonical": "https://www.skyvern.com/docs"
     }
   },
   "css": "/style.css",


### PR DESCRIPTION
Surgical extract of the docs.json one-liner from sync PR #8170, which is conflicted (post-#8169) and blocked by unrelated bundled copilot changes. Content is byte-identical to skyvern-cloud main (source of truth, merged there as Skyvern-AI/skyvern-cloud#14796 after review), so the sync replay for this file converges to an empty diff.

**Why urgent:** the currently-deployed Mintlify build emits canonicals that drop the /docs hosting prefix — every nested docs page canonicalizes to a non-existent landing-page URL (e.g. `www.skyvern.com/api-reference/...`). Setting the base to `https://www.skyvern.com/docs` re-derives correct canonicals under Mintlify's observed base+internal-path semantics. Full evidence in Skyvern-AI/skyvern-cloud#14796.

SKY-13481.