### PR TITLE
Add TrustedRouter as a built-in LLM provider

### DIFF
--- a/docs/developers/self-hosted/llm-configuration.mdx
+++ b/docs/developers/self-hosted/llm-configuration.mdx
@@ -532,6 +532,31 @@ OPENROUTER_MODEL=mistralai/mistral-small-3.1-24b-instruct
 
 ---
 
+## TrustedRouter
+
+Access multiple models through a single API at [trustedrouter.com](https://trustedrouter.com/), with per-request routing and failover.
+
+```bash .env
+ENABLE_TRUSTEDROUTER=true
+LLM_KEY=TRUSTEDROUTER
+TRUSTEDROUTER_API_KEY=sk-tr-...
+TRUSTEDROUTER_MODEL=trustedrouter/auto
+```
+
+Model ids are namespaced — `anthropic/claude-opus-4-7` works, a bare `claude-opus-4-7` is rejected. Ids under `trustedrouter/` are routing policies rather than single models: each picks an upstream per request and fails over.
+
+| Model | Picks for |
+| ----- | --------- |
+| `trustedrouter/auto` | Capability, with failover |
+| `trustedrouter/fast` | Latency |
+| `trustedrouter/cheap` | Cost |
+| `trustedrouter/zdr` | Providers that retain no data |
+| `trustedrouter/e2e` | Confidential-compute providers |
+
+`zdr` and `e2e` constrain which upstreams may serve a request at all — relevant for Skyvern, since page content and screenshots go into these prompts.
+
+---
+
 ## Groq
 
 Inference on open-source models at [groq.com](https://groq.com/).

--- a/skyvern/config.py
+++ b/skyvern/config.py
@@ -633,6 +633,12 @@ class Settings(BaseSettings):
     OPENROUTER_MODEL: str | None = None
     OPENROUTER_API_BASE: str = "https://openrouter.ai/api/v1"
 
+    # TRUSTEDROUTER
+    ENABLE_TRUSTEDROUTER: bool = False
+    TRUSTEDROUTER_API_KEY: str | None = None
+    TRUSTEDROUTER_MODEL: str | None = None
+    TRUSTEDROUTER_API_BASE: str = "https://api.trustedrouter.com/v1"
+
     # GROQ
     ENABLE_GROQ: bool = False
     GROQ_API_KEY: str | None = None

--- a/skyvern/forge/sdk/api/llm/config_registry.py
+++ b/skyvern/forge/sdk/api/llm/config_registry.py
@@ -2278,6 +2278,33 @@ if settings.ENABLE_OLLAMA:
             ),
         )
 
+if settings.ENABLE_TRUSTEDROUTER:
+    # Register TrustedRouter model configured in settings.
+    #
+    # Dispatched through litellm's openai provider with an explicit api_base rather
+    # than a "trustedrouter/" prefix: litellm strips the first path segment as the
+    # provider, and TrustedRouter model ids are namespaced ("anthropic/claude-opus-4-7",
+    # "trustedrouter/auto"), so a prefixed id would reach the API with its namespace
+    # removed and be rejected.
+    if settings.TRUSTEDROUTER_MODEL:
+        trustedrouter_model_name = settings.TRUSTEDROUTER_MODEL
+        LLMConfigRegistry.register_config(
+            "TRUSTEDROUTER",
+            LLMConfig(
+                f"openai/{trustedrouter_model_name}",
+                ["TRUSTEDROUTER_API_KEY", "TRUSTEDROUTER_MODEL"],
+                supports_vision=settings.LLM_CONFIG_SUPPORT_VISION,
+                add_assistant_prefix=False,
+                max_completion_tokens=settings.LLM_CONFIG_MAX_TOKENS,
+                litellm_params=LiteLLMParams(
+                    api_key=settings.TRUSTEDROUTER_API_KEY,
+                    api_base=settings.TRUSTEDROUTER_API_BASE,
+                    api_version=None,
+                    model_info={"model_name": f"openai/{trustedrouter_model_name}"},
+                ),
+            ),
+        )
+
 if settings.ENABLE_OPENROUTER:
     # Register OpenRouter model configured in settings
     if settings.OPENROUTER_MODEL:


### PR DESCRIPTION
Adds TrustedRouter as a built-in LLM provider, mirroring the `ENABLE_OPENROUTER` block: settings in `config.py`, a registration in `config_registry.py`, and a docs section.

**The one non-obvious bit.** OpenRouter registers as `openrouter/{model}`, but TrustedRouter must *not* use a `trustedrouter/` prefix. litellm strips the first path segment as the provider name, and TrustedRouter model ids are namespaced — `anthropic/claude-opus-4-7`, `trustedrouter/auto`. A prefixed id would reach the API with its namespace removed and be rejected.

So this registers `openai/{model}` with an explicit `api_base`, which is the same shape `_litellm_model_name` already uses for `CustomLLMProvider.OPENAI_COMPATIBLE` — that path only strips a literal `openai/` prefix, so the namespace survives.

**Scope note:** I did not add a `CustomLLMProvider.TRUSTEDROUTER` enum member. TrustedRouter already works through the existing `openai_compatible` option by setting `api_base`, and a dedicated member would ripple into the generated client types (`skyvern/client/types/`, `skyvern-ts/`) for no functional gain. Happy to add it if you'd rather it appear as its own choice in the custom-LLM UI.

Verified both changed modules parse. I did not run the suite end-to-end — it needs Postgres and a browser stack — so the change is deliberately confined to the same shape as the existing OpenRouter registration.
