### PR TITLE
Stop frontend session pollers on 401/403 instead of retrying every second

### DIFF
--- a/skyvern-frontend/src/api/forbidden.test.ts
+++ b/skyvern-frontend/src/api/forbidden.test.ts
@@ -1,0 +1,35 @@
+import { AxiosError, AxiosHeaders } from "axios";
+import { describe, expect, test } from "vitest";
+
+import { isForbiddenError } from "./forbidden";
+
+function axiosErrorWithStatus(status: number): AxiosError {
+  const error = new AxiosError(`Request failed with status code ${status}`);
+  error.response = {
+    status,
+    statusText: "",
+    data: null,
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+  };
+  return error;
+}
+
+describe("isForbiddenError", () => {
+  test("is true for 401 and 403", () => {
+    expect(isForbiddenError(axiosErrorWithStatus(401))).toBe(true);
+    expect(isForbiddenError(axiosErrorWithStatus(403))).toBe(true);
+  });
+
+  test("is false for other statuses, including 402 and 404", () => {
+    expect(isForbiddenError(axiosErrorWithStatus(402))).toBe(false);
+    expect(isForbiddenError(axiosErrorWithStatus(404))).toBe(false);
+    expect(isForbiddenError(axiosErrorWithStatus(500))).toBe(false);
+  });
+
+  test("is false for non-response and non-axios errors", () => {
+    expect(isForbiddenError(new AxiosError("Network Error"))).toBe(false);
+    expect(isForbiddenError(new Error("boom"))).toBe(false);
+    expect(isForbiddenError(undefined)).toBe(false);
+  });
+});

--- a/skyvern-frontend/src/api/forbidden.ts
+++ b/skyvern-frontend/src/api/forbidden.ts
@@ -1,0 +1,18 @@
+import { isAxiosError } from "axios";
+
+const UNAUTHORIZED_STATUS = 401;
+const FORBIDDEN_STATUS = 403;
+
+// A 401/403 while polling a resource means the caller is not (or no longer)
+// authorized for it — an expired browser/debug session, or a session that
+// belongs to another org. Re-issuing the same request can only produce another
+// 401/403, so every poller must stop instead of retrying at the same interval.
+function isForbiddenError(error: unknown): boolean {
+  if (!isAxiosError(error)) {
+    return false;
+  }
+  const status = error.response?.status;
+  return status === UNAUTHORIZED_STATUS || status === FORBIDDEN_STATUS;
+}
+
+export { isForbiddenError };

--- a/skyvern-frontend/src/components/BrowserStream.tsx
+++ b/skyvern-frontend/src/components/BrowserStream.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState, useRef, useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { getClient } from "@/api/AxiosClient";
+import { isForbiddenError } from "@/api/forbidden";
 import {
   Status,
   type TaskApiResponse,
@@ -169,11 +170,22 @@ function BrowserStream({
       } catch (error) {
         setHasBrowserSession(false);
         setIsBrowserSessionStarted(false);
+        // A forbidden session (expired, or owned by another org) never becomes
+        // allowed, so surface it as an error and stop the poll instead of
+        // swallowing it into the 1/s "not started yet" branch below.
+        if (isForbiddenError(error)) {
+          throw error;
+        }
         return false;
       }
     },
     enabled: entity === "browserSession" && !!browserSessionId,
-    refetchInterval: (query) => (query.state.data ? 5000 : 1000),
+    refetchInterval: (query) =>
+      query.state.status === "error" && isForbiddenError(query.state.error)
+        ? false
+        : query.state.data
+          ? 5000
+          : 1000,
   });
 
   const [hasBrowserSession, setHasBrowserSession] = useState(true); // be optimistic

--- a/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
+++ b/skyvern-frontend/src/routes/workflows/editor/Workspace.tsx
@@ -46,7 +46,10 @@ import { useCredentialGetter } from "@/hooks/useCredentialGetter";
 import { useMountEffect } from "@/hooks/useMountEffect";
 import { useBrowserSessionRateLimit } from "../hooks/useBrowserSessionRateLimit";
 import { useActiveRunSessionQuery } from "../hooks/useActiveRunSessionQuery";
