### PR TITLE
Parse the enable_download extra header as a boolean instead of truthy non-empty strings

### DIFF
--- a/skyvern/webeye/browser_factory.py
+++ b/skyvern/webeye/browser_factory.py
@@ -118,7 +118,7 @@ def parse_extra_headers(extra_http_headers: dict[str, str] | None) -> ParsedBrow
             if key_lower == FRESH_CONTEXT_HEADER.lower():
                 use_fresh_context = value.lower() == "true"
             elif key_lower == "enable_download":
-                enable_download = bool(value)
+                enable_download = value.lower() == "true"
             else:
                 headers[key] = value
 

--- a/tests/unit/webeye/test_browser_factory_headers.py
+++ b/tests/unit/webeye/test_browser_factory_headers.py
@@ -1,0 +1,34 @@
+from skyvern.webeye.browser_factory import parse_extra_headers
+
+
+def test_parse_extra_headers_strips_internal_headers() -> None:
+    parsed = parse_extra_headers(
+        {
+            "X-Skyvern-Fresh-Context": "true",
+            "Enable_Download": "true",
+            "Accept": "text/html",
+        }
+    )
+    assert parsed.use_fresh_context is True
+    assert parsed.enable_download is True
+    assert parsed.headers == {"Accept": "text/html"}
+
+
+def test_parse_extra_headers_enable_download_requires_explicit_true() -> None:
+    """Any non-empty header value used to be truthy, so even "false" enabled
+    download interception."""
+    for value in ("false", "0", "off", "", "no"):
+        parsed = parse_extra_headers({"enable_download": value})
+        assert parsed.enable_download is False, value
+
+
+def test_parse_extra_headers_enable_download_case_insensitive() -> None:
+    parsed = parse_extra_headers({"ENABLE_DOWNLOAD": "True"})
+    assert parsed.enable_download is True
+
+
+def test_parse_extra_headers_none_and_missing() -> None:
+    parsed = parse_extra_headers(None)
+    assert parsed.headers == {}
+    assert parsed.use_fresh_context is False
+    assert parsed.enable_download is False


### PR DESCRIPTION
## Description

Fixes #7077.

`parse_extra_headers()` read the `enable_download` extra header with `bool(value)`, and header values are strings — so any non-empty value enabled download interception, including `"false"`, `"0"` and `"off"`. There was no way to turn the feature off once the header was present.

The fix parses it case-insensitively as `value.lower() == "true"`, matching how the sibling `X-Skyvern-Fresh-Context` header is parsed a line above. `"true"` keeps enabling downloads; every other value, including `"false"`, now disables them as expected.

## How Has This Been Tested?

- Added `tests/unit/webeye/test_browser_factory_headers.py` covering: internal headers stripped while the rest pass through, explicit-`"true"`-only semantics for `enable_download` (asserting `"false"`, `"0"`, `"off"`, `""` and `"no"` all parse as disabled), case-insensitive matching, and the `None`/empty defaults.
- `uv run pytest tests/unit/webeye/test_browser_factory_headers.py` → 4 passed; the explicit-true test fails against the original `bool(value)` implementation (verified by stashing the fix).
- `ruff check` and `ruff format --check` clean on both changed files.