### PR TITLE
Let AES decrypt read both salt/IV normalizations, and annotate the md5 calls

### DIFF
--- a/skyvern/forge/sdk/encrypt/aes.py
+++ b/skyvern/forge/sdk/encrypt/aes.py
@@ -1,5 +1,6 @@
 import base64
 import hashlib
+from collections.abc import Iterable
 
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
@@ -7,19 +8,18 @@ from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 from skyvern.forge.sdk.encrypt.base import BaseEncryptor, EncryptMethod
 
-# The public defaults and fallback parameters retain the legacy MD5 normalization so
-# existing ciphertext remains decryptable. New ciphertext configured with an explicit
-# salt and IV uses SHA-256 normalization instead.
+# md5 normalizes a string to 16 bytes here and is not asked to supply a security
+# property. Every input is either a fixed public constant below or a 256-bit
+# HMAC-SHA256 digest from bootstrap.py, so what makes a derived salt/IV unguessable
+# is the secrecy of that input, not md5's collision resistance.
 #
-# The SHA-derived IV remains deterministic, matching the persisted ciphertext format.
-# A future authenticated-encryption migration can introduce random nonces stored with
-# each ciphertext; that requires a versioned payload and is separate from removing MD5
-# from the primary encryption path here.
-#
-# Fallback candidates are decrypt-only. They let deployments read values written before
-# this normalization change and naturally age out as those values are rewritten through
-# the primary path.
-default_iv = hashlib.md5(b"deterministic_iv_0123456789").digest()
+# The IV path does carry a real weakness, and it is not the hash: the IV is
+# deterministic — one per deployment rather than one per message — which costs
+# AES-CBC its semantic security. Fixing that needs random IVs carried in a
+# versioned payload, and it is staged rather than done here because every running
+# instance must be able to *read* the new format before any instance starts
+# *writing* it. This change is that read step.
+default_iv = hashlib.md5(b"deterministic_iv_0123456789", usedforsecurity=False).digest()
 default_salt = hashlib.md5(b"deterministic_salt_0123456789", usedforsecurity=False).digest()
 
 
@@ -30,28 +30,46 @@ class AES(BaseEncryptor):
         secret_key: str,
         salt: str | None = None,
         iv: str | None = None,
-        fallback_decrypt_keys: list[tuple[str | None, str | None]] | None = None,
+        fallback_decrypt_keys: Iterable[tuple[str | None, str | None]] | None = None,
     ) -> None:
         self.secret_key = hashlib.md5(secret_key.encode("utf-8"), usedforsecurity=False).digest()
-        self.salt = hashlib.sha256(salt.encode("utf-8")).digest() if salt else default_salt
-        self.iv = hashlib.sha256(iv.encode("utf-8")).digest()[:16] if iv else default_iv
-        self._fallback_decrypt_params: list[tuple[bytes, bytes]] = [
-            (
-                hashlib.sha256(fb_salt.encode("utf-8")).digest() if fb_salt else default_salt,
-                hashlib.sha256(fb_iv.encode("utf-8")).digest()[:16] if fb_iv else default_iv,
-            )
-            for fb_salt, fb_iv in (fallback_decrypt_keys or [])
-        ]
-        self._fallback_decrypt_params.extend(
-            (
-                hashlib.md5(fb_salt.encode("utf-8"), usedforsecurity=False).digest() if fb_salt else default_salt,
-                hashlib.md5(fb_iv.encode("utf-8")).digest() if fb_iv else default_iv,
-            )
-            for fb_salt, fb_iv in (fallback_decrypt_keys or [])
-        )
+        self.salt, self.iv = self._encryption_params(salt, iv)
+        self._fallback_decrypt_params = self._decrypt_fallbacks((self.salt, self.iv), salt, iv, fallback_decrypt_keys)
 
     def method(self) -> EncryptMethod:
         return EncryptMethod.AES
