### PR TITLE
fix: give an explicit browser session precedence over LoginBlock's credential profile (SKY-14902)

### DIFF
--- a/skyvern/forge/agent_functions.py
+++ b/skyvern/forge/agent_functions.py
@@ -1841,6 +1841,7 @@ class AgentFunction:
         ``required_scopes`` gates use of a credential whose grant does not cover
         the API the caller is about to use.
         """
+        credential_id = await self.resolve_google_credential_id(organization_id, credential_id)
         try:
             secrets = await google_oauth_service.load_credential_secrets(
                 organization_id=organization_id,

--- a/skyvern/forge/sdk/workflow/service.py
+++ b/skyvern/forge/sdk/workflow/service.py
@@ -925,17 +925,18 @@ def truncate_oversized_response_value(
 
 @dataclass(frozen=True)
 class DebugSessionProfileDecision:
-    """Asymmetric decision for LoginBlock credential-profile flow.
+    """Decision for LoginBlock credential-profile flow.
 
     attach_browser_session_id: the PBS id to thread into
-        BROWSER_MANAGER.get_or_create_for_workflow_run so the visible browser
-        is the one the agent acts on. None for non-debug runs (preserve
-        existing behavior — credential-profile launches a fresh browser).
+        BROWSER_MANAGER.get_or_create_for_workflow_run so the visible/supplied
+        browser is the one the agent acts on. None when the run has no explicit
+        browser_session_id (preserve existing behavior — credential-profile
+        launches a fresh browser).
 
-    incompatible_reason: None when compatible / non-debug; otherwise the
-        structured reason for the warning emit. Callers branch on this:
+    incompatible_reason: None when compatible / no explicit session; otherwise
+        the structured reason for the warning emit. Callers branch on this:
         None → take the existing skip-login fast path, set → emit the
-        structured warning, attach the PBS, fall through to ordinary login.
+        structured warning, attach the session, fall through to ordinary login.
     """
 
     attach_browser_session_id: str | None
@@ -7089,14 +7090,14 @@ class WorkflowService:
             )
 
             if decision.incompatible_reason is not None:
-                # Debug session whose visible PBS is profile-incompatible.
-                # Stream fidelity wins: attach the visible PBS so the user
-                # can watch the action, but DO NOT write
+                # The run's explicit browser session is profile-incompatible.
+                # Live-session fidelity wins: attach that session so the run (or
+                # the user watching a debug session) sees it, but DO NOT write
                 # workflow_run.browser_profile_id, DO NOT rewrite the
                 # navigation_goal, and DO NOT emit "skipping login agent".
                 # Fall through to ordinary LoginBlock execution below.
                 LOG.warning(
-                    "Debug session profile incompatible with LoginBlock credential",
+                    "Explicit browser session profile incompatible with LoginBlock credential",
                     code=DEBUG_SESSION_PROFILE_INCOMPATIBLE_CODE,
                     reason=decision.incompatible_reason,
                     workflow_run_id=workflow_run_id,
@@ -7591,16 +7592,13 @@ class WorkflowService:
         resolved_browser_profile_id: str,
         organization_id: str,
     ) -> DebugSessionProfileDecision:
