### PR TITLE
Rewrite renamed Jinja references anywhere inside {{ }} and {% %} delimiters

### DIFF
--- a/skyvern/utils/templating.py
+++ b/skyvern/utils/templating.py
@@ -12,7 +12,10 @@ class Constants:
 def replace_jinja_reference(text: str, old_key: str, new_key: str) -> str:
     """Replaces jinja-style references in a string.
 
-    Handles patterns like {{oldKey}}, {{oldKey.field}}, {{oldKey | filter}}, {{oldKey[0]}}
+    Handles references anywhere inside Jinja delimiters: {{oldKey}},
+    {{oldKey.field}}, {{oldKey | filter}}, {{oldKey[0]}}, mid-expression uses
+    like {{ other < oldKey }}, and statement blocks like {% if oldKey %}.
+    Quoted string literals inside an expression are left alone.
 
     Args:
         text: The text to search in
@@ -22,13 +25,20 @@ def replace_jinja_reference(text: str, old_key: str, new_key: str) -> str:
     Returns:
         The text with references replaced
     """
-    # Match {{oldKey}} or {{oldKey.something}} or {{oldKey | filter}} or {{oldKey[0]}} etc.
-    # Use negative lookahead to ensure key is not followed by identifier characters,
-    # which prevents matching {{keyOther}} when searching for {{key}}
-    # Capture whitespace after {{ to preserve formatting (e.g., "{{ key }}" stays "{{ newKey }}")
     escaped_old_key = re.escape(old_key)
-    pattern = rf"\{{\{{(\s*){escaped_old_key}(?![a-zA-Z0-9_])"
-    return re.sub(pattern, rf"{{{{\1{new_key}", text)
+    # Match the whole identifier on both sides so {{keyOther}} and {{my_key}}
+    # stay untouched when searching for {{key}}.
+    word = rf"(?<![a-zA-Z0-9_]){escaped_old_key}(?![a-zA-Z0-9_])"
+    # Only rewrite inside Jinja delimiters; the rest of the text is literal.
+    segment_pattern = re.compile(r"\{\{.*?\}\}|{%.*?%}", re.DOTALL)
+    quoted_pattern = re.compile(r"('[^']*'|\"[^\"]*\")")
+
+    def _rewrite_segment(segment_match: re.Match[str]) -> str:
+        segment = segment_match.group(0)
+        parts = quoted_pattern.split(segment)
+        return "".join(part if index % 2 == 1 else re.sub(word, new_key, part) for index, part in enumerate(parts))
+
+    return segment_pattern.sub(_rewrite_segment, text)
 
 
 def get_missing_variables(template_source: str, template_data: dict) -> set[str]:

--- a/tests/unit/test_workflow_parameter_validation.py
+++ b/tests/unit/test_workflow_parameter_validation.py
@@ -129,6 +129,31 @@ class TestReplaceJinjaReference:
             ),
             pytest.param("{{ old_key_extended }}", "{{ old_key_extended }}", id="partial-match-unchanged"),
             pytest.param("{{ other_key }}", "{{ other_key }}", id="different-key-unchanged"),
+            pytest.param(
+                "{{ current_index < old_key }}",
+                "{{ current_index < new_key }}",
+                id="mid-expression-reference",
+            ),
+            pytest.param(
+                "{% if old_key %}go{% endif %}",
+                "{% if new_key %}go{% endif %}",
+                id="statement-block-reference",
+            ),
+            pytest.param(
+                "{% for item in old_key %}{{ item }}{% endfor %}",
+                "{% for item in new_key %}{{ item }}{% endfor %}",
+                id="for-statement-reference",
+            ),
+            pytest.param(
+                "{{ old_key | default('old_key') }}",
+                "{{ new_key | default('old_key') }}",
+                id="quoted-literal-unchanged",
+            ),
+            pytest.param(
+                "{% if other_old_key %}go{% endif %}",
+                "{% if other_old_key %}go{% endif %}",
+                id="statement-partial-match-unchanged",
+            ),
         ],
     )
     def test_replace_jinja_reference(self, text: str, expected: str) -> None:


### PR DESCRIPTION
## Description

Fixes #7559.

`replace_jinja_reference()` only matched the renamed identifier directly after `{{`, so after a sanitization-driven rename (invalid identifier or collision `_2` suffix) every reference that wasn't at the head of an expression kept pointing at the old name:

- mid-expression uses like `{{ current_index < max_attempts }}` — the shape of a while-loop `Condition`;
- statement blocks like `{% if my-block_output.success %}` and `{% for item in old_key %}`, which the old pattern never matched at all.

With lax templating nothing errors — conditions evaluate against undefined or wrong values, so loops mis-terminate and guards mis-fire.

The function now matches the old identifier as a whole word (lookbehind + lookahead on identifier characters, so `{{ old_key_extended }}` and `{{ other_key }}` stay untouched) inside every `{{ ... }}` / `{% ... %}` segment, and skips quoted string literals so filter defaults like `default('old_key')` keep their values. The sentinel-based atomic rewrite in `_rewrite_error_code_mapping_refs_atomic` keeps working unchanged: sentinels are plain-string-replaced in the second phase and contain no identifier characters.

## How Has This Been Tested?

- Extended the existing parametrized suite in `tests/unit/test_workflow_parameter_validation.py` with the issue's two reproductions (mid-expression `{{ current_index < old_key }}` and statement `{% if old_key %}go{% endif %}`), a `{% for %}` case, a quoted-literal case (`default('old_key')` keeps its value), and a statement partial-match case (`other_old_key` untouched).
- `uv run pytest tests/unit/test_workflow_parameter_validation.py` → 70 passed (63 pre-existing cases all still green, including the sentinel-driven sanitizer tests).
- Verified both reproductions from the issue now return the rewritten text, e.g. `replace_jinja_reference("{{ current_index < max_attempts }}", "max_attempts", "max_attempts_2")` → `"{{ current_index < max_attempts_2 }}"`.
- `ruff check` clean on the touched files; `ruff format` applied.
