### PR TITLE
Stop generate_random_string from reseeding the global random PRNG on every call

### DIFF
--- a/skyvern/utils/strings.py
+++ b/skyvern/utils/strings.py
@@ -1,6 +1,5 @@
-import os
-import random
 import re
+import secrets
 import string
 import unicodedata
 import uuid
@@ -18,9 +17,10 @@ _NEUTRALIZED_UNTRUSTED_WEB_PAGE_DATA_SENTINEL = "UNTRUSTED_BLOCK_SENTINEL_REMOVE
 
 
 def generate_random_string(length: int = 5) -> str:
-    # Use the os.urandom(16) as the seed
-    random.seed(os.urandom(16))
-    return "".join(random.choices(RANDOM_STRING_POOL, k=length))
+    # secrets.choice draws from OS entropy without touching the global
+    # `random` module's state, which callers elsewhere in the process may
+    # rely on staying reproducible.
+    return "".join(secrets.choice(RANDOM_STRING_POOL) for _ in range(length))
 
 
 def is_uuid(string: str) -> bool:

--- a/tests/unit/test_strings.py
+++ b/tests/unit/test_strings.py
@@ -1,0 +1,20 @@
+import random
+
+from skyvern.utils.strings import RANDOM_STRING_POOL, generate_random_string
+
+
+def test_generate_random_string_length_and_alphabet() -> None:
+    for length in (1, 5, 32):
+        value = generate_random_string(length)
+        assert len(value) == length
+        assert all(char in RANDOM_STRING_POOL for char in value)
+
+
+def test_generate_random_string_does_not_reseed_global_random() -> None:
+    """The implementation used to call ``random.seed()`` on every invocation,
+    replacing the global PRNG state shared with the rest of the process."""
+    random.seed(1234)
+    expected = [random.random() for _ in range(8)]
+    random.seed(1234)
+    generate_random_string(5)
+    assert [random.random() for _ in range(8)] == expected


### PR DESCRIPTION
## Description

Fixes #7072.

`generate_random_string()` called `random.seed(os.urandom(16))` before drawing from the global `random` module on every invocation. That has two problems: it destroys the global PRNG state every other consumer of `random` in the process relies on (any code path expecting reproducibility from a seeded `random` breaks as soon as a task/workflow ID is generated), it races between threads, and it burns OS entropy per call for what is just an identifier generator.

The fix draws from `secrets.choice` instead: OS entropy directly, no global state, same output alphabet and length, so every call site keeps working unchanged.

## How Has This Been Tested?

- Added `tests/unit/test_strings.py`:
  - length/alphabet check for the generated strings;
  - regression test that seeds the global `random`, calls `generate_random_string()`, and asserts the following `random.random()` sequence is unchanged — this fails against the old implementation (the seed call corrupts the sequence) and passes with `secrets.choice`.
- `uv run pytest tests/unit/test_strings.py` → 2 passed; verified the regression test fails on the original implementation by stashing the fix.
- `ruff check` and `ruff format --check` clean on both changed files.