-        """Asymmetric LoginBlock credential-profile decision: debug-session runs
-        attach the visible PBS only when its saved profile matches the credential
-        profile; mismatches surface a reason for downstream warning + fall-through."""
-        is_debug_run = workflow_run.is_debug_session
-        if not is_debug_run:
-            return DebugSessionProfileDecision(
-                attach_browser_session_id=None,
-                incompatible_reason=None,
-            )
-
+        """LoginBlock credential-profile decision: a run with an explicit
+        browser_session_id (a debug session, or one supplied by a caller such as
+        MCP's skyvern_login) attaches that live session and only skips the
+        login agent when its saved profile matches the credential profile;
+        mismatches surface a reason for downstream warning + fall-through. A
+        run with no explicit session keeps the legacy behavior: the credential
+        profile boots a fresh browser."""
         if not browser_session_id:
             return DebugSessionProfileDecision(
                 attach_browser_session_id=None,

--- a/tests/unit/google/test_agent_function_google_credentials.py
+++ b/tests/unit/google/test_agent_function_google_credentials.py
@@ -203,6 +203,43 @@ async def test_get_google_workspace_credentials_returns_none_when_encryption_dis
 
 
 @pytest.mark.asyncio
+async def test_get_google_workspace_credentials_resolves_a_connection_name_to_its_credential_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Drive/Docs/Gmail blocks carry the connection's display name, same as Sheets blocks
+    did before SKY-15024's fix; the workspace path must resolve it too or a fully connected
+    account fails with the same "no valid access token" message a bad id would produce."""
+    connection = SimpleNamespace(
+        id="goac_9",
+        credential_name="Ada's Docs",
+        email_address=None,
+        state=google_oauth_service.STATE_ACTIVE,
+    )
+    monkeypatch.setattr(
+        google_oauth_service,
+        "get_visible_credentials_for_org",
+        AsyncMock(return_value=[connection]),
+    )
+    secrets = google_oauth_service.GoogleCredentialSecrets(refresh_token="rt", scopes=[])
+    fake_credentials = SimpleNamespace(token="ya29.access-token")
+    load_secrets = AsyncMock(return_value=secrets)
+    monkeypatch.setattr(google_oauth_service, "load_credential_secrets", load_secrets)
+    monkeypatch.setattr(
+        google_oauth_service,
+        "credentials_from_secrets",
+        AsyncMock(return_value=fake_credentials),
+    )
+
+    result = await AgentFunction().get_google_workspace_credentials(
+        organization_id="org_1",
+        credential_id="Ada's Docs",
+    )
+
+    assert result is fake_credentials
+    load_secrets.assert_awaited_once_with(organization_id="org_1", credential_id="goac_9")
+
+
+@pytest.mark.asyncio
 async def test_get_google_workspace_credentials_returns_none_on_unexpected_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_login_block_debug_session_profile.py
+++ b/tests/unit/test_login_block_debug_session_profile.py
@@ -1,13 +1,14 @@
-"""Asymmetric debug-session vs workflow-run semantics for LoginBlock credential profile.
+"""Explicit-session vs workflow-run semantics for LoginBlock credential profile.
 
-Debug-session runs (workflow_run.debug_session_id is not None) prioritize stream
-fidelity: attach the visible PBS, and keep the skip-login fast path only when the
-PBS profile actually matches the credential. Mismatched / missing PBS profile
-yields a structured warning, no profile_id write, no navigation_goal rewrite, and
-fall-through to ordinary LoginBlock execution so the user watches the actual
-login. Non-debug runs preserve existing behavior — credential-profile launches a
-fresh browser, no PBS attach. The decision lives in
-``WorkflowService._evaluate_debug_session_profile_decision``.
+Any run with an explicit browser_session_id — a debug session, or one supplied
+by a caller such as MCP's skyvern_login — prioritizes that live session:
+attach it, and keep the skip-login fast path only when its profile
+actually matches the credential. Mismatched / missing session profile yields a
+structured warning, no profile_id write, no navigation_goal rewrite, and
+fall-through to ordinary LoginBlock execution so the login runs for real in
+that session. A run with no explicit browser_session_id preserves the legacy
+behavior — credential-profile launches a fresh browser, no attach. The decision
+lives in ``WorkflowService._evaluate_debug_session_profile_decision``.
 """
 
 from __future__ import annotations
@@ -66,6 +67,30 @@ class TestDebugSessionProfileDecision:
             mock_app.DATABASE.browser_sessions.get_persistent_browser_session.assert_not_called()
 
         assert decision.attach_browser_session_id is None
+        assert decision.incompatible_reason is None
+
+    @pytest.mark.asyncio
+    async def test_non_debug_run_with_explicit_session_attaches_it(self) -> None:
+        """A plain (non-debug) run carrying an explicit browser_session_id — e.g.
+        MCP's skyvern_login supplying an already-created persistent session —
+        must attach that session exactly like a debug run does, instead of
+        ignoring it and booting a fresh browser from the credential's saved
+        profile."""
+        service = WorkflowService()
+        workflow_run = _workflow_run(debug_session_id=None)
+
+        with patch("skyvern.forge.sdk.workflow.service.app") as mock_app:
+            mock_app.DATABASE.browser_sessions.get_persistent_browser_session = AsyncMock(
+                return_value=_pbs(browser_profile_id="bp_cred"),
+            )
+            decision = await service._evaluate_debug_session_profile_decision(
+                workflow_run=workflow_run,
+                browser_session_id="pbs_test",
+                resolved_browser_profile_id="bp_cred",
+                organization_id="o_test",
+            )
+
+        assert decision.attach_browser_session_id == "pbs_test"
         assert decision.incompatible_reason is None
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Sync PR: 16334
Sync SHA: ea18db9193717841c04ab7e84e970b69da17e40d