+
+    @staticmethod
+    def _encryption_params(salt: str | None, iv: str | None) -> tuple[bytes, bytes]:
+        return (
+            hashlib.md5(salt.encode("utf-8"), usedforsecurity=False).digest() if salt else default_salt,
+            hashlib.md5(iv.encode("utf-8"), usedforsecurity=False).digest() if iv else default_iv,
+        )
+
+    @staticmethod
+    def _sha256_params(salt: str | None, iv: str | None) -> tuple[bytes, bytes]:
+        # Decrypt-only. Open-source releases normalized salt/IV with sha256 for a
+        # window, so a deployment upgrading from one of those has stored ciphertext
+        # only these parameters can open.
+        return (
+            hashlib.sha256(salt.encode("utf-8")).digest() if salt else default_salt,
+            hashlib.sha256(iv.encode("utf-8")).digest()[:16] if iv else default_iv,
+        )
+
+    @classmethod
+    def _decrypt_fallbacks(
+        cls,
+        primary: tuple[bytes, bytes],
+        salt: str | None,
+        iv: str | None,
+        fallback_decrypt_keys: Iterable[tuple[str | None, str | None]] | None,
+    ) -> list[tuple[bytes, bytes]]:
+        candidates: list[tuple[bytes, bytes]] = []
+        for pair_salt, pair_iv in [(salt, iv), *(fallback_decrypt_keys or [])]:
+            for params in (cls._encryption_params(pair_salt, pair_iv), cls._sha256_params(pair_salt, pair_iv)):
+                if params != primary and params not in candidates:
+                    candidates.append(params)
+        return candidates
 
     def _derive_key(self, salt: bytes | None = None) -> bytes:
         kdf = PBKDF2HMAC(

--- a/tests/unit/test_aes_fallback_decrypt.py
+++ b/tests/unit/test_aes_fallback_decrypt.py
@@ -1,3 +1,5 @@
+import hashlib
+
 import pytest
 
 from skyvern.forge.sdk.encrypt.aes import AES
@@ -84,3 +86,30 @@ async def test_decrypt_tries_multiple_fallbacks_in_order() -> None:
         ],
     )
     assert await aes.decrypt(ciphertext) == "third match"
+
+
+@pytest.mark.asyncio
+async def test_decrypt_reads_sha256_normalized_ciphertext() -> None:
+    # Open-source releases normalized salt/IV with sha256 for a window. A deployment
+    # upgrading off one of those has stored ciphertext that only those parameters open.
+    writer = AES(secret_key=SECRET, salt=PRIMARY_SALT, iv=PRIMARY_IV)
+    writer.salt = hashlib.sha256(PRIMARY_SALT.encode("utf-8")).digest()
+    writer.iv = hashlib.sha256(PRIMARY_IV.encode("utf-8")).digest()[:16]
+    ciphertext = await writer.encrypt("sha normalized")
+
+    assert await AES(secret_key=SECRET, salt=PRIMARY_SALT, iv=PRIMARY_IV).decrypt(ciphertext) == "sha normalized"
+
+
+@pytest.mark.asyncio
+async def test_encrypt_output_still_opens_with_md5_parameters_alone() -> None:
+    # Guards the rollback path: a release that knows only md5 normalization has to be
+    # able to read anything this code writes, so encrypt must not move off md5 yet.
+    ciphertext = await AES(secret_key=SECRET, salt=PRIMARY_SALT, iv=PRIMARY_IV).encrypt("md5 normalized")
+
+    # Derive the reader's parameters here rather than through AES, so this still
+    # fails if the encrypt path moves off md5.
+    md5_only = AES(secret_key=SECRET, salt=PRIMARY_SALT, iv=PRIMARY_IV)
+    md5_only.salt = hashlib.md5(PRIMARY_SALT.encode("utf-8"), usedforsecurity=False).digest()
+    md5_only.iv = hashlib.md5(PRIMARY_IV.encode("utf-8"), usedforsecurity=False).digest()
+    md5_only._fallback_decrypt_params = []
+    assert await md5_only.decrypt(ciphertext) == "md5 normalized"


### PR DESCRIPTION
## Ticket

No Linear ticket. Driven by an Oneleet code-security finding against `skyvern/forge/sdk/encrypt/aes.py` line 48 (high severity), plus its counterpart on line 50 of the sync source.

## Problem