-import { useDebugSessionQuery } from "../hooks/useDebugSessionQuery";
+import {
+  shouldPollDebugSessionInvalidation,
+  useDebugSessionQuery,
+} from "../hooks/useDebugSessionQuery";
 import { useIsGlobalWorkflow } from "../hooks/useIsGlobalWorkflow";
 import { resolveWorkspaceBrowserSessionBindings } from "./browserSessionBindings";
 import { useBlockScriptsQuery } from "@/routes/workflows/hooks/useBlockScriptsQuery";
@@ -1288,10 +1291,13 @@ function Workspace({
   // sustained polling without success.
   useEffect(() => {
     if (
-      (!debugSession || !debugSession.browser_session_id) &&
-      shouldFetchDebugSession &&
-      workflowPermanentId &&
-      !isRateLimited
+      shouldPollDebugSessionInvalidation({
+        debugSession,
+        debugSessionError,
+        shouldFetchDebugSession,
+        workflowPermanentId,
+        isRateLimited,
+      })
     ) {
       if (!pollingStartRef.current) {
         pollingStartRef.current = Date.now();
@@ -1328,6 +1334,7 @@ function Workspace({
     };
   }, [
     debugSession,
+    debugSessionError,
     shouldFetchDebugSession,
     workflowPermanentId,
     queryClient,

--- a/skyvern-frontend/src/routes/workflows/hooks/useActiveRunSessionQuery.test.ts
+++ b/skyvern-frontend/src/routes/workflows/hooks/useActiveRunSessionQuery.test.ts
@@ -1,9 +1,22 @@
+import { AxiosError, AxiosHeaders } from "axios";
 import { describe, expect, test } from "vitest";
 
 import {
   ACTIVE_RUN_SESSION_REFETCH_INTERVAL_MS,
   getActiveRunSessionRefetchInterval,
 } from "./useActiveRunSessionQuery";
+
+function forbiddenError(status = 403): AxiosError {
+  const error = new AxiosError(`Request failed with status code ${status}`);
+  error.response = {
+    status,
+    statusText: "",
+    data: null,
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+  };
+  return error;
+}
 
 describe("getActiveRunSessionRefetchInterval", () => {
   test("polls while the local Copilot turn is active", () => {
@@ -28,6 +41,25 @@ describe("getActiveRunSessionRefetchInterval", () => {
     expect(
       getActiveRunSessionRefetchInterval(
         { data: { active_run_session_id: null } },
+        false,
+      ),
+    ).toBe(false);
+  });
+
+  test("stops polling on a forbidden viewer-state even while active", () => {
+    expect(
+      getActiveRunSessionRefetchInterval(
+        {
+          status: "error",
+          data: { active_run_session_id: "pbs_run" },
+          error: forbiddenError(403),
+        },
+        true,
+      ),
+    ).toBe(false);
+    expect(
+      getActiveRunSessionRefetchInterval(
+        { status: "error", error: forbiddenError(401) },
         false,
       ),
     ).toBe(false);

--- a/skyvern-frontend/src/routes/workflows/hooks/useActiveRunSessionQuery.ts
+++ b/skyvern-frontend/src/routes/workflows/hooks/useActiveRunSessionQuery.ts
@@ -1,4 +1,5 @@
 import { getClient } from "@/api/AxiosClient";
+import { isForbiddenError } from "@/api/forbidden";
 import { DebugSessionViewerStateApiResponse } from "@/api/types";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
 import { useQuery } from "@tanstack/react-query";
@@ -7,13 +8,20 @@ import { useEffect, useRef } from "react";
 const ACTIVE_RUN_SESSION_REFETCH_INTERVAL_MS = 1000;
 
 type ActiveRunSessionRefetchState = {
+  status?: "pending" | "error" | "success";
   data?: DebugSessionViewerStateApiResponse;
+  error?: unknown;
 };
 
 function getActiveRunSessionRefetchInterval(
   queryState: ActiveRunSessionRefetchState,
   isTurnActive: boolean,
 ): number | false {
+  // A forbidden viewer-state (expired session or another org's workflow) never
+  // becomes allowed on its own, so stop polling instead of hammering it 1/s.
+  if (queryState.status === "error" && isForbiddenError(queryState.error)) {
+    return false;
+  }
   return isTurnActive || Boolean(queryState.data?.active_run_session_id)
     ? ACTIVE_RUN_SESSION_REFETCH_INTERVAL_MS
     : false;

--- a/skyvern-frontend/src/routes/workflows/hooks/useDebugSessionQuery.test.ts
+++ b/skyvern-frontend/src/routes/workflows/hooks/useDebugSessionQuery.test.ts
@@ -6,19 +6,24 @@ import {
   DEBUG_SESSION_KEEP_ALIVE_INTERVAL_MS,
   DEBUG_SESSION_MAX_RETRIES,
   getDebugSessionRefetchInterval,
+  shouldPollDebugSessionInvalidation,
   shouldRetryDebugSessionRead,
 } from "./useDebugSessionQuery";
 
-function paymentRequiredError(): AxiosError {
-  const error = new AxiosError("Request failed with status code 402");
+function axiosErrorWithStatus(status: number): AxiosError {
+  const error = new AxiosError(`Request failed with status code ${status}`);
   error.response = {
-    status: 402,
-    statusText: "Payment Required",
+    status,
+    statusText: "",
     data: null,
     headers: {},
     config: { headers: new AxiosHeaders() },
   };
   return error;
+}
+
+function paymentRequiredError(): AxiosError {
+  return axiosErrorWithStatus(402);
 }
 
 describe("getDebugSessionRefetchInterval", () => {
@@ -95,6 +100,97 @@ describe("getDebugSessionRefetchInterval", () => {
       ),
     ).toBe(false);
   });
+
+  test("stops polling on a forbidden or expired session (401/403)", () => {
+    expect(
+      getDebugSessionRefetchInterval(
+        { status: "error", error: axiosErrorWithStatus(403) },
+        false,
+        true,
+      ),
+    ).toBe(false);
+    expect(
+      getDebugSessionRefetchInterval(
+        { status: "error", error: axiosErrorWithStatus(401) },
+        false,
+        true,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("shouldPollDebugSessionInvalidation", () => {
+  const baseState = {
+    debugSession: null,
+    debugSessionError: undefined as unknown,
+    shouldFetchDebugSession: true,
+    workflowPermanentId: "wpid_123",
+    isRateLimited: false,
+  };
+
+  test("polls while waiting for a browser session with no error", () => {
+    expect(shouldPollDebugSessionInvalidation(baseState)).toBe(true);
+  });
+
+  test("keeps polling through a non-terminal error", () => {
+    expect(
+      shouldPollDebugSessionInvalidation({
+        ...baseState,
+        debugSessionError: new AxiosError("Network Error"),
+      }),
+    ).toBe(true);
+  });
+
+  test("stops polling on a forbidden or expired session (401/403)", () => {
+    expect(
+      shouldPollDebugSessionInvalidation({
+        ...baseState,
+        debugSessionError: axiosErrorWithStatus(403),
+      }),
+    ).toBe(false);
+    expect(
+      shouldPollDebugSessionInvalidation({
+        ...baseState,
+        debugSessionError: axiosErrorWithStatus(401),
+      }),
+    ).toBe(false);
+  });
+
+  test("stops polling when the org is out of credits (402)", () => {
+    expect(
+      shouldPollDebugSessionInvalidation({
+        ...baseState,
+        debugSessionError: paymentRequiredError(),
+      }),
+    ).toBe(false);
+  });
+
+  test("stops once a browser session exists", () => {
+    expect(
+      shouldPollDebugSessionInvalidation({
+        ...baseState,
+        debugSession: { browser_session_id: "pbs_123" },
+      }),
+    ).toBe(false);
+  });
+
+  test("does not poll while rate limited or when fetching is disabled", () => {
+    expect(
+      shouldPollDebugSessionInvalidation({ ...baseState, isRateLimited: true }),
+    ).toBe(false);
+    expect(
+      shouldPollDebugSessionInvalidation({
+        ...baseState,
+        shouldFetchDebugSession: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldPollDebugSessionInvalidation({
+        ...baseState,
+        workflowPermanentId: undefined,
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("shouldRetryDebugSessionRead", () => {
@@ -111,5 +207,14 @@ describe("shouldRetryDebugSessionRead", () => {
 
   test("does not retry when the org is out of credits", () => {
     expect(shouldRetryDebugSessionRead(0, paymentRequiredError())).toBe(false);
+  });
+
+  test("does not retry a forbidden or expired session (401/403)", () => {
+    expect(shouldRetryDebugSessionRead(0, axiosErrorWithStatus(403))).toBe(
+      false,
+    );
+    expect(shouldRetryDebugSessionRead(0, axiosErrorWithStatus(401))).toBe(
+      false,
+    );
   });
 });

--- a/skyvern-frontend/src/routes/workflows/hooks/useDebugSessionQuery.ts
+++ b/skyvern-frontend/src/routes/workflows/hooks/useDebugSessionQuery.ts
@@ -1,4 +1,5 @@
 import { getClient } from "@/api/AxiosClient";
+import { isForbiddenError } from "@/api/forbidden";
 import { isPaymentRequiredError } from "@/api/paymentRequired";
 import { DebugSessionApiResponse } from "@/api/types";
 import { useCredentialGetter } from "@/hooks/useCredentialGetter";
@@ -15,14 +16,51 @@ type DebugSessionRefetchState = {
 };
 
 // Reading a debug session creates its browser session when none exists, so an
-// out-of-credits org gets a 402 here. Credits do not come back on their own,
-// so neither retrying nor polling can succeed.
+// out-of-credits org gets a 402 here. A 401/403 means the session is expired or
+// belongs to another org. Neither recovers on its own, so retrying or polling
+// the same request can only reproduce the error — stop in both cases.
+function isTerminalDebugSessionError(error: unknown): boolean {
+  return isPaymentRequiredError(error) || isForbiddenError(error);
+}
+
 function shouldRetryDebugSessionRead(
   failureCount: number,
   error: unknown,
 ): boolean {
   return (
-    !isPaymentRequiredError(error) && failureCount < DEBUG_SESSION_MAX_RETRIES
+    !isTerminalDebugSessionError(error) &&
+    failureCount < DEBUG_SESSION_MAX_RETRIES
+  );
+}
+
+type DebugSessionInvalidationState = {
+  debugSession?: { browser_session_id?: string | null } | null;
+  debugSessionError?: unknown;
+  shouldFetchDebugSession: boolean;
+  workflowPermanentId?: string;
+  isRateLimited: boolean;
+};
+
+// The workflow editor drives its own 5s invalidation loop to acquire a browser
+// session, which refetches the debug-session query independently of the query's
+// refetchInterval. A terminal 401/403/402 can only reproduce itself, so the loop
+// must stop on those just like the query's own polling does — otherwise the
+// forbidden request keeps firing every 5s despite refetchInterval being false.
+function shouldPollDebugSessionInvalidation({
+  debugSession,
+  debugSessionError,
+  shouldFetchDebugSession,
+  workflowPermanentId,
+  isRateLimited,
+}: DebugSessionInvalidationState): boolean {
+  if (isTerminalDebugSessionError(debugSessionError)) {
+    return false;
+  }
+  return (
+    (!debugSession || !debugSession.browser_session_id) &&
+    shouldFetchDebugSession &&
+    !!workflowPermanentId &&
+    !isRateLimited
   );
 }
 
@@ -35,7 +73,7 @@ function getDebugSessionRefetchInterval(
     return false;
   }
   if (queryState.status === "error") {
-    return isPaymentRequiredError(queryState.error)
+    return isTerminalDebugSessionError(queryState.error)
       ? false
       : DEBUG_SESSION_ERROR_REFETCH_INTERVAL_MS;
   }
@@ -95,6 +133,7 @@ export {
   DEBUG_SESSION_KEEP_ALIVE_INTERVAL_MS,
   DEBUG_SESSION_MAX_RETRIES,
   getDebugSessionRefetchInterval,
+  shouldPollDebugSessionInvalidation,
   shouldRetryDebugSessionRead,
   useDebugSessionQuery,
 };


### PR DESCRIPTION
Sync PR: 16527
Sync SHA: 9a6c9c9aafd9bfd8805d3d8aa7486d93082a5e0c