### PR TITLE
Bump version to 1.0.51

### DIFF
--- a/packages/skyvern-ui/pyproject.toml
+++ b/packages/skyvern-ui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skyvern-ui"
-version = "1.0.50"
+version = "1.0.51"
 description = "Prebuilt Skyvern UI assets for the Skyvern CLI"
 authors = [{ name = "Skyvern AI", email = "info@skyvern.com" }]
 requires-python = ">=3.11,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skyvern"
-version = "1.0.50"
+version = "1.0.51"
 description = ""
 authors = [{ name = "Skyvern AI", email = "info@skyvern.com" }]
 requires-python = ">=3.11,<3.15"

--- a/skyvern-ts/client/package-lock.json
+++ b/skyvern-ts/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@skyvern/client",
-    "version": "1.0.50",
+    "version": "1.0.51",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@skyvern/client",
-            "version": "1.0.50",
+            "version": "1.0.51",
             "dependencies": {
                 "playwright": "^1.48.0"
             },

--- a/skyvern-ts/client/package.json
+++ b/skyvern-ts/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@skyvern/client",
-    "version": "1.0.50",
+    "version": "1.0.51",
     "private": false,
     "repository": {
         "type": "git",

--- a/uv.lock
+++ b/uv.lock
@@ -6790,7 +6790,7 @@ wheels = [
 
 [[package]]
 name = "skyvern"
-version = "1.0.50"
+version = "1.0.51"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },


### PR DESCRIPTION
Version-only bump from 1.0.50 → 1.0.51. No code changes.

`fern/openapi/` is unchanged since the last release, so no SDK regeneration was needed — only the version fields were touched:

- `pyproject.toml`
- `packages/skyvern-ui/pyproject.toml`
- `uv.lock` (the `name = "skyvern"` entry)
- `skyvern-ts/client/package.json`
- `skyvern-ts/client/package-lock.json` (root `version` and `packages[""].version`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)