The finding reports `Use of weak MD5 hash for security. Consider usedforsecurity=False`. Two `md5()` calls in this file are missing that annotation — `default_iv` and the fallback IV.

The bigger issue is that **this file has drifted from the repo it is synced from.** This copy normalizes salt/IV with sha256 on the primary path and keeps md5 for decrypt fallbacks; the source copy still uses md5 for both. The sync is a whole-file copy, so the next upstream change that touches `aes.py` overwrites this file — and the source copy has no sha256 decrypt candidates. **Any self-hosted deployment that stored ciphertext under the sha256 normalization would silently lose the ability to decrypt it.** Credentials and org auth tokens go through this path.

That is not a hypothetical: it happens automatically on the next sync that touches this file.

## Solution

Converge both copies on one file that reads every normalization ever written, so the sync becomes a no-op here instead of a data-loss event.

- **Decrypt becomes a superset.** `_decrypt_fallbacks` builds candidates from both the md5 and sha256 normalizations, for the primary pair *and* every configured fallback, deduped and skipping the primary.
- **Every `md5()` call is annotated** `usedforsecurity=False`, with a comment giving the accurate reason: every input is a fixed public constant or a 256-bit HMAC-SHA256 digest from `bootstrap.py`, so what makes a derived salt/IV unguessable is the secrecy of that input, not md5's collision resistance.

**Please read this part before approving.** Converging means this copy's *encrypt* path moves from sha256 back to md5, matching the sync source. Nothing becomes unreadable — sha256 is now a decrypt candidate, so anything already stored still opens, and the rollback direction works too (verified below). But new ciphertext is written with md5-derived parameters again.

That is deliberate and temporary. The constraint is that the sync source cannot change its encrypt path yet: doing so would strand anything written between deploy and a rollback. Moving encrypt is only safe once every running instance can already *read* the target format, which is exactly what this change establishes. The follow-up flips both copies to sha256, and then to random per-message IVs in a versioned payload.

On the IV specifically: md5 is not the weakness there. The IV is **deterministic** — one per deployment rather than one per message — which costs AES-CBC its semantic security. Changing the hash does not fix that; random IVs do.

`bootstrap.py` is intentionally untouched. This copy always inserts the primary pair into the decrypt fallbacks and the source copy only does so when salt and IV are unset; the new `_decrypt_fallbacks` covers the primary pair either way, so the difference no longer matters.

## How Has This Been Tested?

Both upgrade directions were simulated by loading this branch's module and current `main`'s side by side, with explicit salt and IV as `bootstrap.py` supplies them:

- Ciphertext written by current `main` (sha256) → **readable** by this branch.
- Ciphertext written by this branch (md5) → **readable** by current `main`, so a rollback is safe.

Two tests added, both mutation-checked by reverting the mechanism singly:

| Test | Guards | Reverting → |
| --- | --- | --- |
| `test_decrypt_reads_sha256_normalized_ciphertext` | upgrading off a sha256-normalizing release | drop the sha256 candidates → fails |
| `test_encrypt_output_still_opens_with_md5_parameters_alone` | rollback path | move encrypt to sha256 → fails |

The existing `test_decrypts_ciphertext_created_with_legacy_primary_normalization` golden ciphertext still passes unchanged, and has been added to the sync source's copy so a future sync stops stripping it.

Run against the identical files in the source repo: `test_aes_fallback_decrypt.py`, `test_encrypt_bootstrap.py`, `test_secret_encryption.py` — 29 passed; `pytest tests/unit -k "encrypt or aes or secret or credential or token"` — 2285 passed. `ruff format` clean; `ruff check` reports 4 pre-existing findings in `encrypt`/`decrypt` that are identical on `main`.

## Artifacts (if appropriate):

```
OSS-main ciphertext readable after upgrade : True
OSS-main can read post-upgrade ciphertext  : True
```

**Residual risk:** more decrypt candidates means marginally more chances for strict PKCS#7 to accept wrong-key garbage on a decrypt that would otherwise fail outright. That tradeoff already exists in the multi-key loop; this widens it from 1 candidate to 2 per configured pair, and only on the failure path.
