### PR TITLE
docs: fix 'backaward'/'paramter' typos in workflow comments

### DIFF
--- a/skyvern/forge/sdk/workflow/workflow_definition_converter.py
+++ b/skyvern/forge/sdk/workflow/workflow_definition_converter.py
@@ -508,7 +508,7 @@ def block_yaml_to_block(
             loop_over_parameter = parameters.get(block_yaml.loop_over_parameter_key)
 
         if block_yaml.loop_variable_reference:
-            # it's backaward compatible with jinja style parameter and context paramter
+            # it's backward compatible with jinja style parameter and context parameter
             # we trim the format like {{ loop_key }} into loop_key to initialize the context parater,
             # otherwise it might break the context parameter initialization chain, blow up the worklofw parameters
             # TODO: consider remove this if we totally give up context parameter

--- a/skyvern/services/script_service.py
+++ b/skyvern/services/script_service.py
@@ -792,7 +792,7 @@ async def _record_output_parameter_value(
     if not workflow:
         return None
 
-    # get the output_paramter
+    # get the output_parameter
     output_parameter = workflow.get_output_parameter(label)
     if not output_parameter:
         # NOT sure if this is legit hack to create output parameter like this
@@ -1560,7 +1560,7 @@ async def _fallback_to_ai_run(
         context.step_id = ai_step.step_id
         ai_step_id = ai_step.step_id
 
-        # get the output_paramter
+        # get the output_parameter
         output_parameter = workflow.get_output_parameter(cache_key)
         if not output_parameter:
             # NOT sure if this is legit hack to create output parameter like this


### PR DESCRIPTION
- `workflow_definition_converter.py`: "it's **backaward** compatible ... context **paramter**" → "backward ... parameter"
- `services/script_service.py`: "get the output**_paramter**" → "output_parameter"

Comments only.