### PR TITLE
docs: fix wording typos in scraper and action handler comments

### DIFF
--- a/skyvern/webeye/actions/handler.py
+++ b/skyvern/webeye/actions/handler.py
@@ -7306,7 +7306,7 @@ async def _handle_input_text_action(
     # check if it's selectable
     if (
         input_or_select_context is not None
-        and not input_or_select_context.is_search_bar  # no need to to trigger selection logic for search bar
+        and not input_or_select_context.is_search_bar  # no need to trigger selection logic for search bar
         and not is_totp_value
         and not is_secret_value
         and skyvern_element.get_tag_name() == InteractiveElement.INPUT

--- a/skyvern/webeye/scraper/scraper.py
+++ b/skyvern/webeye/scraper/scraper.py
@@ -975,7 +975,7 @@ class IncrementalScrapePage(ElementTreeBuilder):
                 wait_until_finished=False
             )
 
-        # we listen the incremental elements seperated by frames, so all elements will be in the same SkyvernFrame
+        # we listen to the incremental elements separated by frames, so all elements will be in the same SkyvernFrame
         self.id_to_css_dict, self.id_to_element_dict, _, _, _ = build_element_dict(incremental_elements)
 
         self.elements = incremental_elements


### PR DESCRIPTION
- `webeye/scraper/scraper.py`: "we listen the incremental elements seperated by frames" → "we listen to the incremental elements separated by frames"
- `webeye/actions/handler.py`: "no need to to trigger" → "no need to trigger"

Comments only.