### PR TITLE
Fix the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,4 +593,4 @@ If you have any questions or concerns around licensing, please [contact us](mail
 
 # Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Skyvern-AI/skyvern&type=Date)](https://star-history.com/#Skyvern-AI/skyvern&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Skyvern-AI/skyvern&type=Date)](https://star-history.dera.page/#Skyvern-AI/skyvern&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken because the underlying service is subject to GitHub stargazer API restrictions. This change points the chart at star-history.dera.page, an alternative that uses a different data source requiring no API token, so the chart renders again.