### PR TITLE
Bump version to 1.0.49

### DIFF
--- a/packages/skyvern-ui/pyproject.toml
+++ b/packages/skyvern-ui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skyvern-ui"
-version = "1.0.48"
+version = "1.0.49"
 description = "Prebuilt Skyvern UI assets for the Skyvern CLI"
 authors = [{ name = "Skyvern AI", email = "info@skyvern.com" }]
 requires-python = ">=3.11,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skyvern"
-version = "1.0.48"
+version = "1.0.49"
 description = ""
 authors = [{ name = "Skyvern AI", email = "info@skyvern.com" }]
 requires-python = ">=3.11,<3.15"

--- a/skyvern-ts/client/package-lock.json
+++ b/skyvern-ts/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@skyvern/client",
-    "version": "1.0.48",
+    "version": "1.0.49",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@skyvern/client",
-            "version": "1.0.48",
+            "version": "1.0.49",
             "dependencies": {
                 "playwright": "^1.48.0"
             },

--- a/skyvern-ts/client/package.json
+++ b/skyvern-ts/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@skyvern/client",
-    "version": "1.0.48",
+    "version": "1.0.49",
     "private": false,
     "repository": {
         "type": "git",

--- a/uv.lock
+++ b/uv.lock
@@ -6716,7 +6716,7 @@ wheels = [
 
 [[package]]
 name = "skyvern"
-version = "1.0.48"
+version = "1.0.49"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
## Summary
Bump Skyvern OSS version to 1.0.49. Version-only release — no code changes.

## Changes
- `pyproject.toml`
- `packages/skyvern-ui/pyproject.toml`
- `uv.lock` (the `skyvern` package entry)
- `skyvern-ts/client/package.json`
- `skyvern-ts/client/package-lock.json` (root + `packages[""]`)

No Fern SDK regeneration: `fern/openapi/` is byte-identical to 1.0.48, so the generated Python/TS clients are unchanged.

## Deployment
After merge, GitHub Actions will automatically:
- Publish the Python package to PyPI
- Publish `@skyvern/client` to NPM
- Build the `skyvern-ui` Docker image on GitHub Release publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)