### PR TITLE
docs(webeye): fix stale docstrings in page utils

### DIFF
--- a/skyvern/webeye/utils/page.py
+++ b/skyvern/webeye/utils/page.py
@@ -2135,8 +2135,9 @@ class SkyvernFrame:
     async def scroll_to_top(self, draw_boxes: bool, frame: str, frame_index: int) -> float:
         """
         Scroll to the top of the page and take a screenshot.
-        :param drow_boxes: If True, draw bounding boxes around the elements.
-        :param page: Page instance to take the screenshot from.
+        :param draw_boxes: If True, draw bounding boxes around the elements.
+        :param frame: The frame to screenshot.
+        :param frame_index: Index of the frame being screenshotted.
         :return: Screenshot of the page.
         """
         js_script = "async ([draw_boxes, frame, frame_index]) => await safeScrollToTop(draw_boxes, frame, frame_index)"
@@ -2160,8 +2161,9 @@ class SkyvernFrame:
     ) -> float:
         """
         Scroll to the next page and take a screenshot.
-        :param drow_boxes: If True, draw bounding boxes around the elements.
-        :param page: Page instance to take the screenshot from.
+        :param draw_boxes: If True, draw bounding boxes around the elements.
+        :param frame: The frame to screenshot.
+        :param frame_index: Index of the frame being screenshotted.
         :return: Screenshot of the page.
         """
         js_script = "async ([draw_boxes, frame, frame_index, need_overlap]) => await scrollToNextPage(draw_boxes, frame, frame_index, need_overlap)"
@@ -2183,7 +2185,6 @@ class SkyvernFrame:
     async def remove_bounding_boxes(self) -> None:
         """
         Remove the bounding boxes from the page.
-        :param page: Page instance to remove the bounding boxes from.
         """
         js_script = "() => removeBoundingBoxes()"
         await self.evaluate(


### PR DESCRIPTION
Three methods in `skyvern/webeye/utils/page.py` carry docstrings from an older free-function era:

- `scroll_to_top` / `scroll_to_next_page` document `:param drow_boxes:` (misspelled; the real parameter is `draw_boxes`) and `:param page:`, which is not a parameter of either method (they live on a class wrapping the page).
- `remove_bounding_boxes()` takes no parameters but documents `:param page:`.

The docstrings now name the real parameters (`draw_boxes`, `frame`, `frame_index`) and the phantom `page` lines are removed. Docs-only; no behavior change.