### PR TITLE
Revert the OSS-only credential draft-binding guard (SKY-13552)

### DIFF
--- a/skyvern/forge/sdk/copilot/output_policy.py
+++ b/skyvern/forge/sdk/copilot/output_policy.py
@@ -1005,11 +1005,11 @@ def _bound_approved_credential_ids(request_policy: RequestPolicy, workflow_yaml:
 
 
 def _allowed_unresolved_credential_ids(request_policy: RequestPolicy) -> set[str]:
-    # invalid_credential_ids is negation-filtered and affirmative; credential_refs is not — a
-    # model-carried or negated ref must not become draft-bindable (SKY-13552).
     if not request_policy.allow_missing_credentials_in_draft:
         return set()
-    return set(request_policy.invalid_credential_ids)
+    ids = set(request_policy.invalid_credential_ids)
+    ids.update(ref for ref in request_policy.credential_refs if isinstance(ref, str) and ref.startswith("cred_"))
+    return ids
 
 
 def _existing_workflow_credential_ids(request_policy: RequestPolicy) -> set[str]:

--- a/tests/unit/test_copilot_output_policy.py
+++ b/tests/unit/test_copilot_output_policy.py
@@ -1240,24 +1240,6 @@ def test_allows_explicit_unresolved_credential_id_for_untested_draft() -> None:
     assert verdict.allowed
 
 
-def test_rejects_credential_ref_the_user_did_not_state_even_for_untested_draft() -> None:
-    """A cred_ ref carried only in credential_refs (model-authored or negated) is not draft-bindable (SKY-13552)."""
-    verdict = evaluate_output_policy(
-        request_policy=_policy(
-            resolved_credentials=[],
-            credential_input_kind="credential_id",
-            credential_refs=["cred_carried"],
-            invalid_credential_ids=[],
-            allow_missing_credentials_in_draft=True,
-            allow_run_blocks=False,
-        ),
-        workflow_yaml=_workflow_yaml().replace("cred_safe", "cred_carried"),
-    )
-
-    assert not verdict.allowed
-    assert OutputPolicyReason.UNAPPROVED_CREDENTIAL_REFERENCE in verdict.reason_codes
-
-
 def test_rejects_unrequested_credential_id_even_when_untested_draft_allows_missing_credentials() -> None:
     verdict = evaluate_output_policy(
         request_policy=_policy(


### PR DESCRIPTION
## Use case

A user pastes a saved credential ID into the copilot and asks it to log in. The copilot should be able to save a draft workflow that references that credential even before the credential is fully resolved. Today the OSS copy of the check that permits this differs from cloud, so every mirrored PR shows the difference as a revert and needs hand-patching (#8091, #8092, #8093, #8181).

```mermaid
flowchart LR
    U["User pastes cred_ ID"] --> S["Message scan"]
    S --> G["Draft-binding check"]
    G --> D["Draft saved with credential"]
```

## Solution

Revert ab3744a62 so OSS matches cloud. The reverted version is inert and blocks the wrong thing.

**Before** — the check returns only `invalid_credential_ids`, a field nothing has ever written to in either repo and which was never in the classifier's prompt schema. It always yields an empty set, so `allow_missing_credentials_in_draft` (six real writers) becomes a no-op and no unresolved credential can be referenced in a draft.

```mermaid
flowchart LR
    U["User pastes cred_ ID"] --> S["Message scan"]
    S --> G["Draft-binding check"]
    G -->|"reads invalid_credential_ids<br/>(no writer, always empty)"| X["Draft rejected"]
```

**After** — the check also admits `cred_` entries the scan found, so an ID the user typed is bindable. The guard's stated threat was a model-authored `credential_refs`; that was real before the RequestPolicy classifier was removed (#14737 / ADR-0024), but the field is now a deterministic scan of the user's literal message.

```mermaid
flowchart LR
    U["User pastes cred_ ID"] --> S["Message scan"]
    S --> G["Draft-binding check"]
    G -->|"reads invalid_credential_ids<br/>+ scanned cred_ refs"| D["Draft saved with credential"]
```

## How Has This Been Tested?

`.venv/bin/python -m pytest tests/unit/test_copilot_output_policy.py -q` → 277 passed.

The function is now byte-identical to `Skyvern-AI/skyvern-cloud@main`, so mirrored PRs stop showing a spurious diff here.

## Artifacts (if appropriate):

Not applicable — backend-only, no user-visible surface.
